### PR TITLE
Add support for setting python version for venv

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
-exclude = .git,__pycache__,.eggs,dist,venv,.venv,venv27,virtualenv,docs,docs-source,build
+exclude = .git,__pycache__,.eggs,dist,venv,.venv*,venv27,virtualenv,docs,docs-source,build
 # explicitly set flake8 to not ignore any rules
 ignore = W503,W504

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ matrix:
     - python: "pypy3"
 cache: pip
 script:
-  - make test/opts
+  - make test/opts PYTHON_VERSION=$TRAVIS_PYTHON_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,10 @@ matrix:
     - python: "pypy"
     - python: "pypy3"
 cache: pip
+install:
+  - pip install .
+  - pip install -r optional-dependencies.txt
+  - pip install -r test-requirements.txt
 script:
-  - make test/opts PYTHON_VERSION=$TRAVIS_PYTHON_VERSION
+  - flake8
+  - nose2 --verbose

--- a/Makefile
+++ b/Makefile
@@ -49,10 +49,9 @@ $(VIRTUALENV)/bin/flake8 $(VIRTUALENV)/bin/nose2: test-requirements.txt $(VIRTUA
 	touch $(VIRTUALENV)/bin/flake8
 	touch $(VIRTUALENV)/bin/nose2
 opt-dependencies: $(VIRTUALENV)
-	# don't specify version -- grab the latest!
-	$(VIRTUALENV)/bin/pip install python-jose
+	$(VIRTUALENV)/bin/pip install -r optional-dependencies.txt
 remove-opt-dependencies: $(VIRTUALENV)
-	-$(VIRTUALENV)/bin/pip uninstall -y python-jose
+	-$(VIRTUALENV)/bin/pip uninstall -y -r optional-dependencies.txt
 
 test: $(VIRTUALENV)/bin/flake8 $(VIRTUALENV)/bin/nose2
 	$(VIRTUALENV)/bin/flake8

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-VIRTUALENV=.venv
+# default to system python
+PYTHON_VERSION ?=
+PYTHON_INTERPRETER=python$(PYTHON_VERSION)
+VIRTUALENV=.venv$(PYTHON_VERSION)
 
 .PHONY: docs build upload test test/opts test/no-opts clean help
 
@@ -24,7 +27,7 @@ localdev: $(VIRTUALENV)
 
 
 $(VIRTUALENV): setup.py
-	virtualenv $(VIRTUALENV)
+	virtualenv --python $(PYTHON_INTERPRETER) $(VIRTUALENV)
 	$(VIRTUALENV)/bin/python setup.py develop
 	# explicit touch to ensure good update time relative to setup.py
 	touch $(VIRTUALENV)

--- a/optional-dependencies.txt
+++ b/optional-dependencies.txt
@@ -1,0 +1,2 @@
+# don't specify version -- grab the latest!
+python-jose


### PR DESCRIPTION
Fixes Travis testing always using Python2 (whoops!).

Makes it easier to test against all of your available pythons.
And also have Travis set it explicitly to `TRAVIS_PYTHON_VERSION`.