### PR TITLE
Dependency updates + make `python-jose` installable via an extra

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,7 @@ matrix:
     - python: "pypy3"
 cache: pip
 install:
-  - pip install .
-  - pip install -r optional-dependencies.txt
+  - pip install -e .[jwt]
   - pip install -r test-requirements.txt
 script:
   - flake8

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PYTHON_VERSION ?=
 PYTHON_INTERPRETER=python$(PYTHON_VERSION)
 VIRTUALENV=.venv$(PYTHON_VERSION)
 
-.PHONY: docs build upload test test/opts test/no-opts clean help
+.PHONY: docs build upload test test/opts clean help
 
 
 help:
@@ -48,17 +48,12 @@ $(VIRTUALENV)/bin/flake8 $(VIRTUALENV)/bin/nose2: test-requirements.txt $(VIRTUA
 	# command sees that they exist and does not update their mtime
 	touch $(VIRTUALENV)/bin/flake8
 	touch $(VIRTUALENV)/bin/nose2
-opt-dependencies: $(VIRTUALENV)
-	$(VIRTUALENV)/bin/pip install -r optional-dependencies.txt
-remove-opt-dependencies: $(VIRTUALENV)
-	-$(VIRTUALENV)/bin/pip uninstall -y -r optional-dependencies.txt
 
 test: $(VIRTUALENV)/bin/flake8 $(VIRTUALENV)/bin/nose2
 	$(VIRTUALENV)/bin/flake8
 	$(VIRTUALENV)/bin/nose2 --verbose
-test/opts: opt-dependencies
-	$(MAKE) test
-test/no-opts: remove-opt-dependencies
+test/opts: $(VIRTUALENV)
+	$(VIRTUALENV)/bin/pip install -e .[jwt]
 	$(MAKE) test
 
 

--- a/docs/optional_dependencies.rst
+++ b/docs/optional_dependencies.rst
@@ -8,6 +8,12 @@ These dependencies are python packages which are *not* required by the SDK, but
 If you attempt to use such a feature without installing the relevant
 dependency, you will get a ``GlobusOptionalDependencyError``.
 
+Optional dependencies are also made available via these extras, specified as
+part of your dependency on the ``globus_sdk`` package:
+
+- ``globus_sdk[jwt]``
+
+
 OIDC ID Tokens
 --------------
 
@@ -17,3 +23,7 @@ conforming to the Open ID Connect specification.
 If you wish to decode this token via :meth:`decode_id_token
 <globus_sdk.auth.token_response.OAuthTokenResponse.decode_id_token>`, you must
 install ``python-jose``, which we use to implement ID Token verification.
+
+You may install supported versions of ``python-jose`` by install the SDK with
+its ``globus_sdk[jwt]`` extra. Simply specify ``globus_sdk[jwt]`` in your
+dependencies.

--- a/globus_sdk/auth/token_response.py
+++ b/globus_sdk/auth/token_response.py
@@ -68,7 +68,7 @@ class OAuthTokenResponse(GlobusHTTPResponse):
         except ImportError:
             logger.error('OptionalDependencyError(python-jose)')
             raise GlobusOptionalDependencyError(
-                ["python-jose"],
+                ["python-jose or globus_sdk[jwt]"],
                 "JWT Parsing via OAuthTokenResponse.id_token")
 
         logger.debug('Fetch JWK Data: Start')

--- a/optional-dependencies.txt
+++ b/optional-dependencies.txt
@@ -1,2 +1,0 @@
-# don't specify version -- grab the latest!
-python-jose

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,13 @@ setup(name="globus-sdk",
       packages=find_packages(),
       install_requires=[
           'requests>=2.0.0,<3.0.0',
-          'six==1.10.0'
+          'six>=1.10.0,<2.0.0'
       ],
+
+      extras_require={
+          'jwt': ['python-jose>=1.3.0,<2.0.0']
+      },
+
       include_package_data=True,
 
       keywords=["globus", "file transfer"],


### PR DESCRIPTION
Resolves #167 and #168 

Small updates to `GlobusOptionalDependencyError`, Makefile, and .travis.yml included to use this new fanciness. Small doc update too.