### PR TITLE
Clean .globus files older than an hour. Also a few minor python 3 compatability changes

### DIFF
--- a/tests/manual_tools/clean_sdk_test_assets.py
+++ b/tests/manual_tools/clean_sdk_test_assets.py
@@ -56,7 +56,7 @@ def clean():
         r = tc.operation_ls(ep_id)
         for item in r:
             ddata.add_item("/~/" + item["name"])
-            print ("deleting {}: {}".format(item["type"], item["name"]))
+            print("deleting {}: {}".format(item["type"], item["name"]))
             file_deletions += 1
         if len(ddata["DATA"]):
             r = tc.submit_delete(ddata)
@@ -67,7 +67,7 @@ def clean():
     r = tc.bookmark_list()
     for bookmark in r:
         tc.delete_bookmark(bookmark["id"])
-        print ("deleting bookmark: {}".format(bookmark["name"]))
+        print("deleting bookmark: {}".format(bookmark["name"]))
         bookmark_deletions += 1
 
     # clean endpoints owned by SDK Tester
@@ -75,7 +75,7 @@ def clean():
     r = tc.endpoint_search(filter_scope="my-endpoints")
     for ep in r:
         tc.delete_endpoint(ep["id"])
-        print ("deleting endpoint: {}".format(ep["display_name"]))
+        print("deleting endpoint: {}".format(ep["display_name"]))
         endpoint_deletions += 1
 
     # wait for deletes to complete

--- a/tests/unit/test_paging.py
+++ b/tests/unit/test_paging.py
@@ -1,5 +1,6 @@
 import requests
 import json
+import six
 
 from tests.framework import (CapturedIOTestCase)
 from globus_sdk.transfer.paging import PaginatedResource
@@ -31,7 +32,7 @@ class PagingSimulator(object):
 
         # make the simulated response
         response = requests.Response()
-        response._content = bytes(json.dumps(data))
+        response._content = six.b(json.dumps(data))
         response.headers["Content-Type"] = "application/json"
         return IterableTransferResponse(response)
 
@@ -92,7 +93,7 @@ class PaginatedResourceTests(CapturedIOTestCase):
 
         generator = pr.iterable_func()
         for i in range(self.n):
-            self.assertEqual(generator.next()["value"], i)
+            self.assertEqual(six.next(generator)["value"], i)
 
         with self.assertRaises(StopIteration):
-            generator.next()
+            six.next(generator)

--- a/tests/unit/test_transfer_client.py
+++ b/tests/unit/test_transfer_client.py
@@ -24,9 +24,7 @@ def setUpModule():
     path = "~/.globus/sharing/"
     hour_ago = datetime.utcnow() - timedelta(hours=1)
     filter_string = "last_modified:," + hour_ago.strftime("%Y-%m-%d %H:%M:%S")
-
-    ls_params = {"path": path, "filter": filter_string}
-    old_files = tc.operation_ls(GO_EP1_ID, **ls_params)
+    old_files = tc.operation_ls(GO_EP1_ID, path=path, filter=filter_string)
 
     kwargs = {"notify_on_succeeded": False, "notify_on_fail": False}
     ddata = globus_sdk.DeleteData(tc, GO_EP1_ID, **kwargs)

--- a/tests/unit/test_transfer_client.py
+++ b/tests/unit/test_transfer_client.py
@@ -1,4 +1,6 @@
 from random import getrandbits
+from datetime import datetime, timedelta
+
 import globus_sdk
 from tests.framework import (CapturedIOTestCase, get_client_data,
                              GO_EP1_ID, GO_EP2_ID,
@@ -6,6 +8,34 @@ from tests.framework import (CapturedIOTestCase, get_client_data,
                              SDKTESTER1A_NATIVE1_RT)
 from globus_sdk.exc import TransferAPIError
 from globus_sdk.transfer.paging import PaginatedResource
+
+
+def setUpModule():
+    """
+    Cleans out any files in ~/.globus/sharing/ on go#ep1 older than an hour
+    TODO: remove this once deleting shared directories does full cleanup
+    """
+    ac = globus_sdk.NativeAppAuthClient(
+        client_id=get_client_data()["native_app_client1"]["id"])
+    authorizer = globus_sdk.RefreshTokenAuthorizer(
+        SDKTESTER1A_NATIVE1_RT, ac)
+    tc = globus_sdk.TransferClient(authorizer=authorizer)
+
+    path = "~/.globus/sharing/"
+    hour_ago = datetime.utcnow() - timedelta(hours=1)
+    filter_string = "last_modified:," + hour_ago.strftime("%Y-%m-%d %H:%M:%S")
+
+    ls_params = {"path": path, "filter": filter_string}
+    old_files = tc.operation_ls(GO_EP1_ID, **ls_params)
+
+    kwargs = {"notify_on_succeeded": False, "notify_on_fail": False}
+    ddata = globus_sdk.DeleteData(tc, GO_EP1_ID, **kwargs)
+
+    for item in old_files:
+        ddata.add_item(path + item["name"])
+
+    if len(ddata["DATA"]):
+        tc.submit_delete(ddata)
 
 
 # class that has setUp and tearDown for all transfer client testing classes
@@ -29,6 +59,7 @@ class BaseTransferClientTests(CapturedIOTestCase):
         Creates a list for tracking cleanup of assets created during testing
         Sets up a test endpoint
         """
+        super(BaseTransferClientTests, self).setUp()
         # list of dicts, each containing a function and a list of args
         # to pass to that function s.t. calling f(*args) cleans an asset
         self.asset_cleanup = []
@@ -46,6 +77,7 @@ class BaseTransferClientTests(CapturedIOTestCase):
         """
         Parses created_assets to destroy all assets created during testing
         """
+        super(BaseTransferClientTests, self).tearDown()
         # call the cleanup functions with the arguments they were given
         for cleanup in self.asset_cleanup:
             cleanup["function"](*cleanup["args"])
@@ -416,7 +448,7 @@ class TransferClientTests(BaseTransferClientTests):
 
         # get role id from role list, assumes admin id is first
         list_doc = self.tc.endpoint_role_list(self.test_ep_id)
-        role_id = iter(list_doc["DATA"]).next()["id"]
+        role_id = list_doc["DATA"][0]["id"]
 
         # get the role by its id
         get_doc = self.tc.get_endpoint_role(self.test_ep_id, role_id)
@@ -441,7 +473,7 @@ class TransferClientTests(BaseTransferClientTests):
 
         # get role id from role list
         list_doc = self.tc.endpoint_role_list(self.test_ep_id)
-        role_id = iter(list_doc["DATA"]).next()["id"]
+        role_id = list_doc["DATA"][0]["id"]
 
         with self.assertRaises(TransferAPIError) as apiErr:
             self.tc.delete_endpoint_role(self.test_ep_id, role_id)
@@ -654,7 +686,7 @@ class TransferClientTests(BaseTransferClientTests):
         self.assertEqual(filter_doc["endpoint"], GO_EP1_ID)
         self.assertEqual(filter_doc["path"], path)
         # confirm only file 3 was returned
-        file_data = iter(filter_doc["DATA"]).next()
+        file_data = filter_doc["DATA"][0]
         self.assertEqual(file_data["name"], file_name)
         self.assertTrue(file_data["size"] > min_size)
 


### PR DESCRIPTION
Took a little more fiddling with timezones than I was expecting, but seems to be working after testing on some shared dirs I made before lunch.

Also I confirmed on the globus transfer web app that deleting a shared endpoint does not clean up ~/.globus/sharing. Should this issue be tracked somewhere?