### PR TITLE
Unit tests for base.py, config.py, exc.py, and response.py

### DIFF
--- a/tests/files/sample_configs/get_test.cfg
+++ b/tests/files/sample_configs/get_test.cfg
@@ -1,0 +1,10 @@
+[general]
+option = general_value
+
+[section]
+option = section_value
+
+[environment section]
+option = environment_value
+
+[nonexistant]

--- a/tests/files/sample_configs/ssl_test.cfg
+++ b/tests/files/sample_configs/ssl_test.cfg
@@ -1,0 +1,12 @@
+[general]
+
+[environment true]
+ssl_verify = true
+
+[environment false]
+ssl_verify = false
+
+[environment invalid]
+ssl_verify = invalid
+
+[environment nonexistant]

--- a/tests/files/sample_configs/url_test.cfg
+++ b/tests/files/sample_configs/url_test.cfg
@@ -1,0 +1,11 @@
+[general]
+
+[environment default]
+auth_service = https://auth.globus.org/
+transfer_service = https://transfer.api.globusonline.org/
+
+[environment beta]
+auth_service = https://auth.beta.globus.org/
+transfer_service = https://transfer.api.beta.globus.org/
+
+[environment nonexistant]

--- a/tests/unit/test_base_client.py
+++ b/tests/unit/test_base_client.py
@@ -1,0 +1,294 @@
+import six
+import logging
+from random import getrandbits
+
+import globus_sdk
+from globus_sdk.base import (BaseClient, safe_stringify,
+                             slash_join, merge_params)
+from tests.framework import (CapturedIOTestCase, get_client_data,
+                             SDKTESTER1A_NATIVE1_RT)
+from globus_sdk.exc import GlobusAPIError
+
+
+class BaseClientTests(CapturedIOTestCase):
+
+    @classmethod
+    def setUpClass(self):
+        """
+        Creates a BaseClient object for testing
+        """
+        ac = globus_sdk.NativeAppAuthClient(
+            client_id=get_client_data()["native_app_client1"]["id"])
+        authorizer = globus_sdk.RefreshTokenAuthorizer(
+            SDKTESTER1A_NATIVE1_RT, ac)
+        self.bc = BaseClient("transfer", base_path="/v0.10/",
+                             authorizer=authorizer)
+
+    def setUp(self):
+        """
+        Creates a list for tracking cleanup of assets created during testing
+        Sets up a test endpoint
+        """
+        super(BaseClientTests, self).setUp()
+
+        # list of dicts, each containing a function and a list of args
+        # to pass to that function s.t. calling f(*args) cleans an asset
+        self.asset_cleanup = []
+
+        # set up test endpoint
+        # name randomized to prevent collision
+        data = {"display_name": "Base Test Endpoint-" + str(getrandbits(128))}
+        r = self.bc.post("endpoint", data)
+        self.test_ep_id = safe_stringify(r["id"])
+        # track asset for cleanup
+        path = self.bc.qjoin_path("endpoint", self.test_ep_id)
+        self.asset_cleanup.append({"function": self.bc.delete,
+                                   "args": [path],
+                                   "name": "test_ep"})  # for ease of removal
+
+    def tearDown(self):
+        """
+        Parses asset_cleanup to destroy all assets created during testing
+        """
+        super(BaseClientTests, self).tearDown()
+        # call the cleanup functions with the arguments they were given
+        for cleanup in self.asset_cleanup:
+            cleanup["function"](*cleanup["args"])
+
+    def test_client_log_adapter(self):
+        """
+        Logs a test message with the base client's logger,
+        Confirms the ClientLogAdapter marks the message with the client
+        """
+        # make a MemoryHandler for capturing the log in a buffer)
+        memory_handler = logging.handlers.MemoryHandler(1028)
+        self.bc.logger.logger.addHandler(memory_handler)
+        # send the test message
+        in_msg = "Testing ClientLogAdapter"
+        self.bc.logger.info(in_msg)
+        # confirm results
+        out_msg = memory_handler.buffer[0].getMessage()
+        expected_msg = "[instance:{}] {}".format(id(self.bc), in_msg)
+        self.assertEqual(expected_msg, out_msg)
+
+        memory_handler.close()
+        self.bc.logger.logger.removeHandler(memory_handler)
+
+    def test_set_app_name(self):
+        """
+        Sets app name, confirms results
+        """
+        # set app name
+        app_name = "SDK Test"
+        self.bc.set_app_name(app_name)
+        # confirm results
+        self.assertEqual(self.bc.app_name, app_name)
+        self.assertEqual(self.bc._headers['User-Agent'],
+                         '{0}/{1}'.format(self.bc.BASE_USER_AGENT, app_name))
+
+    def test_qjoin_path(self):
+        """
+        Calls qjoin on parts to form a path, confirms results
+        """
+        parts = ["SDK", "Test", "Path", "Items"]
+        path = self.bc.qjoin_path(*parts)
+        self.assertEqual(path, "/SDK/Test/Path/Items")
+
+    def test_get(self):
+        """
+        Gets test endpoint, verifies results
+        Sends nonsense get, confirms 404
+        Sends get to non-get resource, confirms 405
+        """
+        # get test endpoint
+        path = self.bc.qjoin_path("endpoint", self.test_ep_id)
+        get_res = self.bc.get(path)
+        # validate results
+        self.assertIn("display_name", get_res)
+        self.assertIn("canonical_name", get_res)
+        self.assertEqual(get_res["DATA_TYPE"], "endpoint")
+        self.assertEqual(get_res["id"], self.test_ep_id)
+
+        # send nonsense get
+        with self.assertRaises(GlobusAPIError) as apiErr:
+            self.bc.get("nonsense_path")
+        self.assertEqual(apiErr.exception.http_status, 404)
+        self.assertEqual(apiErr.exception.code, "ClientError.NotFound")
+
+        # send get to endpoint without id (post resource)
+        with self.assertRaises(GlobusAPIError) as apiErr:
+            self.bc.get("endpoint")
+        self.assertEqual(apiErr.exception.http_status, 405)
+        self.assertEqual(apiErr.exception.code, "ClientError.BadMethod")
+
+    def test_post(self):
+        """
+        Makes a test endpoint, verifies results
+        Sends nonsense post, confirms 404
+        Sends post without data, confirms 400
+        Sends post to non-post resource, confirms 405
+        """
+        # post to create a new endpoint, name randomized to prevent collision
+        post_data = {"display_name": "Post Test-" + str(getrandbits(128))}
+        post_res = self.bc.post("endpoint", post_data)
+        # validate results
+        self.assertIn("id", post_res)
+        self.assertEqual(post_res["DATA_TYPE"], "endpoint_create_result")
+        self.assertEqual(post_res["code"], "Created")
+        self.assertEqual(post_res["message"], "Endpoint created successfully")
+        # track asset for cleanup
+        path = self.bc.qjoin_path("endpoint", safe_stringify(post_res["id"]))
+        self.asset_cleanup.append({"function": self.bc.delete, "args": [path]})
+
+        # send nonsense post
+        with self.assertRaises(GlobusAPIError) as apiErr:
+            self.bc.post("nonsense_path")
+        self.assertEqual(apiErr.exception.http_status, 404)
+        self.assertEqual(apiErr.exception.code, "ClientError.NotFound")
+
+        # send post without data
+        with self.assertRaises(GlobusAPIError) as apiErr:
+            self.bc.post("endpoint")
+        self.assertEqual(apiErr.exception.http_status, 400)
+        self.assertEqual(apiErr.exception.code, "BadRequest")
+
+        # send post to endpoint with id (get/delete resource)
+        with self.assertRaises(GlobusAPIError) as apiErr:
+            path = self.bc.qjoin_path("endpoint", self.test_ep_id)
+            self.bc.post(path)
+        self.assertEqual(apiErr.exception.http_status, 405)
+        self.assertEqual(apiErr.exception.code, "ClientError.BadMethod")
+
+    def test_delete(self):
+        """
+        Deletes the test endpoint, verifies results
+        Confirms trying to delete non existent items raises 404
+        Sends nonsense delete, confirms 404
+        Sends delete to non-delete resource, confirms 405
+        """
+        # delete the test endpoint
+        path = self.bc.qjoin_path("endpoint", self.test_ep_id)
+        del_res = self.bc.delete(path)
+        # validate results
+        self.assertEqual(del_res["DATA_TYPE"], "result")
+        self.assertEqual(del_res["code"], "Deleted")
+        self.assertEqual(del_res["message"],
+                         "Endpoint deleted successfully")
+        # stop tracking asset for cleanup
+        for cleanup in self.asset_cleanup:
+            if "name" in cleanup and cleanup["name"] == "test_ep":
+                self.asset_cleanup.remove(cleanup)
+                break
+
+        # attempt to delete the test endpoint again
+        with self.assertRaises(GlobusAPIError) as apiErr:
+            self.bc.delete(path)
+        self.assertEqual(apiErr.exception.http_status, 404)
+        self.assertEqual(apiErr.exception.code, "EndpointNotFound")
+
+        # send nonsense delete
+        with self.assertRaises(GlobusAPIError) as apiErr:
+            self.bc.delete("nonsense_path")
+        self.assertEqual(apiErr.exception.http_status, 404)
+        self.assertEqual(apiErr.exception.code, "ClientError.NotFound")
+
+        # send delete to endpoint w/o id (post resource)
+        with self.assertRaises(GlobusAPIError) as apiErr:
+            self.bc.delete("endpoint")
+        self.assertEqual(apiErr.exception.http_status, 405)
+        self.assertEqual(apiErr.exception.code, "ClientError.BadMethod")
+
+    def test_put(self):
+        """
+        Updates test endpoint, verifies results
+        Sends nonsense put, confirms 404
+        Sends put without data, confirms 400
+        Sends put to non-put resource, confirms 405
+        """
+        # update test endpoint with put, name randomized to prevent collision
+        put_data = {"display_name": "Put Test-" + str(getrandbits(128))}
+        path = self.bc.qjoin_path("endpoint", self.test_ep_id)
+        put_res = self.bc.put(path, put_data)
+        # validate results
+        self.assertEqual(put_res["DATA_TYPE"], "result")
+        self.assertEqual(put_res["code"], "Updated")
+        self.assertEqual(put_res["message"], "Endpoint updated successfully")
+
+        # send nonsense put
+        with self.assertRaises(GlobusAPIError) as apiErr:
+            self.bc.put("nonsense_path")
+        self.assertEqual(apiErr.exception.http_status, 404)
+        self.assertEqual(apiErr.exception.code, "ClientError.NotFound")
+
+        # send put without data
+        with self.assertRaises(GlobusAPIError) as apiErr:
+            self.bc.put(path)
+        self.assertEqual(apiErr.exception.http_status, 400)
+        self.assertEqual(apiErr.exception.code, "BadRequest")
+
+        # send put to endpoint w/o id (post resource)
+        with self.assertRaises(GlobusAPIError) as apiErr:
+            self.bc.put("endpoint")
+        self.assertEqual(apiErr.exception.http_status, 405)
+        self.assertEqual(apiErr.exception.code, "ClientError.BadMethod")
+
+    def test_slash_join(self):
+        """
+        slash_joins a's with and without trailing "/"
+        to b's with and without leading "/"
+        Confirms all have the same correct slash_join output
+        """
+        for a in ["a", "a/"]:
+            for b in ["b", "/b"]:
+                self.assertEqual(slash_join(a, b), "a/b")
+
+    def test_merge_params(self):
+        """
+        Merges a base parameter dict with other paramaters, validates results
+        Confirms works with explicit dictionaries and arguments
+        Confirms new parameters set to None are ignored
+        Confirms new parameters overwrite old ones (is this correct?)
+        """
+
+        # explicit dictionary merging
+        params = {"param1": "value1"}
+        extra = {"param2": "value2", "param3": "value3"}
+        merge_params(params, **extra)
+        expected = {"param1": "value1", "param2": "value2", "param3": "value3"}
+        self.assertEqual(params, expected)
+
+        # arguments
+        params = {"param1": "value1"}
+        merge_params(params, param2="value2", param3="value3")
+        expected = {"param1": "value1", "param2": "value2", "param3": "value3"}
+        self.assertEqual(params, expected)
+
+        # ignoring parameters set to none
+        params = {"param1": "value1"}
+        merge_params(params, param2=None, param3=None)
+        expected = {"param1": "value1"}
+        self.assertEqual(params, expected)
+
+        # existing parameters
+        params = {"param": "value"}
+        merge_params(params, param="newValue")
+        expected = {"param": "newValue"}
+        self.assertEqual(params, expected)
+
+    def test_safe_stringify(self):
+        """
+        safe_stringifies strings, bytes, explicit unicode, an int, an object
+        and confirms safe_stringify returns utf-8 encoding for all inputs
+        """
+
+        class testObject(object):
+            def __str__(self):
+                return "1"
+
+        inputs = ["1", str(1), b"1", u"1", 1, testObject()]
+
+        # confirm each input outputs unicode
+        for value in inputs:
+            safe_value = safe_stringify(value)
+            self.assertEqual(safe_value, u"1")
+            self.assertEqual(type(safe_value), six.text_type)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,169 @@
+import os
+try:
+    import mock
+except ImportError:
+    from unittest import mock
+
+import globus_sdk
+from globus_sdk.config import GlobusConfigParser
+
+from tests.framework import get_fixture_file_dir, CapturedIOTestCase
+
+
+class ConfigParserTests(CapturedIOTestCase):
+
+    def tearDown(self):
+        super(ConfigParserTests, self).tearDown()
+        globus_sdk.config._parser = None
+
+    def _load_config_file(self, filename):
+        """
+        Uses patch to bypass normal _load_config to load filename instead
+        """
+        filename = os.path.join(
+            get_fixture_file_dir(), 'sample_configs', filename)
+
+        globus_sdk.config._parser = None
+
+        def loadconf(cfgparser):
+            cfgparser._parser.read([filename])
+
+        with mock.patch(
+                'globus_sdk.config.GlobusConfigParser._load_config', loadconf):
+            globus_sdk.config._get_parser()
+
+    def test_get_lib_config_path(self):
+        """
+        Gets the globus.cfg file path, confirms valid config file exists there
+        """
+        file_name = "globus.cfg"
+        path = globus_sdk.config._get_lib_config_path()
+        self.assertEqual(path[-(len(file_name)):], file_name)
+
+        # make sure the cfg file at least has transfer and auth services
+        with open(path, "r") as f:
+            file_text = f.read()
+            self.assertIn("transfer_service", file_text)
+            self.assertIn("auth_service", file_text)
+
+    def test_init_and_load_config(self):
+        """
+        Creates a GlobusConfigParser object, veriries that calling _load_config
+        in __init__ gets general values for the internal ConfigParser
+        """
+        globus_parser = globus_sdk.config.GlobusConfigParser()
+        general_items = globus_parser._parser.items("general")
+        self.assertNotEqual(general_items, None)
+
+    def test_get(self):
+        """
+        Confirms that get reads expected results
+        Tests section, environment, failover_to_general, and check_env params
+        """
+        self._load_config_file("get_test.cfg")
+        gcp = globus_sdk.config._get_parser()
+        os.environ["GLOBUS_SDK_OPTION"] = "os_environ_value"
+
+        # no parameters
+        self.assertEqual(gcp.get("option"), "general_value")
+        # section
+        self.assertEqual(gcp.get("option", section="section"), "section_value")
+        # environment
+        self.assertEqual(gcp.get("option", environment="section"),
+                         "environment_value")
+        # failover_to_general
+        self.assertEqual(gcp.get("option", section="nonexistant"), None)
+        self.assertEqual(gcp.get("option", section="nonexistant",
+                                 failover_to_general=True), "general_value")
+        # check_env
+        self.assertEqual(gcp.get("option", check_env=True), "os_environ_value")
+        # environment > section
+        self.assertEqual(gcp.get("option", section="section",
+                                 environment="section"), "environment_value")
+        # check_env > enviroment
+        self.assertEqual(gcp.get("option", environment="section",
+                                 check_env=True), "os_environ_value")
+
+    def test_get_parser(self):
+        """
+        Confirms that at starting time _parser is none,
+        but get_parser makes and returns a valid GlobusConfigParser
+        """
+        self.assertEqual(globus_sdk.config._parser, None)
+        self.assertIsInstance(globus_sdk.config._get_parser(),
+                              GlobusConfigParser)
+        self.assertIsInstance(globus_sdk.config._parser, GlobusConfigParser)
+
+    def test_get_service_url(self):
+        """
+        Confirms get_service_url returns expected results
+        Tests environments, services, and missing values
+        """
+        self._load_config_file("url_test.cfg")
+
+        # combinations of environments and services
+        self.assertEqual(
+            globus_sdk.config.get_service_url("default", "auth"),
+            "https://auth.globus.org/")
+        self.assertEqual(
+            globus_sdk.config.get_service_url("default", "transfer"),
+            "https://transfer.api.globusonline.org/")
+        self.assertEqual(
+            globus_sdk.config.get_service_url("beta", "auth"),
+            "https://auth.beta.globus.org/")
+        self.assertEqual(
+            globus_sdk.config.get_service_url("beta", "transfer"),
+            "https://transfer.api.beta.globus.org/")
+
+        # missing values
+        self.assertEqual(
+            globus_sdk.config.get_service_url("nonexistant", "auth"), None)
+
+    def test_get_ssl_verify(self):
+        """
+        Confirms get_ssl_verify returns expected results
+        Tests true/false, and invalid values
+        """
+        self._load_config_file("ssl_test.cfg")
+
+        # true
+        self.assertTrue(globus_sdk.config.get_ssl_verify("true"))
+        # false
+        self.assertFalse(globus_sdk.config.get_ssl_verify("false"))
+        # invalid
+        with self.assertRaises(ValueError):
+            globus_sdk.config.get_ssl_verify("invalid")
+
+    def test_bool_cast(self):
+        """
+        Confirms bool cast returns correct bools from sets off string values
+        """
+        true_vals = [str(1), str(True), "1", "YES", "true", "True", "ON"]
+        for val in true_vals:
+            self.assertTrue(globus_sdk.config._bool_cast(val))
+        false_vals = [str(0), str(False), "0", "NO", "false", "False", "OFF"]
+        for val in false_vals:
+            self.assertFalse(globus_sdk.config._bool_cast(val))
+        # invalid string
+        with self.assertRaises(ValueError):
+            globus_sdk.config._bool_cast("invalid")
+
+    def test_get_default_environ(self):
+        """
+        Confirms returns "default", or the value of GLOBUS_SDK_ENVIRONMENT
+        """
+        # default if no environ value exists
+        prev_setting = None
+        if "GLOBUS_SDK_ENVIRONMENT" in os.environ:
+            prev_setting = os.environ["GLOBUS_SDK_ENVIRONMENT"]
+            del os.environ["GLOBUS_SDK_ENVIRONMENT"]
+        self.assertEqual(globus_sdk.config.get_default_environ(), "default")
+        # otherwise environ value
+        os.environ["GLOBUS_SDK_ENVIRONMENT"] = "beta"
+        self.assertEqual(globus_sdk.config.get_default_environ(), "beta")
+
+        # cleanup for other tests
+        if prev_setting:
+            os.environ["GLOBUS_SDK_ENVIRONMENT"] = prev_setting
+        else:
+            del os.environ["GLOBUS_SDK_ENVIRONMENT"]

