### PR TITLE
Remove confusing top-level attrs of Token Response

### DIFF
--- a/globus_sdk/authorizers/refresh_token.py
+++ b/globus_sdk/authorizers/refresh_token.py
@@ -116,7 +116,8 @@ class RefreshTokenAuthorizer(GlobusAuthorizer):
             raise ValueError(
                 "Attempting refresh for refresh token authorizer "
                 "didn't return exactly one value. Possible service error.")
-        token_data = token_data[0]
+        # get the first (and only) item from this iterable
+        token_data = next(iter(token_data))
 
         self._set_expiration_time(token_data['expires_at_seconds'])
         self.access_token = token_data['access_token']

--- a/globus_sdk/authorizers/refresh_token.py
+++ b/globus_sdk/authorizers/refresh_token.py
@@ -110,8 +110,16 @@ class RefreshTokenAuthorizer(GlobusAuthorizer):
         """
         token_response = self.auth_client.oauth2_refresh_token(
             self.refresh_token)
-        self._set_expiration_time(token_response.expires_at_seconds)
-        self.access_token = token_response.access_token
+
+        token_data = token_response.by_resource_server.values()
+        if len(token_data) != 1:
+            raise ValueError(
+                "Attempting refresh for refresh token authorizer "
+                "didn't return exactly one value. Possible service error.")
+        token_data = token_data[0]
+
+        self._set_expiration_time(token_data['expires_at_seconds'])
+        self.access_token = token_data['access_token']
         logger.info(("RefreshTokenAuthorizer.access_token updated to "
                      '"...{}" (last 5 chars)')
                     .format(self.access_token[-5:]))

--- a/tests/integration/test_refresh_token_auth_client.py
+++ b/tests/integration/test_refresh_token_auth_client.py
@@ -25,9 +25,12 @@ class RefreshTokenAuthorizerIntegrationTests(CapturedIOTestCase):
                      'grant_type': 'refresh_token',
                      'client_id': client_id}
         token_res = globus_sdk.AuthClient().oauth2_token(form_data)
+        token_res = token_res.by_resource_server
 
-        self.access_token = token_res.access_token
-        self.expires_at = token_res.expires_at_seconds
+        self.access_token = token_res[
+            'transfer.api.globus.org']['access_token']
+        self.expires_at = token_res[
+            'transfer.api.globus.org']['expires_at_seconds']
 
         self.on_refresh = mock.Mock()
         self.nac = globus_sdk.NativeAppAuthClient(

--- a/tests/unit/test_token_response.py
+++ b/tests/unit/test_token_response.py
@@ -117,54 +117,6 @@ class OAuthTokenResponseTests(CapturedIOTestCase):
             self.assertIn(server_data["expires_at_seconds"],
                           (expected - 1, expected, expected + 1))
 
-    def test_expires_at_seconds(self):
-        """
-        Gets response's expires_at_seconds attribute, confirms expected value
-        """
-        # assumes test runs within 1 second range
-        expected = int(time.time()) + self.top_token["expires_in"]
-        self.assertIn(self.response.expires_at_seconds,
-                      (expected - 1, expected, expected + 1))
-
-    def test_expires_in(self):
-        """
-        Gets two measurements of response's expires_in attribute,
-        Sanity checks that expires_in decreases as time goes on
-        """
-        first_measure = self.response.expires_in
-        time.sleep(1.1)
-        second_measure = self.response.expires_in
-        self.assertTrue(first_measure <= self.top_token["expires_in"])
-        self.assertTrue(second_measure < first_measure)
-
-    def test_access_token(self):
-        """
-        Gets response's access_token attribute, confirms expected value
-        """
-        self.assertEqual(self.response.access_token,
-                         self.top_token["access_token"])
-
-    def test_refresh_token(self):
-        """
-        Gets response's refresh_token attribute, confirms expected value
-        """
-        self.assertEqual(self.response.refresh_token,
-                         self.top_token["refresh_token"])
-
-    def test_resource_server(self):
-        """
-        Gets response's resource_server attribute, confirms expected value
-        """
-        self.assertEqual(self.response.resource_server,
-                         self.top_token["resource_server"])
-
-    def test_other_tokens(self):
-        """
-        Gets response's other_tokens attribute, confirms expected value
-        """
-        self.assertEqual(self.response.other_tokens,
-                         self.top_token["other_tokens"])
-
     @unittest.skipIf(JOSE_FLAG, "python-jose successfully imported")
     def test_decode_id_token_no_jose(self):
         """


### PR DESCRIPTION
After some thought about #158, I've become convinced that these attributes should be removed.
The silent "promotion" of scopes by Auth, the lack of any public specification as to the method of determination for that top-level token, and the inability of users to change what that token is by any means mean that these properties offer very little value and a lot of confusion.

`OAuthTokenResponse` top-level properties for accessing the top-level token aren't the desired/canonical/safe way to access tokens. We're telling people to always use `by_resource_server`, so we should cut down the interface for this class to that and only that.

Minor change included: make the dependent token response a subclass of the typical token response, only overriding a helper used by `__init__`.

This will require that we bump to `0.7.0` in the next release.