### PR TITLE
Improve builds on AppVeyor; add pypy builds to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,16 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  # allow failures on CPython dev and pypy
+  # we want to be warned about these, but they aen't critical
   - "3.6-dev"
+  - "pypy"
+  - "pypy3"
 matrix:
   allow_failures:
     - python: "3.6-dev"
+    - python: "pypy"
+    - python: "pypy3"
 install:
   - pip install .
   - pip install -r test-requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 sudo: false
-dist: trusty
 language: python
 python:
   - "2.7"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,46 +2,24 @@ environment:
   matrix:
     # Appveyor may upgrade python to new point releases
     # See: http://www.appveyor.com/docs/installed-software#python
-
     - PYTHON: "C:\\Python27"
-      PYTHON_VERSION: "2.7.x"
-      PYTHON_ARCH: "32"
-
     - PYTHON: "C:\\Python27-x64"
-      PYTHON_VERSION: "2.7.x"
-      PYTHON_ARCH: "64"
-
-    - PYTHON: "C:\\Python33"
-      PYTHON_VERSION: "3.3.x"
-      PYTHON_ARCH: "32"
-
     - PYTHON: "C:\\Python33-x64"
-      PYTHON_VERSION: "3.3.x"
-      PYTHON_ARCH: "64"
-
-    - PYTHON: "C:\\Python34"
-      PYTHON_VERSION: "3.4.x"
-      PYTHON_ARCH: "32"
-
     - PYTHON: "C:\\Python34-x64"
-      PYTHON_VERSION: "3.4.x"
-      PYTHON_ARCH: "64"
-
-    - PYTHON: "C:\\Python35"
-      PYTHON_VERSION: "3.5.x"
-      PYTHON_ARCH: "32"
-
     - PYTHON: "C:\\Python35-x64"
-      PYTHON_VERSION: "3.5.x"
-      PYTHON_ARCH: "64"
+    - PYTHON: "C:\\Python36-x64"
 
 install:
-  - "pip install ."
-  - "pip install -r test-requirements.txt"
+  # invoke python explicitly, and wrap it in build.cmd so that compilation of
+  # C-extensions uses the correct python
+  # for reference: https://packaging.python.org/appveyor/
+  - "build.cmd %PYTHON%\\python.exe -m pip install ."
+  - "build.cmd %PYTHON%\\python.exe -m pip install -r test-requirements.txt"
 
 test_script:
-  - "flake8"
-  - "nose2"
+  # explicitly invoke under the build environment's python
+  - "%PYTHON%\\python.exe -m flake8"
+  - "%PYTHON%\\python.exe -m nose2"
 
 build: off
 deploy: off

--- a/build.cmd
+++ b/build.cmd
@@ -1,0 +1,25 @@
+:: Taken from packaging.python.org,
+:: see: https://github.com/pypa/python-packaging-user-guide
+::      https://github.com/pypa/python-packaging-user-guide/blob/master/source/code/build.cmd
+
+@echo off
+:: To build extensions for 64 bit Python 3, we need to configure environment
+:: variables to use the MSVC 2010 C++ compilers from GRMSDKX_EN_DVD.iso of:
+:: MS Windows SDK for Windows 7 and .NET Framework 4
+::
+:: More details at:
+:: https://github.com/cython/cython/wiki/64BitCythonExtensionsOnWindows
+
+IF "%DISTUTILS_USE_SDK%"=="1" (
+    ECHO Configuring environment to build with MSVC on a 64bit architecture
+    ECHO Using Windows SDK 7.1
+    "C:\Program Files\Microsoft SDKs\Windows\v7.1\Setup\WindowsSdkVer.exe" -q -version:v7.1
+    CALL "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64 /release
+    SET MSSdk=1
+    REM Need the following to allow tox to see the SDK compiler
+    SET TOX_TESTENV_PASSENV=DISTUTILS_USE_SDK MSSdk INCLUDE LIB
+) ELSE (
+    ECHO Using default MSVC build environment
+)
+
+CALL %*

--- a/tests/manual_tools/clean_sdk_test_assets.py
+++ b/tests/manual_tools/clean_sdk_test_assets.py
@@ -56,7 +56,7 @@ def clean():
         r = tc.operation_ls(ep_id)
         for item in r:
             ddata.add_item("/~/" + item["name"])
