### PR TITLE
Correct mapping for transfer submission sync_level

### DIFF
--- a/docs/_modules/globus_sdk/transfer/data.html
+++ b/docs/_modules/globus_sdk/transfer/data.html
@@ -65,9 +65,9 @@
 <span class="sd">    :meth:`add_item &lt;globus_sdk.TransferData.add_item&gt;`.</span>
 
 <span class="sd">    For compatibility with older code and those knowledgeable about the API</span>
-<span class="sd">    sync_level can be ``1``, ``2``, or ``3``, but it can also be</span>
-<span class="sd">    ``&quot;exists&quot;``, ``&quot;mtime&quot;``, or ``&quot;checksum&quot;`` if you want greater clarity in</span>
-<span class="sd">    client code.</span>
+<span class="sd">    sync_level can be ``0``, ``1``, ``2``, or ``3``, but it can also be</span>
+<span class="sd">    ``&quot;exists&quot;``, ``&quot;size&quot;``, ``&quot;mtime&quot;``, or ``&quot;checksum&quot;`` if you want</span>
+<span class="sd">    greater clarity in client code.</span>
 
 <span class="sd">    Includes fetching the submission ID as part of document generation. The</span>
 <span class="sd">    submission ID can be pulled out of here to inspect, but the document</span>
@@ -94,8 +94,8 @@
         <span class="c1"># will just reject you with an error. This is kind of important: if</span>
         <span class="c1"># more levels are added in the future this method doesn&#39;t become</span>
         <span class="c1"># garbage overnight</span>
-        <span class="k">if</span> <span class="n">sync_level</span> <span class="ow">is</span> <span class="ow">not</span> <span class="bp">None</span><span class="p">:</span>
-            <span class="n">sync_dict</span> <span class="o">=</span> <span class="p">{</span><span class="s2">&quot;exists&quot;</span><span class="p">:</span> <span class="mi">1</span><span class="p">,</span> <span class="s2">&quot;mtime&quot;</span><span class="p">:</span> <span class="mi">2</span><span class="p">,</span> <span class="s2">&quot;checksum&quot;</span><span class="p">:</span> <span class="mi">3</span><span class="p">}</span>
+        <span class="k">if</span> <span class="n">sync_level</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span><span class="p">:</span>
+            <span class="n">sync_dict</span> <span class="o">=</span> <span class="p">{</span><span class="s2">&quot;exists&quot;</span><span class="p">:</span> <span class="mi">0</span><span class="p">,</span> <span class="s2">&quot;size&quot;</span><span class="p">:</span> <span class="mi">1</span><span class="p">,</span> <span class="s2">&quot;mtime&quot;</span><span class="p">:</span> <span class="mi">2</span><span class="p">,</span> <span class="s2">&quot;checksum&quot;</span><span class="p">:</span> <span class="mi">3</span><span class="p">}</span>
             <span class="n">sync_level</span> <span class="o">=</span> <span class="n">sync_dict</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="n">sync_level</span><span class="p">,</span> <span class="n">sync_level</span><span class="p">)</span>
             <span class="bp">self</span><span class="p">[</span><span class="s1">&#39;sync_level&#39;</span><span class="p">]</span> <span class="o">=</span> <span class="n">sync_level</span>
 

--- a/docs/clients/transfer.html
+++ b/docs/clients/transfer.html
@@ -1070,9 +1070,9 @@ second at a time:</p>
 <p>At least one item must be added using
 <a class="reference internal" href="#globus_sdk.TransferData.add_item" title="globus_sdk.TransferData.add_item"><code class="xref py py-meth docutils literal"><span class="pre">add_item</span></code></a>.</p>
 <p>For compatibility with older code and those knowledgeable about the API
-sync_level can be <code class="docutils literal"><span class="pre">1</span></code>, <code class="docutils literal"><span class="pre">2</span></code>, or <code class="docutils literal"><span class="pre">3</span></code>, but it can also be
-<code class="docutils literal"><span class="pre">&quot;exists&quot;</span></code>, <code class="docutils literal"><span class="pre">&quot;mtime&quot;</span></code>, or <code class="docutils literal"><span class="pre">&quot;checksum&quot;</span></code> if you want greater clarity in
-client code.</p>
+sync_level can be <code class="docutils literal"><span class="pre">0</span></code>, <code class="docutils literal"><span class="pre">1</span></code>, <code class="docutils literal"><span class="pre">2</span></code>, or <code class="docutils literal"><span class="pre">3</span></code>, but it can also be
+<code class="docutils literal"><span class="pre">&quot;exists&quot;</span></code>, <code class="docutils literal"><span class="pre">&quot;size&quot;</span></code>, <code class="docutils literal"><span class="pre">&quot;mtime&quot;</span></code>, or <code class="docutils literal"><span class="pre">&quot;checksum&quot;</span></code> if you want
+greater clarity in client code.</p>
 <p>Includes fetching the submission ID as part of document generation. The
 submission ID can be pulled out of here to inspect, but the document
 can be used as-is multiple times over to retry a potential submission

--- a/globus_sdk/transfer/data.py
+++ b/globus_sdk/transfer/data.py
@@ -16,9 +16,9 @@ class TransferData(dict):
     :meth:`add_item <globus_sdk.TransferData.add_item>`.
 
     For compatibility with older code and those knowledgeable about the API
-    sync_level can be ``1``, ``2``, or ``3``, but it can also be
-    ``"exists"``, ``"mtime"``, or ``"checksum"`` if you want greater clarity in
-    client code.
+    sync_level can be ``0``, ``1``, ``2``, or ``3``, but it can also be
+    ``"exists"``, ``"size"``, ``"mtime"``, or ``"checksum"`` if you want
+    greater clarity in client code.
 
     Includes fetching the submission ID as part of document generation. The
     submission ID can be pulled out of here to inspect, but the document
@@ -46,7 +46,7 @@ class TransferData(dict):
         # more levels are added in the future this method doesn't become
         # garbage overnight
         if sync_level is not None:
-            sync_dict = {"exists": 1, "mtime": 2, "checksum": 3}
+            sync_dict = {"exists": 0, "size": 1, "mtime": 2, "checksum": 3}
             sync_level = sync_dict.get(sync_level, sync_level)
             self['sync_level'] = sync_level
 


### PR DESCRIPTION
Fixes `exists` to be sync level `0` and adds `size` for sync level `1`.

https://docs.globus.org/api/transfer/task_submit#transfer_specific_fields