### PR TITLE
Transfer client submission documentation

### DIFF
--- a/globus_sdk/transfer/client.py
+++ b/globus_sdk/transfer/client.py
@@ -976,7 +976,7 @@ class TransferClient(BaseClient):
 
         See
         `Submit a transfer task \
-        <https://docs.globus.org/api/transfer/task_submit/#submit_a_transfer_task>`_
+        <https://docs.globus.org/api/transfer/task_submit/#submit_transfer_task>`_
         in the REST documentation for more details.
         """
         self.logger.info("TransferClient.submit_transfer(...)")
@@ -1005,7 +1005,7 @@ class TransferClient(BaseClient):
 
         See
         `Submit a delete task \
-        <https://docs.globus.org/api/transfer/task_submit/#submit_a_delete_task>`_
+        <https://docs.globus.org/api/transfer/task_submit/#submit_delete_task>`_
         in the REST documentation for details.
         """
         self.logger.info("TransferClient.submit_delete(...)")

--- a/globus_sdk/transfer/client.py
+++ b/globus_sdk/transfer/client.py
@@ -944,6 +944,22 @@ class TransferClient(BaseClient):
 
         :rtype: :class:`TransferResponse
                 <globus_sdk.transfer.response.TransferResponse>`
+
+        Submission IDs are required to submit tasks to the Transfer service
+        via the :meth:`submit_transfer <.submit_transfer>` and
+        :meth:`submit_delete <.submit_delete>` methods.
+
+        Most users will not need to call this method directly, as the
+        convenience classes :class:`TransferData <globus_sdk.TransferData>`
+        and :class:`DeleteData <globus_sdk.DeleteData>` will call it
+        automatically if they are not passed a ``submission_id`` explicitly.
+
+        **External Documentation**
+
+        See
+        `Get a submission id \
+        <https://docs.globus.org/api/transfer/task_submit/#get_submission_id>`_
+        in the REST documentation for more details.
         """
         self.logger.info("TransferClient.get_submission_id({})".format(params))
         return self.get("submission_id", params=params)


### PR DESCRIPTION
Fixes two broken links and expands the documentation for `get_submission_id()`.

Fixes #115.
