### PR TITLE
Documentation Cleanup Pre-GlobusWorld 2016

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -33,11 +33,21 @@ Transfer Client
    :member-order: bysource
    :inherited-members:
    :show-inheritance:
-   :exclude-members: error_class, response_class
+   :exclude-members: error_class, default_response_class
+
+Helper Objects
+~~~~~~~~~~~~~~
 
 .. autoclass:: globus_sdk.TransferData
    :members:
    :show-inheritance:
+
+.. autoclass:: globus_sdk.DeleteData
+   :members:
+   :show-inheritance:
+
+Specialized Errors
+~~~~~~~~~~~~~~~~~~
 
 .. autoclass:: globus_sdk.exc.TransferAPIError
    :members:
@@ -51,4 +61,4 @@ Auth Client
    :member-order: bysource
    :inherited-members:
    :show-inheritance:
-   :exclude-members: error_class, response_class
+   :exclude-members: error_class, default_response_class

--- a/docs/api/response.rst
+++ b/docs/api/response.rst
@@ -2,10 +2,11 @@ Responses
 =========
 
 All method return values for Globus SDK Clients are ``GlobusResponse``
-objects or a simple data structure (typically a Python list or other
-iterable) containing ``GlobusResponse`` objects.
+objects.
+Some ``GlobusResponse`` objects are iterables.
+In those cases, their contents will also be ``GlobusResponse`` objects.
 
-To customize client methods with additional detail, we may use subclasses of
+To customize client methods with additional detail, the SDK uses subclasses of
 ``GlobusResponse``.
 For example the ``GlobusHTTPResponse`` attaches HTTP response information.
 

--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -1,0 +1,15 @@
+Deprecations
+============
+
+The Globus SDK uses python ``DeprecationWarning`` and
+``PendingDeprecationWarning`` classes to indicate deprecated and soon-to-be
+deprecated behaviors.  In order to see these warnings, run python with the
+flags:
+
+::
+
+ python -Wonce::DeprecationWarning \
+        -Wonce::PendingDeprecationWarning
+
+Note: The ``-W`` flag must precede any module you are passing to ``python``,
+or it will be fed into ``sys.argv`` inside of the module.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -65,15 +65,15 @@ To use the Transfer API:
 
 .. code-block:: python
 
-    from future import __print_function__ # for python 2
+    from __future__ import print_function # for python 2
     from globus_sdk import TransferClient
 
     tc = TransferClient() # uses transfer_token from the config file
 
     # high level interface; provides iterators for list responses
     print("My Endpoints:")
-    for r in tc.endpoint_search(filter_scope="my-endpoints"):
-        print(r.data["display_name"], r.data["id"])
+    for ep in tc.endpoint_search(filter_scope="my-endpoints"):
+        print(ep["display_name"], ep["id"])
 
 API Documentation
 =================
@@ -85,22 +85,7 @@ API Documentation
    api/exceptions
    api/baseclient
    config
-
-Deprecations
-============
-
-The Globus SDK uses python ``DeprecationWarning`` and
-``PendingDeprecationWarning`` classes to indicate deprecated and soon-to-be
-deprecated behaviors.  In order to see these warnings, run python with the
-flags:
-
-::
-
- python -Wonce::DeprecationWarning \
-        -Wonce::PendingDeprecationWarning
-
-Note: The ``-W`` flag must precede any module you are passing to ``python``,
-or it will be fed into ``sys.argv`` inside of the module.
+   deprecations
 
 License
 =======

--- a/globus_sdk/auth.py
+++ b/globus_sdk/auth.py
@@ -7,22 +7,46 @@ from globus_sdk.base import BaseClient, merge_params
 
 
 class AuthClient(BaseClient):
+    """
+    Client for the
+    `Globus Auth API <https://docs.globus.org/api/auth/>`_
+
+    This class provides helper methods for most common resources in the
+    Auth API, and the common low-level interface from
+    :class:`BaseClient <globus_sdk.base.BaseClient>` of ``get``, ``put``,
+    ``post``, and ``delete`` methods, which can be used to access any API
+    resource.
+
+    There are generally two types of resources, distinguished by the type
+    of authentication which they use. Resources available to end users of
+    Globus are authenticated with a Globus Auth Token
+    ("Authentication: Bearer ..."), while resources available to OAuth
+    Clients are authenticated using Basic Auth with the Client's ID and
+    Secret.
+    Some resources may be available with either authentication type.
+    """
     def __init__(self, environment=config.get_default_environ(), token=None,
                  app_name=None):
