### PR TITLE
Integration tests between auth clients and flow managers

### DIFF
--- a/tests/integration/test_auth_client_flow.py
+++ b/tests/integration/test_auth_client_flow.py
@@ -1,0 +1,133 @@
+from six.moves.urllib.parse import quote_plus
+
+import globus_sdk
+from globus_sdk.auth.oauth2_constants import DEFAULT_REQUESTED_SCOPES
+from globus_sdk.auth.oauth2_native_app import make_native_app_challenge
+from tests.framework import CapturedIOTestCase, get_client_data
+from globus_sdk.exc import GlobusAPIError
+
+
+class AuthClientIntegrationTests(CapturedIOTestCase):
+
+    def test_oauth2_get_authorize_url_native(self):
+        """
+        Starts an auth flow with a NativeAppFlowManager, gets the authorize url
+        validates expected results with both default and specified parameters.
+        """
+        ac = globus_sdk.AuthClient(
+            client_id=get_client_data()["native_app_client1"]["id"])
+
+        # default parameters for starting auth flow
+        flow_manager = globus_sdk.auth.GlobusNativeAppFlowManager(ac)
+        ac.current_oauth2_flow_manager = flow_manager
+
+        # get url_and validate results
+        url_res = ac.oauth2_get_authorize_url()
+        expected_vals = [ac.base_url + "v2/oauth2/authorize?",
+                         "client_id=" + ac.client_id,
+                         "redirect_uri=" +
+                         quote_plus(ac.base_url + "v2/web/auth-code"),
+                         "scope=" + quote_plus(DEFAULT_REQUESTED_SCOPES),
+                         "state=" + "_default",
+                         "response_type=" + "code",
+                         "code_challenge=" +
+                         quote_plus(flow_manager.challenge),
+                         "code_challenge_method=" + "S256",
+                         "access_type=" + "online"]
+        for val in expected_vals:
+            self.assertIn(val, url_res)
+
+        # starting flow with specified paramaters
+        flow_manager = globus_sdk.auth.GlobusNativeAppFlowManager(
+            ac, requested_scopes="scopes", redirect_uri="uri",
+            state="state", verifier="verifier", refresh_tokens=True)
+        ac.current_oauth2_flow_manager = flow_manager
+
+        # get url_and validate results
+        url_res = ac.oauth2_get_authorize_url()
+        verifier, remade_challenge = make_native_app_challenge("verifier")
+        expected_vals = [ac.base_url + "v2/oauth2/authorize?",
+                         "client_id=" + ac.client_id,
+                         "redirect_uri=" + "uri",
+                         "scope=" + "scopes",
+                         "state=" + "state",
+                         "response_type=" + "code",
+                         "code_challenge=" + quote_plus(remade_challenge),
+                         "code_challenge_method=" + "S256",
+                         "access_type=" + "offline"]
+        for val in expected_vals:
+            self.assertIn(val, url_res)
+
+    def test_oauth2_get_authorize_url_confidential(self):
+        """
+        Starts an auth flow with a NativeAppFlowManager, gets the authorize url
+        validates expected results with both default and specified parameters.
+        """
+        ac = globus_sdk.AuthClient(
+            client_id=get_client_data()["confidential_app_client1"]["id"])
+
+        # default parameters for starting auth flow
+        flow_manager = globus_sdk.auth.GlobusAuthorizationCodeFlowManager(
+            ac, "uri")
+        ac.current_oauth2_flow_manager = flow_manager
+
+        # get url_and validate results
+        url_res = ac.oauth2_get_authorize_url()
+        expected_vals = [ac.base_url + "v2/oauth2/authorize?",
+                         "client_id=" + ac.client_id,
+                         "redirect_uri=" + "uri",
+                         "scope=" + quote_plus(DEFAULT_REQUESTED_SCOPES),
+                         "state=" + "_default",
+                         "response_type=" + "code",
+                         "access_type=" + "online"]
+        for val in expected_vals:
+            self.assertIn(val, url_res)
+
+        # starting flow with specified paramaters
+        flow_manager = globus_sdk.auth.GlobusAuthorizationCodeFlowManager(
+            ac, requested_scopes="scopes", redirect_uri="uri",
+            state="state", refresh_tokens=True)
+        ac.current_oauth2_flow_manager = flow_manager
+
+        # get url_and validate results
+        url_res = ac.oauth2_get_authorize_url()
+        expected_vals = [ac.base_url + "v2/oauth2/authorize?",
+                         "client_id=" + ac.client_id,
+                         "redirect_uri=" + "uri",
+                         "scope=" + "scopes",
+                         "state=" + "state",
+                         "response_type=" + "code",
+                         "access_type=" + "offline"]
+        for val in expected_vals:
+            self.assertIn(val, url_res)
+
+    def test_oauth2_exchange_code_for_tokens_native(self):
+        """
+        Starts a NativeAppFlowManager, Confirms invalid code raises 401
+        Further testing cannot be done without user login credentials
+        """
+        ac = globus_sdk.AuthClient(
+            client_id=get_client_data()["native_app_client1"]["id"])
+        flow_manager = globus_sdk.auth.GlobusNativeAppFlowManager(ac)
+        ac.current_oauth2_flow_manager = flow_manager
+
+        with self.assertRaises(GlobusAPIError) as apiErr:
+            ac.oauth2_exchange_code_for_tokens("invalid_code")
+        self.assertEqual(apiErr.exception.http_status, 401)
+        self.assertEqual(apiErr.exception.code, "Error")
+
+    def test_oauth2_exchange_code_for_tokens_confidential(self):
+        """
+        Starts an AuthorizationCodeFlowManager, Confirms bad code raises 401
+        Further testing cannot be done without user login credentials
+        """
+        ac = globus_sdk.AuthClient(
+            client_id=get_client_data()["confidential_app_client1"]["id"])
+        flow_manager = globus_sdk.auth.GlobusAuthorizationCodeFlowManager(
+            ac, "uri")
+        ac.current_oauth2_flow_manager = flow_manager
+
+        with self.assertRaises(GlobusAPIError) as apiErr:
+            ac.oauth2_exchange_code_for_tokens("invalid_code")
+        self.assertEqual(apiErr.exception.http_status, 401)
+        self.assertEqual(apiErr.exception.code, "Error")

