### PR TITLE
add OO transfer data helper

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -35,6 +35,10 @@ Transfer Client
    :show-inheritance:
    :exclude-members: error_class, response_class
 
+.. autoclass:: globus_sdk.TransferData
+   :members:
+   :show-inheritance:
+
 .. autoclass:: globus_sdk.exc.TransferAPIError
    :members:
    :show-inheritance:

--- a/globus_sdk/__init__.py
+++ b/globus_sdk/__init__.py
@@ -1,5 +1,6 @@
 from globus_sdk.response import GlobusResponse, GlobusHTTPResponse
 from globus_sdk.transfer import TransferClient
+from globus_sdk.transfer.data import TransferData
 from globus_sdk.auth import AuthClient
 
 from globus_sdk.exc import GlobusError, GlobusAPIError, TransferAPIError
@@ -8,7 +9,8 @@ from globus_sdk.exc import NetworkError, ConnectionError, TimeoutError
 from globus_sdk.version import __version__
 
 __all__ = ["GlobusResponse", "GlobusHTTPResponse",
-           "TransferClient", "AuthClient",
+           "TransferClient", "TransferData",
+           "AuthClient",
            "GlobusError", "GlobusAPIError", "TransferAPIError",
            "NetworkError", "ConnectionError", "TimeoutError",
            "__version__"]

--- a/globus_sdk/__init__.py
+++ b/globus_sdk/__init__.py
@@ -1,6 +1,6 @@
 from globus_sdk.response import GlobusResponse, GlobusHTTPResponse
 from globus_sdk.transfer import TransferClient
-from globus_sdk.transfer.data import TransferData
+from globus_sdk.transfer.data import TransferData, DeleteData
 from globus_sdk.auth import AuthClient
 
 from globus_sdk.exc import GlobusError, GlobusAPIError, TransferAPIError
