### PR TITLE
Add python 3.6 to test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,11 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
-  - "3.5-dev"
+  - "3.6"
+  - "3.6-dev"
 matrix:
   allow_failures:
-    - python: "3.5-dev"
+    - python: "3.6-dev"
 install:
   - pip install .
   - pip install -r test-requirements.txt


### PR DESCRIPTION
Looks like python 3.6 is available in Travis now. Adding that and `3.6-dev` as an allowed failure seems reasonable?