### PR TITLE
Avoid fetching a submission ID when unnecessary

### DIFF
--- a/globus_sdk/transfer/data.py
+++ b/globus_sdk/transfer/data.py
@@ -25,7 +25,7 @@ class TransferData(dict):
     ``"exists"``, ``"size"``, ``"mtime"``, or ``"checksum"`` if you want
     greater clarity in client code.
 
-    Includes fetching the submission ID as part of document generation. The
+    If ``submission_id`` isn't passed, one will be fetched automatically. The
     submission ID can be pulled out of here to inspect, but the document
     can be used as-is multiple times over to retry a potential submission
     failure (so there shouldn't be any need to inspect it).
@@ -35,13 +35,15 @@ class TransferData(dict):
     documentation for example usage.
     """
     def __init__(self, transfer_client, source_endpoint, destination_endpoint,
-                 label=None, sync_level=None, verify_checksum=False,
-                 preserve_timestamp=False, encrypt_data=False, **kwargs):
+                 label=None, submission_id=None, sync_level=None,
+                 verify_checksum=False, preserve_timestamp=False,
+                 encrypt_data=False, **kwargs):
         source_endpoint = safe_stringify(source_endpoint)
         destination_endpoint = safe_stringify(destination_endpoint)
         logger.info("Creating a new TransferData object")
         self["DATA_TYPE"] = "transfer"
-        self["submission_id"] = transfer_client.get_submission_id()["value"]
+        self["submission_id"] = submission_id or \
+            transfer_client.get_submission_id()["value"]
         logger.info("TransferData.submission_id = {}"
                     .format(self["submission_id"]))
         self["source_endpoint"] = source_endpoint
@@ -112,7 +114,7 @@ class DeleteData(dict):
     At least one item must be added using
     :meth:`add_item <globus_sdk.DeleteData.add_item>`.
 
-    Includes fetching the submission ID as part of document generation. The
+    If ``submission_id`` isn't passed, one will be fetched automatically. The
     submission ID can be pulled out of here to inspect, but the document
     can be used as-is multiple times over to retry a potential submission
     failure (so there shouldn't be any need to inspect it).
@@ -121,11 +123,12 @@ class DeleteData(dict):
     documentation for example usage.
     """
     def __init__(self, transfer_client, endpoint, label=None,
-                 recursive=False, **kwargs):
+                 submission_id=None, recursive=False, **kwargs):
         endpoint = safe_stringify(endpoint)
         logger.info("Creating a new DeleteData object")
         self["DATA_TYPE"] = "delete"
-        self["submission_id"] = transfer_client.get_submission_id()["value"]
+        self["submission_id"] = submission_id or \
+            transfer_client.get_submission_id()["value"]
         logger.info("DeleteData.submission_id = {}"
                     .format(self["submission_id"]))
         self["endpoint"] = endpoint


### PR DESCRIPTION
When constructing a `TransferData` or `DeleteData` instance, if the caller supplies us with a `submission_id` that they already obtained, do not fetch another one.

Additionally, allow callers to pass `submission_id=None` explicitly to signal that they need a submission ID.

Closes #80.

---

```
(.venv3) ~/Repos/globus-sdk$ python
Python 3.5.2 (default, Jun 28 2016, 08:46:01) 
[GCC 6.1.1 20160602] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from globus_sdk import TransferClient, TransferData
>>> 
>>> tc = TransferClient()
>>> tc.get_submission_id = lambda: print("\nget_submission_id() was called!\n") or \
...                                {'value': '99999999-9999-9999-9999-999999999999'}
>>> 
>>> TransferData(transfer_client=tc,
...              submission_id='c0ffeec0ff-eec0-ffee-c0ff-eec0ffeec0ff',
...              source_endpoint='00000000-0000-0000-0000-000000000000',
...              destination_endpoint='00000000-0000-0000-0000-000000000000')
{'destination_endpoint': '00000000-0000-0000-0000-000000000000', 'DATA_TYPE': 'transfer', 'submission_id': 'c0ffeec0ff-eec0-ffee-c0ff-eec0ffeec0ff', 'verify_checksum': False, 'preserve_timestamp': False, 'encrypt_data': False, 'DATA': [], 'source_endpoint': '00000000-0000-0000-0000-000000000000'}
>>> 
>>> TransferData(transfer_client=tc,
...              source_endpoint='00000000-0000-0000-0000-000000000000',
...              destination_endpoint='00000000-0000-0000-0000-000000000000')

get_submission_id() was called!

{'destination_endpoint': '00000000-0000-0000-0000-000000000000', 'DATA_TYPE': 'transfer', 'submission_id': '99999999-9999-9999-9999-999999999999', 'verify_checksum': False, 'preserve_timestamp': False, 'encrypt_data': False, 'DATA': [], 'source_endpoint': '00000000-0000-0000-0000-000000000000'}
>>> 
>>> TransferData(transfer_client=tc,
...              submission_id=None,
...              source_endpoint='00000000-0000-0000-0000-000000000000',
...              destination_endpoint='00000000-0000-0000-0000-000000000000')

get_submission_id() was called!

{'destination_endpoint': '00000000-0000-0000-0000-000000000000', 'DATA_TYPE': 'transfer', 'submission_id': '99999999-9999-9999-9999-999999999999', 'verify_checksum': False, 'preserve_timestamp': False, 'encrypt_data': False, 'DATA': [], 'source_endpoint': '00000000-0000-0000-0000-000000000000'}
>>> 
