### PR TITLE
Add AuthAPIError exception class

### DIFF
--- a/globus_sdk/auth/client_types/base.py
+++ b/globus_sdk/auth/client_types/base.py
@@ -4,6 +4,7 @@ import six
 import collections
 import logging
 
+from globus_sdk import exc
 from globus_sdk.base import BaseClient, safe_stringify
 from globus_sdk.authorizers import NullAuthorizer
 from globus_sdk.auth.token_response import OAuthTokenResponse
@@ -41,6 +42,8 @@ class AuthClient(BaseClient):
     You can, of course, use other kinds of Authorizers (notably the
     ``RefreshTokenAuthorizer``).
     """
+    error_class = exc.AuthAPIError
+
     def __init__(self, client_id=None, authorizer=None, **kwargs):
         self.client_id = client_id
 

--- a/globus_sdk/exc.py
+++ b/globus_sdk/exc.py
@@ -1,5 +1,6 @@
 import logging
 import textwrap
+import six
 import requests
 
 logger = logging.getLogger(__name__)
@@ -131,6 +132,30 @@ class TransferAPIError(GlobusAPIError):
         self.code = data["code"]
         self.message = data["message"]
         self.request_id = data["request_id"]
+
+
+class AuthAPIError(GlobusAPIError):
+    """
+    Error class for the API components of Globus Auth.
+
+    Customizes JSON parsing.
+    """
+    def _load_from_json(self, data):
+        """
+        Load error data from a JSON document.
+
+        Sets `code` statically because Auth doesn't have API error codes, and
+        looks for a top-level "error" attribute.
+        """
+        self.code = "Error"
+        if "message" in data:
+            self.message = data["message"]
+        elif "detail" in data:
+            self.message = data["detail"]
+        elif "error" in data and isinstance(data["error"], six.string_types):
+            self.message = data["error"]
+        else:
+            self.message = "no_extractable_message"
 
 
 class InvalidDocumentBodyError(GlobusError):

--- a/globus_sdk/exc.py
+++ b/globus_sdk/exc.py
@@ -147,7 +147,17 @@ class AuthAPIError(GlobusAPIError):
         Sets `code` statically because Auth doesn't have API error codes, and
         looks for a top-level "error" attribute.
         """
-        self.code = "Error"
+        if "errors" in data:
+            if len(data["errors"]) != 1:
+                logger.warn(("Doing JSON load of error response with multiple "
+                             "errors. Exception data will only include the "
+                             "first error, but there are really {} errors")
+                            .format(len(data["errors"])))
+            # TODO: handle responses with more than one error
+            data = data["errors"][0]
+
+        self.code = data.get("code", "Error")
+
         if "message" in data:
             self.message = data["message"]
         elif "detail" in data:


### PR DESCRIPTION
Handles the case of Auth errors with a single top-level "error" key more gracefully. Also gives Auth errors their own class.
Although not all of Auth is an API, the parts used by the SDK are, so the class name is okay.

Resolves #138 

Because we're under the gun for GW on Tuesday, I'm not trying to think through tests for this right now. I know it's bad not to have them, but limited time -> limited quality.