### PR TITLE
Make parsing more restrictive -- require INI format

### DIFF
--- a/globus_sdk/version.py
+++ b/globus_sdk/version.py
@@ -1,3 +1,3 @@
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "0.2.5a1"
+__version__ = "0.2.5"


### PR DESCRIPTION
Config files must be real INI files to parse correctly now.

Anyone using the older "simpler"/"nicer" format (which allowed omission of the top level "[general]" section heading) will get a GlobusError directing them to go back to tokens.globus.org to get new config.
Updates version to 0.2.5 for publication to The CheeseShop

Closes #34