-        """
-        Client for the
-        `Globus Auth API <https://docs.globus.org/api/auth/>`_
-
-        This class provides helper methods for most common resources in the
-        Auth API, and the common low-level interface from
-        :class:`BaseClient <globus_sdk.base.BaseClient>`
-        """
         BaseClient.__init__(self, "auth", environment, token=token,
                             app_name=app_name)
 
     def get_identities(self, **params):
         """
         GET /v2/api/identities
+
+        Given ``usernames=<U>`` or (exclusive) ``identity_ids=<I>`` as keyword
+        arguments, looks up identity information for the set of identities
+        provided.
+        ``<U>`` and ``<I>`` in this case are comma-delimited strings listing
+        multiple Identity Usernames or Identity IDs.
+
+        Available with either authentication type.
+
+        See
+        `Identities Resources \
+        <https://docs.globus.org/api/auth/reference/\
+        #v2_api_identities_resources>`_
+        in the API documentation for details.
         """
         return self.get("/v2/api/identities", params=params)
 
@@ -30,9 +54,15 @@ class AuthClient(BaseClient):
         """
         POST /v2/oauth2/token/introspect
 
-        Get information about a Globus Auth token. Requires basic auth
-        using oauth client credentials, where username=client_id
-        and password=client_secret.
+        Get information about a Globus Auth token.
+
+        Requires Basic Auth using Oauth Client credentials.
+
+        See
+        `Token Introspection \
+        <https://docs.globus.org/api/auth/reference/\
+        #token_introspection_post_v2_oauth2_token_introspect>`_
+        in the API documentation for details.
         """
         merge_params(kw, token=token)
         return self.post("/v2/oauth2/token/introspect",

--- a/globus_sdk/transfer/client.py
+++ b/globus_sdk/transfer/client.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+import warnings
 
 from globus_sdk import exc, config
 from globus_sdk.base import BaseClient, merge_params
@@ -729,19 +730,11 @@ class TransferClient(BaseClient):
                                   transfer_items, label=None, sync_level=None,
                                   **kwargs):
         """
-        Build a full document for submitting a Transfer.
-        Takes an array of transfer items, a mandatory label for the Transfer,
-        and an optional sync_level.
-        For compatibility with older code and those knowledgeable about the API
-        sync_level can be 1, 2, or 3, but it can also be
-        "exists", "mtime", or "checksum" if you want greater clarity in
-        client code.
-
-        Includes fetching the submission ID as part of document generation. The
-        submission ID can be pulled out of here to inspect, but the document
-        can be used as-is multiple times over to retry a potential submission
-        failure (so there shouldn't be any need to inspect it).
+        DEPRECATED: Use :class:`TransferData <globus_sdk.TransferData>`
+        instead.
         """