--- a/tests/unit/test_exc.py
+++ b/tests/unit/test_exc.py
@@ -1,0 +1,166 @@
+import requests
+import json
+import six
+
+from globus_sdk.exc import (GlobusAPIError, TransferAPIError,
+                            GlobusOptionalDependencyError)
+from tests.framework import CapturedIOTestCase
+
+
+# super class for Globus and Transfer APIError tests with shared setup
+class APIErrorTests(CapturedIOTestCase):
+
+    __test__ = False  # prevents base class from trying to run tests
+
+    def setUp(self):
+        """
+        Creates a json error response a text error response, and a malformed
+        json response for testing
+        """
+        super(APIErrorTests, self).setUp()
+
+        self.json_data = {"errors": [{"message": "json error message",
+                                      "code": "Json Error"}]}
+        self.json_response = requests.Response()
+        self.json_response._content = six.b(json.dumps(self.json_data))
+        self.json_response.headers["Content-Type"] = "application/json"
+        self.json_response.status_code = "400"
+
+        self.text_data = "error message"
+        self.text_response = requests.Response()
+        self.text_response._content = six.b(self.text_data)
+        self.text_response.headers["Content-Type"] = "text/plain"
+        self.text_response.status_code = "401"
+
+        self.malformed_response = requests.Response()
+        self.malformed_response._content = six.b("{")
+        self.malformed_response.headers["Content-Type"] = "application/json"
+        self.malformed_response.status_code = "403"
+
+
+class GlobusAPIErrorTests(APIErrorTests):
+
+    __test__ = True  # marks sub-class as having tests
+
+    def test_raw_json(self):
+        """
+        Confirms the GlobusAPIError can get raw json from the json responses,
+        and defaults to text for the text response
+        """
+        # json
+        with self.assertRaises(GlobusAPIError) as apiErr:
+            raise GlobusAPIError(self.json_response)
+        self.assertEqual(apiErr.exception.raw_json, self.json_data)
+
+        # text
+        with self.assertRaises(GlobusAPIError) as apiErr:
+            raise GlobusAPIError(self.text_response)
+        self.assertEqual(apiErr.exception.raw_json, None)
+
+        # malformed
+        with self.assertRaises(GlobusAPIError) as apiErr:
+            raise GlobusAPIError(self.malformed_response)
+        self.assertEqual(apiErr.exception.raw_json, None)
+
+    def test_raw_text(self):
+        """
+        Gets raw text from both json and text responses, confirms results
+        """
+        # json
+        with self.assertRaises(GlobusAPIError) as apiErr:
+            raise GlobusAPIError(self.json_response)
+        self.assertEqual(apiErr.exception.raw_text, json.dumps(self.json_data))
+
+        # text
+        with self.assertRaises(GlobusAPIError) as apiErr:
+            raise GlobusAPIError(self.text_response)
+        self.assertEqual(apiErr.exception.raw_text, self.text_data)
+
+    def test_get_args(self):
+        """
+        Gets args from json text and malformed responses, confirms results
+        Implicitly tests _load_from_json and _load_from_text
+        """
+
+        # json
+        with self.assertRaises(GlobusAPIError) as apiErr:
+            raise GlobusAPIError(self.json_response)
+        expected = ("400", "Json Error", "json error message")
+        self.assertEqual(apiErr.exception._get_args(), expected)
+
+        # text
+        with self.assertRaises(GlobusAPIError) as apiErr:
+            raise GlobusAPIError(self.text_response)
+        expected = ("401", "Error", "error message")
+        self.assertEqual(apiErr.exception._get_args(), expected)
+
+        # malformed
+        with self.assertRaises(GlobusAPIError) as apiErr:
+            raise GlobusAPIError(self.malformed_response)
+        expected = ("403", "Error", "{")
+        self.assertEqual(apiErr.exception._get_args(), expected)
+
+
+class TransferAPIErrorTests(APIErrorTests):
+
+    __test__ = True  # marks sub-class as having tests
+
+    def setUp(self):
+        """
+        Creates a transfer-like json response in addition to the APIError
+        setUp responses for testing
+        """
+        super(TransferAPIErrorTests, self).setUp()
+
+        self.transfer_data = {"message": "transfer error message",
+                              "code": "Transfer Error", "request_id": 123}
+        self.transfer_response = requests.Response()
+        self.transfer_response._content = six.b(json.dumps(self.transfer_data))
+        self.transfer_response.headers["Content-Type"] = "application/json"
+        self.transfer_response.status_code = "404"
+
+    def test_get_args(self):
+        """
+        Gets args from all four response types, confirms expected results
+        implicitly tests _load_from_json
+        """
+        # transfer
+        with self.assertRaises(TransferAPIError) as apiErr:
+            raise TransferAPIError(self.transfer_response)
+        expected = ("404", "Transfer Error", "transfer error message", 123)
+        self.assertEqual(apiErr.exception._get_args(), expected)
+
+        # json in wrong format
+        with self.assertRaises(TransferAPIError) as apiErr:
+            raise TransferAPIError(self.json_response)
+        expected = ("400", "Error", json.dumps(self.json_data), None)
+        self.assertEqual(apiErr.exception._get_args(), expected)
+
+        # text
+        with self.assertRaises(TransferAPIError) as apiErr:
+            raise TransferAPIError(self.text_response)
+        expected = ("401", "Error", "error message", None)
+        self.assertEqual(apiErr.exception._get_args(), expected)
+
+        # malformed json
+        with self.assertRaises(TransferAPIError) as apiErr:
+            raise TransferAPIError(self.malformed_response)
+        expected = ("403", "Error", "{", None)
+        self.assertEqual(apiErr.exception._get_args(), expected)
+
+
+class GlobusOptionalDependencyErrorTests(CapturedIOTestCase):
+
+    def test_init(self):
+        """
+        Creates a GlobusOptionalDependencyError, confirms message is set
+        """
+
+        feature_name = "feature"
+        dep_names = ["dep1", "dep2", "dep3"]
+        with self.assertRaises(GlobusOptionalDependencyError) as depErr:
+            raise GlobusOptionalDependencyError(dep_names, feature_name)
+        self.assertIn("in order to use " + feature_name,
+                      depErr.exception.message)
+        for dep in dep_names:
+            self.assertIn(dep + "\n", depErr.exception.message)

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -1,0 +1,127 @@
+import requests
+import json
+import six
+
+from globus_sdk.response import GlobusResponse, GlobusHTTPResponse
+from tests.framework import CapturedIOTestCase
+
+
+class GlobusResponseTests(CapturedIOTestCase):
+
+    def setUp(self):
+        """
+        Makes GlobusResponses wrapped around known data for testing
+        """
+        super(GlobusResponseTests, self).setUp()
+        self.dict_data = {"label1": "value1", "label2": "value2"}
+        self.dict_response = GlobusResponse(self.dict_data)
+
+        self.list_data = ["value1", "value2", "value3"]
+        self.list_response = GlobusResponse(self.list_data)
+
+    def test_data(self):
+        """
+        Gets the data from the GlobusResponses, confirms results
+        """
+        self.assertEqual(self.dict_response.data, self.dict_data)
+        self.assertEqual(self.dict_response.data, self.dict_data)
+
+    def test_str(self):
+        """
+        Confirms that individual values are seen in data
+        """
+        for item in self.dict_data:
+            self.assertTrue(item in self.dict_response)
+        self.assertFalse("nonexistant" in self.dict_response)
+
+        for item in self.list_data:
+            self.assertTrue(item in self.list_response)
+        self.assertFalse("nonexistant" in self.list_response)
+
+    def test_getitem(self):
+        """
+        Confirms that values can be accessed from the GlobusResponse
+        """
+        for key in self.dict_data:
+            self.assertEqual(self.dict_response[key], self.dict_data[key])
+
+        for i in range(len(self.list_data)):
+            self.assertEqual(self.list_response[i], self.list_data[i])
+
+    def test_contains(self):
+        """
+        Confirms that individual values are seen in the GlobusResponse
+        """
+        for item in self.dict_data:
+            self.assertTrue(item in self.dict_response)
+        self.assertFalse("nonexistant" in self.dict_response)
+
+        for item in self.list_data:
+            self.assertTrue(item in self.list_response)
+        self.assertFalse("nonexistant" in self.list_response)
+
+    def test_get(self):
+        """
+        Gets individual values from dict response, confirms results
+        Confirms list response correctly fails as non indexable
+        """
+        for item in self.dict_data:
+            self.assertEqual(self.dict_response.get(item),
+                             self.dict_data.get(item))
+
+        with self.assertRaises(AttributeError):
+            self.list_response.get("value1")
+
+
+class GlobusHTTPResponseTests(CapturedIOTestCase):
+
+    def setUp(self):
+        """
+        Makes GlobusHTTPResponses wrapped around HTTP responses for testing
+        Uses responses with well formed json, malformed json, and plain text
+        """
+        super(GlobusHTTPResponseTests, self).setUp()
+
+        # well formed json
+        self.json_data = {"label1": "value1", "label2": "value2"}
+        json_response = requests.Response()
+        json_response._content = six.b(json.dumps(self.json_data))
+        json_response.headers["Content-Type"] = "application/json"
+        self.globus_json_response = GlobusHTTPResponse(json_response)
+
+        # malformed json
+        malformed_response = requests.Response()
+        malformed_response._content = six.b("{")
+        malformed_response.headers["Content-Type"] = "application/json"
+        self.globus_malformed_response = GlobusHTTPResponse(malformed_response)
+
+        # text
+        self.text_data = "text data"
+        text_response = requests.Response()
+        text_response._content = six.b(self.text_data)
+        text_response.headers["Content-Type"] = "text/plain"
+        self.globus_text_response = GlobusHTTPResponse(text_response)
+
+    def test_data(self):
+        """
+        Gets the data from each HTTPResponse, confirms expected data from json
+        and None from malformed or plain text HTTP
+        """
+        # well formed json
+        self.assertEqual(self.globus_json_response.data, self.json_data)
+        # malformed json
+        self.assertEqual(self.globus_malformed_response.data, None)
+        # text
+        self.assertEqual(self.globus_text_response.data, None)
+
+    def test_text(self):
+        """
+        Gets the text from each HTTPResponse, confirms expected results
+        """
+        # well formed json
+        self.assertEqual(self.globus_json_response.text,
+                         json.dumps(self.json_data))
+        # malformed json
+        self.assertEqual(self.globus_malformed_response.text, "{")
+        # text
+        self.assertEqual(self.globus_text_response.text, self.text_data)

--- a/tests/unit/test_transfer_client.py
+++ b/tests/unit/test_transfer_client.py
@@ -24,7 +24,10 @@ def setUpModule():
     path = "~/.globus/sharing/"
     hour_ago = datetime.utcnow() - timedelta(hours=1)
     filter_string = "last_modified:," + hour_ago.strftime("%Y-%m-%d %H:%M:%S")
-    old_files = tc.operation_ls(GO_EP1_ID, path=path, filter=filter_string)
+    try:
+        old_files = tc.operation_ls(GO_EP1_ID, path=path, filter=filter_string)
+    except TransferAPIError:  # if a complete cleanup removed the .globus dir
+        return
 
     kwargs = {"notify_on_succeeded": False, "notify_on_fail": False}
     ddata = globus_sdk.DeleteData(tc, GO_EP1_ID, **kwargs)


### PR DESCRIPTION
I ran test_base_client.py with 16 concurrent test suites running without any errors or assets getting past cleanup, so it should still be safe to have multiple builds running.

test_config.py is an expansion of test_config_loading.py and should probably replace it at some point?

For testing exc.py I only tested exceptions that were more than a wrapper around hard-coded text as I assume those don't need tests?