### PR TITLE
Improve GlobusResponses to have native __getitem__ and optional __iter__

### DIFF
--- a/globus_sdk/base.py
+++ b/globus_sdk/base.py
@@ -35,7 +35,7 @@ class BaseClient(object):
 
     # Can be overridden by subclasses, but must be a subclass of GlobusError
     error_class = exc.GlobusAPIError
-    response_class = GlobusHTTPResponse
+    default_response_class = GlobusHTTPResponse
 
     AUTHTYPE_TOKEN = "token"
     AUTHTYPE_BASIC = "basic"
@@ -116,7 +116,8 @@ class BaseClient(object):
     def qjoin_path(self, *parts):
         return "/" + "/".join(quote(part) for part in parts)
 
-    def get(self, path, params=None, headers=None, auth=None):
+    def get(self, path, params=None, headers=None, auth=None,
+            response_class=None):
         """
         Make a GET request to the specified path.
 
@@ -124,15 +125,17 @@ class BaseClient(object):
         :param params: dict to be encoded as a query string
         :param headers: dict of HTTP headers to add to the request
         :param auth: tuple of (user, password) for basic auth [DEPRECATED]
+        :param response_class: class for response object, overrides the
+                               client's ``default_response_class``
 
         :return: :class:`GlobusHTTPResponse \
         <globus_sdk.response.GlobusHTTPResponse>` object
         """
         return self._request("GET", path, params=params, headers=headers,
-                             auth=auth)
+                             auth=auth, response_class=response_class)
 
     def post(self, path, json_body=None, params=None, headers=None,
-             text_body=None, auth=None):
+             text_body=None, auth=None, response_class=None):
         """
         Make a POST request to the specified path.
 
@@ -142,14 +145,18 @@ class BaseClient(object):
         :param auth: tuple of (user, password) for basic auth [DEPRECATED]
         :param json_body: dict that will be encoded as a JSON request body
         :param text_body: raw string that will be the request body
+        :param response_class: class for response object, overrides the
+                               client's ``default_response_class``
 
         :return: :class:`GlobusHTTPResponse \
         <globus_sdk.response.GlobusHTTPResponse>` object
         """
         return self._request("POST", path, json_body=json_body, params=params,
-                             headers=headers, text_body=text_body, auth=auth)
+                             headers=headers, text_body=text_body, auth=auth,
+                             response_class=response_class)
 
-    def delete(self, path, params=None, headers=None, auth=None):
+    def delete(self, path, params=None, headers=None, auth=None,
+               response_class=None):
         """
         Make a DELETE request to the specified path.
 
@@ -157,15 +164,18 @@ class BaseClient(object):
         :param params: dict to be encoded as a query string
         :param headers: dict of HTTP headers to add to the request
         :param auth: tuple of (user, password) for basic auth [DEPRECATED]
+        :param response_class: class for response object, overrides the
+                               client's ``default_response_class``
 
         :return: :class:`GlobusHTTPResponse \
         <globus_sdk.response.GlobusHTTPResponse>` object
         """
         return self._request("DELETE", path, params=params,
-                             headers=headers, auth=auth)
+                             headers=headers, auth=auth,
+                             response_class=response_class)
 
     def put(self, path, json_body=None, params=None, headers=None,
-            text_body=None, auth=None):
+            text_body=None, auth=None, response_class=None):
         """
         Make a PUT request to the specified path.
 
@@ -175,15 +185,19 @@ class BaseClient(object):
         :param auth: tuple of (user, password) for basic auth [DEPRECATED]
         :param json_body: dict that will be encoded as a JSON request body
         :param text_body: raw string that will be the request body
+        :param response_class: class for response object, overrides the
+                               client's ``default_response_class``
 
         :return: :class:`GlobusHTTPResponse \
         <globus_sdk.response.GlobusHTTPResponse>` object
         """
         return self._request("PUT", path, json_body=json_body, params=params,
-                             headers=headers, text_body=text_body, auth=auth)
+                             headers=headers, text_body=text_body, auth=auth,
+                             response_class=response_class)
 
     def _request(self, method, path, params=None, headers=None,
-                 json_body=None, text_body=None, auth=None):
+                 json_body=None, text_body=None, auth=None,
+                 response_class=None):
         """
         :param method: HTTP request method, as an all caps string
         :param path: path for the request, with or without leading slash
@@ -192,6 +206,8 @@ class BaseClient(object):
         :param auth: tuple of (user, password) for basic auth [DEPRECATED]
         :param json_body: dict that will be encoded as a JSON request body
         :param text_body: raw string that will be the request body
+        :param response_class: class for response object, overrides the
+                               client's ``default_response_class``
 
         :return: :class:`GlobusHTTPResponse \
         <globus_sdk.response.GlobusHTTPResponse>` object
@@ -211,7 +227,10 @@ class BaseClient(object):
                                   verify=self._verify,
                                   auth=auth)
         if 200 <= r.status_code < 400:
-            return self.response_class(r)
+            if response_class is None:
+                return self.default_response_class(r)
+            else:
+                return response_class(r)
         raise self.error_class(r)
 
 

--- a/globus_sdk/response.py
+++ b/globus_sdk/response.py
@@ -16,6 +16,22 @@ class GlobusResponse(object):
     def __repr__(self):
         return "{}({!r})".format(self.__class__.__name__, self.data)
 
+    def __getitem__(self, key):
+        # force evaluation of the data property outside of the upcoming
+        # try-catch so that we don't accidentally catch TypeErrors thrown
+        # during the getter function itself
+        data = self.data
+        try:
+            return data[key]
+        except TypeError:
+            # re-raise with an altered message -- the issue is that whatever
+            # type of GlobusResponse you're working with doesn't support
+            # indexing
+            # "type" is ambiguous, but we don't know if it's the fault of the
+            # class at large, or just a particular call's `data` property
+            raise TypeError(('This type of GlobusResponse object '
+                             'does not support indexing.'))
+
     @property
     def data(self):
         """