+        warnings.warn(("make_submit_transfer_data() is deprecated. Use "
+                       "globus_sdk.TransferData instead."), DeprecationWarning)
         datadoc = {
             'DATA_TYPE': 'transfer',
             'submission_id': self.get_submission_id()['value'],
@@ -773,11 +766,11 @@ class TransferClient(BaseClient):
 
     def make_submit_transfer_item(self, source, dest, recursive=False):
         """
-        Helper to build a single transfer item document (as a dict)
-        Takes a source path, dest path, and recursivity, plugs them in and
-        spits out the dict. In general, clients of the SDK should be using this
-        to feed into make_transfer_data, but not inspecting the contents.
+        DEPRECATED: Use :class:`TransferData <globus_sdk.TransferData>`
+        instead.
         """
+        warnings.warn(("make_submit_transfer_item() is deprecated. Use "
+                       "globus_sdk.TransferData instead."), DeprecationWarning)
         datadoc = {
             'DATA_TYPE': 'transfer_item',
             'source_path': source,

--- a/globus_sdk/transfer/client.py
+++ b/globus_sdk/transfer/client.py
@@ -51,6 +51,9 @@ class TransferClient(BaseClient):
         """
         ``GET /endpoint/<endpoint_id>``
 
+        :rtype: :class:`TransferResponse
+                <globus_sdk.transfer.response.TransferResponse>`
+
         >>> tc = globus_sdk.TransferClient()
         >>> endpoint = tc.get_endpoint(endpoint_id)
         >>> print("Endpoint name:",
@@ -68,6 +71,9 @@ class TransferClient(BaseClient):
         """
         ``PUT /endpoint/<endpoint_id>``
 
+        :rtype: :class:`TransferResponse
+                <globus_sdk.transfer.response.TransferResponse>`
+
         >>> tc = globus_sdk.TransferClient()
         >>> epup = dict(display_name="My New Endpoint Name",
         >>>             description="Better Description")
@@ -84,6 +90,9 @@ class TransferClient(BaseClient):
     def create_endpoint(self, data):
         """
         ``POST /endpoint/<endpoint_id>``
+
+        :rtype: :class:`TransferResponse
+                <globus_sdk.transfer.response.TransferResponse>`
 
         >>> tc = globus_sdk.TransferClient()
         >>> ep_data = {
@@ -110,6 +119,9 @@ class TransferClient(BaseClient):
         """
         ``DELETE /endpoint/<endpoint_id>``
 
+        :rtype: :class:`TransferResponse
+                <globus_sdk.transfer.response.TransferResponse>`
+
         >>> tc = globus_sdk.TransferClient()
         >>> delete_result = tc.delete_endpoint(endpoint_id)
 
@@ -129,41 +141,42 @@ class TransferClient(BaseClient):
             GET /endpoint_search\
             ?filter_fulltext=<filter_fulltext>&filter_scope=<filter_scope>
 
-        Additional params and valid filter_scopes are documented at
-        https://docs.globus.org/api/transfer/endpoint_search
-
-        This method acts as an iterator, returning results from the API as
-        :class:`GlobusResponse <globus_sdk.response.GlobusResponse>`
-        objects wrapping python dictionaries built from JSON documents.
+        :rtype: iterable of :class:`GlobusResponse
+                <globus_sdk.response.GlobusResponse>`
 
         Search for a given string as a fulltext search:
 
         >>> tc = globus_sdk.TransferClient()
-        >>> for r in tc.endpoint_search('String to search for!'):
-        >>>     print(r['display_name'])
+        >>> for ep in tc.endpoint_search('String to search for!'):
+        >>>     print(ep['display_name'])
 
         Search for a given string, but only on endpoints that you own:
 
-        >>> for r in tc.endpoint_search('foo', filter_scope='my-endpoints'):
-        >>>     print('{} has ID {}'.format(r['display_name'], ep['id']))
+        >>> for ep in tc.endpoint_search('foo', filter_scope='my-endpoints'):
+        >>>     print('{} has ID {}'.format(ep['display_name'], ep['id']))
 
         Search results are capped at a number of elements equal to the
         ``num_results`` parameter.
         If you want more than the default, 25, elements, do like so:
 
-        >>> for r in tc.endpoint_search('String to search for!',
+        >>> for ep in tc.endpoint_search('String to search for!',
         >>>                             num_results=120):
-        >>>     print(r['display_name'])
+        >>>     print(ep['display_name'])
 
-        It is very important to be aware that the Endpoint Search API limits
-        you to 1000 results for any search query. If you attempt to exceed this
-        limit, you will trigger a PaginationOverrunError.
+        It is important to be aware that the Endpoint Search API limits
+        you to 1000 results for any search query.
+        If you attempt to exceed this limit, you will trigger a
+        :class:`PaginationOverrunError <globus_sdk.exc.PaginationOverrunError>`
 
-        >>> for r in tc.endpoint_search('globus', # a very common string
-        >>>                             num_results=1200):
-        >>>     print(r['display_name'])
+        >>> for ep in tc.endpoint_search('globus', # a very common string
+        >>>                             num_results=1200): # num too large!
+        >>>     print(ep['display_name'])
 
         will trigger this error.
+
+        For additional information, see `Endpoint Search
+        <https://docs.globus.org/api/transfer/endpoint_search>`_.
+        in the REST documentation for details.
         """
         merge_params(params, filter_scope=filter_scope,
                      filter_fulltext=filter_fulltext)
@@ -175,6 +188,9 @@ class TransferClient(BaseClient):
     def endpoint_autoactivate(self, endpoint_id, **params):
         r"""
         ``POST /endpoint/<endpoint_id>/autoactivate``
+
+        :rtype: :class:`TransferResponse
+                <globus_sdk.transfer.response.TransferResponse>`
 
         The following example will try to "auto" activate the endpoint
         using a credential available from another endpoint or sign in by
@@ -212,6 +228,9 @@ class TransferClient(BaseClient):
         """
         ``POST /endpoint/<endpoint_id>/deactivate``
 
+        :rtype: :class:`TransferResponse
+                <globus_sdk.transfer.response.TransferResponse>`
+
         See
         `Deactive endpoint \
         <https://docs.globus.org/api/transfer/endpoint_activation/#deactivate_endpoint>`_
@@ -223,6 +242,9 @@ class TransferClient(BaseClient):
     def endpoint_activate(self, endpoint_id, data, **params):
         """
         ``POST /endpoint/<endpoint_id>/activate``
+
+        :rtype: :class:`TransferResponse
+                <globus_sdk.transfer.response.TransferResponse>`
 
         Consider using autoactivate and web activation instead, described
         in the example for
@@ -240,6 +262,9 @@ class TransferClient(BaseClient):
         """
         ``GET /endpoint/<endpoint_id>/activation_requirements``
 
+        :rtype: :class:`TransferResponse
+                <globus_sdk.transfer.response.TransferResponse>`
+
         See
         `Get activation requirements \
         <https://docs.globus.org/api/transfer/endpoint_activation/#get_activation_requirements>`_
@@ -251,6 +276,9 @@ class TransferClient(BaseClient):
     def my_effective_pause_rule_list(self, endpoint_id, **params):
         """
         ``GET /endpoint/<endpoint_id>/my_effective_pause_rule_list``
+
+        :rtype: :class:`IterableTransferResponse
+                <globus_sdk.transfer.response.IterableTransferResponse>`
 
         See
         `Get my effective endpoint pause rules \
@@ -268,6 +296,9 @@ class TransferClient(BaseClient):
         """
         ``GET /endpoint/<endpoint_id>/my_shared_endpoint_list``
 
+        :rtype: :class:`IterableTransferResponse
+                <globus_sdk.transfer.response.IterableTransferResponse>`
+
         See
         `Get shared endpoint list \
         <https://docs.globus.org/api/transfer/endpoint/#get_shared_endpoint_list>`_
@@ -281,6 +312,9 @@ class TransferClient(BaseClient):
     def create_shared_endpoint(self, data):
         """
         ``POST /shared_endpoint``
+
+        :rtype: :class:`TransferResponse
+                <globus_sdk.transfer.response.TransferResponse>`
 
         :param data: A python dict representation of a ``shared_endpoint``
                      document
@@ -302,14 +336,16 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/endpoint/#create_shared_endpoint>`_
         in the REST documentation for details.
         """
-        return self.post('shared_endpoint', json_body=data,
-                         response_class=IterableTransferResponse)
+        return self.post('shared_endpoint', json_body=data)
 
     # Endpoint servers
 
     def endpoint_server_list(self, endpoint_id, **params):
         """
         ``GET /endpoint/<endpoint_id>/server_list``
+
+        :rtype: :class:`IterableTransferResponse
+                <globus_sdk.transfer.response.IterableTransferResponse>`
 
         See
         `Get endpoint server list \
@@ -324,6 +360,9 @@ class TransferClient(BaseClient):
         """
         ``GET /endpoint/<endpoint_id>/server/<server_id>``
 
+        :rtype: :class:`TransferResponse
+                <globus_sdk.transfer.response.TransferResponse>`
+
         See
         `Get endpoint server list \
         <https://docs.globus.org/api/transfer/endpoint/#get_endpoint_server_list>`_
@@ -335,6 +374,9 @@ class TransferClient(BaseClient):
     def add_endpoint_server(self, endpoint_id, server_data):
         """
         ``POST /endpoint/<endpoint_id>/server``
+
+        :rtype: :class:`TransferResponse
+                <globus_sdk.transfer.response.TransferResponse>`
 
         See
         `Add endpoint server \
@@ -348,6 +390,9 @@ class TransferClient(BaseClient):
         """
         ``POST /endpoint/<endpoint_id>/server/<server_id>``
 
+        :rtype: :class:`TransferResponse
+                <globus_sdk.transfer.response.TransferResponse>`
+
         See
         `Update endpoint server by id \
         <https://docs.globus.org/api/transfer/endpoint/#update_endpoint_server_by_id>`_
@@ -359,6 +404,9 @@ class TransferClient(BaseClient):
     def delete_endpoint_server(self, endpoint_id, server_id):
         """
         ``DELETE /endpoint/<endpoint_id>/server/<server_id>``
+
+        :rtype: :class:`TransferResponse
+                <globus_sdk.transfer.response.TransferResponse>`
 
         See
         `Delete endpoint server by id \
@@ -376,6 +424,9 @@ class TransferClient(BaseClient):
         """
         ``GET /endpoint/<endpoint_id>/role_list``
 
+        :rtype: :class:`IterableTransferResponse
+                <globus_sdk.transfer.response.IterableTransferResponse>`
+
         See
         `Get list of endpoint roles \
         <https://docs.globus.org/api/transfer/endpoint_roles/#get_list_of_endpoint_roles>`_
@@ -389,6 +440,9 @@ class TransferClient(BaseClient):
         """
         ``POST /endpoint/<endpoint_id>/role``
 
+        :rtype: :class:`TransferResponse
+                <globus_sdk.transfer.response.TransferResponse>`
+
         See
         `Create endpoint role \
         <https://docs.globus.org/api/transfer/endpoint_roles/#create_endpoint_role>`_
@@ -401,6 +455,9 @@ class TransferClient(BaseClient):
         """
         ``GET /endpoint/<endpoint_id>/role/<role_id>``
 
+        :rtype: :class:`TransferResponse
+                <globus_sdk.transfer.response.TransferResponse>`
+
         See
         `Get endpoint role by id \
         <https://docs.globus.org/api/transfer/endpoint_roles/#get_endpoint_role_by_id>`_
@@ -412,6 +469,9 @@ class TransferClient(BaseClient):
     def delete_endpoint_role(self, endpoint_id, role_id):
         """
         ``DELETE /endpoint/<endpoint_id>/role/<role_id>``
+
+        :rtype: :class:`TransferResponse
+                <globus_sdk.transfer.response.TransferResponse>`
 
         See
         `Delete endpoint role by id \
@@ -428,6 +488,9 @@ class TransferClient(BaseClient):
     def endpoint_acl_list(self, endpoint_id, **params):
         """
         ``GET /endpoint/<endpoint_id>/access_list``
+
+        :rtype: :class:`IterableTransferResponse
+                <globus_sdk.transfer.response.IterableTransferResponse>`
         """
         path = self.qjoin_path('endpoint', endpoint_id, 'access_list')
         return self.get(path, params=params,
@@ -436,6 +499,9 @@ class TransferClient(BaseClient):
     def get_endpoint_acl_rule(self, endpoint_id, rule_id, **params):
         """
         ``GET /endpoint/<endpoint_id>/access/<rule_id>``
+
+        :rtype: :class:`TransferResponse
+                <globus_sdk.transfer.response.TransferResponse>`
         """
         path = self.qjoin_path('endpoint', endpoint_id, 'access', rule_id)
         return self.get(path, params=params)
@@ -443,6 +509,9 @@ class TransferClient(BaseClient):
     def add_endpoint_acl_rule(self, endpoint_id, rule_data):
         """
         ``POST /endpoint/<endpoint_id>/access``
+
+        :rtype: :class:`TransferResponse
+                <globus_sdk.transfer.response.TransferResponse>`
         """
         path = self.qjoin_path('endpoint', endpoint_id, 'access')
         return self.post(path, rule_data)
@@ -450,6 +519,9 @@ class TransferClient(BaseClient):
     def update_endpoint_acl_rule(self, endpoint_id, rule_id, rule_data):
         """
         ``PUT /endpoint/<endpoint_id>/access/<rule_id>``
+
+        :rtype: :class:`TransferResponse
+                <globus_sdk.transfer.response.TransferResponse>`
         """
         path = self.qjoin_path('endpoint', endpoint_id, 'access', rule_id)
         return self.put(path, rule_data)
@@ -457,6 +529,9 @@ class TransferClient(BaseClient):
     def delete_endpoint_acl_rule(self, endpoint_id, rule_id):
         """
         ``DELETE /endpoint/<endpoint_id>/access/<rule_id>``
+
+        :rtype: :class:`TransferResponse
+                <globus_sdk.transfer.response.TransferResponse>`
         """
         path = self.qjoin_path('endpoint', endpoint_id, 'access', rule_id)
         return self.delete(path)
@@ -468,6 +543,9 @@ class TransferClient(BaseClient):
     def bookmark_list(self, **params):
         """
         ``GET /bookmark_list``
+
+        :rtype: :class:`IterableTransferResponse
+                <globus_sdk.transfer.response.IterableTransferResponse>`
         """
         return self.get('bookmark_list', params=params,
                         response_class=IterableTransferResponse)
@@ -475,12 +553,18 @@ class TransferClient(BaseClient):
     def create_bookmark(self, bookmark_data):
         """
         ``POST /bookmark``
+
+        :rtype: :class:`TransferResponse
+                <globus_sdk.transfer.response.TransferResponse>`
         """
         return self.post('bookmark', bookmark_data)
 
     def get_bookmark(self, bookmark_id, **params):
         """
         ``GET /bookmark/<bookmark_id>``
+
+        :rtype: :class:`TransferResponse
+                <globus_sdk.transfer.response.TransferResponse>`
         """
         path = self.qjoin_path('bookmark', bookmark_id)
         return self.get(path, params=params)
@@ -488,6 +572,9 @@ class TransferClient(BaseClient):
     def update_bookmark(self, bookmark_id, bookmark_data):
         """
         ``PUT /bookmark/<bookmark_id>``
+
+        :rtype: :class:`TransferResponse
+                <globus_sdk.transfer.response.TransferResponse>`
         """
         path = self.qjoin_path('bookmark', bookmark_id)
         return self.put(path, bookmark_data)
@@ -495,6 +582,9 @@ class TransferClient(BaseClient):
     def delete_bookmark(self, bookmark_id):
         """
         ``DELETE /bookmark/<bookmark_id>``
+
+        :rtype: :class:`TransferResponse
+                <globus_sdk.transfer.response.TransferResponse>`
         """
         path = self.qjoin_path('bookmark', bookmark_id)
         return self.delete(path)
@@ -506,6 +596,9 @@ class TransferClient(BaseClient):
     def operation_ls(self, endpoint_id, **params):
         """
         ``GET /operation/endpoint/<endpoint_id>/ls``
+
+        :rtype: :class:`IterableTransferResponse
+                <globus_sdk.transfer.response.IterableTransferResponse>`
 
         >>> tc = globus_sdk.TransferClient()
         >>> for entry in tc.operation_ls(ep_id, path="/~/project1/"):
@@ -523,6 +616,9 @@ class TransferClient(BaseClient):
     def operation_mkdir(self, endpoint_id, path, **params):
         """
         ``POST /operation/endpoint/<endpoint_id>/mkdir``
+
+        :rtype: :class:`TransferResponse
+                <globus_sdk.transfer.response.TransferResponse>`
 
         >>> tc = globus_sdk.TransferClient()
         >>> tc.operation_mkdir(ep_id, path="/~/newdir/")
@@ -543,6 +639,9 @@ class TransferClient(BaseClient):
     def operation_rename(self, endpoint_id, oldpath, newpath, **params):
         """
         ``POST /operation/endpoint/<endpoint_id>/rename``
+
+        :rtype: :class:`TransferResponse
+                <globus_sdk.transfer.response.TransferResponse>`
 
         >>> tc = globus_sdk.TransferClient()
         >>> tc.operation_rename(ep_id, oldpath="/~/file1.txt",
@@ -569,12 +668,18 @@ class TransferClient(BaseClient):
     def get_submission_id(self, **params):
         """
         ``GET /submission_id``
+
+        :rtype: :class:`TransferResponse
+                <globus_sdk.transfer.response.TransferResponse>`
         """
         return self.get("submission_id", params=params)
 
     def submit_transfer(self, data):
         """
         ``POST /transfer``
+
+        :rtype: :class:`TransferResponse
+                <globus_sdk.transfer.response.TransferResponse>`
 
         >>> tc = globus_sdk.TransferClient()
         >>> tdata = globus_sdk.TransferData(tc, source_endpoint_id,
@@ -599,6 +704,9 @@ class TransferClient(BaseClient):
     def submit_delete(self, data):
         """
         ``POST /delete``
+
+        :rtype: :class:`TransferResponse
+                <globus_sdk.transfer.response.TransferResponse>`
 
         >>> tc = globus_sdk.TransferClient()
         >>> ddata = globus_sdk.DeleteData(tc, endpoint_id, recursive=True)
@@ -687,6 +795,9 @@ class TransferClient(BaseClient):
     def task_list(self, num_results=10, **params):
         """
         ``GET /task_list``
+
+        :rtype: iterable of :class:`GlobusResponse
+                <globus_sdk.response.GlobusResponse>`
         """
         return PaginatedResource(
             self.get, 'task_list', {'params': params},
@@ -696,6 +807,9 @@ class TransferClient(BaseClient):
     def task_event_list(self, task_id, num_results=10, **params):
         """
         ``GET /task/<task_id>/event_list``
+
+        :rtype: iterable of :class:`GlobusResponse
+                <globus_sdk.response.GlobusResponse>`
         """
         path = self.qjoin_path('task', task_id, 'event_list')
         return PaginatedResource(
@@ -706,6 +820,9 @@ class TransferClient(BaseClient):
     def get_task(self, task_id, **params):
         """
         ``GET /task/<task_id>``
+
+        :rtype: :class:`TransferResponse
+                <globus_sdk.transfer.response.TransferResponse>`
         """
         resource_path = self.qjoin_path("task", task_id)
         return self.get(resource_path, params=params)
@@ -713,6 +830,9 @@ class TransferClient(BaseClient):
     def update_task(self, task_id, data, **params):
         """
         ``PUT /task/<task_id>``
+
+        :rtype: :class:`TransferResponse
+                <globus_sdk.transfer.response.TransferResponse>`
         """
         resource_path = self.qjoin_path("task", task_id)
         return self.put(resource_path, data, params=params)
@@ -720,6 +840,9 @@ class TransferClient(BaseClient):
     def cancel_task(self, task_id):
         """
         ``POST /task/<task_id>/cancel``
+
+        :rtype: :class:`TransferResponse
+                <globus_sdk.transfer.response.TransferResponse>`
         """
         resource_path = self.qjoin_path("task", task_id, "cancel")
         return self.post(resource_path)
@@ -727,6 +850,9 @@ class TransferClient(BaseClient):
     def task_pause_info(self, task_id, **params):
         """
         ``POST /task/<task_id>/pause_info``
+
+        :rtype: :class:`TransferResponse
+                <globus_sdk.transfer.response.TransferResponse>`
         """
         resource_path = self.qjoin_path("task", task_id, "pause_info")
         return self.get(resource_path, params=params)

--- a/globus_sdk/transfer/client.py
+++ b/globus_sdk/transfer/client.py
@@ -682,9 +682,13 @@ class TransferClient(BaseClient):
         :rtype: :class:`TransferResponse
                 <globus_sdk.transfer.response.TransferResponse>`
 
+        Example usage:
+
         >>> tc = globus_sdk.TransferClient()
         >>> tdata = globus_sdk.TransferData(tc, source_endpoint_id,
-        >>>                                 destination_endpoint_id)
+        >>>                                 destination_endpoint_id,
+        >>>                                 label="SDK example",
+        >>>                                 sync_level="checksum")
         >>> tdata.add_item("/source/path/dir/", "/dest/path/dir/",
         >>>                recursive=True)
         >>> tdata.add_item("/source/path/file.txt",
@@ -709,6 +713,8 @@ class TransferClient(BaseClient):
         :rtype: :class:`TransferResponse
                 <globus_sdk.transfer.response.TransferResponse>`
 
+        Example usage:
+
         >>> tc = globus_sdk.TransferClient()
         >>> ddata = globus_sdk.DeleteData(tc, endpoint_id, recursive=True)
         >>> ddata.add_item("/dir/to/delete/")
@@ -717,7 +723,7 @@ class TransferClient(BaseClient):
         >>> print("task_id =", delete_result["task_id"])
 
         The `data` parameter can be a normal Python dictionary, or
-        a :class:`DeleteData <globus_sdk.TransferData>` object.
+        a :class:`DeleteData <globus_sdk.DeleteData>` object.
 
         See
         `Submit a delete task \

--- a/globus_sdk/transfer/client.py
+++ b/globus_sdk/transfer/client.py
@@ -17,10 +17,13 @@ class TransferClient(BaseClient):
     from the base rest client that can be used to access any REST resource.
 
     There are two types of helper methods: list methods which return an
-    iterator of :class:`GlobusResponse <globus_sdk.response.GlobusResponse>`
+    iterator of :class:`GlobusResponse \
+    <globus_sdk.response.GlobusResponse>`
     objects, and simple methods that return a single
-    :class:`GlobusHTTPResponse <globus_sdk.response.GlobusHTTPResponse>`
-    object. Detailed documentation is available in the official REST API
+    :class:`TransferResponse <globus_sdk.transfer.response.TransferResponse>`
+    object.
+
+    Detailed documentation is available in the official REST API
     documentation, which is linked to from the method documentation. Methods
     that allow arbitrary keyword arguments will pass the extra arguments as
     query parameters.

--- a/globus_sdk/transfer/data.py
+++ b/globus_sdk/transfer/data.py
@@ -25,39 +25,9 @@ class TransferData(dict):
     can be used as-is multiple times over to retry a potential submission
     failure (so there shouldn't be any need to inspect it).
 
-    Example usage:
-
-    >>> from globus_sdk import TransferClient, TransferData
-    >>> tc = TransferClient()
-    >>> src_ep = ... # get source somehow
-    >>> dst_ep = ... # get dest somehow
-    >>> # the initial TransferData requires Client and Endpoints
-    >>> data = TransferData(tc, src_ep, dst_ep,
-    >>>                     label='SDK Transfer Task', sync_level="checksum")
-    >>> # add some files and dirs
-    >>> data.add_item('~/sourcefile', '~/destfile')
-    >>> data.add_item('~/sourcedir/', '~/destdir/', recursive=True)
-    >>> # and submit!
-    >>> tc.submit_transfer(data)
-
-    Because submission IDs make re-submission safe, you could do something like
-    this:
-
-    >>> retries = 3
-    >>> submitted = False
-    >>> while retries and not submitted:
-    >>>     try:
-    >>>         tc.submit_transfer(data)
-    >>>     except NetworkError:
-    >>>         retries -= 1
-    >>>     except GlobusAPIError as e:
-    >>>         # you have to write this func
-    >>>         if is_duplicate_submission_err(e):
-    >>>             submitted = True
-    >>>         else:
-    >>>             raise e
-    >>>     else:
-    >>>         submitted = True
+    See the
+    :meth:`submit_transfer <globus_sdk.TransferClient.submit_transfer>`
+    documentation for example usage.
     """
     def __init__(self, transfer_client, source_endpoint, destination_endpoint,
                  label=None, sync_level=None, **kwargs):
@@ -114,7 +84,8 @@ class DeleteData(dict):
     can be used as-is multiple times over to retry a potential submission
     failure (so there shouldn't be any need to inspect it).
 
-    Usage is similar to :class:`TransferData <globus_sdk.TransferData>` above.
+    See the :meth:`submit_delete <globus_sdk.TransferClient.submit_delete>`
+    documentation for example usage.
     """
     def __init__(self, transfer_client, endpoint, label=None,
                  recursive=False, **kwargs):


### PR DESCRIPTION
@bd4 If you don't get to this, I'll merge it early tomorrow morning, before the conference starts.

I want us to have cleaned up docs before people start seeing the site.
Things in here that I think are important:
- `AuthClient` method docs link to locations on `docs.globus.org`
- `TransferClient` has `:rtype:` set on every method -- you'll know for sure if its iterable or not from the docs
- Old Transfer helpers are clearly deprecated and refer to new OOP helpers. They also raise a deprecation warning
- Fix to Basic Usage example
- Get Deprecation info off of index page (it's not that level of importance, distracts from real content)
- Add an example for using `TransferData`

There are also a few little things here and there.

Can we call this our "final" review of docs, and we'll leave it frozen after this?
We should also push to pypi when we're done, so that we're sure that everything is synced up.