### PR TITLE
Unit tests for Native clients, Confidential clients, and flow managers.

### DIFF
--- a/tests/files/auth_fixtures/confidential_app_client1.json
+++ b/tests/files/auth_fixtures/confidential_app_client1.json
@@ -1,4 +1,5 @@
 {
   "username": "cfb9c955-795e-4815-bdcf-35c0e52b7d42@clients.auth.globus.org",
-  "id": "cfb9c955-795e-4815-bdcf-35c0e52b7d42"
+  "id": "cfb9c955-795e-4815-bdcf-35c0e52b7d42",
+  "secret": "WbKrxzMgzlWPX/5vRKdAbLHSHlD4oPMhaeaNCiFN1LE="
 }

--- a/tests/files/auth_fixtures/resource_server_client.json
+++ b/tests/files/auth_fixtures/resource_server_client.json
@@ -1,0 +1,5 @@
+{
+  "username": "ae4f9490-cd05-4c3b-8178-838bdbc839c0 @clients.auth.globus.org",
+  "id": "ae4f9490-cd05-4c3b-8178-838bdbc839c0",
+  "secret": "7D0ZpO9G0/2JCnTtO1n0BSFJl9LLLnts4BtaVReRMNA="
+}

--- a/tests/framework/tools.py
+++ b/tests/framework/tools.py
@@ -14,10 +14,11 @@ def get_fixture_file_dir():
 def get_client_data():
     dirname = get_fixture_file_dir()
     ret = {}
-    for fname in ('native_app_client1', 'confidential_app_client1'):
+    for fname in ("native_app_client1", "confidential_app_client1",
+                  "resource_server_client"):
         with open(os.path.join(dirname,
-                               'auth_fixtures',
-                               fname + '.json')) as f:
+                               "auth_fixtures",
+                               fname + ".json")) as f:
             ret[fname] = json.load(f)
     return ret
 
@@ -25,9 +26,9 @@ def get_client_data():
 def get_user_data():
     dirname = get_fixture_file_dir()
     ret = {}
-    for uname in ('sdktester1a', 'go'):
+    for uname in ("sdktester1a", "go"):
         with open(os.path.join(dirname,
-                               'auth_fixtures',
-                               uname + '@globusid.org.json')) as f:
+                               "auth_fixtures",
+                               uname + "@globusid.org.json")) as f:
             ret[uname] = json.load(f)
     return ret