--- a/globus_sdk/response.py
+++ b/globus_sdk/response.py
@@ -50,7 +50,7 @@ class GlobusHTTPResponse(GlobusResponse):
     @property
     def data(self):
         try:
-            return self.json_body
+            return self._data.json()
         # JSON decoding may raise a ValueError due to an invalid JSON
         # document. In the case of trying to fetch the "data" on an HTTP
         # response, this means we didn't get a JSON response. Rather than
@@ -61,16 +61,8 @@ class GlobusHTTPResponse(GlobusResponse):
             return None
 
     @property
-    def json_body(self):
+    def text(self):
         """
-        Alias for ``data`` (contains the parsed JSON data), but will raise
-        an exception if the response is not JSON instead of being ``None``.
-        """
-        return self._data.json()
-
-    @property
-    def text_body(self):
-        """
-        The raw response data, as a string.
+        The raw response data as a string.
         """
         return self._data.text

--- a/globus_sdk/transfer/client.py
+++ b/globus_sdk/transfer/client.py
@@ -16,6 +16,15 @@ class TransferResponse(GlobusHTTPResponse):
     def __str__(self):
         return json.dumps(self.data, indent=2)
 
+    def set_iterable(self):
+        self.iterable = True
+
+    def __iter__(self):
+        if hasattr(self, 'iterable') and self.iterable:
+            return iter(self['DATA'])
+        else:
+            raise TypeError('This TransferResponse does not support iteration')
+
 
 class TransferClient(BaseClient):
     """
@@ -492,8 +501,9 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         path = self.qjoin_path("operation/endpoint", endpoint_id, "ls")
-        return [GlobusResponse(file_info) for file_info in
-                self.get(path, params=params).data["DATA"]]
+        res = self.get(path, params=params)
+        res.set_iterable()
+        return res
 
     def operation_mkdir(self, endpoint_id, path, **params):
         """

--- a/globus_sdk/transfer/client.py
+++ b/globus_sdk/transfer/client.py
@@ -14,7 +14,7 @@ class TransferResponse(GlobusHTTPResponse):
     body is always json to make printing the response more friendly.
     """
     def __str__(self):
-        return json.dumps(self.json_body, indent=2)
+        return json.dumps(self.data, indent=2)
 
 
 class TransferClient(BaseClient):
@@ -238,7 +238,7 @@ class TransferClient(BaseClient):
         path = self.qjoin_path('endpoint', endpoint_id,
                                'my_effective_pause_rule_list')
         return [GlobusResponse(rule) for rule in
-                self.get(path, params=params).json_body['DATA']]
+                self.get(path, params=params).data['DATA']]
 
     # Shared Endpoints
 
@@ -254,7 +254,7 @@ class TransferClient(BaseClient):
         path = self.qjoin_path('endpoint', endpoint_id,
                                'my_shared_endpoint_list')
         return [GlobusResponse(ep) for ep in
-                self.get(path, params=params).json_body['DATA']]
+                self.get(path, params=params).data['DATA']]
 
     def create_shared_endpoint(self, data):
         """
