### PR TITLE
Handle missing Content-Type in headers

### DIFF
--- a/globus_sdk/exc.py
+++ b/globus_sdk/exc.py
@@ -22,10 +22,12 @@ class GlobusAPIError(GlobusError):
                    useful to developers, but there may be cases where it's
                    suitable for display to end users.
     """
+
     def __init__(self, r, *args, **kw):
         self._underlying_response = r
         self.http_status = r.status_code
-        if "application/json" in r.headers["Content-Type"]:
+        if "Content-Type" in r.headers and (
+                "application/json" in r.headers["Content-Type"]):
             logger.debug(('Content-Type on error is application/json. '
                           'Doing error load from JSON'))
             try:


### PR DESCRIPTION
In the case where Content-Type is completely missing from response
headers, the test for Content-Type value is failing. Check for presence
of Content-Type in the headers before checking for the value in the
Content-Type header.

I've actually seen this behavior (at least in an error condition) on a response from a server.