### PR TITLE
Authorizer unit and integration tests

### DIFF
--- a/tests/framework/constants.py
+++ b/tests/framework/constants.py
@@ -6,12 +6,12 @@ GO_EP2_ID = "ddb59af0-6d04-11e5-ba46-22000b92c6ec"
 # ------ #
 # sdktester1a@globusid.org transfer refresh token for Native App 1
 SDKTESTER1A_NATIVE1_TRANSFER_RT = (
-    "AQEAAAAAAASDACYy_O7mQx-CCTX9ZGg7FAHiv5v3bU"
-    "2b1puK1jxRXnt69ClBpJbtygAjS7BHLokxKRyRQ-7H")
+    "AQEAAAAAAASDALhXmQdX30NbEIkIvDDyC2ngifCIVd"
+    "ta2mMc1JlM5dYWlzrBS0sxr5t55n2--PjKTCTbrE3K")
 # sdktester1a@globusid.org auth refresh token for Native App 1
 SDKTESTER1A_NATIVE1_AUTH_RT = (
-    "AQEAAAAAAASC_0CX1ozEsZ-F4SjhFhMPgi-MgyxWTn"
-    "e0_Tl6Wx3HnVMO3QUnVhDx65xXrR0Y0p8mBAJWjl-R")
+    "AQEAAAAAAASC_zJT5zvwFgYUyY38YIXghtaUXr1amo"
+    "0PLeJLJ2G_iwjbIutwOansrW6RpTQ2WkWsfidYUAyY")
 # ---------- #
 # end tokens #
 # ---------- #

--- a/tests/integration/test_refresh_token_auth_client.py
+++ b/tests/integration/test_refresh_token_auth_client.py
@@ -1,0 +1,110 @@
+try:
+    import mock
+except ImportError:
+    from unittest import mock
+
+import globus_sdk
+from tests.framework import (CapturedIOTestCase,
+                             get_client_data, GO_EP1_ID,
+                             SDKTESTER1A_NATIVE1_TRANSFER_RT)
+from globus_sdk.exc import GlobusAPIError
+
+
+class RefreshTokenAuthorizerIntegrationTests(CapturedIOTestCase):
+
+    def setUp(self):
+        """
+        Makes a refresh_token grant to get new tokens for teseting
+        Sets up an AuthClient and a RefreshTokenAuthorizer with a mock
+        on_refresh function for testing their interactions
+        """
+        super(RefreshTokenAuthorizerIntegrationTests, self).setUp()
+
+        client_id = get_client_data()["native_app_client1"]["id"]
+        form_data = {'refresh_token': SDKTESTER1A_NATIVE1_TRANSFER_RT,
+                     'grant_type': 'refresh_token',
+                     'client_id': client_id}
+        token_res = globus_sdk.AuthClient().oauth2_token(form_data)
+
+        self.access_token = token_res.access_token
+        self.expires_at = token_res.expires_at_seconds
+
+        self.on_refresh = mock.Mock()
+        self.nac = globus_sdk.NativeAppAuthClient(
+            client_id=get_client_data()["native_app_client1"]["id"])
+        self.authorizer = globus_sdk.RefreshTokenAuthorizer(
+            SDKTESTER1A_NATIVE1_TRANSFER_RT, self.nac,
+            access_token=self.access_token, expires_at=self.expires_at,
+            on_refresh=self.on_refresh)
+        self.tc = globus_sdk.TransferClient(authorizer=self.authorizer)
+
+    def test_get_new_access_token(self):
+        """
+        Has the Authorizer get a new access_token via the AuthClient
+        Confirms on_refresh is called, and a different, valid token exists
+        """
+        # get new access token and confirm side effects
+        self.authorizer._get_new_access_token()
+        self.on_refresh.assert_called_once()
+        self.assertNotEqual(self.access_token, self.authorizer.access_token)
+
+        # confirm AuthClient is still usable with new token
+        get_res = self.tc.get_endpoint(GO_EP1_ID)
+        self.assertEqual(get_res["id"], GO_EP1_ID)
+
+    def test_invalid_access_token(self):
+        """
+        Invalidates the Authorizer's access_token, then makes a request
+        Confirms new access_token is is gotten and request is successful.
+        """
+        self.nac.oauth2_revoke_token(self.access_token)
+
+        # make request, confirm successful despite invalid access_token
+        get_res = self.tc.get_endpoint(GO_EP1_ID)
+        self.assertEqual(get_res["id"], GO_EP1_ID)
+        # confirm new token was gotten
+        self.on_refresh.assert_called_once()
+        self.assertNotEqual(self.access_token, self.authorizer.access_token)
+
+    def test_invalid_access_token_no_retry(self):
+        """
+        Invalidates the Authorizer's access_token, then makes a request
+        with retry_401=False, confirms 401
+        """
+        self.nac.oauth2_revoke_token(self.access_token)
+
+        # make request, confirm 401
+        with self.assertRaises(GlobusAPIError) as apiErr:
+            path = self.tc.qjoin_path("endpoint", GO_EP1_ID)
+            self.tc.get(path, retry_401=False)
+        self.assertEqual(apiErr.exception.http_status, 401)
+        self.assertEqual(apiErr.exception.code, "AuthenticationFailed")
+
+    def test_invalid_refresh_token(self):
+        """
+        Invalidates the Authorizer's refresh_token, confirms access_token
+        continues to function.
+        """
+        # TODO: Get a new refresh_token to revoke here instead
+        self.authorizer.refresh_token = None
+
+        # make request, confirm successful
+        get_res = self.tc.get_endpoint(GO_EP1_ID)
+        self.assertEqual(get_res["id"], GO_EP1_ID)
+        # confirm no new token was gotten
+        self.assertEqual(self.access_token, self.authorizer.access_token)
+
+    def test_invalid_tokens(self):
+        """
+        Invalidates the Authorizer's refresh_token and access_tokens,
+        confirms irrecoverable
+        """
+        # TODO: Get a new refresh_token to revoke here instead
+        self.authorizer.refresh_token = None
+        self.nac.oauth2_revoke_token(self.access_token)
+
+        # confirm irrecoverable
+        with self.assertRaises(GlobusAPIError) as apiErr:
+            self.tc.get_endpoint(GO_EP1_ID)
+        self.assertEqual(apiErr.exception.http_status, 400)
+        self.assertEqual(apiErr.exception.code, "Error")