@@ -278,7 +278,7 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         return [GlobusResponse(ep) for ep in
-                self.get('shared_endpoint').json_body['DATA']]
+                self.get('shared_endpoint').data['DATA']]
 
     # Endpoint servers
 
@@ -293,7 +293,7 @@ class TransferClient(BaseClient):
         """
         path = self.qjoin_path('endpoint', endpoint_id, 'server_list')
         return [GlobusResponse(server) for server in
-                self.get(path, params=params).json_body['DATA']]
+                self.get(path, params=params).data['DATA']]
 
     def get_endpoint_server(self, endpoint_id, server_id, **params):
         """
@@ -358,7 +358,7 @@ class TransferClient(BaseClient):
         """
         path = self.qjoin_path('endpoint', endpoint_id, 'role_list')
         return [GlobusResponse(role) for role in
-                self.get(path, params=params).json_body['DATA']]
+                self.get(path, params=params).data['DATA']]
 
     def add_endpoint_role(self, endpoint_id, role_data):
         """
@@ -406,7 +406,7 @@ class TransferClient(BaseClient):
         """
         path = self.qjoin_path('endpoint', endpoint_id, 'access_list')
         return [GlobusResponse(rule) for rule in
-                self.get(path, params=params).json_body['DATA']]
+                self.get(path, params=params).data['DATA']]
 
     def get_endpoint_acl_rule(self, endpoint_id, rule_id, **params):
         """
@@ -445,7 +445,7 @@ class TransferClient(BaseClient):
         ``GET /bookmark_list``
         """
         return [GlobusResponse(bookmark) for bookmark in
-                self.get('bookmark_list', params=params).json_body['DATA']]
+                self.get('bookmark_list', params=params).data['DATA']]
 
     def create_bookmark(self, bookmark_data):
         """

--- a/globus_sdk/transfer/client.py
+++ b/globus_sdk/transfer/client.py
@@ -1,25 +1,10 @@
 from __future__ import print_function
 
-import json
-
 from globus_sdk import exc, config
-from globus_sdk.response import GlobusResponse, GlobusHTTPResponse
 from globus_sdk.base import BaseClient, merge_params
+from globus_sdk.transfer.response import (
+    TransferResponse, IterableTransferResponse)
 from globus_sdk.transfer.paging import PaginatedResource
-
-
-class TransferResponse(GlobusHTTPResponse):
-    """
-    Custom response for TransferClient, which relies on the fact that the
-    body is always json to make printing the response more friendly.
-    """
-    def __str__(self):
-        return json.dumps(self.data, indent=2)
-
-
-class IterableTransferResponse(TransferResponse):
-    def __iter__(self):
-        return iter(self['DATA'])
 
 
 class TransferClient(BaseClient):

--- a/globus_sdk/transfer/client.py
+++ b/globus_sdk/transfer/client.py
@@ -16,14 +16,10 @@ class TransferResponse(GlobusHTTPResponse):
     def __str__(self):
         return json.dumps(self.data, indent=2)
 
-    def set_iterable(self):
-        self.iterable = True
 
+class IterableTransferResponse(TransferResponse):
     def __iter__(self):
-        if hasattr(self, 'iterable') and self.iterable:
-            return iter(self['DATA'])
-        else:
-            raise TypeError('This TransferResponse does not support iteration')
+        return iter(self['DATA'])
 
 
 class TransferClient(BaseClient):
@@ -46,7 +42,7 @@ class TransferClient(BaseClient):
     """
 
     error_class = exc.TransferAPIError
-    response_class = TransferResponse
+    default_response_class = TransferResponse
 
     def __init__(self, environment=config.get_default_environ(),
                  token=None, app_name=None):
@@ -246,8 +242,8 @@ class TransferClient(BaseClient):
         """
         path = self.qjoin_path('endpoint', endpoint_id,
                                'my_effective_pause_rule_list')
-        return [GlobusResponse(rule) for rule in
-                self.get(path, params=params).data['DATA']]
+        return self.get(path, params=params,
+                        response_class=IterableTransferResponse)
 
     # Shared Endpoints
 
