### PR TITLE
AuthClient unit tests, and changes needed for them.

### DIFF
--- a/globus_sdk/auth/client_types/base.py
+++ b/globus_sdk/auth/client_types/base.py
@@ -187,7 +187,7 @@ class AuthClient(BaseClient):
         return self.current_oauth2_flow_manager.exchange_code_for_tokens(
             auth_code)
 
-    def oauth2_refresh_token(self, refresh_token):
+    def oauth2_refresh_token(self, refresh_token, additional_params=None):
         r"""
         Exchange a refresh token for a :class:`OAuthTokenResponse
         <globus_sdk.auth.token_response.OAuthTokenResponse>`, containing
@@ -213,6 +213,8 @@ class AuthClient(BaseClient):
         form_data = {'refresh_token': refresh_token,
                      'grant_type': 'refresh_token'}
 
+        if additional_params:
+            form_data.update(additional_params)
         return self.oauth2_token(form_data)
 
     def oauth2_revoke_token(self, token, additional_params=None):

--- a/tests/files/auth_fixtures/go@globusid.org.json
+++ b/tests/files/auth_fixtures/go@globusid.org.json
@@ -1,0 +1,8 @@
+{
+  "username": "go@globusid.org",
+  "name": "www.globus.org",
+  "id": "c699d42e-d274-11e5-bf75-1fc5bf53bb24",
+  "identity_provider": "41143743-f3c8-4d60-bbdb-eeecaba85bd9",
+  "organization": "Globus",
+  "email": "noreply@globus.org"
+}

--- a/tests/framework/__init__.py
+++ b/tests/framework/__init__.py
@@ -1,19 +1,21 @@
 from tests.framework.capturedio_testcase import CapturedIOTestCase
-from tests.framework.tools import get_fixture_file_dir, get_client_data
+from tests.framework.tools import (get_fixture_file_dir,
+                                   get_client_data, get_user_data)
 
-from tests.framework.constants import (
-    GO_EP1_ID, GO_EP2_ID, GO_USER_ID, SDK_USER_ID,
-    SDKTESTER1A_NATIVE1_RT)
+from tests.framework.constants import (GO_EP1_ID, GO_EP2_ID,
+                                       SDKTESTER1A_NATIVE1_TRANSFER_RT,
+                                       SDKTESTER1A_NATIVE1_AUTH_RT)
 
 __all__ = [
     "CapturedIOTestCase",
 
     "get_fixture_file_dir",
     "get_client_data",
+    "get_user_data",
 
     "GO_EP1_ID",
     "GO_EP2_ID",
-    "GO_USER_ID",
-    "SDK_USER_ID",
-    "SDKTESTER1A_NATIVE1_RT",
+
+    "SDKTESTER1A_NATIVE1_TRANSFER_RT",
+    "SDKTESTER1A_NATIVE1_AUTH_RT",
 ]

--- a/tests/framework/constants.py
+++ b/tests/framework/constants.py
@@ -1,15 +1,17 @@
 GO_EP1_ID = "ddb59aef-6d04-11e5-ba46-22000b92c6ec"
 GO_EP2_ID = "ddb59af0-6d04-11e5-ba46-22000b92c6ec"
-GO_USER_ID = "c699d42e-d274-11e5-bf75-1fc5bf53bb24"
-SDK_USER_ID = "84942ca8-17c4-4080-9036-2f58e0093869"
 
 # ------ #
 # tokens #
 # ------ #
-# sdktester1a@globusid.org refresh token for Native App 1
-SDKTESTER1A_NATIVE1_RT = (
-    "AQEAAAAAAARUURRF-ntsL5mSOpDsOblAlkyV1cbt7Sg-"
-    "dYcHxQyoPFsi_G72zf-F9zi5fTAcNHZcihj8hVhs")
+# sdktester1a@globusid.org transfer refresh token for Native App 1
+SDKTESTER1A_NATIVE1_TRANSFER_RT = (
+    "AQEAAAAAAASDACYy_O7mQx-CCTX9ZGg7FAHiv5v3bU"
+    "2b1puK1jxRXnt69ClBpJbtygAjS7BHLokxKRyRQ-7H")
+# sdktester1a@globusid.org auth refresh token for Native App 1
+SDKTESTER1A_NATIVE1_AUTH_RT = (
+    "AQEAAAAAAASC_0CX1ozEsZ-F4SjhFhMPgi-MgyxWTn"
+    "e0_Tl6Wx3HnVMO3QUnVhDx65xXrR0Y0p8mBAJWjl-R")
 # ---------- #
 # end tokens #
 # ---------- #

--- a/tests/framework/tools.py
+++ b/tests/framework/tools.py
@@ -20,3 +20,14 @@ def get_client_data():
                                fname + '.json')) as f:
             ret[fname] = json.load(f)
     return ret
+
+
+def get_user_data():
+    dirname = get_fixture_file_dir()
+    ret = {}
+    for uname in ('sdktester1a', 'go'):
+        with open(os.path.join(dirname,
+                               'auth_fixtures',
+                               uname + '@globusid.org.json')) as f:
+            ret[uname] = json.load(f)
+    return ret

--- a/tests/manual_tools/login_native_app1.py
+++ b/tests/manual_tools/login_native_app1.py
@@ -4,7 +4,8 @@ from globus_sdk import NativeAppAuthClient
 
 
 CLIENT_ID = 'd0f1d9b0-bd81-4108-be74-ea981664453a'
-SCOPES = 'urn:globus:auth:scope:transfer.api.globus.org:all'
+SCOPES = ('openid profile email '
+          'urn:globus:auth:scope:transfer.api.globus.org:all')
 
 get_input = getattr(__builtins__, 'raw_input', input)
 
@@ -20,5 +21,7 @@ auth_code = get_input('Enter the auth code: ').strip()
 tokens = client.oauth2_exchange_code_for_tokens(auth_code).by_resource_server
 
 transfer_token = tokens['transfer.api.globus.org']['refresh_token']
+auth_token = tokens['auth.globus.org']['refresh_token']
 
-print('Token: {}'.format(transfer_token))
+print('Transfer Token: {}'.format(transfer_token))
+print('Auth Token    : {}'.format(auth_token))

--- a/tests/unit/test_auth_client.py
+++ b/tests/unit/test_auth_client.py
@@ -1,0 +1,230 @@
+import globus_sdk
+from tests.framework import (CapturedIOTestCase,
+                             get_client_data, get_user_data,
+                             SDKTESTER1A_NATIVE1_AUTH_RT)
+from globus_sdk.auth import (GlobusNativeAppFlowManager,
+                             GlobusAuthorizationCodeFlowManager)
+from globus_sdk.exc import GlobusAPIError
+
+
+class AuthClientTests(CapturedIOTestCase):
+
+    def setUp(self):
+        """
+        Instantiates an AuthClient with an access_token authorizer
+        """
+        super(AuthClientTests, self).setUp()
+
+        self.access_token = self.test_oauth2_token()
+        self.ac = globus_sdk.AuthClient(
+            authorizer=globus_sdk.AccessTokenAuthorizer(self.access_token),
+            client_id=get_client_data()["native_app_client1"]["id"])
+
+    def test_get_identities(self):
+        """
+        Makes calls to the get identities resource using singleton and lists
+        of ids and usernames, both in use and not. Validates results.
+        Confirms incorrect requests throw GlobusAPIErrors
+        """
+        def get_identity(identities, uid=None, username=None):
+            """
+            helper for getting identities since response order isn't guaranteed
+            """
+            for identity in identities:
+                if identity["id"] == uid or identity["username"] == username:
+                    return identity
+            return None
+
+        # expected values
+        sdk_expected = get_user_data()["sdktester1a"]
+        go_expected = get_user_data()["go"]
+
+        # get single ID
+        id_res = self.ac.get_identities(
+            ids=get_user_data()["sdktester1a"]["id"])
+        sdk_identity = get_identity(
+            id_res["identities"], uid=get_user_data()["sdktester1a"]["id"])
+        for item in sdk_expected:
+            self.assertEqual(sdk_identity[item], sdk_expected[item])
+
+        # get multiple IDs
+        unused_id = "12345678-1234-1234-1234-1234567890ab"
+        ids = [get_user_data()["sdktester1a"]["id"],
+               get_user_data()["go"]["id"], unused_id]
+        id_res = self.ac.get_identities(ids=ids)
+        # validate sdk
+        sdk_identity = get_identity(
+            id_res["identities"], uid=get_user_data()["sdktester1a"]["id"])
+        for item in sdk_expected:
+            self.assertEqual(sdk_identity[item], sdk_expected[item])
+        # validate go
+        go_identity = get_identity(id_res["identities"],
+                                   uid=get_user_data()["go"]["id"])
+        for item in go_expected:
+            self.assertEqual(go_identity[item], go_expected[item])
+        unused_identity = get_identity(id_res["identities"], uid=unused_id)
+        # confirm unused id isn't returned
+        self.assertIsNone(unused_identity)
+
+        # get single username
+        id_res = self.ac.get_identities(
+            usernames=get_user_data()["sdktester1a"]["username"])
+        sdk_identity = get_identity(
+            id_res["identities"],
+            username=get_user_data()["sdktester1a"]["username"])
+        for item in sdk_expected:
+            self.assertEqual(sdk_identity[item], sdk_expected[item])
+
+        # get multiple usernames
+        unused_username = "unused@unused.org"
+        usernames = [get_user_data()["sdktester1a"]["username"],
+                     get_user_data()["go"]["username"], unused_username]
+        id_res = self.ac.get_identities(usernames=usernames)
+        # validate sdk
+        sdk_identity = get_identity(
+            id_res["identities"],
+            username=get_user_data()["sdktester1a"]["username"])
+        for item in sdk_expected:
+            self.assertEqual(sdk_identity[item], sdk_expected[item])
+        # validate go
+        go_identity = get_identity(
+            id_res["identities"], username=get_user_data()["go"]["username"])
+        for item in go_expected:
+            self.assertEqual(go_identity[item], go_expected[item])
+        unused_identity = get_identity(id_res["identities"],
+                                       username=unused_username)
+        # validate unused
+        self.assertEqual(unused_identity["username"], unused_username)
+        self.assertEqual(unused_identity["name"], None)
+        self.assertEqual(unused_identity["status"], "unused")
+
+        # bad request
+        with self.assertRaises(GlobusAPIError) as apiErr:
+            self.ac.get_identities(usernames=usernames, ids=ids)
+        self.assertEqual(apiErr.exception.http_status, 400)
+        self.assertEqual(apiErr.exception.code, "INVALID_PARAMETERS")
+
+        # no auth
+        with self.assertRaises(GlobusAPIError) as apiErr:
+            globus_sdk.AuthClient().get_identities()
+        self.assertEqual(apiErr.exception.http_status, 401)
+        self.assertEqual(apiErr.exception.code, "UNAUTHORIZED")
+
+    def test_oauth2_get_authorize_url(self):
+        """
+        Gets an authorize url after starting a native app auth flow, a
+        confidential app auth flow, and no auth flow. Validates results.
+        """
+        base_url = "https://auth.globus.org/v2/"
+
+        # no auth flow
+        with self.assertRaises(ValueError):
+            self.ac.oauth2_get_authorize_url()
+
+        # native auth flow
+        self.ac.current_oauth2_flow_manager = GlobusNativeAppFlowManager(
+            self.ac, None)
+        url_res = self.ac.oauth2_get_authorize_url()
+        self.assertIn(base_url + "oauth2/authorize?code_challenge=", url_res)
+
+        # confidential auth flow
+        uri = "test-redirect-uri.org"
+        self.ac.current_oauth2_flow_manager = (
+            GlobusAuthorizationCodeFlowManager(self.ac, uri))
+        url_res = self.ac.oauth2_get_authorize_url()
+        self.assertIn(base_url + "oauth2/authorize?", url_res)
+        expected_args = ["access_type=online", "state=_default",
+                         "response_type=code", "redirect_uri=" + uri,
+                         "client_id=" + self.ac.client_id]
+        for arg in expected_args:
+            self.assertIn(arg, url_res)
+
+    def test_oauth2_exchange_code_for_tokens(self):
+        """
+        Confirms flow required and an invalid code returns a 401,
+        Correct usage can only be tested in integration tests
+        """
+        # no auth flow
+        with self.assertRaises(ValueError):
+            self.ac.oauth2_exchange_code_for_tokens("")
+
+        # bad code
+        self.ac.current_oauth2_flow_manager = GlobusNativeAppFlowManager(
+            self.ac, None)
+        with self.assertRaises(GlobusAPIError) as apiErr:
+            self.ac.oauth2_exchange_code_for_tokens("bad_code")
+        self.assertEqual(apiErr.exception.http_status, 401)
+        self.assertEqual(apiErr.exception.code, "Error")  # json is malformed?
+
+    def test_oauth2_refresh_token(self):
+        """
+        Gets an access token from the testing Refresh Token, validates results
+        """
+        param = {"client_id": self.ac.client_id}
+        ref_res = self.ac.oauth2_refresh_token(
+            SDKTESTER1A_NATIVE1_AUTH_RT, additional_params=param)
+        self.assertIn("access_token", ref_res)
+        self.assertIn("expires_in", ref_res)
+        self.assertIn("scope", ref_res)
+        self.assertEqual(ref_res["resource_server"], "auth.globus.org")
+        self.assertEqual(ref_res["token_type"], "Bearer")
+
+        # without valid client id
+        with self.assertRaises(GlobusAPIError) as apiErr:
+            ref_res = self.ac.oauth2_refresh_token(SDKTESTER1A_NATIVE1_AUTH_RT)
+        self.assertEqual(apiErr.exception.http_status, 401)
+        self.assertEqual(apiErr.exception.code, "Error")  # json is malformed?
+
+    def test_oauth2_revoke_token(self):
+        """
+        Revokes the access_token used in test AuthClient's authorizer
+        Confirms can no longer make authorized requests
+        """
+        param = {"client_id": self.ac.client_id}
+        rev_res = self.ac.oauth2_revoke_token(self.access_token,
+                                              additional_params=param)
+        self.assertFalse(rev_res["active"])
+
+        with self.assertRaises(GlobusAPIError) as apiErr:
+            self.ac.get_identities()
+        self.assertEqual(apiErr.exception.http_status, 401)
+        self.assertEqual(apiErr.exception.code, "UNAUTHORIZED")
+
+    def test_oauth2_token(self):
+        """
+        Gets an access_token using oauth2/token directly, validates results
+        returns the access_token for use in testing
+        """
+        client_id = get_client_data()["native_app_client1"]["id"]
+        form_data = {'refresh_token': SDKTESTER1A_NATIVE1_AUTH_RT,
+                     'grant_type': 'refresh_token',
+                     'client_id': client_id}
+        # valid client
+        token_res = globus_sdk.AuthClient().oauth2_token(form_data)
+        self.assertIn("access_token", token_res)
+        self.assertIn("expires_in", token_res)
+        self.assertIn("scope", token_res)
+
+        return token_res["access_token"]
+
+    def test_oauth2_userinfo(self):
+        """
+        Gets userinfo, validates results
+        Confirms unauthorized client cannot access userinfo
+        """
+        userinfo_res = self.ac.oauth2_userinfo()
+        self.assertEqual(
+            userinfo_res["preferred_username"],
+            get_user_data()["sdktester1a"]["username"])
+        self.assertEqual(
+            userinfo_res["name"],
+            get_user_data()["sdktester1a"]["name"])
+        self.assertEqual(
+            userinfo_res["sub"],
+            get_user_data()["sdktester1a"]["id"])
+
+        # unauthorized client
+        with self.assertRaises(GlobusAPIError) as apiErr:
+            globus_sdk.AuthClient().oauth2_userinfo()
+        self.assertEqual(apiErr.exception.http_status, 403)
+        self.assertEqual(apiErr.exception.code, "FORBIDDEN")

--- a/tests/unit/test_auth_client.py
+++ b/tests/unit/test_auth_client.py
@@ -125,19 +125,28 @@ class AuthClientTests(CapturedIOTestCase):
         self.ac.current_oauth2_flow_manager = GlobusNativeAppFlowManager(
             self.ac, None)
         url_res = self.ac.oauth2_get_authorize_url()
-        self.assertIn(base_url + "oauth2/authorize?code_challenge=", url_res)
+        # validate results
+        expected_vals = [base_url + "oauth2/authorize?", "code_challenge=",
+                         "scope=", "openid", "profile", "email",
+                         "access_type=online", "state=_default",
+                         "response_type=code",
+                         "client_id=" + self.ac.client_id]
+        for val in expected_vals:
+            self.assertIn(val, url_res)
 
         # confidential auth flow
         uri = "test-redirect-uri.org"
         self.ac.current_oauth2_flow_manager = (
             GlobusAuthorizationCodeFlowManager(self.ac, uri))
         url_res = self.ac.oauth2_get_authorize_url()
-        self.assertIn(base_url + "oauth2/authorize?", url_res)
-        expected_args = ["access_type=online", "state=_default",
+        # validate results
+        expected_vals = [base_url + "oauth2/authorize?",
+                         "access_type=online", "state=_default",
+                         "scope=", "openid", "profile", "email",
                          "response_type=code", "redirect_uri=" + uri,
                          "client_id=" + self.ac.client_id]
-        for arg in expected_args:
-            self.assertIn(arg, url_res)
+        for val in expected_vals:
+            self.assertIn(val, url_res)
 
     def test_oauth2_exchange_code_for_tokens(self):
         """