--- a/tests/integration/test_refresh_token_auth_client.py
+++ b/tests/integration/test_refresh_token_auth_client.py
@@ -80,20 +80,6 @@ class RefreshTokenAuthorizerIntegrationTests(CapturedIOTestCase):
         self.assertEqual(apiErr.exception.http_status, 401)
         self.assertEqual(apiErr.exception.code, "AuthenticationFailed")
 
-    def test_invalid_refresh_token(self):
-        """
-        Invalidates the Authorizer's refresh_token, confirms access_token
-        continues to function.
-        """
-        # TODO: Get a new refresh_token to revoke here instead
-        self.authorizer.refresh_token = None
-
-        # make request, confirm successful
-        get_res = self.tc.get_endpoint(GO_EP1_ID)
-        self.assertEqual(get_res["id"], GO_EP1_ID)
-        # confirm no new token was gotten
-        self.assertEqual(self.access_token, self.authorizer.access_token)
-
     def test_invalid_tokens(self):
         """
         Invalidates the Authorizer's refresh_token and access_tokens,

--- a/tests/unit/test_access_token_authorizer.py
+++ b/tests/unit/test_access_token_authorizer.py
@@ -1,0 +1,39 @@
+from globus_sdk.authorizers import AccessTokenAuthorizer
+from tests.framework import CapturedIOTestCase
+
+
+class AccessTokenAuthorizerTests(CapturedIOTestCase):
+
+    def setUp(self):
+        """
+        Initializes a AccessTokenAuthorizer for testing
+        """
+        super(AccessTokenAuthorizerTests, self).setUp()
+        self.token = "token"
+        self.authorizer = AccessTokenAuthorizer(self.token)
+
+    def test_set_authorization_header(self):
+        """
+        Sets authorization header in a test dictionary, confirms expected value
+        """
+        header_dict = {}
+        self.authorizer.set_authorization_header(header_dict)
+        # confirm value
+        self.assertEqual(header_dict["Authorization"], "Bearer " + self.token)
+
+    def test_set_authorization_header_existing(self):
+        """
+        Confirms that an existing Authorization field is overwritten
+        """
+        header_dict = {"Header": "value",
+                       "Authorization": "previous_value"}
+        self.authorizer.set_authorization_header(header_dict)
+        # confirm values
+        self.assertEqual(header_dict["Authorization"], "Bearer " + self.token)
+        self.assertEqual(header_dict["Header"], "value")
+
+    def test_handle_missing_authorization(self):
+        """
+        Confirms that AccessTokenAuthorizer doesnt handle missing authorization
+        """
+        self.assertFalse(self.authorizer.handle_missing_authorization())

--- a/tests/unit/test_basic_authorizer.py
+++ b/tests/unit/test_basic_authorizer.py
@@ -1,0 +1,50 @@
+import base64
+
+from globus_sdk.authorizers import BasicAuthorizer
+from tests.framework import CapturedIOTestCase
+
+
+class BasicAuthorizerTests(CapturedIOTestCase):
+
+    def setUp(self):
+        """
+        Initializes a BasicAuthorizer for testing
+        """
+        super(BasicAuthorizerTests, self).setUp()
+        self.username = "testUser"
+        self.password = "PASSWORD"
+        self.authorizer = BasicAuthorizer(self.username, self.password)
+
+    def test_set_authorization_header(self):
+        """
+        Sets authorization header in a test dictionary, confirms expected value
+        """
+        header_dict = {}
+        self.authorizer.set_authorization_header(header_dict)
+        # confirm value
+        self.assertEqual(header_dict["Authorization"][:6], "Basic ")
+        decoded = base64.b64decode(
+            header_dict["Authorization"][6:]).decode('utf-8')
+        self.assertEqual(decoded, "{0}:{1}".format(self.username,
+                                                   self.password))
+
+    def test_set_authorization_header_existing(self):
+        """
+        Confirms that an existing Authorization field is overwritten
+        """
+        header_dict = {"Header": "value",
+                       "Authorization": "previous_value"}
+        self.authorizer.set_authorization_header(header_dict)
+        # confirm values
+        self.assertEqual(header_dict["Authorization"][:6], "Basic ")
+        decoded = base64.b64decode(
+            header_dict["Authorization"][6:]).decode('utf-8')
+        self.assertEqual(decoded, "{0}:{1}".format(self.username,
+                                                   self.password))
+        self.assertEqual(header_dict["Header"], "value")
+
+    def test_handle_missing_authorization(self):
+        """
+        Confirms that BasicAuthorizer doesn't handle missing authorization
+        """
+        self.assertFalse(self.authorizer.handle_missing_authorization())

--- a/tests/unit/test_null_authorizer.py
+++ b/tests/unit/test_null_authorizer.py
@@ -1,0 +1,37 @@
+from globus_sdk.authorizers import NullAuthorizer
+from tests.framework import CapturedIOTestCase
+
+
+class NullAuthorizerTests(CapturedIOTestCase):
+
+    def setUp(self):
+        """
+        Initializes a NullAuthorizer for testing
+        """
+        super(NullAuthorizerTests, self).setUp()
+        self.authorizer = NullAuthorizer()
+
+    def test_set_authorization_header(self):
+        """
+        Sets authorization header in a test dictionary,
+        Confirms that nothing happens.
+        and any existing Authorization header is removed
+        """
+        header_dict = {}
+        self.authorizer.set_authorization_header(header_dict)
+        self.assertEqual(header_dict, {})
+
+    def test_set_authorization_header_existing(self):
+        """
+        Confirms that an existing Authorization field is removed
+        """
+        header_dict = {"Header": "value",
+                       "Authorization": "previous_value"}
+        self.authorizer.set_authorization_header(header_dict)
+        self.assertEqual(header_dict, {"Header": "value"})
+
+    def test_handle_missing_authorization(self):
+        """
+        Confirms that NullAuthorizer doesn't handle missing authorization
+        """
+        self.assertFalse(self.authorizer.handle_missing_authorization())

--- a/tests/unit/test_refresh_token_authorizer.py
+++ b/tests/unit/test_refresh_token_authorizer.py
@@ -1,0 +1,197 @@
+import time
+try:
+    import mock
+except ImportError:
+    from unittest import mock
+
+from globus_sdk.authorizers import RefreshTokenAuthorizer
+from globus_sdk.authorizers.refresh_token import EXPIRES_ADJUST_SECONDS
+from tests.framework import CapturedIOTestCase
+
+
+class RefreshTokenAuthorizerTests(CapturedIOTestCase):
+
+    def setUp(self):
+        """
+        Sets up a RefreshTokenAuthorizer using a mock AuthClient for testing
+        """
+        super(RefreshTokenAuthorizerTests, self).setUp()
+        # init values for testing
+        self.refresh_token = "refresth_token_1"
+        self.access_token = "access_token_1"
+        # set to expires 1 second in the future (after buffer time)
+        self.expires_at = int(time.time()) + EXPIRES_ADJUST_SECONDS + 1
+        self.on_refresh = mock.Mock()
+
+        # mock response value for simulating a refresh token grant response
+        self.response = mock.Mock()
+        self.response.expires_at_seconds = int(time.time()) + 1000
+        self.response.access_token = "access_token_2"
+
+        # mock AuthClient for testing
+        self.ac = mock.Mock()
+        self.ac.oauth2_refresh_token = mock.Mock(return_value=self.response)
+
+        self.authorizer = RefreshTokenAuthorizer(
+            self.refresh_token, self.ac, access_token=self.access_token,
+            expires_at=self.expires_at, on_refresh=self.on_refresh)
+
+    def test_init(self):
+        """
+        Inits a RefreshTokenAuthorizer with an access_token, but no expires_at,
+        and a RefreshTokenAuthorizer with an expires_at, but no access_token.
+        Confirms that a new access_token is gotten for safety
+        """
+        authorizer = RefreshTokenAuthorizer(
+            self.refresh_token, self.ac, access_token=self.access_token)
+        self.assertEqual(authorizer.access_token, self.response.access_token)
+
+        authorizer = RefreshTokenAuthorizer(
+            self.refresh_token, self.ac, expires_at=self.access_token)
+        self.assertEqual(authorizer.access_token, self.response.access_token)
+
+    def test_set_expiration_time(self):
+        """
+        Confirms expiration time is set earlier than input value for a buffer
+        """
+        # confirm initial value was adjusted automatically
+        self.assertEqual(self.authorizer.expires_at,
+                         self.expires_at - EXPIRES_ADJUST_SECONDS)
+
+        # confirm results with test inputs
+        for test_input in [0, 60, 120, 1200]:
+            self.authorizer._set_expiration_time(test_input)
+            self.assertEqual(self.authorizer.expires_at,
+                             test_input - EXPIRES_ADJUST_SECONDS)
+
+    def test_get_new_access_token(self):
+        """
+        Calls get_new_acces token, confirms that the mock AuthClient is used
+        and that the mock on_refresh function is called.
+        """
+        # confirm starting with original access_token
+        self.assertEqual(self.authorizer.access_token, self.access_token)
+
+        # get new_access_token
+        self.authorizer._get_new_access_token()
+        # confirm side effects
+        self.assertEqual(self.authorizer.access_token,
+                         self.response.access_token)
+        self.assertEqual(self.authorizer.expires_at,
+                         self.response.expires_at_seconds -
+                         EXPIRES_ADJUST_SECONDS)
+        self.ac.oauth2_refresh_token.assert_called_once_with(
+            self.refresh_token)
+        self.on_refresh.assert_called_once()
+
+    def test_check_expiration_time_valid(self):
+        """
+        Confirms nothing is done before the access_token expires,
+        """
+        self.authorizer._check_expiration_time()
+        self.assertEqual(self.authorizer.access_token, self.access_token)
+
+    def test_check_expiration_time_expired(self):
+        """
+        Confirms a new access_token is gotten after waiting for expiration
+        """
+        time.sleep(1)
+        self.authorizer._check_expiration_time()
+        self.assertEqual(self.authorizer.access_token,
+                         self.response.access_token)
+        self.assertEqual(self.authorizer.expires_at,
+                         self.response.expires_at_seconds -
+                         EXPIRES_ADJUST_SECONDS)
+
+    def test_check_expiration_time_no_token(self):
+        """
+        Confirms a new access_token is gotten if the old one is set to None
+        """
+        self.authorizer.access_token = None
+        self.authorizer._check_expiration_time()
+        self.assertEqual(self.authorizer.access_token,
+                         self.response.access_token)
+        self.assertEqual(self.authorizer.expires_at,
+                         self.response.expires_at_seconds -
+                         EXPIRES_ADJUST_SECONDS)
+
+    def test_check_expiration_time_no_expiration(self):
+        """
+        Confirms a new access_token is gotten if expires_at is set to None
+        """
+        self.authorizer.expires_at = None
+        self.authorizer._check_expiration_time()
+        self.assertEqual(self.authorizer.access_token,
+                         self.response.access_token)
+        self.assertEqual(self.authorizer.expires_at,
+                         self.response.expires_at_seconds -
+                         EXPIRES_ADJUST_SECONDS)
+
+    def test_set_authorization_header(self):
+        """
+        Sets authorization header on a test dictionary, confirms expected value
+        """
+        header_dict = {}
+        self.authorizer.set_authorization_header(header_dict)
+        # confirm value
+        self.assertEqual(header_dict["Authorization"],
+                         "Bearer " + self.access_token)
+
+    def test_set_authorization_header_existing(self):
+        """
+        Confirms that an existing Authorization field is overwritten
+        """
+        header_dict = {"Header": "value",
+                       "Authorization": "previous_value"}
+        self.authorizer.set_authorization_header(header_dict)
+        # confirm values
+        self.assertEqual(header_dict["Authorization"],
+                         "Bearer " + self.access_token)
+        self.assertEqual(header_dict["Header"], "value")
+
+    def test_set_authorization_header_expired(self):
+        """
+        Waits for the access_token to expire, then sets authorization header
+        Confirms header value uses the new access_token.
+        """
+        header_dict = {}
+        time.sleep(1)
+
+        self.authorizer.set_authorization_header(header_dict)
+        # confirm value
+        self.assertEqual(header_dict["Authorization"],
+                         "Bearer " + self.response.access_token)
+
+    def test_set_authorization_header_no_token(self):
+        """
+        Sets the access_token to None, then sets authorization header
+        Confirms header value uses the new access_token.
+        """
+        header_dict = {}
+        self.authorizer.access_token = None
+
+        self.authorizer.set_authorization_header(header_dict)
+        # confirm value
+        self.assertEqual(header_dict["Authorization"],
+                         "Bearer " + self.response.access_token)
+
+    def test_set_authorization_header_no_expires(self):
+        """
+        Sets expires_at to None, then sets authorization header
+        Confirms header value uses the new access_token.
+        """
+        header_dict = {}
+        self.authorizer.expires_at = None
+
+        self.authorizer.set_authorization_header(header_dict)
+        # confirm value
+        self.assertEqual(header_dict["Authorization"],
+                         "Bearer " + self.response.access_token)
+
+    def test_handle_missing_authorization(self):
+        """
+        Confirms that RefreshTokenAuthorizers will attempt to fix 401s
+        by treating their existing access_token as expired
+        """
+        self.assertTrue(self.authorizer.handle_missing_authorization())
+        self.assertIsNone(self.authorizer.expires_at)


### PR DESCRIPTION
So it turns out the refresh_token returned in a refresh token grant is identical to the one sent, so I wasn't able to test revoking a refresh token in the integration tests like we wanted to, unless there is another way to get new refresh tokens from an existing one?