### PR TITLE
Fix docs references to oauth2_start_flow_*

### DIFF
--- a/docs/examples/native_app.rst
+++ b/docs/examples/native_app.rst
@@ -82,4 +82,4 @@ Simply add this option to the example above:
 
 .. code-block:: python
 
-    client.oauth2_start_flow_native_app(refresh_tokens=True)
+    client.oauth2_start_flow(refresh_tokens=True)

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -91,7 +91,7 @@ Run the following code sample to get your Access Tokens:
     CLIENT_ID = '<YOUR_ID_HERE>'
 
     client = globus_sdk.NativeAppAuthClient(CLIENT_ID)
-    client.oauth2_start_flow_native_app()
+    client.oauth2_start_flow()
 
     authorize_url = client.oauth2_get_authorize_url()
     print('Please go to this URL and login: {0}'.format(authorize_url))
@@ -168,7 +168,7 @@ Remember:
 .. code-block:: python
 
     client = globus_sdk.NativeAppAuthClient(CLIENT_ID)
-    client.oauth2_start_flow_native_app()
+    client.oauth2_start_flow()
 
     print('Please go to this URL and login: {0}'
           .format(client.oauth2_get_authorize_url()))
@@ -239,7 +239,7 @@ tweak your login flow with one argument:
 .. code-block:: python
 
     client = globus_sdk.NativeAppAuthClient(CLIENT_ID)
-    client.oauth2_start_flow_native_app(refresh_tokens=True)
+    client.oauth2_start_flow(refresh_tokens=True)
 
     print('Please go to this URL and login: {0}'
           .format(client.oauth2_get_authorize_url()))

--- a/globus_sdk/auth/client_types/base.py
+++ b/globus_sdk/auth/client_types/base.py
@@ -146,7 +146,7 @@ class AuthClient(BaseClient):
     def oauth2_get_authorize_url(self, additional_params=None):
         """
         Get the authorization URL to which users should be sent.
-        This method may only be called after an ``oauth2_start_flow_*`` method
+        This method may only be called after ``oauth2_start_flow``
         has been called on this ``AuthClient``.
 
         **Parameters**
@@ -163,7 +163,7 @@ class AuthClient(BaseClient):
                                'get_authorize_url before start_flow)'))
             raise ValueError(
                 ('Cannot get authorize URL until starting an OAuth2 flow. '
-                 'Call one of the oauth2_start_flow_*() methods on this '
+                 'Call the oauth2_start_flow() method on this '
                  'AuthClient to resolve'))
         auth_url = self.current_oauth2_flow_manager.get_authorize_url(
             additional_params=additional_params)
@@ -190,7 +190,7 @@ class AuthClient(BaseClient):
                                'exchange_code before start_flow)'))
             raise ValueError(
                 ('Cannot exchange auth code until starting an OAuth2 flow. '
-                 'Call one of the oauth2_start_flow_*() methods on this '
+                 'Call the oauth2_start_flow() method on this '
                  'AuthClient to resolve'))
 
         return self.current_oauth2_flow_manager.exchange_code_for_tokens(


### PR DESCRIPTION
Dan pointed out that these docs are using an out-of-date name for this
method from pre-1.0 release versions.