--- a/tests/integration/test_confidential_client_flow.py
+++ b/tests/integration/test_confidential_client_flow.py
@@ -1,0 +1,87 @@
+from six.moves.urllib.parse import quote_plus
+
+import globus_sdk
+from globus_sdk.auth.oauth2_constants import DEFAULT_REQUESTED_SCOPES
+from tests.framework import CapturedIOTestCase, get_client_data
+from globus_sdk.auth import GlobusAuthorizationCodeFlowManager
+from globus_sdk.exc import GlobusAPIError
+
+
+class ConfidentialAppAuthClientIntegrationTests(CapturedIOTestCase):
+
+    def setUp(self):
+        """
+        Creates a ConfidentialAppAuthClient for testing
+        """
+        super(ConfidentialAppAuthClientIntegrationTests, self).setUp()
+        client_data = get_client_data()["confidential_app_client1"]
+        self.cac = globus_sdk.ConfidentialAppAuthClient(
+            client_id=client_data["id"],
+            client_secret=client_data["secret"])
+
+    def test_oauth2_start_flow_default(self):
+        """
+        Starts a default GlobusAuthorizationCodeFlowManager,
+        Confirms flow is initialized as expected, and can be used.
+        """
+        # starting with no flow
+        self.assertIsNone(self.cac.current_oauth2_flow_manager)
+
+        # confirms flow initialized with default flow values
+        flow = self.cac.oauth2_start_flow("uri")
+        self.assertIsInstance(flow, GlobusAuthorizationCodeFlowManager)
+        self.assertEqual(flow.redirect_uri, "uri")
+        self.assertEqual(flow.requested_scopes, DEFAULT_REQUESTED_SCOPES)
+        self.assertEqual(flow.state, "_default")
+        self.assertFalse(flow.refresh_tokens)
+
+        # confirm client can get url via flow
+        url_res = self.cac.oauth2_get_authorize_url()
+        expected_vals = [self.cac.base_url + "v2/oauth2/authorize?",
+                         "client_id=" + self.cac.client_id,
+                         "redirect_uri=" + "uri",
+                         "scope=" + quote_plus(DEFAULT_REQUESTED_SCOPES),
+                         "state=" + "_default",
+                         "access_type=" + "online"]
+        for val in expected_vals:
+            self.assertIn(val, url_res)
+
+        # confirm client can try exchanging code for tokens via flow
+        with self.assertRaises(GlobusAPIError) as apiErr:
+            self.cac.oauth2_exchange_code_for_tokens("invalid_code")
+        self.assertEqual(apiErr.exception.http_status, 401)
+        self.assertEqual(apiErr.exception.code, "Error")
+
+    def test_oauth2_start_flow_specified(self):
+        """
+        Starts a GlobusAuthorizationCodeFlowManager with specified parameters,
+        Confirms flow is initialized as expected, and can be used.
+        """
+        # starting with no flow
+        self.assertIsNone(self.cac.current_oauth2_flow_manager)
+
+        # confirms flow initialized with specified values
+        flow = self.cac.oauth2_start_flow("uri", requested_scopes="scopes",
+                                          state="state", refresh_tokens=True)
+        self.assertIsInstance(flow, GlobusAuthorizationCodeFlowManager)
+        self.assertEqual(flow.redirect_uri, "uri")
+        self.assertEqual(flow.requested_scopes, "scopes")
+        self.assertEqual(flow.state, "state")
+        self.assertTrue(flow.refresh_tokens)
+
+        # confirm client can get url via flow
+        url_res = self.cac.oauth2_get_authorize_url()
+        expected_vals = [self.cac.base_url + "v2/oauth2/authorize?",
+                         "client_id=" + self.cac.client_id,
+                         "redirect_uri=" + "uri",
+                         "scope=" + "scope",
+                         "state=" + "state",
+                         "access_type=" + "offline"]
+        for val in expected_vals:
+            self.assertIn(val, url_res)
+
+        # confirm client can try exchanging code for tokens via flow
+        with self.assertRaises(GlobusAPIError) as apiErr:
+            self.cac.oauth2_exchange_code_for_tokens("invalid_code")
+        self.assertEqual(apiErr.exception.http_status, 401)
+        self.assertEqual(apiErr.exception.code, "Error")

