### PR TITLE
Add an always_activated property to the activation response

### DIFF
--- a/globus_sdk/transfer/response/activation.py
+++ b/globus_sdk/transfer/response/activation.py
@@ -139,3 +139,13 @@ class ActivationRequirementsResponse(TransferResponse):
             return (time.time() + time_seconds) < self.expires_at
         else:
             return time_seconds < self.expires_at
+
+    @property
+    def always_activated(self):
+        """
+        Returns True if the endpoint activation never expires
+        (e.g. shared endpoints, globus connect personal endpoints).
+
+        :rtype: ``bool``
+        """
+        return self["expires_in"] == -1


### PR DESCRIPTION
* Adds an `always_activated` property that will be `True` if the endpoint is always activated (e.g., shared or GCP endpoints).

Closes #86