### PR TITLE
Add raw_{json,text} properties to GlobusAPIError

### DIFF
--- a/globus_sdk/exc.py
+++ b/globus_sdk/exc.py
@@ -45,6 +45,28 @@ class GlobusAPIError(GlobusError):
         args = self._get_args()
         GlobusError.__init__(self, *args)
 
+    @property
+    def raw_json(self):
+        """
+        Get the verbatim error message received from a Globus API, interpreted
+        as a JSON string and evaluated as a *dict*
+
+        If the body cannot be loaded as JSON, this is None
+        """
+        r = self._underlying_response
+        if "Content-Type" in r.headers and (
+                "application/json" in r.headers["Content-Type"]):
+            return r.json()
+        else:
+            return None
+
+    @property
+    def raw_text(self):
+        """
+        Get the verbatim error message receved from a Globus API as a *string*
+        """
+        return self._underlying_response.text
+
     def _get_args(self):
         """
         Get arguments to pass to the Exception base class. These args are


### PR DESCRIPTION
These are very simple passthrough properties that access the underlying
response data and either load it as JSON or return it as a string. This
way, it's not awkward or difficult to get at the "raw" data from the
APIs.

Resolves #107 

Dave :+1:ed #107, so I'm assigning to him.