--- a/tests/integration/test_native_client_flow.py
+++ b/tests/integration/test_native_client_flow.py
@@ -1,0 +1,92 @@
+from six.moves.urllib.parse import quote_plus
+
+import globus_sdk
+from globus_sdk.auth.oauth2_constants import DEFAULT_REQUESTED_SCOPES
+from globus_sdk.auth.oauth2_native_app import make_native_app_challenge
+from tests.framework import CapturedIOTestCase, get_client_data
+from globus_sdk.auth import GlobusNativeAppFlowManager
+from globus_sdk.exc import GlobusAPIError
+
+
+class NativeAppAuthClientIntegrationTests(CapturedIOTestCase):
+
+    def setUp(self):
+        """
+        Creates a NativeAppAuthClient for testing
+        """
+        super(NativeAppAuthClientIntegrationTests, self).setUp()
+        self.nac = globus_sdk.NativeAppAuthClient(
+            client_id=get_client_data()["native_app_client1"]["id"])
+
+    def test_oauth2_start_flow_default(self):
+        """
+        Starts a default GlobusNativeAppFlowManager,
+        Confirms flow is initialized as expected, and can be used.
+        """
+        # starting with no flow
+        self.assertIsNone(self.nac.current_oauth2_flow_manager)
+
+        # confirms flow initialized with default flow values
+        flow = self.nac.oauth2_start_flow()
+        self.assertIsInstance(flow, GlobusNativeAppFlowManager)
+        self.assertEqual(flow.redirect_uri,
+                         self.nac.base_url + "v2/web/auth-code")
+        self.assertEqual(flow.requested_scopes, DEFAULT_REQUESTED_SCOPES)
+        self.assertEqual(flow.state, "_default")
+        self.assertFalse(flow.refresh_tokens)
+
+        # confirm client can get url via flow
+        url_res = self.nac.oauth2_get_authorize_url()
+        expected_vals = [self.nac.base_url + "v2/oauth2/authorize?",
+                         "client_id=" + self.nac.client_id,
+                         "redirect_uri=" +
+                         quote_plus(self.nac.base_url + "v2/web/auth-code"),
+                         "scope=" + quote_plus(DEFAULT_REQUESTED_SCOPES),
+                         "state=" + "_default",
+                         "code_challenge=" + quote_plus(flow.challenge),
+                         "access_type=" + "online"]
+        for val in expected_vals:
+            self.assertIn(val, url_res)
+
+        # confirm client can try exchanging code for tokens via flow
+        with self.assertRaises(GlobusAPIError) as apiErr:
+            self.nac.oauth2_exchange_code_for_tokens("invalid_code")
+        self.assertEqual(apiErr.exception.http_status, 401)
+        self.assertEqual(apiErr.exception.code, "Error")
+
+    def test_oauth2_start_flow_specified(self):
+        """
+        Starts a GlobusNativeAppFlowManager with specified parameters,
+        Confirms flow is initialized as expected, and can be used.
+        """
+        # starting with no flow
+        self.assertIsNone(self.nac.current_oauth2_flow_manager)
+
+        # confirms flow initialized with specified values
+        flow = self.nac.oauth2_start_flow(
+            requested_scopes="scopes", redirect_uri="uri",
+            state="state", verifier="verifier", refresh_tokens=True)
+        self.assertIsInstance(flow, GlobusNativeAppFlowManager)
+        self.assertEqual(flow.redirect_uri, "uri")
+        self.assertEqual(flow.requested_scopes, "scopes")
+        self.assertEqual(flow.state, "state")
+        self.assertTrue(flow.refresh_tokens)
+
+        # confirm client can get url via flow
+        url_res = self.nac.oauth2_get_authorize_url()
+        verifier, remade_challenge = make_native_app_challenge("verifier")
+        expected_vals = [self.nac.base_url + "v2/oauth2/authorize?",
+                         "client_id=" + self.nac.client_id,
+                         "redirect_uri=" + "uri",
+                         "scope=" + "scopes",
+                         "state=" + "state",
+                         "code_challenge=" + quote_plus(remade_challenge),
+                         "access_type=" + "offline"]
+        for val in expected_vals:
+            self.assertIn(val, url_res)
+
+        # confirm client can try exchanging code for tokens via flow
+        with self.assertRaises(GlobusAPIError) as apiErr:
+            self.nac.oauth2_exchange_code_for_tokens("invalid_code")
+        self.assertEqual(apiErr.exception.http_status, 401)
+        self.assertEqual(apiErr.exception.code, "Error")


### PR DESCRIPTION
Integration tests for AuthClient, ConfidentialAppAuthClient, and NativeAppAuthClient with GlobusAuthorizationCodeFlowManager and GlobusNativeAppFlowManager.

Testing code exchange only tests that auth returns 401's for now. When we handle those auth errors better we should check that they are invalid_grant errors and not invalid_client errors, but unless we automate SDK tester login or somehow get a code that wont expire I don't think we can automate testing a successful code exchange.