### PR TITLE
Turn expires_in into a concrete expires at time.

### DIFF
--- a/globus_sdk/authorizers/refresh_token.py
+++ b/globus_sdk/authorizers/refresh_token.py
@@ -1,19 +1,12 @@
 import warnings
 import time
+
 from globus_sdk.authorizers.base import GlobusAuthorizer
 
-# a percent error expected in the `expires_in` values on AccessTokens,
-# expressed as a fractional value
-# taken out of the expiration value, not the total time (because that would be
-# weird, yeah?)
-# This is 5%, not 0.05%!
-_EXPIRATION_PERCENT_ERROR = 0.05
-# this is a fixed number of seconds to be pulled down from the expiration
-# timer, so that when the expires_in value is very small, the percent error
-# doesn't go to 0 and make us run the timer all the way down
-# so, we want (NOW - expires_in - (expires_in*PCT_ERROR) - FIXED_ERROR)
-# ultimately
-_EXPIRATION_FIXED_ERROR = 5
+
+# Provides a buffer for token expiration time to account for
+# possible delays or clock skew.
+EXPIRES_ADJUST_SECONDS = 60
 
 
 class RefreshTokenAuthorizer(GlobusAuthorizer):
@@ -47,20 +40,20 @@ class RefreshTokenAuthorizer(GlobusAuthorizer):
           ``AuthClient`` capable of using the ``refresh_token``
 
         ``access_token`` (*string*)
-          Initial Access Token to use, only used if ``expires_in`` is also set
+          Initial Access Token to use, only used if ``expires_at`` is also set
 
-        ``expires_in`` (*int*)
-          Expiration time for the starting ``access_token`` expressed as
-          seconds in the future
+        ``expires_at`` (*int*)
+          Expiration time for the starting ``access_token`` expressed as a
+          POSIX timestamp (i.e. seconds since the epoch)
     """
     def __init__(self, refresh_token, auth_client,
-                 access_token=None, expires_in=None):
-        if access_token is not None and expires_in is None:
+                 access_token=None, expires_at=None):
+        if access_token is not None and expires_at is None:
             warnings.warn(
                 ("Initializing a RefreshTokenAuthorizer with an "
-                 "access_token and no expires_in time means that this "
+                 "access_token and no expires_at time means that this "
                  "access_token will be discarded. You should either pass "
-                 "expires_in or not pass an access_token at all"))
+                 "expires_at or not pass an access_token at all"))
             # coerce to None for simplicity / consistency
             access_token = None
 
@@ -74,25 +67,18 @@ class RefreshTokenAuthorizer(GlobusAuthorizer):
 
         # check access_token too -- it's not clear what it would mean to set
         # expiration without an access token
-        if expires_in is not None and self.access_token is not None:
-            self._set_expiration_time(expires_in)
+        if expires_at is not None and self.access_token is not None:
+            self._set_expiration_time(expires_at)
 
         # if these were unspecified, fetch a new access token
         if self.access_token is None and self.expires_at is None:
             self._get_new_access_token()
 
-    def _set_expiration_time(self, expires_in):
+    def _set_expiration_time(self, expires_at):
         """
-        Set the expiration time, accounting for the fixed and percent error
-        expected in expiration timers. This error accounts for any jitter that
-        may be introduced by network delays &c., async clocks between the
-        client and server, and unknown quirky delays between the response being
-        received and processed.
+        Set the expiration time.
         """
-        # happens to be a floating point value -- that's fine, no need to int()
-        # it, since we'll never do == comparisons anyway
-        self.expires_at = time.time() + expires_in - (
-            _EXPIRATION_PERCENT_ERROR * expires_in) - _EXPIRATION_FIXED_ERROR
+        self.expires_at = expires_at - EXPIRES_ADJUST_SECONDS
 
     def _get_new_access_token(self):
         """
@@ -103,7 +89,7 @@ class RefreshTokenAuthorizer(GlobusAuthorizer):
         """
         token_response = self.auth_client.oauth2_refresh_token(
             self.refresh_token)
-        self._set_expiration_time(token_response.expires_in)
+        self._set_expiration_time(token_response.expires_at_seconds)
         self.access_token = token_response.access_token
 
     def _check_expiration_time(self):


### PR DESCRIPTION
- An OAuth2 token response includes an `expires_in`
  field which is the number of seconds a token is valid.
  Since there's no reference point to base the `expires_in`
  offset against, it's only useful immediately upon receipt.
  In order to provide an accurate view of when a token expires,
  we turn this value into a POSIX timestamp.

The net result of this is the token payload, as presented by the SDK now has an `expires_at_seconds` property instead of `expires_in`.