--- a/tests/unit/test_confidential_client.py
+++ b/tests/unit/test_confidential_client.py
@@ -1,0 +1,120 @@
+import globus_sdk
+from tests.framework import CapturedIOTestCase, get_client_data
+from globus_sdk.exc import GlobusAPIError
+
+
+class ConfidentialAppAuthClientTests(CapturedIOTestCase):
+
+    @classmethod
+    def setUpClass(self):
+        """
+        Instantiates an ConfidentialAppAuthClient for confidential_app_client1
+        and for resource_server_client
+        """
+
+        client_data = get_client_data()["confidential_app_client1"]
+        self.cac = globus_sdk.ConfidentialAppAuthClient(
+            client_id=client_data["id"],
+            client_secret=client_data["secret"])
+
+        client_data = get_client_data()["resource_server_client"]
+        self.rsc = globus_sdk.ConfidentialAppAuthClient(
+            client_id=client_data["id"],
+            client_secret=client_data["secret"])
+
+    def test_oauth2_client_credentials_tokens(self):
+        """
+        Get client credentials tokens, validate results
+        Confirm tokens allow use of userinfo for the client
+        Returns access_token for testing
+        """
+        token_res = self.cac.oauth2_client_credentials_tokens()
+        # validate results
+        self.assertIn("access_token", token_res)
+        self.assertIn("expires_in", token_res)
+        self.assertIn("scope", token_res)
+        self.assertEqual(token_res["resource_server"], "auth.globus.org")
+        self.assertEqual(token_res["token_type"], "Bearer")
+
+        # confirm usage of userinfo for client
+        access_token = token_res["access_token"]
+        ac = globus_sdk.AuthClient(
+            authorizer=globus_sdk.AccessTokenAuthorizer(access_token))
+        userinfo_res = ac.oauth2_userinfo()
+        self.assertEqual(
+            userinfo_res["sub"],
+            get_client_data()["confidential_app_client1"]["id"])
+
+    def test_oauth2_get_dependent_tokens(self):
+        """
+        Gets dependent tokens for a client access_token, validates results
+        Confirms non resource servers are not allowed to use this resource
+        Confirms tokens must have scope for the resource_server using them
+        """
+        # get access_token for confidential client to use the resource server
+        scopes = "openid"  # TODO: add resource_server's scope
+        tokens = self.cac.oauth2_client_credentials_tokens(
+            requested_scopes=scopes).by_resource_server
+
+        '''
+        TODO: set up resource_server for testing against
+        # resource server gets dependent tokens from the clients token
+        # as if the client had sent the token to the resource server
+        access_token = tokens["Resource Server Name"]["access_token"]
+        dep_res = self.rsc.oauth2_get_dependent_tokens(access_token)
+
+        # validate results
+        for token_info in dep_res:
+            self.assertEqual(token_info["token_type"], "Bearer")
+            self.assertIn("scope", token_info)
+            self.assertIn("access_token", token_info)
+            self.assertIn("expires_in", token_info)
+            self.assertIn("resource_server", token_info)
+
+        # confirm non resource servers are unauthorized
+        with self.assertRaises(GlobusAPIError) as apiErr:
+            self.cac.oauth2_client_credentials_tokens(access_token)
+        self.assertEqual(apiErr.exception.http_status, 400)
+        self.assertEqual(apiErr.exception.code, "UNKNOWN_SCOPE_ERROR")
+        '''
+
+        # confirm invalid tokens are unauthorized
+        invalid_token = tokens["auth.globus.org"]["access_token"]
+        with self.assertRaises(GlobusAPIError) as apiErr:
+            self.cac.oauth2_client_credentials_tokens(invalid_token)
+        self.assertEqual(apiErr.exception.http_status, 400)
+        self.assertEqual(apiErr.exception.code, "UNKNOWN_SCOPE_ERROR")
+
+    def test_oauth2_token_introspect(self):
+        """
+        Introspects a client access_token, validates results
+        Confirms invalid and revoked tokens are not seen as active
+        """
+        # get access_token and introspect it
+        tokens = self.cac.oauth2_client_credentials_tokens()
+        access_token = tokens["access_token"]
+        intro_res = self.cac.oauth2_token_introspect(access_token)
+
+        # validate results
+        self.assertEqual(intro_res["sub"], self.cac.client_id)
+        self.assertEqual(intro_res["client_id"], self.cac.client_id)
+        self.assertEqual(
+            intro_res["username"],
+            get_client_data()["confidential_app_client1"]["username"])
+        self.assertEqual(intro_res["name"],
+                         "Python SDK Test Suite Confidential Client 1")
+        self.assertEqual(intro_res["token_type"], "Bearer")
+        self.assertIn("openid", intro_res["scope"])
+        self.assertIn("email", intro_res["scope"])
+        self.assertIn("profile", intro_res["scope"])
+        self.assertIn("exp", intro_res)
+        self.assertTrue(intro_res["active"])
+
+        # revoked tokens are not active
+        self.cac.oauth2_revoke_token(access_token)
+        revoked_res = self.cac.oauth2_token_introspect(access_token)
+        self.assertFalse(revoked_res["active"])
+
+        # invalid tokens are not active
+        invalid_res = self.cac.oauth2_token_introspect("invalid token")
+        self.assertFalse(invalid_res["active"])

