### PR TITLE
Make jwk_data get respect ssl_verify=no

### DIFF
--- a/globus_sdk/auth/token_response.py
+++ b/globus_sdk/auth/token_response.py
@@ -116,7 +116,8 @@ class OAuthTokenResponse(GlobusHTTPResponse):
         logger.debug('Fetch JWK Data: Start')
         oidc_conf = auth_client.get('/.well-known/openid-configuration')
         jwks_uri = oidc_conf['jwks_uri']
-        jwk_data = requests.get(jwks_uri).json()
+        # use the auth_client's decision on ssl_verify=yes/no
+        jwk_data = requests.get(jwks_uri, verify=auth_client._verify).json()
         logger.debug('Fetch JWK Data: Complete')
 
         return jwt.decode(

--- a/tests/unit/test_token_response.py
+++ b/tests/unit/test_token_response.py
@@ -55,6 +55,7 @@ class OAuthTokenResponseTests(CapturedIOTestCase):
         # mock AuthClient
         self.ac = mock.Mock()
         self.ac.client_id = get_client_data()["native_app_client1"]["id"]
+        self.ac._verify = True
         self.ac.get = mock.Mock(return_value={
             "jwks_uri":
             u"https://auth.globus.org/jwk.json"})


### PR DESCRIPTION
Take the value off of the given AuthClient object.
Closes #160 

It turns out this was the only call where `verify` wasn't set.

I think I might be the only person who cares about this?