### PR TITLE
Fix the broken contract with on_refresh

### DIFF
--- a/globus_sdk/authorizers/client_credentials.py
+++ b/globus_sdk/authorizers/client_credentials.py
@@ -64,14 +64,18 @@ class ClientCredentialsAuthorizer(RenewingAuthorizer):
         super(ClientCredentialsAuthorizer, self).__init__(
             access_token, expires_at, on_refresh)
 
-    def _get_token_data(self):
+    def _get_token_response(self):
         """
-        Make a client credentials grant, get the tokens .by_resource_server,
-        Ensure that only one token was gotten, and return that token.
+        Make a client credentials grant
         """
-        res = self.confidential_client.oauth2_client_credentials_tokens(
+        return self.confidential_client.oauth2_client_credentials_tokens(
             requested_scopes=self.scopes)
 
+    def _extract_token_data(self, res):
+        """
+        Get the tokens .by_resource_server,
+        Ensure that only one token was gotten, and return that token.
+        """
         token_data = res.by_resource_server.values()
         if len(token_data) != 1:
             raise ValueError(

--- a/globus_sdk/authorizers/refresh_token.py
+++ b/globus_sdk/authorizers/refresh_token.py
@@ -59,13 +59,17 @@ class RefreshTokenAuthorizer(RenewingAuthorizer):
         super(RefreshTokenAuthorizer, self).__init__(
             access_token, expires_at, on_refresh)
 
-    def _get_token_data(self):
+    def _get_token_response(self):
         """
-        Make a refresh token grant, get the tokens .by_resource_server,
+        Make a refresh token grant
+        """
+        return self.auth_client.oauth2_refresh_token(self.refresh_token)
+
+    def _extract_token_data(self, res):
+        """
+        Get the tokens .by_resource_server,
         Ensure that only one token was gotten, and return that token.
         """
-        res = self.auth_client.oauth2_refresh_token(self.refresh_token)
-
         token_data = res.by_resource_server.values()
         if len(token_data) != 1:
             raise ValueError(

--- a/tests/unit/test_client_credentials_authorizer.py
+++ b/tests/unit/test_client_credentials_authorizer.py
@@ -40,15 +40,15 @@ class ClientCredentialsAuthorizerTests(CapturedIOTestCase):
             self.cac, self.scopes, access_token=self.access_token,
             expires_at=self.expires_at)
 
-    def test_get_token_data(self):
+    def test_get_token_response(self):
         """
-        Calls _get_token_data, confirms that the mock
+        Calls _get_token_response, confirms that the mock
         ConfidentialAppAuthClient is used and the known data was returned.
         """
         # get new_access_token
-        res = self.authorizer._get_token_data()
+        res = self.authorizer._get_token_response()
         # confirm expected response
-        self.assertEqual(res, self.rs_data)
+        self.assertEqual(res, self.response)
         # confirm mock ConfidentailAppAuthClient was used as expected
         self.cac.oauth2_client_credentials_tokens.assert_called_once_with(
             requested_scopes=self.scopes)
@@ -56,7 +56,8 @@ class ClientCredentialsAuthorizerTests(CapturedIOTestCase):
     def test_multiple_resource_servers(self):
         """
         Sets the mock ConfidentialAppAuthClient to return multiple resource
-        servers. Confirms GlobusError is raised when _get_token_data is called.
+        servers. Confirms GlobusError is raised when _extract_token_data is
+        called.
         """
         self.response.by_resource_server = {
             "rs1": {
@@ -69,7 +70,7 @@ class ClientCredentialsAuthorizerTests(CapturedIOTestCase):
             }
         }
         with self.assertRaises(ValueError) as err:
-            self.authorizer._get_token_data()
+            self.authorizer._extract_token_data(self.response)
 
         self.assertIn("didn't return exactly one token", str(err.exception))
         self.assertIn(self.scopes, str(err.exception))

--- a/tests/unit/test_refresh_token_authorizer.py
+++ b/tests/unit/test_refresh_token_authorizer.py
@@ -38,15 +38,15 @@ class RefreshTokenAuthorizerTests(CapturedIOTestCase):
             self.refresh_token, self.ac, access_token=self.access_token,
             expires_at=self.expires_at)
 
-    def test_get_token_data(self):
+    def test_get_token_response(self):
         """
-        Calls _get_token_data, confirms that the mock
+        Calls _get_token_response, confirms that the mock
         AuthClient is used and the known data was returned.
         """
         # get new_access_token
-        res = self.authorizer._get_token_data()
+        res = self.authorizer._get_token_response()
         # confirm expected response
-        self.assertEqual(res, self.rs_data)
+        self.assertEqual(res, self.response)
         # confirm mock ConfidentailAppAuthClient was used as expected
         self.ac.oauth2_refresh_token.assert_called_once_with(
             self.refresh_token)
@@ -54,7 +54,8 @@ class RefreshTokenAuthorizerTests(CapturedIOTestCase):
     def test_multiple_resource_servers(self):
         """
         Sets the mock ConfidentialAppAuthClient to return multiple resource
-        servers. Confirms GlobusError is raised when _get_token_data is called.
+        servers. Confirms GlobusError is raised when _extract_token_data is
+        called.
         """
         self.response.by_resource_server = {
             "rs1": {
@@ -67,5 +68,5 @@ class RefreshTokenAuthorizerTests(CapturedIOTestCase):
             }
         }
         with self.assertRaises(ValueError) as err:
-            self.authorizer._get_token_data()
+            self.authorizer._extract_token_data(self.response)
         self.assertIn("didn't return exactly one token", str(err.exception))

--- a/tests/unit/test_renewing_authorizer.py
+++ b/tests/unit/test_renewing_authorizer.py
@@ -11,14 +11,18 @@ from tests.framework import CapturedIOTestCase
 
 class MockRenewer(RenewingAuthorizer):
     """
-    Class that implements RenewingAuthorizer so that _get_token_data
-    can return known values for testing
+    Class that implements RenewingAuthorizer so that _get_token_response and
+    _extract_token_data can return known values for testing
     """
     def __init__(self, token_data, **kwargs):
         self.token_data = token_data
+        self.token_response = mock.Mock()
         super(MockRenewer, self).__init__(**kwargs)
 
-    def _get_token_data(self):
+    def _get_token_response(self):
+        return self.token_response
+
+    def _extract_token_data(self, res):
         return self.token_data
 
 


### PR DESCRIPTION
The RenewingAuthorizer broke our contract with supplied `on_refresh` callbacks. Those are supposed to be called on the raw response -- to do whatever manipulation they would like. Instead, they were being called on the `by_resource_server` dict property.

Fix this by separating the steps of getting a token (and response) from processing it. This might not be the cleanest imaginable fix, but it works.