--- a/tests/unit/test_native_client.py
+++ b/tests/unit/test_native_client.py
@@ -1,0 +1,82 @@
+import globus_sdk
+from tests.framework import (CapturedIOTestCase,
+                             get_client_data, get_user_data,
+                             SDKTESTER1A_NATIVE1_AUTH_RT)
+from globus_sdk.exc import GlobusAPIError
+
+
+class NativeAppAuthClientTests(CapturedIOTestCase):
+
+    def setUp(self):
+        """
+        Instantiates an NativeAppAuthClient
+        """
+        super(NativeAppAuthClientTests, self).setUp()
+
+        self.nac = globus_sdk.NativeAppAuthClient(
+            client_id=get_client_data()["native_app_client1"]["id"])
+
+    def test_init(self):
+        """
+        Confirms value error when trying to init with an authorizer
+        """
+        with self.assertRaises(ValueError):
+            globus_sdk.NativeAppAuthClient(
+                client_id=get_client_data()["native_app_client1"]["id"],
+                authorizer=globus_sdk.AccessTokenAuthorizer(""))
+
+    def test_get_identities(self):
+        """
+        Confirms native apps aren't authorized to get_identities on their own
+        """
+        with self.assertRaises(GlobusAPIError) as apiErr:
+            self.nac.get_identities(ids=get_user_data()["sdktester1a"]["id"])
+        self.assertEqual(apiErr.exception.http_status, 401)
+        self.assertEqual(apiErr.exception.code, "UNAUTHORIZED")
+
+    def test_oauth2_refresh_token(self):
+        """
+        Sends a refresh_token grant, validates results
+        Confirms received access_token can be used to authorize userinfo
+        Returns the access token for use in test_oauth2_revoke_token
+        """
+        ref_res = self.nac.oauth2_refresh_token(SDKTESTER1A_NATIVE1_AUTH_RT)
+        self.assertIn("access_token", ref_res)
+        self.assertIn("expires_in", ref_res)
+        self.assertIn("scope", ref_res)
+        self.assertEqual(ref_res["resource_server"], "auth.globus.org")
+        self.assertEqual(ref_res["token_type"], "Bearer")
+
+        # confirm token can be used
+        access_token = ref_res["access_token"]
+        ac = globus_sdk.AuthClient(
+            authorizer=globus_sdk.AccessTokenAuthorizer(access_token),
+            client_id=get_client_data()["native_app_client1"]["id"])
+        userinfo_res = ac.oauth2_userinfo()
+        self.assertEqual(
+            userinfo_res["sub"],
+            get_user_data()["sdktester1a"]["id"])
+
+        # return access_token
+        return access_token
+
+    def test_oauth2_revoke_token(self):
+        """
+        Gets an access_token from test_oauth2_refresh_token, then revokes it
+        Confirms that the base AuthClient logic for handling Null Authorizers
+        passes the client id correctly, and the token can no longer be used
+        """
+        # get and then revoke the token
+        access_token = self.test_oauth2_refresh_token()
+        rev_res = self.nac.oauth2_revoke_token(access_token)
+        # validate results
+        self.assertFalse(rev_res["active"])
+
+        # confirm token is no longer usable
+        with self.assertRaises(GlobusAPIError) as apiErr:
+            ac = globus_sdk.AuthClient(
+                authorizer=globus_sdk.AccessTokenAuthorizer(access_token),
+                client_id=get_client_data()["native_app_client1"]["id"])
+            ac.oauth2_userinfo()
+        self.assertEqual(apiErr.exception.http_status, 403)
+        self.assertEqual(apiErr.exception.code, "FORBIDDEN")

--- a/tests/unit/test_oauth2_authorization_code.py
+++ b/tests/unit/test_oauth2_authorization_code.py
@@ -1,0 +1,63 @@
+try:
+    import mock
+except ImportError:
+    from unittest import mock
+
+import globus_sdk
+from tests.framework import CapturedIOTestCase
+
+
+class GlobusAuthorizationCodeFlowManagerTests(CapturedIOTestCase):
+
+    def setUp(self):
+        """
+        Inits a GlobusAuthorizationCodeFlowManager using a mock AuthClient
+        """
+        super(GlobusAuthorizationCodeFlowManagerTests, self).setUp()
+
+        self.ac = mock.Mock()
+        self.ac.client_id = "client_id"
+        self.ac.base_url = "base_url/"
+        self.flow_manager = globus_sdk.auth.GlobusNativeAppFlowManager(
+            self.ac, requested_scopes="scopes", redirect_uri="uri",
+            state="state", verifier="verifier")
+
+    def test_get_authorize_url(self):
+        """
+        Creates an authorize url, confirms results match object values
+        Confirms additional params passed appear in the url
+        """
+        url = self.flow_manager.get_authorize_url()
+
+        expected_vals = [self.ac.base_url + "v2/oauth2/authorize?",
+                         "client_id=", self.ac.client_id,
+                         "redirect_uri=", self.flow_manager.redirect_uri,
+                         "scope=", self.flow_manager.requested_scopes,
+                         "state=", self.flow_manager.state,
+                         "response_type=code",
+                         "access_type=online"
+                         ]
+        for val in expected_vals:
+            self.assertIn(val, url)
+
+        # confirm additional params are passed
+        params = {"param1": "value1", "param2": "value2"}
+        param_url = self.flow_manager.get_authorize_url(
+            additional_params=params)
+        for param, value in params.items():
+            self.assertIn(param + "=" + value, param_url)
+
+    def test_exchange_code_for_tokens(self):
+        """
+        Makes a token exchange with the mock AuthClient,
+        Confirms AuthClient gets and sends correct data.
+        """
+        auth_code = "code"
+        self.flow_manager.exchange_code_for_tokens(auth_code)
+
+        expected = {"client_id": self.ac.client_id,
+                    "grant_type": "authorization_code",
+                    "code": auth_code.encode("utf-8"),
+                    "code_verifier": self.flow_manager.verifier,
+                    "redirect_uri": self.flow_manager.redirect_uri}
+        self.ac.oauth2_token.assert_called_with(expected)

