### PR TITLE
Add comprehensive logging following library logging best practices

### DIFF
--- a/globus_sdk/__init__.py
+++ b/globus_sdk/__init__.py
@@ -1,3 +1,6 @@
+import logging
+
+
 from globus_sdk.response import GlobusResponse, GlobusHTTPResponse
 from globus_sdk.transfer import TransferClient
 from globus_sdk.transfer.data import TransferData, DeleteData
@@ -30,3 +33,9 @@ __all__ = ["GlobusResponse", "GlobusHTTPResponse",
            "GlobusOptionalDependencyError",
 
            "__version__"]
+
+
+# configure logging for a library, per python best practices:
+# https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library
+# NB: this won't work on py2.6 because `logging.NullHandler` wasn't added yet
+logging.getLogger('globus_sdk').addHandler(logging.NullHandler())

--- a/globus_sdk/auth/client_types/base.py
+++ b/globus_sdk/auth/client_types/base.py
@@ -50,13 +50,14 @@ class AuthClient(BaseClient):
         # managers
         self.current_oauth2_flow_manager = None
 
-        # deprecated behavior; this is a temporary backwards compatibility hack
-        access_token = config.get_auth_token(
-            kwargs.get('environment', config.get_default_environ()))
-        if authorizer is None and access_token is not None:
-            logger.warn(('Using deprecated config token. '
-                         'Switch to explicit use of AccessTokenAuthorizer'))
-            authorizer = AccessTokenAuthorizer(access_token)
+        if authorizer is None:
+            # TODO: remove; this is a temporary backwards compatibility hack
+            access_token = config.get_auth_token(
+                kwargs.get('environment', config.get_default_environ()))
+            if access_token is not None:
+                logger.warn(('Using deprecated config token. '
+                             'Switch to use of AccessTokenAuthorizer'))
+                authorizer = AccessTokenAuthorizer(access_token)
 
         BaseClient.__init__(self, "auth", authorizer=authorizer, **kwargs)
 
@@ -102,6 +103,7 @@ class AuthClient(BaseClient):
         in the API documentation for details.
         """
         self.logger.info('Looking up Globus Auth Identities')
+        self.logger.debug('params={}'.format(params))
         if 'usernames' in params and 'identities' in params:
             self.logger.warn(('get_identities call with both usernames and '
                               'identities set! Expected to result in errors'))

--- a/globus_sdk/auth/client_types/base.py
+++ b/globus_sdk/auth/client_types/base.py
@@ -42,8 +42,7 @@ class AuthClient(BaseClient):
     >>> from globus_sdk import AuthClient, AccessTokenAuthorizer
     >>> ac = AuthClient(authorizer=AccessTokenAuthorizer('<token_string>'))
     """
-    def __init__(self, environment=config.get_default_environ(),
-                 client_id=None, authorizer=None, app_name=None):
+    def __init__(self, client_id=None, authorizer=None, **kwargs):
         self.client_id = client_id
 
         # an AuthClient may contain a GlobusOAuth2FlowManager in order to
@@ -51,14 +50,15 @@ class AuthClient(BaseClient):
         # managers
         self.current_oauth2_flow_manager = None
 
-        access_token = config.get_auth_token(environment)
+        # deprecated behavior; this is a temporary backwards compatibility hack
+        access_token = config.get_auth_token(
+            kwargs.get('environment', config.get_default_environ()))
         if authorizer is None and access_token is not None:
             logger.warn(('Using deprecated config token. '
                          'Switch to explicit use of AccessTokenAuthorizer'))
             authorizer = AccessTokenAuthorizer(access_token)
 
-        BaseClient.__init__(self, "auth", environment, authorizer=authorizer,
-                            app_name=app_name)
+        BaseClient.__init__(self, "auth", authorizer=authorizer, **kwargs)
 
     def get_identities(self, **params):
         r"""

--- a/globus_sdk/auth/client_types/native_client.py
+++ b/globus_sdk/auth/client_types/native_client.py
@@ -1,6 +1,9 @@
+import logging
 from globus_sdk.authorizers import NullAuthorizer
 from globus_sdk.auth.client_types.base import AuthClient
 from globus_sdk.auth.oauth2_native_app import GlobusNativeAppFlowManager
+
+logger = logging.getLogger(__name__)
 
 
 class NativeAppAuthClient(AuthClient):
@@ -23,11 +26,14 @@ class NativeAppAuthClient(AuthClient):
 
     def __init__(self, client_id, **kwargs):
         if "authorizer" in kwargs:
+            logger.error('ArgumentError(NativeAppClient.authorizer)')
             raise ValueError(
                 "Cannot give a NativeAppAuthClient an authorizer")
 
         AuthClient.__init__(
             self, client_id=client_id, authorizer=NullAuthorizer(), **kwargs)
+        self.logger.info('Finished initializing client, client_id={}'
+                         .format(client_id))
 
     def oauth2_start_flow_native_app(
             self, requested_scopes=None, redirect_uri=None,
@@ -42,6 +48,7 @@ class NativeAppAuthClient(AuthClient):
 
         #notthreadsafe
         """
