### PR TITLE
Change "identities_set" to "identity_set" for token introspection

### DIFF
--- a/globus_sdk/auth/client_types/confidential_client.py
+++ b/globus_sdk/auth/client_types/confidential_client.py
@@ -156,7 +156,7 @@ class ConfidentialAppAuthClient(AuthClient):
 
           ``include`` (*string*)
             A value for the ``include`` parameter in the request body. Default
-            is to omit the parameter, also supports ``"identities_set"``.
+            is to omit the parameter, also supports ``"identity_set"``.
 
         **External Documentation**
 


### PR DESCRIPTION
Per https://github.com/globusonline/globus-auth/pull/931/. Auth supports both, and eventually we'd like to deprecate the awkward `identities_set`. Do not merge until https://github.com/globusonline/globus-auth/pull/931 in deployed everywhere.