### PR TITLE
Improve Native App PKCE support

### DIFF
--- a/tests/integration/test_auth_client_flow.py
+++ b/tests/integration/test_auth_client_flow.py
@@ -40,12 +40,12 @@ class AuthClientIntegrationTests(CapturedIOTestCase):
         # starting flow with specified paramaters
         flow_manager = globus_sdk.auth.GlobusNativeAppFlowManager(
             ac, requested_scopes="scopes", redirect_uri="uri",
-            state="state", verifier="verifier", refresh_tokens=True)
+            state="state", verifier=("a" * 43), refresh_tokens=True)
         ac.current_oauth2_flow_manager = flow_manager
 
         # get url_and validate results
         url_res = ac.oauth2_get_authorize_url()
-        verifier, remade_challenge = make_native_app_challenge("verifier")
+        verifier, remade_challenge = make_native_app_challenge("a" * 43)
         expected_vals = [ac.base_url + "v2/oauth2/authorize?",
                          "client_id=" + ac.client_id,
                          "redirect_uri=" + "uri",

--- a/tests/integration/test_native_client_flow.py
+++ b/tests/integration/test_native_client_flow.py
@@ -65,7 +65,7 @@ class NativeAppAuthClientIntegrationTests(CapturedIOTestCase):
         # confirms flow initialized with specified values
         flow = self.nac.oauth2_start_flow(
             requested_scopes="scopes", redirect_uri="uri",
-            state="state", verifier="verifier", refresh_tokens=True)
+            state="state", verifier=("v" * 43), refresh_tokens=True)
         self.assertIsInstance(flow, GlobusNativeAppFlowManager)
         self.assertEqual(flow.redirect_uri, "uri")
         self.assertEqual(flow.requested_scopes, "scopes")
@@ -74,7 +74,7 @@ class NativeAppAuthClientIntegrationTests(CapturedIOTestCase):
 
         # confirm client can get url via flow
         url_res = self.nac.oauth2_get_authorize_url()
-        verifier, remade_challenge = make_native_app_challenge("verifier")
+        verifier, remade_challenge = make_native_app_challenge("v" * 43)
         expected_vals = [self.nac.base_url + "v2/oauth2/authorize?",
                          "client_id=" + self.nac.client_id,
                          "redirect_uri=" + "uri",

--- a/tests/unit/test_oauth2_authorization_code.py
+++ b/tests/unit/test_oauth2_authorization_code.py
@@ -20,7 +20,7 @@ class GlobusAuthorizationCodeFlowManagerTests(CapturedIOTestCase):
         self.ac.base_url = "base_url/"
         self.flow_manager = globus_sdk.auth.GlobusNativeAppFlowManager(
             self.ac, requested_scopes="scopes", redirect_uri="uri",
-            state="state", verifier="verifier")
+            state="state")
 
     def test_get_authorize_url(self):
         """


### PR DESCRIPTION
* Generate `code_verifier` and `code_challenge` strings that are RFC 7636 compliant:
  * 43-128 characters in length.
  * Contain only the following characters: `a-z`, `A-Z`, `-`, `_`, `.`, `~`.

Needs to wait until Auth handles code verifiers without the padding.

