### PR TITLE
Update to v0.7.0 for release

### DIFF
--- a/globus_sdk/version.py
+++ b/globus_sdk/version.py
@@ -1,3 +1,3 @@
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "0.6.0"
+__version__ = "0.7.0"


### PR DESCRIPTION
@jaswilli, I'd like to push out `0.7.0` so that I can start using it.
Any objections? I've already drafted release notes for v0.7.0