@@ -262,8 +258,8 @@ class TransferClient(BaseClient):
         """
         path = self.qjoin_path('endpoint', endpoint_id,
                                'my_shared_endpoint_list')
-        return [GlobusResponse(ep) for ep in
-                self.get(path, params=params).data['DATA']]
+        return self.get(path, params=params,
+                        response_class=IterableTransferResponse)
 
     def create_shared_endpoint(self, data):
         """
@@ -286,8 +282,8 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/endpoint/#create_shared_endpoint>`_
         in the REST documentation for details.
         """
-        return [GlobusResponse(ep) for ep in
-                self.get('shared_endpoint').data['DATA']]
+        return self.get('shared_endpoint',
+                        response_class=IterableTransferResponse)
 
     # Endpoint servers
 
@@ -301,8 +297,8 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         path = self.qjoin_path('endpoint', endpoint_id, 'server_list')
-        return [GlobusResponse(server) for server in
-                self.get(path, params=params).data['DATA']]
+        return self.get(path, params=params,
+                        response_class=IterableTransferResponse)
 
     def get_endpoint_server(self, endpoint_id, server_id, **params):
         """
@@ -366,8 +362,8 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         path = self.qjoin_path('endpoint', endpoint_id, 'role_list')
-        return [GlobusResponse(role) for role in
-                self.get(path, params=params).data['DATA']]
+        return self.get(path, params=params,
+                        response_class=IterableTransferResponse)
 
     def add_endpoint_role(self, endpoint_id, role_data):
         """
@@ -414,8 +410,8 @@ class TransferClient(BaseClient):
         ``GET /endpoint/<endpoint_id>/access_list``
         """
         path = self.qjoin_path('endpoint', endpoint_id, 'access_list')
-        return [GlobusResponse(rule) for rule in
-                self.get(path, params=params).data['DATA']]
+        return self.get(path, params=params,
+                        response_class=IterableTransferResponse)
 
     def get_endpoint_acl_rule(self, endpoint_id, rule_id, **params):
         """
@@ -453,8 +449,8 @@ class TransferClient(BaseClient):
         """
         ``GET /bookmark_list``
         """
-        return [GlobusResponse(bookmark) for bookmark in
-                self.get('bookmark_list', params=params).data['DATA']]
+        return self.get('bookmark_list', params=params,
+                        response_class=IterableTransferResponse)
 
     def create_bookmark(self, bookmark_data):
         """
@@ -501,9 +497,8 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         path = self.qjoin_path("operation/endpoint", endpoint_id, "ls")
-        res = self.get(path, params=params)
-        res.set_iterable()
-        return res
+        return self.get(path, params=params,
+                        response_class=IterableTransferResponse)
 
     def operation_mkdir(self, endpoint_id, path, **params):
         """

--- a/globus_sdk/transfer/paging.py
+++ b/globus_sdk/transfer/paging.py
@@ -157,7 +157,7 @@ class PaginatedResource(six.Iterator):
             self.client_kwargs['params']['limit'] = limit
 
             res = self.client_method(self.client_path,
-                                     **self.client_kwargs).json_body
+                                     **self.client_kwargs).data
 
             # walk the results from the page we fetched, returning them as
             # the iterated elements

--- a/globus_sdk/transfer/response.py
+++ b/globus_sdk/transfer/response.py
@@ -1,0 +1,17 @@
+import json
+
+from globus_sdk.response import GlobusHTTPResponse
+
+
+class TransferResponse(GlobusHTTPResponse):
+    """
+    Custom response for TransferClient, which relies on the fact that the
+    body is always json to make printing the response more friendly.
+    """
+    def __str__(self):
+        return json.dumps(self.data, indent=2)
+
+
+class IterableTransferResponse(TransferResponse):
+    def __iter__(self):
+        return iter(self['DATA'])

--- a/globus_sdk/version.py
+++ b/globus_sdk/version.py
@@ -1,3 +1,3 @@
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "0.1.5"
+__version__ = "0.2.0"


### PR DESCRIPTION
This handles #23 

Short summary:

- HTTP methods on the `BaseClient` now accept `response_class` as a keyword arg
- `GlobusResponse` has `__getitem__`, which does a `__getitem__` on the `data` property
- Drop `GlobusHTTPResponse.json_body`
- Rename `GlobusHTTPResponse.text_body` to `GlobusHTTPResponse.text`
- Iterable responses from `TransferClient` calls have `response_class=IterableTransferResponse`, which defines `__iter__` on the `"DATA"` array
- `PaginatedResource` for the `TransferClient` now inherits directly from `GlobusResponse`, so that we're always returning a `GlobusResponse`, no matter what