### PR TITLE
Add aliasing for new `oauth2_start_flow()` methods

### DIFF
--- a/globus_sdk/auth/client_types/confidential_client.py
+++ b/globus_sdk/auth/client_types/confidential_client.py
@@ -76,7 +76,16 @@ class ConfidentialAppAuthClient(AuthClient):
             'grant_type': 'client_credentials',
             'scope': requested_scopes})
 
-    def oauth2_start_flow_authorization_code(
+    def oauth2_start_flow_authorization_code(self, *args, **kwargs):
+        """
+        Deprecated passthrough method for getting at ``self.oauth2_start_flow``
+        """
+        self.logger.warn(("Using oauth2_start_authorization_code() is "
+                          "deprecated. Recommend upgrade to "
+                          "oauth2_start_flow()"))
+        return self.oauth2_start_flow(*args, **kwargs)
+
+    def oauth2_start_flow(
             self, redirect_uri, requested_scopes=None,
             state='_default', refresh_tokens=False):
         """

--- a/globus_sdk/auth/client_types/native_client.py
+++ b/globus_sdk/auth/client_types/native_client.py
@@ -35,7 +35,16 @@ class NativeAppAuthClient(AuthClient):
         self.logger.info('Finished initializing client, client_id={}'
                          .format(client_id))
 
-    def oauth2_start_flow_native_app(
+    def oauth2_start_flow_native_app(self, *args, **kwargs):
+        """
+        Deprecated passthrough method for getting at ``self.oauth2_start_flow``
+        """
+        self.logger.warn(("Using oauth2_start_flow_native_app() is "
+                          "deprecated. Recommend upgrade to "
+                          "oauth2_start_flow()"))
+        return self.oauth2_start_flow(*args, **kwargs)
+
+    def oauth2_start_flow(
             self, requested_scopes=None, redirect_uri=None,
             state='_default', verifier=None, refresh_tokens=False):
         """


### PR DESCRIPTION
Renames the existing `oauth_start_flow_*` methods to drop their suffixes, and converts their own names into aliases which log a warning and passthrough.
Resolves #62

@jaswilli I know you expressed a desire that we just drop the old names, but I still think it's polite to roll out a version which warns or otherwise indicates the deprecation.
I'd like to roll out `0.4.3` sometime soon before we run out of runway to update the SDK and CLI prior to SC16. Otherwise, we'll be dropping a significant number of breaking changes at once, which seems less pleasant.