--- a/tests/unit/test_oauth2_native_app.py
+++ b/tests/unit/test_oauth2_native_app.py
@@ -1,0 +1,97 @@
+import hashlib
+import base64
+from six.moves.urllib.parse import quote
+try:
+    import mock
+except ImportError:
+    from unittest import mock
+
+import globus_sdk
+from globus_sdk.auth.oauth2_native_app import make_native_app_challenge
+from tests.framework import CapturedIOTestCase
+
+
+class GlobusNativeAppFlowManagerTests(CapturedIOTestCase):
+
+    def setUp(self):
+        """
+        Inits a GlobusNativeAppFlowManager, uses a mock AuthClient for testing
+        """
+        super(GlobusNativeAppFlowManagerTests, self).setUp()
+
+        self.ac = mock.Mock()
+        self.ac.client_id = "client_id"
+        self.ac.base_url = "base_url/"
+        self.flow_manager = globus_sdk.auth.GlobusNativeAppFlowManager(
+            self.ac, requested_scopes="scopes", redirect_uri="uri",
+            state="state", verifier="verifier")
+
+    def test_make_native_app_challenge(self):
+        """
+        Makes native app challenge with and without verifier,
+        Sanity checks results
+        """
+        # with verifier
+        input_verifier = "verifier"
+        output_verifier, challenge = make_native_app_challenge(
+            input_verifier)
+
+        # sanity check verifier equality and hashing
+        self.assertEqual(input_verifier, output_verifier)
+        re_hash = hashlib.sha256(input_verifier.encode('utf-8')).digest()
+        remade_challenge = base64.urlsafe_b64encode(re_hash).decode('utf-8')
+        self.assertEqual(challenge, remade_challenge)
+
+        # without verifier
+        verifier, challenge = make_native_app_challenge()
+
+        # sanity check verifier format and hashing
+        self.assertEqual(len(verifier), 36)
+        for i in [8, 13, 18, 23]:
+            self.assertEqual(verifier[i], "-")
+        re_hash = hashlib.sha256(verifier.encode('utf-8')).digest()
+        remade_challenge = base64.urlsafe_b64encode(re_hash).decode('utf-8')
+        self.assertEqual(challenge, remade_challenge)
+
+    def test_get_authorize_url(self):
+        """
+        Creates an authorize url, confirms results match object values
+        Confirms additional params passed appear in the url
+        """
+        url = self.flow_manager.get_authorize_url()
+
+        expected_vals = [self.ac.base_url + "v2/oauth2/authorize?",
+                         "client_id=" + self.ac.client_id,
+                         "redirect_uri=" + self.flow_manager.redirect_uri,
+                         "scope=" + self.flow_manager.requested_scopes,
+                         "state=" + self.flow_manager.state,
+                         "response_type=code",
+                         "code_challenge=" +
+                         quote(self.flow_manager.challenge),
+                         "code_challenge_method=S256",
+                         "access_type=online",
+                         ]
+        for val in expected_vals:
+            self.assertIn(val, url)
+
+        # confirm additional params are passed
+        params = {"param1": "value1", "param2": "value2"}
+        param_url = self.flow_manager.get_authorize_url(
+            additional_params=params)
+        for param, value in params.items():
+            self.assertIn(param + "=" + value, param_url)
+
+    def test_exchange_code_for_tokens(self):
+        """
+        Makes a token exchange with the mock AuthClient,
+        Confirms AuthClient gets and sends correct data.
+        """
+        auth_code = "code"
+        self.flow_manager.exchange_code_for_tokens(auth_code)
+
+        expected = {"client_id": self.ac.client_id,
+                    "grant_type": "authorization_code",
+                    "code": auth_code.encode("utf-8"),
+                    "code_verifier": self.flow_manager.verifier,
+                    "redirect_uri": self.flow_manager.redirect_uri}
+        self.ac.oauth2_token.assert_called_with(expected)


### PR DESCRIPTION
I tested as much as I could without having the clients tests import the flow managers and vice versa, Integration tests will cover the interactions not covered here.

I'll make an issue tracking the eventual need for a Resource Server to test oauth2_get_dependent_tokens.