### PR TITLE
DOC - minor fix

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,7 +40,7 @@ git repository and installing it manually:
 
 ::
 
-    git checkout https://github.com/globus/globus-sdk-python.git
+    git clone https://github.com/globus/globus-sdk-python.git
     cd globus-sdk-python
     python setup.py install
 


### PR DESCRIPTION
This patch fixes a minor problem in the documentation for downloading the latest git repository:
It is ``git clone`` and not ``git checkout`` (unlike for svn where svn checkout downloads the latest version of the repository.