--- a/tests/unit/test_base_client.py
+++ b/tests/unit/test_base_client.py
@@ -6,7 +6,7 @@ import globus_sdk
 from globus_sdk.base import (BaseClient, safe_stringify,
                              slash_join, merge_params)
 from tests.framework import (CapturedIOTestCase, get_client_data,
-                             SDKTESTER1A_NATIVE1_RT)
+                             SDKTESTER1A_NATIVE1_TRANSFER_RT)
 from globus_sdk.exc import GlobusAPIError
 
 
@@ -20,7 +20,7 @@ class BaseClientTests(CapturedIOTestCase):
         ac = globus_sdk.NativeAppAuthClient(
             client_id=get_client_data()["native_app_client1"]["id"])
         authorizer = globus_sdk.RefreshTokenAuthorizer(
-            SDKTESTER1A_NATIVE1_RT, ac)
+            SDKTESTER1A_NATIVE1_TRANSFER_RT, ac)
         self.bc = BaseClient("transfer", base_path="/v0.10/",
                              authorizer=authorizer)
 

--- a/tests/unit/test_data.py
+++ b/tests/unit/test_data.py
@@ -1,7 +1,7 @@
 import globus_sdk
 
 from tests.framework import (CapturedIOTestCase, get_client_data,
-                             SDKTESTER1A_NATIVE1_RT,
+                             SDKTESTER1A_NATIVE1_TRANSFER_RT,
                              GO_EP1_ID, GO_EP2_ID)
 
 
@@ -15,7 +15,7 @@ class DataTests(CapturedIOTestCase):
         ac = globus_sdk.NativeAppAuthClient(
             client_id=get_client_data()["native_app_client1"]["id"])
         authorizer = globus_sdk.RefreshTokenAuthorizer(
-            SDKTESTER1A_NATIVE1_RT, ac)
+            SDKTESTER1A_NATIVE1_TRANSFER_RT, ac)
         self.tc = globus_sdk.TransferClient(authorizer=authorizer)
 
     def setUp(self):


### PR DESCRIPTION
I made some changes to facilitate AuthClient unit tests, and wanted to make sure they were reasonable.

I added an additional_params argument to AuthClient.oauth2_refresh_token() so I could pass the client_id needed for native authorization. I figure this shouldn't hurt anything, especially since AuthClient.oauth2_revoke_token() already does this.

I added openid, profile, and email to the requested scopes for the Native app grant and requested new auth and transfer refresh tokens that are now in constants.

It felt wrong to have a long list of user data values in constants for validating auth responses, so I made a get_user_data() function similar to get_client_data()