### PR TITLE
Add appveyor config

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,47 @@
+environment:
+  matrix:
+    # Appveyor may upgrade python to new point releases
+    # See: http://www.appveyor.com/docs/installed-software#python
+
+    - PYTHON: "C:\\Python27"
+      PYTHON_VERSION: "2.7.x"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python27-x64"
+      PYTHON_VERSION: "2.7.x"
+      PYTHON_ARCH: "64"
+
+    - PYTHON: "C:\\Python33"
+      PYTHON_VERSION: "3.3.x"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python33-x64"
+      PYTHON_VERSION: "3.3.x"
+      PYTHON_ARCH: "64"
+
+    - PYTHON: "C:\\Python34"
+      PYTHON_VERSION: "3.4.x"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python34-x64"
+      PYTHON_VERSION: "3.4.x"
+      PYTHON_ARCH: "64"
+
+    - PYTHON: "C:\\Python35"
+      PYTHON_VERSION: "3.5.x"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python35-x64"
+      PYTHON_VERSION: "3.5.x"
+      PYTHON_ARCH: "64"
+
+install:
+  - "pip install ."
+  - "pip install -r test-requirements.txt"
+
+test_script:
+  - "flake8"
+  - "nose2"
+
+build: off
+deploy: off


### PR DESCRIPTION
Hopefully correct. Turn off appveyor build and deploy steps, just run tests.

Seems to be working to get us windows testing. Addresses #26 and part of #105 

I think this is all that we need?
I setup the appveyor integration under my personal account ( https://ci.appveyor.com/project/sirosen/globus-sdk-python ).

If someone wants to jump through the surprisingly painful looking hoops to wire up the organization, feel free, but I'm not bothering.