+        self.logger.info('Starting Native App Grant Flow')
         self.current_oauth2_flow_manager = GlobusNativeAppFlowManager(
             self, requested_scopes=requested_scopes,
             redirect_uri=redirect_uri, state=state, verifier=verifier,
@@ -55,6 +62,7 @@ class NativeAppAuthClient(AuthClient):
         It needs this specialization because it cannot authenticate the refresh
         grant call with client credentials, as is normal.
         """
+        self.logger.info('Executing token refresh without client credentials')
         form_data = {'refresh_token': refresh_token,
                      'grant_type': 'refresh_token',
                      'client_id': self.client_id}

--- a/globus_sdk/auth/oauth2_authorization_code.py
+++ b/globus_sdk/auth/oauth2_authorization_code.py
@@ -1,8 +1,11 @@
+import logging
 from six.moves.urllib.parse import urlencode
 
 from globus_sdk.base import slash_join
 from globus_sdk.auth.oauth2_constants import DEFAULT_REQUESTED_SCOPES
 from globus_sdk.auth.oauth_flow_manager import GlobusOAuthFlowManager
+
+logger = logging.getLogger(__name__)
 
 
 class GlobusAuthorizationCodeFlowManager(GlobusOAuthFlowManager):
@@ -60,6 +63,13 @@ class GlobusAuthorizationCodeFlowManager(GlobusOAuthFlowManager):
         self.refresh_tokens = refresh_tokens
         self.state = state
 
+        logger.debug('Starting Authorization Code Flow with params:')
+        logger.debug('auth_client.client_id={}'.format(auth_client.client_id))
+        logger.debug('redirect_uri={}'.format(redirect_uri))
+        logger.debug('refresh_tokens={}'.format(refresh_tokens))
+        logger.debug('state={}'.format(state))
+        logger.debug('requested_scopes={}'.format(self.requested_scopes))
+
     def get_authorize_url(self, additional_params=None):
         """
         Start a Authorization Code flow by getting the authorization URL to
@@ -81,6 +91,8 @@ class GlobusAuthorizationCodeFlowManager(GlobusOAuthFlowManager):
         """
         authorize_base_url = slash_join(self.auth_client.base_url,
                                         '/v2/oauth2/authorize')
+        logger.debug('Building authorization URI. Base URL: {}'
+                     .format(authorize_base_url))
 
         params = {
             'client_id': self.client_id,
@@ -104,6 +116,8 @@ class GlobusAuthorizationCodeFlowManager(GlobusOAuthFlowManager):
         :rtype: :class:`OAuthTokenResponse \
         <globus_sdk.auth.token_response.OAuthTokenResponse>`
         """
+        logger.debug(('Performing Native App auth_code exchange. '
+                      'Sending client_id and client_secret'))
         return self.auth_client.oauth2_token(
             {'grant_type': 'authorization_code',
              'code': auth_code.encode('utf-8'),

--- a/globus_sdk/auth/oauth2_authorization_code.py
+++ b/globus_sdk/auth/oauth2_authorization_code.py
@@ -93,6 +93,7 @@ class GlobusAuthorizationCodeFlowManager(GlobusOAuthFlowManager):
                                         '/v2/oauth2/authorize')
         logger.debug('Building authorization URI. Base URL: {}'
                      .format(authorize_base_url))
+        logger.debug('additional_params={}'.format(additional_params))
 
         params = {
             'client_id': self.client_id,

--- a/globus_sdk/auth/oauth2_native_app.py
+++ b/globus_sdk/auth/oauth2_native_app.py
@@ -141,6 +141,7 @@ class GlobusNativeAppFlowManager(GlobusOAuthFlowManager):
                                         '/v2/oauth2/authorize')
         logger.debug('Building authorization URI. Base URL: {}'
                      .format(authorize_base_url))
+        logger.debug('additional_params={}'.format(additional_params))
 
         params = {
             'client_id': self.client_id,

--- a/globus_sdk/auth/oauth2_native_app.py
+++ b/globus_sdk/auth/oauth2_native_app.py
@@ -1,3 +1,4 @@
+import logging
 import uuid
 import hashlib
 import base64
@@ -6,6 +7,8 @@ from six.moves.urllib.parse import urlencode
 from globus_sdk.base import slash_join
 from globus_sdk.auth.oauth2_constants import DEFAULT_REQUESTED_SCOPES
 from globus_sdk.auth.oauth_flow_manager import GlobusOAuthFlowManager
+
+logger = logging.getLogger(__name__)
 
 
 def make_native_app_challenge(verifier=None):
@@ -17,6 +20,10 @@ def make_native_app_challenge(verifier=None):
     continuing it.
     Hashing is always done with simple SHA256
     """
+    if not verifier:
+        logger.info(('Autogenerating verifier secret. On low-entropy systems '
+                     'this may be insecure'))
+
     # unless provided, the "secret" is just a UUID4
     code_verifier = verifier or str(uuid.uuid4())
     # hash it, pull out a digest
@@ -80,6 +87,8 @@ class GlobusNativeAppFlowManager(GlobusOAuthFlowManager):
         # set client_id, then check for validity
         self.client_id = auth_client.client_id
         if not self.client_id:
+            logger.error('Invalid auth_client ID to start Native App Flow: {}'
+                         .format(self.client_id))
             raise ValueError(
                 'Invalid value for client_id. Got "{0}"'
                 .format(self.client_id))
@@ -100,6 +109,14 @@ class GlobusNativeAppFlowManager(GlobusOAuthFlowManager):
         # store the remaining parameters directly, with no transformation
         self.refresh_tokens = refresh_tokens
         self.state = state
+
+        logger.debug('Starting Native App Flow with params:')
+        logger.debug('auth_client.client_id={}'.format(auth_client.client_id))
+        logger.debug('redirect_uri={}'.format(self.redirect_uri))
+        logger.debug('refresh_tokens={}'.format(refresh_tokens))
+        logger.debug('state={}'.format(state))
+        logger.debug('requested_scopes={}'.format(self.requested_scopes))
+        logger.debug('verifier=<REDACTED>,challenge={}'.format(self.challenge))
 
     def get_authorize_url(self, additional_params=None):
         """
@@ -122,6 +139,8 @@ class GlobusNativeAppFlowManager(GlobusOAuthFlowManager):
         """
         authorize_base_url = slash_join(self.auth_client.base_url,
                                         '/v2/oauth2/authorize')
+        logger.debug('Building authorization URI. Base URL: {}'
+                     .format(authorize_base_url))
 
         params = {
             'client_id': self.client_id,
@@ -147,6 +166,8 @@ class GlobusNativeAppFlowManager(GlobusOAuthFlowManager):
         :rtype: :class:`OAuthTokenResponse \
         <globus_sdk.auth.token_response.OAuthTokenResponse>`
         """
+        logger.debug(('Performing Native App auth_code exchange. '
+                      'Sending verifier and client_id'))
         return self.auth_client.oauth2_token(
             {'client_id': self.client_id,
              'grant_type': 'authorization_code',

--- a/globus_sdk/authorizers/access_token.py
+++ b/globus_sdk/authorizers/access_token.py
@@ -1,4 +1,8 @@
+import logging
+
 from globus_sdk.authorizers.base import GlobusAuthorizer
+
+logger = logging.getLogger(__name__)
 
 
 class AccessTokenAuthorizer(GlobusAuthorizer):
@@ -13,6 +17,10 @@ class AccessTokenAuthorizer(GlobusAuthorizer):
           An access token for Globus Auth
     """
     def __init__(self, access_token):
+        logger.info(("Setting up an AccessTokenAuthorizer. It will use an "
+                     "auth type of Bearer and cannot handle 401s."))
+        logger.debug('Bearer token ends in "...{}" (last 5 chars)'
+                     .format(access_token[-5:]))
         self.access_token = access_token
         self.header_val = "Bearer %s" % access_token
 
@@ -21,4 +29,7 @@ class AccessTokenAuthorizer(GlobusAuthorizer):
         Sets the ``Authorization`` header to
         "Bearer <access_token>"
         """
+        logger.debug(("Setting AccessToken Authorization Header: "
+                      '"Bearer ...{}" (last 5 chars)')
+                     .format(self.header_val[-5:]))
         header_dict['Authorization'] = self.header_val

--- a/globus_sdk/authorizers/basic.py
+++ b/globus_sdk/authorizers/basic.py
@@ -1,6 +1,9 @@
+import logging
 import base64
 
 from globus_sdk.authorizers.base import GlobusAuthorizer
+
+logger = logging.getLogger(__name__)
 
 
 class BasicAuthorizer(GlobusAuthorizer):
@@ -18,6 +21,9 @@ class BasicAuthorizer(GlobusAuthorizer):
           Password component for Basic Auth
     """
     def __init__(self, username, password):
+        logger.info(("Setting up a BasicAuthorizer. It will use an "
+                     "auth type of Basic and cannot handle 401s."))
+        logger.info("BasicAuthorizer.username = {}".format(username))
         self.username = username
         self.password = password
 
@@ -30,4 +36,6 @@ class BasicAuthorizer(GlobusAuthorizer):
         Sets the ``Authorization`` header to
         "Basic <base64 encoded username:password>"
         """
+        logger.debug(("Setting Basic Authorization Header: "
+                      '"Basic <{}:SECRET>"').format(self.username))
         header_dict['Authorization'] = self.header_val

--- a/globus_sdk/authorizers/null.py
+++ b/globus_sdk/authorizers/null.py
@@ -1,4 +1,8 @@
+import logging
+
 from globus_sdk.authorizers.base import GlobusAuthorizer
+
+logger = logging.getLogger(__name__)
 
 
 class NullAuthorizer(GlobusAuthorizer):
@@ -11,4 +15,5 @@ class NullAuthorizer(GlobusAuthorizer):
         Removes the Authorization header from the given header dict if one was
         present.
         """
+        logger.debug("NullAuthorizer: ensuring there is no Authorization")
         header_dict.pop('Authorization', None)

--- a/globus_sdk/base.py
+++ b/globus_sdk/base.py
@@ -65,6 +65,8 @@ class BaseClient(object):
         if self.allowed_authorizer_types is not None and (
                 authorizer is not None and
                 type(authorizer) not in self.allowed_authorizer_types):
+            self.logger.error("{} doesn't support authorizer={}"
+                              .format(type(self), type(authorizer)))
             raise ValueError(
                 ("{0} can only take authorizers from {1}, "
                  "but you have provided {2}").format(
@@ -320,10 +322,13 @@ class BaseClient(object):
                     method=method, url=url, headers=rheaders, params=params,
                     data=text_body, verify=self._verify)
             except requests.Timeout as e:
+                self.logger.error("TimeoutError on request")
                 raise exc.GlobusTimeoutError(*e.args)
             except requests.ConnectionError as e:
+                self.logger.error("ConnectionError on request")
                 raise exc.GlobusConnectionError(*e.args)
             except requests.RequestException as e:
+                self.logger.error("NetworkError on request")
                 raise exc.NetworkError(*e.args)
 
         # initial request

--- a/globus_sdk/base.py
+++ b/globus_sdk/base.py
@@ -15,7 +15,7 @@ class ClientLogAdapter(logging.LoggerAdapter):
     Stuff in the memory location of the client to make log records unambiguous.
     """
     def process(self, msg, kwargs):
-        return '[client:{}] {}'.format(id(self.extra['client']), msg), kwargs
+        return '[instance:{}] {}'.format(id(self.extra['client']), msg), kwargs
 
 
 class BaseClient(object):
@@ -50,7 +50,7 @@ class BaseClient(object):
 
     BASE_USER_AGENT = 'globus-sdk-py-{0}'.format(__version__)
 
-    def __init__(self, service, environment=config.get_default_environ(),
+    def __init__(self, service, environment=None,
                  base_path=None, authorizer=None, app_name=None):
         # get the fully qualified name of the client class, so that it's a
         # child of globus_sdk
@@ -72,6 +72,11 @@ class BaseClient(object):
                  "but you have provided {2}").format(
                     type(self), self.allowed_authorizer_types,
                     type(authorizer)))
+
+        # defer this default until instantiation time so that logging can
+        # capture the execution of the config load
+        if environment is None:
+            environment = config.get_default_environ()
 
         self.environment = environment
         self.authorizer = authorizer

--- a/globus_sdk/config.py
+++ b/globus_sdk/config.py
@@ -1,13 +1,15 @@
 """
 Load config files once per interpreter invocation.
 """
-
+import logging
 import os
 from six.moves.configparser import (
     ConfigParser, MissingSectionHeaderError,
     NoOptionError, NoSectionError)
 
 from globus_sdk.exc import GlobusError
+
+logger = logging.getLogger(__name__)
 
 
 def _get_lib_config_path():
@@ -120,6 +122,7 @@ def get_ssl_verify(environment):
                   type_cast=_bool_cast)
     if value is None:
         return True
+    logger.debug('ssl_verify set to {}'.format(value))
     return value
 
 
@@ -129,6 +132,7 @@ def _bool_cast(value):
         return True
     elif value in ("0", "no", "false", "off"):
         return False
+    logger.error('Value "{}" can\'t cast to bool'.format(value))
     raise ValueError("Invalid config bool")
 
 
@@ -162,4 +166,8 @@ def get_default_environ():
     `GLOBUS_SDK_ENVIRONMENT` in the shell environment. In that case, any client
     which does not explicitly specify its environment will use this value.
     """
-    return os.environ.get('GLOBUS_SDK_ENVIRONMENT', 'default')
+    env = os.environ.get('GLOBUS_SDK_ENVIRONMENT', 'default')
+    if env != 'default':
+        logger.info(('On lookup, non-default Environment: '
+                     'GLOBUS_SDK_ENVIRONMENT={}'.format(env)))
+    return env

--- a/globus_sdk/config.py
+++ b/globus_sdk/config.py
@@ -168,6 +168,6 @@ def get_default_environ():
     """
     env = os.environ.get('GLOBUS_SDK_ENVIRONMENT', 'default')
     if env != 'default':
-        logger.info(('On lookup, non-default Environment: '
+        logger.info(('On lookup, non-default environment: '
                      'GLOBUS_SDK_ENVIRONMENT={}'.format(env)))
     return env

--- a/globus_sdk/exc.py
+++ b/globus_sdk/exc.py
@@ -1,4 +1,7 @@
+import logging
 import textwrap
+
+logger = logging.getLogger(__name__)
 
 
 class GlobusError(Exception):
@@ -23,11 +26,18 @@ class GlobusAPIError(GlobusError):
         self._underlying_response = r
         self.http_status = r.status_code
         if "application/json" in r.headers["Content-Type"]:
+            logger.debug(('Content-Type on error is application/json. '
+                          'Doing error load from JSON'))
             try:
                 self._load_from_json(r.json())
             except KeyError:
+                logger.error(('Error body could not be JSON decoded! '
+                              'This means the Content-Type is wrong, or the '
+                              'body is malformed!'))
                 self._load_from_text(r.text)
         else:
+            logger.debug(('Content-Type on error is unknown. '
+                          'Failing over to error load as text (default)'))
             # fallback to using the entire body as the message for all
             # other types
             self._load_from_text(r.text)
@@ -47,10 +57,18 @@ class GlobusAPIError(GlobusError):
         code and message instance variables.
         """
         if "errors" in data:
+            if len(data["errors"]) != 1:
+                logger.warn(("Doing JSON load of error response with multiple "
+                             "errors. Exception data will only include the "
+                             "first error, but there are really {} errors")
+                            .format(len(data["errors"])))
             # TODO: handle responses with more than one error
             data = data["errors"][0]
         self.code = data["code"]
         if "message" in data:
+            logger.debug(("Doing JSON load of error response with 'message' "
+                          "field. There may also be a useful 'detail' field "
+                          "to inspect"))
             self.message = data["message"]
         else:
             self.message = data["detail"]

--- a/globus_sdk/response.py
+++ b/globus_sdk/response.py
@@ -1,3 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
 class GlobusResponse(object):
     """
     Generic response object, with a single ``data`` member.
@@ -33,6 +38,8 @@ class GlobusResponse(object):
         try:
             return data[key]
         except TypeError:
+            logger.error("Can't index into responses of type {}"
+                         .format(type(self)))
             # re-raise with an altered message -- the issue is that whatever
             # type of GlobusResponse you're working with doesn't support
             # indexing
@@ -89,6 +96,8 @@ class GlobusHTTPResponse(GlobusResponse):
         # if the caller *really* wants the raw body of the response, they can
         # always use text_body
         except ValueError:
+            logger.warn(('GlobusHTTPResponse.data is null when body is not '
+                         'valid JSON'))
             return None
 
     @property

--- a/globus_sdk/transfer/client.py
+++ b/globus_sdk/transfer/client.py
@@ -60,13 +60,14 @@ class TransferClient(BaseClient):
     default_response_class = TransferResponse
 
     def __init__(self, authorizer=None, **kwargs):
-        # deprecated behavior; this is a temporary backwards compatibility hack
-        access_token = config.get_transfer_token(
-            kwargs.get('environment', config.get_default_environ()))
-        if authorizer is None and access_token is not None:
-            logger.warn(('Using deprecated config token. '
-                         'Switch to explicit use of AccessTokenAuthorizer'))
-            authorizer = AccessTokenAuthorizer(access_token)
+        if authorizer is None:
+            # TODO: remove; this is a temporary backwards compatibility hack
+            access_token = config.get_transfer_token(
+                kwargs.get('environment', config.get_default_environ()))
+            if access_token is not None:
+                logger.warn(('Using deprecated config token. '
+                             'Switch to use of AccessTokenAuthorizer'))
+                authorizer = AccessTokenAuthorizer(access_token)
 
         BaseClient.__init__(self, "transfer", base_path="/v0.10/",
                             authorizer=authorizer, **kwargs)

--- a/globus_sdk/transfer/client.py
+++ b/globus_sdk/transfer/client.py
@@ -99,6 +99,7 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/endpoint/#get_endpoint_by_id>`_
         in the REST documentation for details.
         """
+        self.logger.info("TransferClient.get_endpoint({})".format(endpoint_id))
         path = self.qjoin_path("endpoint", endpoint_id)
         return self.get(path, params=params)
 
@@ -123,6 +124,8 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/endpoint/#update_endpoint_by_id>`_
         in the REST documentation for details.
         """
+        self.logger.info("TransferClient.update_endpoint({}, ...)"
+                         .format(endpoint_id))
         path = self.qjoin_path("endpoint", endpoint_id)
         return self.put(path, data, params=params)
 
@@ -156,6 +159,7 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/endpoint/#create_endpoint>`_
         in the REST documentation for details.
         """
+        self.logger.info("TransferClient.create_endpoint(...)")
         return self.post("endpoint", data)
 
     def delete_endpoint(self, endpoint_id):
@@ -177,6 +181,8 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/endpoint/#delete_endpoint_by_id>`_
         in the REST documentation for details.
         """
+        self.logger.info("TransferClient.delete_endpoint({})"
+                         .format(endpoint_id))
         path = self.qjoin_path("endpoint", endpoint_id)
         return self.delete(path)
 
@@ -187,6 +193,9 @@ class TransferClient(BaseClient):
         :rtype: iterable of :class:`GlobusResponse
                 <globus_sdk.response.GlobusResponse>`
         """
+        self.logger.info(
+            "TransferClient.endpoint_manager_monitored_endpoints({})"
+            .format(params))
         path = self.qjoin_path('endpoint_manager', 'monitored_endpoints')
         return self.get(path, params=params,
                         response_class=IterableTransferResponse)
@@ -242,6 +251,9 @@ class TransferClient(BaseClient):
         """
         merge_params(params, filter_scope=filter_scope,
                      filter_fulltext=filter_fulltext)
+        self.logger.info(
+            "TransferClient.endpoint_manager_monitored_endpoints({})"
+            .format(params))
         return PaginatedResource(
             self.get, "endpoint_search", {'params': params},
             num_results=num_results, max_results_per_call=100,
@@ -287,6 +299,8 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/endpoint_activation/#autoactivate_endpoint>`_
         in the REST documentation for details.
         """
+        self.logger.info("TransferClient.endpoint_autoactivate({})"
+                         .format(endpoint_id))
         path = self.qjoin_path("endpoint", endpoint_id, "autoactivate")
         return self.post(path, params=params)
 
@@ -304,6 +318,8 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/endpoint_activation/#deactivate_endpoint>`_
         in the REST documentation for details.
         """
+        self.logger.info("TransferClient.endpoint_deactivate({})"
+                         .format(endpoint_id))
         path = self.qjoin_path("endpoint", endpoint_id, "deactivate")
         return self.post(path, params=params)
 
@@ -325,6 +341,8 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/endpoint_activation/#activate_endpoint>`_
         in the REST documentation for details.
         """
+        self.logger.info("TransferClient.endpoint_activate({})"
+                         .format(endpoint_id))
         path = self.qjoin_path("endpoint", endpoint_id, "activate")
         return self.post(path, json_body=requirements_data, params=params)
 
@@ -359,6 +377,8 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/endpoint/#get_my_effective_endpoint_pause_rules>`_
         in the REST documentation for details.
         """
+        self.logger.info("TransferClient.my_effective_pause_rule_list({}, ...)"
+                         .format(endpoint_id))
         path = self.qjoin_path('endpoint', endpoint_id,
                                'my_effective_pause_rule_list')
         return self.get(path, params=params,
@@ -380,6 +400,8 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/endpoint/#get_shared_endpoint_list>`_
         in the REST documentation for details.
         """
+        self.logger.info("TransferClient.my_shared_endpoint_list({}, ...)"
+                         .format(endpoint_id))
         path = self.qjoin_path('endpoint', endpoint_id,
                                'my_shared_endpoint_list')
         return self.get(path, params=params,
@@ -418,6 +440,7 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/endpoint/#create_shared_endpoint>`_
         in the REST documentation for details.
         """
+        self.logger.info("TransferClient.create_shared_endpoint(...)")
         return self.post('shared_endpoint', json_body=data)
 
     # Endpoint servers
@@ -436,6 +459,8 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/endpoint/#get_endpoint_server_list>`_
         in the REST documentation for details.
         """
+        self.logger.info("TransferClient.endpoint_server_list({}, ...)"
+                         .format(endpoint_id))
         path = self.qjoin_path('endpoint', endpoint_id, 'server_list')
         return self.get(path, params=params,
                         response_class=IterableTransferResponse)
@@ -454,6 +479,8 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/endpoint/#get_endpoint_server_list>`_
         in the REST documentation for details.
         """
+        self.logger.info("TransferClient.get_endpoint_server({}, {}, ...)"
+                         .format(endpoint_id, server_id))
         path = self.qjoin_path("endpoint", endpoint_id,
                                "server", str(server_id))
         return self.get(path, params=params)
@@ -472,6 +499,8 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/endpoint/#add_endpoint_server>`_
         in the REST documentation for details.
         """
+        self.logger.info("TransferClient.add_endpoint_server({}, ...)"
+                         .format(endpoint_id))
         path = self.qjoin_path("endpoint", endpoint_id, "server")
         return self.post(path, server_data)
 
@@ -489,6 +518,8 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/endpoint/#update_endpoint_server_by_id>`_
         in the REST documentation for details.
         """
+        self.logger.info("TransferClient.update_endpoint_server({}, {}, ...)"
+                         .format(endpoint_id, server_id))
         path = self.qjoin_path("endpoint", endpoint_id,
                                "server", str(server_id))
         return self.put(path, server_data)
@@ -507,6 +538,8 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/endpoint/#delete_endpoint_server_by_id>`_
         in the REST documentation for details.
         """
+        self.logger.info("TransferClient.delete_endpoint_server({}, {})"
+                         .format(endpoint_id, server_id))
         path = self.qjoin_path("endpoint", endpoint_id,
                                "server", str(server_id))
         return self.delete(path)
@@ -529,6 +562,8 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/endpoint_roles/#get_list_of_endpoint_roles>`_
         in the REST documentation for details.
         """
+        self.logger.info("TransferClient.endpoint_role_list({}, ...)"
+                         .format(endpoint_id))
         path = self.qjoin_path('endpoint', endpoint_id, 'role_list')
         return self.get(path, params=params,
                         response_class=IterableTransferResponse)
@@ -547,6 +582,8 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/endpoint_roles/#create_endpoint_role>`_
         in the REST documentation for details.
         """
+        self.logger.info("TransferClient.add_endpoint_role({}, ...)"
+                         .format(endpoint_id))
         path = self.qjoin_path('endpoint', endpoint_id, 'role')
         return self.post(path, role_data)
 
@@ -564,6 +601,8 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/endpoint_roles/#get_endpoint_role_by_id>`_
         in the REST documentation for details.
         """
+        self.logger.info("TransferClient.get_endpoint_role({}, {}, ...)"
+                         .format(endpoint_id, role_id))
         path = self.qjoin_path('endpoint', endpoint_id, 'role', role_id)
         return self.get(path, params=params)
 
@@ -581,6 +620,8 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/endpoint_roles/#delete_endpoint_role_by_id>`_
         in the REST documentation for details.
         """
+        self.logger.info("TransferClient.delete_endpoint_role({}, {})"
+                         .format(endpoint_id, role_id))
         path = self.qjoin_path('endpoint', endpoint_id, 'role', role_id)
         return self.delete(path)
 
@@ -595,6 +636,8 @@ class TransferClient(BaseClient):
         :rtype: :class:`IterableTransferResponse
                 <globus_sdk.transfer.response.IterableTransferResponse>`
         """
+        self.logger.info("TransferClient.endpoint_acl_list({}, ...)"
+                         .format(endpoint_id))
         path = self.qjoin_path('endpoint', endpoint_id, 'access_list')
         return self.get(path, params=params,
                         response_class=IterableTransferResponse)
@@ -606,6 +649,8 @@ class TransferClient(BaseClient):
         :rtype: :class:`TransferResponse
                 <globus_sdk.transfer.response.TransferResponse>`
         """
+        self.logger.info("TransferClient.get_endpoint_acl_rule({}, {}, ...)"
+                         .format(endpoint_id, rule_id))
         path = self.qjoin_path('endpoint', endpoint_id, 'access', rule_id)
         return self.get(path, params=params)
 
@@ -644,6 +689,8 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/acl/#rest_access_create>`_
         in the REST documentation for details.
         """
+        self.logger.info("TransferClient.add_endpoint_acl_rule({}, ...)"
+                         .format(endpoint_id))
         path = self.qjoin_path('endpoint', endpoint_id, 'access')
         return self.post(path, rule_data)
 
@@ -654,6 +701,8 @@ class TransferClient(BaseClient):
         :rtype: :class:`TransferResponse
                 <globus_sdk.transfer.response.TransferResponse>`
         """
+        self.logger.info("TransferClient.update_endpoint_acl_rule({}, {}, ...)"
+                         .format(endpoint_id, rule_id))
         path = self.qjoin_path('endpoint', endpoint_id, 'access', rule_id)
         return self.put(path, rule_data)
 
@@ -664,6 +713,8 @@ class TransferClient(BaseClient):
         :rtype: :class:`TransferResponse
                 <globus_sdk.transfer.response.TransferResponse>`
         """
+        self.logger.info("TransferClient.delete_endpoint_acl_rule({}, {})"
+                         .format(endpoint_id, rule_id))
         path = self.qjoin_path('endpoint', endpoint_id, 'access', rule_id)
         return self.delete(path)
 
@@ -678,6 +729,7 @@ class TransferClient(BaseClient):
         :rtype: :class:`IterableTransferResponse
                 <globus_sdk.transfer.response.IterableTransferResponse>`
         """
+        self.logger.info("TransferClient.bookmark_list({})".format(params))
         return self.get('bookmark_list', params=params,
                         response_class=IterableTransferResponse)
 
@@ -688,6 +740,8 @@ class TransferClient(BaseClient):
         :rtype: :class:`TransferResponse
                 <globus_sdk.transfer.response.TransferResponse>`
         """
+        self.logger.info("TransferClient.create_bookmark({})"
+                         .format(bookmark_data))
         return self.post('bookmark', bookmark_data)
 
     def get_bookmark(self, bookmark_id, **params):
@@ -697,6 +751,7 @@ class TransferClient(BaseClient):
         :rtype: :class:`TransferResponse
                 <globus_sdk.transfer.response.TransferResponse>`
         """
+        self.logger.info("TransferClient.get_bookmark({})".format(bookmark_id))
         path = self.qjoin_path('bookmark', bookmark_id)
         return self.get(path, params=params)
 
@@ -707,6 +762,8 @@ class TransferClient(BaseClient):
         :rtype: :class:`TransferResponse
                 <globus_sdk.transfer.response.TransferResponse>`
         """
+        self.logger.info("TransferClient.update_bookmark({})"
+                         .format(bookmark_id))
         path = self.qjoin_path('bookmark', bookmark_id)
         return self.put(path, bookmark_data)
 
@@ -717,6 +774,8 @@ class TransferClient(BaseClient):
         :rtype: :class:`TransferResponse
                 <globus_sdk.transfer.response.TransferResponse>`
         """
+        self.logger.info("TransferClient.delete_bookmark({})"
+                         .format(bookmark_id))
         path = self.qjoin_path('bookmark', bookmark_id)
         return self.delete(path)
 
@@ -744,6 +803,8 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/file_operations/#list_directory_contents>`_
         in the REST documentation for details.
         """
+        self.logger.info("TransferClient.operation_ls({}, {})"
+                         .format(endpoint_id, params))
         path = self.qjoin_path("operation/endpoint", endpoint_id, "ls")
         return self.get(path, params=params,
                         response_class=IterableTransferResponse)
@@ -767,6 +828,8 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/file_operations/#make_directory>`_
         in the REST documentation for details.
         """
+        self.logger.info("TransferClient.operation_mkdir({}, {}, {})"
+                         .format(endpoint_id, path, params))
         resource_path = self.qjoin_path("operation/endpoint", endpoint_id,
                                         "mkdir")
         json_body = {
@@ -795,6 +858,8 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/file_operations/#rename>`_
         in the REST documentation for details.
         """
+        self.logger.info("TransferClient.operation_rename({}, {}, {}, {})"
+                         .format(endpoint_id, oldpath, newpath, params))
         resource_path = self.qjoin_path("operation/endpoint", endpoint_id,
                                         "rename")
         json_body = {
@@ -815,6 +880,7 @@ class TransferClient(BaseClient):
         :rtype: :class:`TransferResponse
                 <globus_sdk.transfer.response.TransferResponse>`
         """
+        self.logger.info("TransferClient.get_submission_id({})".format(params))
         return self.get("submission_id", params=params)
 
     def submit_transfer(self, data):
@@ -848,6 +914,7 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/task_submit/#submit_a_transfer_task>`_
         in the REST documentation for more details.
         """
+        self.logger.info("TransferClient.submit_transfer(...)")
         return self.post('/transfer', data)
 
     def submit_delete(self, data):
@@ -876,6 +943,7 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/task_submit/#submit_a_delete_task>`_
         in the REST documentation for details.
         """
+        self.logger.info("TransferClient.submit_delete(...)")
         return self.post('/delete', data)
 
     #
@@ -889,6 +957,7 @@ class TransferClient(BaseClient):
         :rtype: iterable of :class:`GlobusResponse
                 <globus_sdk.response.GlobusResponse>`
         """
+        self.logger.info("TransferClient.endpoint_manager_task_list(...)")
         path = self.qjoin_path('endpoint_manager', 'task_list')
         return PaginatedResource(
             self.get, path, {'params': params},
@@ -902,6 +971,7 @@ class TransferClient(BaseClient):
         :rtype: iterable of :class:`GlobusResponse
                 <globus_sdk.response.GlobusResponse>`
         """
+        self.logger.info("TransferClient.task_list(...)")
         return PaginatedResource(
             self.get, 'task_list', {'params': params},
             num_results=num_results, max_results_per_call=1000,
@@ -914,6 +984,8 @@ class TransferClient(BaseClient):
         :rtype: iterable of :class:`GlobusResponse
                 <globus_sdk.response.GlobusResponse>`
         """
+        self.logger.info("TransferClient.task_event_list({}, ...)"
+                         .format(task_id))
         path = self.qjoin_path('task', task_id, 'event_list')
         return PaginatedResource(
             self.get, path, {'params': params},
@@ -927,6 +999,7 @@ class TransferClient(BaseClient):
         :rtype: :class:`TransferResponse
                 <globus_sdk.transfer.response.TransferResponse>`
         """
+        self.logger.info("TransferClient.get_task({}, ...)".format(task_id))
         resource_path = self.qjoin_path("task", task_id)
         return self.get(resource_path, params=params)
 
@@ -937,6 +1010,7 @@ class TransferClient(BaseClient):
         :rtype: :class:`TransferResponse
                 <globus_sdk.transfer.response.TransferResponse>`
         """
+        self.logger.info("TransferClient.update_task({}, ...)".format(task_id))
         resource_path = self.qjoin_path("task", task_id)
         return self.put(resource_path, data, params=params)
 
@@ -947,6 +1021,7 @@ class TransferClient(BaseClient):
         :rtype: :class:`TransferResponse
                 <globus_sdk.transfer.response.TransferResponse>`
         """
+        self.logger.info("TransferClient.cancel_task({})".format(task_id))
         resource_path = self.qjoin_path("task", task_id, "cancel")
         return self.post(resource_path)
 
@@ -997,11 +1072,20 @@ class TransferClient(BaseClient):
         >>>     print(".", end="")
         >>> print("\n{0} completed!".format(task_id))
         """
+        self.logger.info("TransferClient.task_wait({}, {}, {})"
+                         .format(task_id, timeout, polling_interval))
+
         # check valid args
         if timeout < 1:
+            self.logger.error(
+                "task_wait() timeout={} is less than minimum of 1s"
+                .format(timeout))
             raise ValueError(
                 "TransferClient.task_wait timeout has a minimum of 1")
         if polling_interval < 1:
+            self.logger.error(
+                "task_wait() polling_interval={} is less than minimum of 1s"
+                .format(polling_interval))
             raise ValueError(
                 "TransferClient.task_wait polling_interval has a minimum of 1")
 
@@ -1022,14 +1106,22 @@ class TransferClient(BaseClient):
             task = self.get_task(task_id)
             status = task['status']
             if status != 'ACTIVE':
+                self.logger.debug(
+                    "task_wait(task_id={}) terminated with status={}"
+                    .format(task_id, status))
                 return True
 
             # make sure to check if we timed out before sleeping again, so we
             # don't sleep an extra polling_interval
             waited_time += polling_interval
             if timed_out(waited_time):
+                self.logger.debug(
+                    "task_wait(task_id={}) timed out".format(task_id))
                 return False
 
+            self.logger.debug(
+                "task_wait(task_id={}) waiting {}s"
+                .format(task_id, polling_interval))
             time.sleep(polling_interval)
         # unreachable -- end of task_wait
 
@@ -1040,5 +1132,7 @@ class TransferClient(BaseClient):
         :rtype: :class:`TransferResponse
                 <globus_sdk.transfer.response.TransferResponse>`
         """
+        self.logger.info("TransferClient.task_pause_info({}, ...)"
+                         .format(task_id))
         resource_path = self.qjoin_path("task", task_id, "pause_info")
         return self.get(resource_path, params=params)


### PR DESCRIPTION
Resolves #29 

Initializes a NullHandler top-level logger for `globus_sdk`, attaches loggers to every instance of a `globus_sdk.BaseClient` subclass (so that inherited methods can "know who called" them), uses module-level loggers to describe most remaining activity, and pass `globus_sdk.BaseClient` logs through a `LoggerAdapter` which injects the memory address of the client object.

The last bit (the `LoggerAdapter`) is aimed at contexts where there are multiple clients of the same type being either used in tandem or generated and discarded, so that coherent "flows" can be traced through the logs.


By way of example for what this looks like, some logging output from a very simple test script at the painfully-verbose `DEBUG` level:
```shell
$ cat lt.py  # "logger_test.py"
import globus_sdk
import logging.config

conf = {
    'version': 1,
    'formatters': {
        'basic': {
            'format': '[%(levelname)s] %(name)s %(message)s'
        }
    },
    'handlers': {
        'console': {
            'class': 'logging.StreamHandler',
            'level': 'DEBUG',
            'formatter': 'basic'
        }
    },
    'loggers': {
        'globus_sdk': {
            'level': 'DEBUG',
            'handlers': [
                'console'
            ]
        }
    }
}

logging.config.dictConfig(conf)

ac = globus_sdk.AuthClient()
ac.get_identities(usernames='go@globusid.org')

$ python lt.py
[WARNING] globus_sdk.config Fetching auth_token from config -- this behavior will be removed in a future version of the SDK
[DEBUG] globus_sdk.config Loading SDK Config parser
[DEBUG] globus_sdk.config Attempting pkg_resources load of lib config
[DEBUG] globus_sdk.config pkg_resources load of lib config success
[DEBUG] globus_sdk.config Config load succeeded
[DEBUG] globus_sdk.config Config lookup of [environment default]:auth_token failed, checking [general] for a value as well
[WARNING] globus_sdk.auth.client_types.base Using deprecated config token. Switch to use of AccessTokenAuthorizer
[INFO] globus_sdk.authorizers.access_token Setting up an AccessTokenAuthorizer. It will use an auth type of Bearer and cannot handle 401s.
[DEBUG] globus_sdk.authorizers.access_token Bearer token ends in "...q3mnj" (last 5 chars)
[INFO] globus_sdk.auth.client_types.base.AuthClient [instance:140132030843280] Creating client of type <class 'globus_sdk.auth.client_types.base.AuthClient'> for service "auth"
[DEBUG] globus_sdk.config Service URL Lookup Result: "auth" is at "https://auth.globus.org/"
[INFO] globus_sdk.auth.client_types.base.AuthClient [instance:140132030843280] Looking up Globus Auth Identities
[DEBUG] globus_sdk.auth.client_types.base.AuthClient [instance:140132030843280] params={'usernames': 'go@globusid.org'}
[DEBUG] globus_sdk.auth.client_types.base.AuthClient [instance:140132030843280] GET to /v2/api/identities with params {'usernames': 'go@globusid.org'}
[DEBUG] globus_sdk.auth.client_types.base.AuthClient [instance:140132030843280] request will have authorization of type <class 'globus_sdk.authorizers.access_token.AccessTokenAuthorizer'>
[DEBUG] globus_sdk.authorizers.access_token Setting AccessToken Authorization Header: "Bearer ...q3mnj" (last 5 chars)
[DEBUG] globus_sdk.auth.client_types.base.AuthClient [instance:140132030843280] request will hit URL:https://auth.globus.org/v2/api/identities
[DEBUG] globus_sdk.auth.client_types.base.AuthClient [instance:140132030843280] request got 401, checking retry-capability
[DEBUG] globus_sdk.auth.client_types.base.AuthClient [instance:140132030843280] request completed with (error) response code: 401
[DEBUG] globus_sdk.exc Content-Type on error is application/json. Doing error load from JSON
Traceback (most recent call last):
  File "lt.py", line 31, in <module>
    ac.get_identities(usernames='go@globusid.org')
  File "/home/sirosen/dev/globus/globus-sdk-python/globus_sdk/auth/client_types/base.py", line 110, in get_identities
    return self.get("/v2/api/identities", params=params)
  File "/home/sirosen/dev/globus/globus-sdk-python/globus_sdk/base.py", line 150, in get
    retry_401=retry_401)
  File "/home/sirosen/dev/globus/globus-sdk-python/globus_sdk/base.py", line 364, in _request
    raise self.error_class(r)
globus_sdk.exc.GlobusAPIError: (401, u'UNAUTHORIZED', u'Call must be authenticated')
```