### PR TITLE
Fix logging for transfer data sync_level

### DIFF
--- a/globus_sdk/transfer/data.py
+++ b/globus_sdk/transfer/data.py
@@ -62,13 +62,9 @@ class TransferData(dict):
         # garbage overnight
         if sync_level is not None:
             sync_dict = {"exists": 0, "size": 1, "mtime": 2, "checksum": 3}
-            sync_level = sync_dict.get(sync_level, sync_level)
-            self['sync_level'] = sync_level
+            self['sync_level'] = sync_dict.get(sync_level, sync_level)
             logger.info("TransferData.sync_level = {} ({})"
-                        .format(sync_level,
-                                (x for x in sync_dict
-                                 if sync_dict[x] == sync_level).next()
-                                ))
+                        .format(self['sync_level'], sync_level))
 
         self["DATA"] = []
 


### PR DESCRIPTION
Two problems with the existing implementation:

- Python 3 needs `next(generator)` rather than `generator.next()`
- if the SDK caller uses a `sync_level` that isn't in the dict, the use
  of a fallback argument in `sync_dict.get(sync_level, sync_level)` will
  make back to the user's input, which means that the use of the
  generator here will raise a `StopIteration`

Really, we should be able to just avoid the use of the generator
altogether by not clobbering the original `sync_level` that the caller
used and outputting it with what we map it to (`self['sync_level']`).