### PR TITLE
Update TransferClient to accept UUID for endpoints

### DIFF
--- a/globus_sdk/base.py
+++ b/globus_sdk/base.py
@@ -2,7 +2,7 @@ import json
 import logging
 
 import requests
-
+import six
 from six.moves.urllib.parse import quote
 
 from globus_sdk import config, exc
@@ -419,3 +419,16 @@ def merge_params(base_params, **more_params):
     for param in more_params:
         if more_params[param] is not None:
             base_params[param] = more_params[param]
+
+
+def safe_stringify(value):
+    """
+    Convert bytes by decoding, strings verbatim, and __str__ on anything
+    else
+    """
+    if isinstance(value, bytes):
+        return value.decode('utf-8')
+    elif isinstance(value, six.string_types):
+        return value
+    else:
+        return str(value)

--- a/globus_sdk/transfer/client.py
+++ b/globus_sdk/transfer/client.py
@@ -2,7 +2,7 @@ import logging
 import time
 
 from globus_sdk import exc, config
-from globus_sdk.base import BaseClient, merge_params
+from globus_sdk.base import BaseClient, merge_params, safe_stringify
 from globus_sdk.authorizers import (
     AccessTokenAuthorizer, RefreshTokenAuthorizer)
 from globus_sdk.transfer.response import (
@@ -100,6 +100,7 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/endpoint/#get_endpoint_by_id>`_
         in the REST documentation for details.
         """
+        endpoint_id = safe_stringify(endpoint_id)
         self.logger.info("TransferClient.get_endpoint({})".format(endpoint_id))
         path = self.qjoin_path("endpoint", endpoint_id)
         return self.get(path, params=params)
@@ -125,6 +126,7 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/endpoint/#update_endpoint_by_id>`_
         in the REST documentation for details.
         """
+        endpoint_id = safe_stringify(endpoint_id)
         self.logger.info("TransferClient.update_endpoint({}, ...)"
                          .format(endpoint_id))
         path = self.qjoin_path("endpoint", endpoint_id)
@@ -182,6 +184,7 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/endpoint/#delete_endpoint_by_id>`_
         in the REST documentation for details.
         """
+        endpoint_id = safe_stringify(endpoint_id)
         self.logger.info("TransferClient.delete_endpoint({})"
                          .format(endpoint_id))
         path = self.qjoin_path("endpoint", endpoint_id)
@@ -300,6 +303,7 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/endpoint_activation/#autoactivate_endpoint>`_
         in the REST documentation for details.
         """
+        endpoint_id = safe_stringify(endpoint_id)
         self.logger.info("TransferClient.endpoint_autoactivate({})"
                          .format(endpoint_id))
         path = self.qjoin_path("endpoint", endpoint_id, "autoactivate")
@@ -319,6 +323,7 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/endpoint_activation/#deactivate_endpoint>`_
         in the REST documentation for details.
         """
+        endpoint_id = safe_stringify(endpoint_id)
         self.logger.info("TransferClient.endpoint_deactivate({})"
                          .format(endpoint_id))
         path = self.qjoin_path("endpoint", endpoint_id, "deactivate")
@@ -342,6 +347,7 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/endpoint_activation/#activate_endpoint>`_
         in the REST documentation for details.
         """
+        endpoint_id = safe_stringify(endpoint_id)
         self.logger.info("TransferClient.endpoint_activate({})"
                          .format(endpoint_id))
         path = self.qjoin_path("endpoint", endpoint_id, "activate")
@@ -361,6 +367,7 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/endpoint_activation/#get_activation_requirements>`_
         in the REST documentation for details.
         """
+        endpoint_id = safe_stringify(endpoint_id)
         path = self.qjoin_path("endpoint", endpoint_id,
                                "activation_requirements")
         return self.get(path, params=params,
@@ -380,6 +387,7 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/endpoint/#get_my_effective_endpoint_pause_rules>`_
         in the REST documentation for details.
         """
+        endpoint_id = safe_stringify(endpoint_id)
         self.logger.info("TransferClient.my_effective_pause_rule_list({}, ...)"
                          .format(endpoint_id))
         path = self.qjoin_path('endpoint', endpoint_id,
@@ -403,6 +411,7 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/endpoint/#get_shared_endpoint_list>`_
         in the REST documentation for details.
         """
+        endpoint_id = safe_stringify(endpoint_id)
         self.logger.info("TransferClient.my_shared_endpoint_list({}, ...)"
                          .format(endpoint_id))
         path = self.qjoin_path('endpoint', endpoint_id,
@@ -462,6 +471,7 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/endpoint/#get_endpoint_server_list>`_
         in the REST documentation for details.
         """
+        endpoint_id = safe_stringify(endpoint_id)
         self.logger.info("TransferClient.endpoint_server_list({}, ...)"
                          .format(endpoint_id))
         path = self.qjoin_path('endpoint', endpoint_id, 'server_list')
@@ -482,6 +492,7 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/endpoint/#get_endpoint_server_list>`_
         in the REST documentation for details.
         """
+        endpoint_id = safe_stringify(endpoint_id)
         self.logger.info("TransferClient.get_endpoint_server({}, {}, ...)"
                          .format(endpoint_id, server_id))
         path = self.qjoin_path("endpoint", endpoint_id,
@@ -502,6 +513,7 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/endpoint/#add_endpoint_server>`_
         in the REST documentation for details.
         """
+        endpoint_id = safe_stringify(endpoint_id)
         self.logger.info("TransferClient.add_endpoint_server({}, ...)"
                          .format(endpoint_id))
         path = self.qjoin_path("endpoint", endpoint_id, "server")
@@ -521,6 +533,7 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/endpoint/#update_endpoint_server_by_id>`_
         in the REST documentation for details.
         """
+        endpoint_id = safe_stringify(endpoint_id)
         self.logger.info("TransferClient.update_endpoint_server({}, {}, ...)"
                          .format(endpoint_id, server_id))
         path = self.qjoin_path("endpoint", endpoint_id,
@@ -541,6 +554,7 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/endpoint/#delete_endpoint_server_by_id>`_
         in the REST documentation for details.
         """
+        endpoint_id = safe_stringify(endpoint_id)
         self.logger.info("TransferClient.delete_endpoint_server({}, {})"
                          .format(endpoint_id, server_id))
         path = self.qjoin_path("endpoint", endpoint_id,
@@ -565,6 +579,7 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/endpoint_roles/#get_list_of_endpoint_roles>`_
         in the REST documentation for details.
         """
+        endpoint_id = safe_stringify(endpoint_id)
         self.logger.info("TransferClient.endpoint_role_list({}, ...)"
                          .format(endpoint_id))
         path = self.qjoin_path('endpoint', endpoint_id, 'role_list')
@@ -585,6 +600,7 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/endpoint_roles/#create_endpoint_role>`_
         in the REST documentation for details.
         """
+        endpoint_id = safe_stringify(endpoint_id)
         self.logger.info("TransferClient.add_endpoint_role({}, ...)"
                          .format(endpoint_id))
         path = self.qjoin_path('endpoint', endpoint_id, 'role')
@@ -604,6 +620,7 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/endpoint_roles/#get_endpoint_role_by_id>`_
         in the REST documentation for details.
         """
+        endpoint_id = safe_stringify(endpoint_id)
         self.logger.info("TransferClient.get_endpoint_role({}, {}, ...)"
                          .format(endpoint_id, role_id))
         path = self.qjoin_path('endpoint', endpoint_id, 'role', role_id)
@@ -623,6 +640,7 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/endpoint_roles/#delete_endpoint_role_by_id>`_
         in the REST documentation for details.
         """
+        endpoint_id = safe_stringify(endpoint_id)
         self.logger.info("TransferClient.delete_endpoint_role({}, {})"
                          .format(endpoint_id, role_id))
         path = self.qjoin_path('endpoint', endpoint_id, 'role', role_id)
@@ -639,6 +657,7 @@ class TransferClient(BaseClient):
         :rtype: :class:`IterableTransferResponse
                 <globus_sdk.transfer.response.IterableTransferResponse>`
         """
+        endpoint_id = safe_stringify(endpoint_id)
         self.logger.info("TransferClient.endpoint_acl_list({}, ...)"
                          .format(endpoint_id))
         path = self.qjoin_path('endpoint', endpoint_id, 'access_list')
@@ -652,6 +671,7 @@ class TransferClient(BaseClient):
         :rtype: :class:`TransferResponse
                 <globus_sdk.transfer.response.TransferResponse>`
         """
+        endpoint_id = safe_stringify(endpoint_id)
         self.logger.info("TransferClient.get_endpoint_acl_rule({}, {}, ...)"
                          .format(endpoint_id, rule_id))
         path = self.qjoin_path('endpoint', endpoint_id, 'access', rule_id)
@@ -692,6 +712,7 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/acl/#rest_access_create>`_
         in the REST documentation for details.
         """
+        endpoint_id = safe_stringify(endpoint_id)
         self.logger.info("TransferClient.add_endpoint_acl_rule({}, ...)"
                          .format(endpoint_id))
         path = self.qjoin_path('endpoint', endpoint_id, 'access')
@@ -704,6 +725,7 @@ class TransferClient(BaseClient):
         :rtype: :class:`TransferResponse
                 <globus_sdk.transfer.response.TransferResponse>`
         """
+        endpoint_id = safe_stringify(endpoint_id)
         self.logger.info("TransferClient.update_endpoint_acl_rule({}, {}, ...)"
                          .format(endpoint_id, rule_id))
         path = self.qjoin_path('endpoint', endpoint_id, 'access', rule_id)
@@ -716,6 +738,7 @@ class TransferClient(BaseClient):
         :rtype: :class:`TransferResponse
                 <globus_sdk.transfer.response.TransferResponse>`
         """
+        endpoint_id = safe_stringify(endpoint_id)
         self.logger.info("TransferClient.delete_endpoint_acl_rule({}, {})"
                          .format(endpoint_id, rule_id))
         path = self.qjoin_path('endpoint', endpoint_id, 'access', rule_id)
@@ -806,6 +829,7 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/file_operations/#list_directory_contents>`_
         in the REST documentation for details.
         """
+        endpoint_id = safe_stringify(endpoint_id)
         self.logger.info("TransferClient.operation_ls({}, {})"
                          .format(endpoint_id, params))
         path = self.qjoin_path("operation/endpoint", endpoint_id, "ls")
@@ -831,6 +855,7 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/file_operations/#make_directory>`_
         in the REST documentation for details.
         """
+        endpoint_id = safe_stringify(endpoint_id)
         self.logger.info("TransferClient.operation_mkdir({}, {}, {})"
                          .format(endpoint_id, path, params))
         resource_path = self.qjoin_path("operation/endpoint", endpoint_id,
@@ -861,6 +886,7 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/file_operations/#rename>`_
         in the REST documentation for details.
         """
+        endpoint_id = safe_stringify(endpoint_id)
         self.logger.info("TransferClient.operation_rename({}, {}, {}, {})"
                          .format(endpoint_id, oldpath, newpath, params))
         resource_path = self.qjoin_path("operation/endpoint", endpoint_id,

--- a/globus_sdk/transfer/data.py
+++ b/globus_sdk/transfer/data.py
@@ -6,6 +6,8 @@ conversion.
 """
 import logging
 
+from globus_sdk.base import safe_stringify
+
 logger = logging.getLogger(__name__)
 
 
@@ -34,6 +36,8 @@ class TransferData(dict):
     """
     def __init__(self, transfer_client, source_endpoint, destination_endpoint,
                  label=None, sync_level=None, **kwargs):
+        source_endpoint = safe_stringify(source_endpoint)
+        destination_endpoint = safe_stringify(destination_endpoint)
         logger.info("Creating a new TransferData object")
         self["DATA_TYPE"] = "transfer"
         self["submission_id"] = transfer_client.get_submission_id()["value"]
@@ -109,6 +113,7 @@ class DeleteData(dict):
     """
     def __init__(self, transfer_client, endpoint, label=None,
                  recursive=False, **kwargs):
+        endpoint = safe_stringify(endpoint)
         logger.info("Creating a new DeleteData object")
         self["DATA_TYPE"] = "delete"
         self["submission_id"] = transfer_client.get_submission_id()["value"]


### PR DESCRIPTION
Anywhere that we were assuming something to be an endpoint_id as a string, we now merely assume that it has a `__str__` which produces an endpoint ID.

This captures any cases where the SDK is given a uuid.UUID, is fully backwards compatible, and supports potential future types. For example, you could have your own `GlobusEndpoint` type, and as long as its `__str__` is the endpoint ID, it's safe to pass to SDK methods.

This is needed for globus/globus-cli#86