-            print ("deleting {}: {}".format(item["type"], item["name"]))
+            print("deleting {}: {}".format(item["type"], item["name"]))
             file_deletions += 1
         if len(ddata["DATA"]):
             r = tc.submit_delete(ddata)
@@ -67,7 +67,7 @@ def clean():
     r = tc.bookmark_list()
     for bookmark in r:
         tc.delete_bookmark(bookmark["id"])
-        print ("deleting bookmark: {}".format(bookmark["name"]))
+        print("deleting bookmark: {}".format(bookmark["name"]))
         bookmark_deletions += 1
 
     # clean endpoints owned by SDK Tester
@@ -75,7 +75,7 @@ def clean():
     r = tc.endpoint_search(filter_scope="my-endpoints")
     for ep in r:
         tc.delete_endpoint(ep["id"])
-        print ("deleting endpoint: {}".format(ep["display_name"]))
+        print("deleting endpoint: {}".format(ep["display_name"]))
         endpoint_deletions += 1
 
     # wait for deletes to complete

--- a/tests/unit/test_paging.py
+++ b/tests/unit/test_paging.py
@@ -1,5 +1,6 @@
 import requests
 import json
+import six
 
 from tests.framework import (CapturedIOTestCase)
 from globus_sdk.transfer.paging import PaginatedResource
@@ -31,7 +32,7 @@ class PagingSimulator(object):
 
         # make the simulated response
         response = requests.Response()
-        response._content = bytes(json.dumps(data))
+        response._content = six.b(json.dumps(data))
         response.headers["Content-Type"] = "application/json"
         return IterableTransferResponse(response)
 
@@ -92,7 +93,7 @@ class PaginatedResourceTests(CapturedIOTestCase):
 
         generator = pr.iterable_func()
         for i in range(self.n):
-            self.assertEqual(generator.next()["value"], i)
+            self.assertEqual(next(generator)["value"], i)
 
         with self.assertRaises(StopIteration):
-            generator.next()
+            next(generator)

--- a/tests/unit/test_transfer_client.py
+++ b/tests/unit/test_transfer_client.py
@@ -416,7 +416,7 @@ class TransferClientTests(BaseTransferClientTests):
 
         # get role id from role list, assumes admin id is first
         list_doc = self.tc.endpoint_role_list(self.test_ep_id)
-        role_id = iter(list_doc["DATA"]).next()["id"]
+        role_id = next(iter(list_doc["DATA"]))["id"]
 
         # get the role by its id
         get_doc = self.tc.get_endpoint_role(self.test_ep_id, role_id)
@@ -441,7 +441,7 @@ class TransferClientTests(BaseTransferClientTests):
 
         # get role id from role list
         list_doc = self.tc.endpoint_role_list(self.test_ep_id)
-        role_id = iter(list_doc["DATA"]).next()["id"]
+        role_id = next(iter(list_doc["DATA"]))["id"]
 
         with self.assertRaises(TransferAPIError) as apiErr:
             self.tc.delete_endpoint_role(self.test_ep_id, role_id)
@@ -654,7 +654,7 @@ class TransferClientTests(BaseTransferClientTests):
         self.assertEqual(filter_doc["endpoint"], GO_EP1_ID)
         self.assertEqual(filter_doc["path"], path)
         # confirm only file 3 was returned
-        file_data = iter(filter_doc["DATA"]).next()
+        file_data = next(iter(filter_doc["DATA"]))
         self.assertEqual(file_data["name"], file_name)
         self.assertTrue(file_data["size"] > min_size)
 


### PR DESCRIPTION
As soon as I added the Appveyor build, I was bothered by how slow it is. Too slow!
I wanted to make it faster, so I looked into parallelization features.
Good thing the tests are now concurrency-safe! They have to be if two independent CI servers will run them.
Unfortunately, Appveyor doesn't do parallel builds on free repos.

Two main angles of attack: do parallel builds on Travis, reduce the number of versions we cover on Appveyor.

With Travis, because we can do parallel builds, we use the build matrix feature. While we're add it, add pypy builds and allow failure to get some extra coverage.

In the case of Appveyor, remove all of the Python3 on 32-bit builds. We'll keep the 2.7 on 32-bit build so that we hit a 32 bit machine at some point, but if you're running py3 on a non-64-bit box, that's pretty unusual. I think this is okay to drop.
Additionally, simplify the Appveyor config per direction given by packaging.python.org