@@ -9,7 +9,7 @@ from globus_sdk.exc import NetworkError, ConnectionError, TimeoutError
 from globus_sdk.version import __version__
 
 __all__ = ["GlobusResponse", "GlobusHTTPResponse",
-           "TransferClient", "TransferData",
+           "TransferClient", "TransferData", "DeleteData",
            "AuthClient",
            "GlobusError", "GlobusAPIError", "TransferAPIError",
            "NetworkError", "ConnectionError", "TimeoutError",

--- a/globus_sdk/transfer/client.py
+++ b/globus_sdk/transfer/client.py
@@ -546,25 +546,22 @@ class TransferClient(BaseClient):
         ``POST /transfer``
 
         >>> tc = globus_sdk.TransferClient()
-        >>> transfer_items = []
-        >>> transfer_items.append(
-        >>>     tc.make_submit_transfer_item("/source/path/dir/",
-        >>>                                  "/dest/path/dir/",
-        >>>                                  recursive=True))
-        >>> transfer_items.append(
-        >>>     tc.make_submit_transfer_item("/source/path/file.txt",
-        >>>                                  "/dest/path/file.txt"))
-        >>> transfer_data = tc.make_submit_transfer_data(
-        >>>     source_endpoint_id,
-        >>>     destination_endpoint_id,
-        >>>     transfer_items)
-        >>> transfer_result = tc.submit_transfer(transfer_data)
+        >>> tdata = globus_sdk.TransferData(tc, source_endpoint_id,
+        >>>                                 destination_endpoint_id)
+        >>> tdata.add_item("/source/path/dir/", "/dest/path/dir/",
+        >>>                recursive=True)
+        >>> tdata.add_item("/source/path/file.txt",
+        >>>                "/dest/path/file.txt")
+        >>> transfer_result = tc.submit_transfer(tdata)
         >>> print("task_id = ", transfer_result["task_id"])
+
+        The `data` parameter can be a normal Python dictionary, or
+        a :class:`TransferData <globus_sdk.TransferData>` object.
 
         See
         `Submit a transfer task \
         <https://docs.globus.org/api/transfer/task_submit/#submit_a_transfer_task>`_
-        in the REST documentation for details.
+        in the REST documentation for more details.
         """
         return self.post('/transfer', data)
 

--- a/globus_sdk/transfer/client.py
+++ b/globus_sdk/transfer/client.py
@@ -553,7 +553,7 @@ class TransferClient(BaseClient):
         >>> tdata.add_item("/source/path/file.txt",
         >>>                "/dest/path/file.txt")
         >>> transfer_result = tc.submit_transfer(tdata)
-        >>> print("task_id = ", transfer_result["task_id"])
+        >>> print("task_id =", transfer_result["task_id"])
 
         The `data` parameter can be a normal Python dictionary, or
         a :class:`TransferData <globus_sdk.TransferData>` object.
@@ -568,6 +568,16 @@ class TransferClient(BaseClient):
     def submit_delete(self, data):
         """
         ``POST /delete``
+
+        >>> tc = globus_sdk.TransferClient()
+        >>> ddata = globus_sdk.DeleteData(tc, endpoint_id, recursive=True)
+        >>> ddata.add_item("/dir/to/delete/")
+        >>> ddata.add_item("/file/to/delete/file.txt")
+        >>> delete_result = tc.submit_delete(ddata)
+        >>> print("task_id =", delete_result["task_id"])
+
+        The `data` parameter can be a normal Python dictionary, or
+        a :class:`DeleteData <globus_sdk.TransferData>` object.
 
         See
         `Submit a delete task \

--- a/globus_sdk/transfer/data.py
+++ b/globus_sdk/transfer/data.py
@@ -64,3 +64,45 @@ class TransferData(dict):
             "recursive": recursive,
         }
         self["DATA"].append(item_data)
+
+
+class DeleteData(dict):
+    """
+    Convenience class for constructing a delete document, to use as the
+    `data` parameter to
+    :meth:`submit_delete <globus_sdk.deleteClient.submit_delete>`.
+
+    At least one item must be added using
+    :meth:`add_item <globus_sdk.DeleteData.add_item>`.
+
+    Includes fetching the submission ID as part of document generation. The
+    submission ID can be pulled out of here to inspect, but the document
+    can be used as-is multiple times over to retry a potential submission
+    failure (so there shouldn't be any need to inspect it).
+    """
+    def __init__(self, transfer_client, source_endpoint, label=None,
+                 recursive=False, **kwargs):
+        self["DATA_TYPE"] = "delete"
+        self["submission_id"] = transfer_client.get_submission_id()["value"]
+        self["source_endpoint"] = source_endpoint
+
+        if label is not None:
+            self["label"] = label
+
+        self["DATA"] = []
+        self.update(kwargs)
+
+    def add_item(self, path):
+        """
+        Add a file or directory to be deleted. If any of the paths are
+        directories, ``recursive`` must be set True on the top level
+        ``DeleteData``.
+
+        Appends a delete_item document to the DATA key of the delete
+        document.
+        """
+        item_data = {
+            "DATA_TYPE": "delete_item",
+            "path": path,
+        }
+        self["DATA"].append(item_data)

--- a/globus_sdk/transfer/data.py
+++ b/globus_sdk/transfer/data.py
@@ -1,0 +1,66 @@
+"""
+Data helper classes for constructing Transfer API documents. All classes should
+extend ``dict``, so they can be passed seemlesly to
+:class:`TransferClient <globus_sdk.TransferClient>` methods without
+conversion.
+"""
+
+
+class TransferData(dict):
+    """
+    Convenience class for constructing a transfer document, to use as the
+    `data` parameter to
+    :meth:`submit_transfer <globus_sdk.TransferClient.submit_transfer>`.
+
+    At least one item must be added using
+    :meth:`add_item <globus_sdk.TransferData.add_item>`.
+
+    For compatibility with older code and those knowledgeable about the API
+    sync_level can be 1, 2, or 3, but it can also be
+    "exists", "mtime", or "checksum" if you want greater clarity in
+    client code.
+
+    Includes fetching the submission ID as part of document generation. The
+    submission ID can be pulled out of here to inspect, but the document
+    can be used as-is multiple times over to retry a potential submission
+    failure (so there shouldn't be any need to inspect it).
+    """
+    def __init__(self, transfer_client, source_endpoint, destination_endpoint,
+                 label=None, sync_level=None, **kwargs):
+        self["DATA_TYPE"] = "transfer"
+        self["submission_id"] = transfer_client.get_submission_id()["value"]
+        self["source_endpoint"] = source_endpoint
+        self["destination_endpoint"] = destination_endpoint
+
+        if label is not None:
+            self["label"] = label
+
+        # map the sync_level (if it's a nice string) to one of the known int
+        # values
+        # you can get away with specifying an invalid sync level -- the API
+        # will just reject you with an error. This is kind of important: if
+        # more levels are added in the future this method doesn't become
+        # garbage overnight
+        if sync_level is not None:
+            sync_dict = {"exists": 1, "mtime": 2, "checksum": 3}
+            sync_level = sync_dict.get(sync_level, sync_level)
+            self['sync_level'] = sync_level
+
+        self["DATA"] = []
+
+        self.update(kwargs)
+
+    def add_item(self, source_path, destination_path, recursive=False):
+        """
+        Add a file or directory to be transfered.
+
+        Appends a transfer_item document to the DATA key of the transfer
+        document.
+        """
+        item_data = {
+            "DATA_TYPE": "transfer_item",
+            "source_path": source_path,
+            "destination_path": destination_path,
+            "recursive": recursive,
+        }
+        self["DATA"].append(item_data)

--- a/globus_sdk/transfer/main.py
+++ b/globus_sdk/transfer/main.py
@@ -11,7 +11,7 @@ from __future__ import print_function
 
 import argparse
 
-from globus_sdk.transfer import TransferClient
+import globus_sdk
 
 
 def get_transfer_client_from_args(args=None):
@@ -32,7 +32,7 @@ def get_transfer_client_from_args(args=None):
     if args.environment:
         environment = args.environment
 
-    client = TransferClient(environment)
+    client = globus_sdk.TransferClient(environment)
     if token is not None:
         client.set_token(token)
     return client


### PR DESCRIPTION
Not ready to merge, just putting this up for comments. I think the OO version, where add_item is a method on the object itself, is much cleaner.

I'm not sure about having the public api as a separate class that takes a `TransferClient` in it's constructor, vs modifying `make_submit_transfer_data` so it returns the `TransferData` instance and killing the item helper.