### PR TITLE
Add endpoint_manager_task_successful_transfers, and unit tests

### DIFF
--- a/tests/files/auth_fixtures/sdktester2b@globusid.org.json
+++ b/tests/files/auth_fixtures/sdktester2b@globusid.org.json
@@ -1,0 +1,8 @@
+{
+  "username": "sdktester2b@globusid.org",
+  "name": "SDK Tester 2",
+  "id": "d56811ae-8490-4c1a-944a-dfc2deb4cc88",
+  "identity_provider": "41143743-f3c8-4d60-bbdb-eeecaba85bd9",
+  "organization": "Globus",
+  "email": "aaschaer+sdktester2b@globus.org"
+}

--- a/tests/framework/__init__.py
+++ b/tests/framework/__init__.py
@@ -6,7 +6,8 @@ from tests.framework.constants import (GO_EP1_ID, GO_EP2_ID,
                                        SDKTESTER1A_NATIVE1_TRANSFER_RT,
                                        SDKTESTER1A_NATIVE1_AUTH_RT,
                                        SDKTESTER1A_NATIVE1_ID_TOKEN,
-                                       SDKTESTER1A_ID_ACCESS_TOKEN)
+                                       SDKTESTER1A_ID_ACCESS_TOKEN,
+                                       SDKTESTER2B_NATIVE1_TRANSFER_RT)
 
 __all__ = [
     "CapturedIOTestCase",
@@ -21,5 +22,6 @@ __all__ = [
     "SDKTESTER1A_NATIVE1_TRANSFER_RT",
     "SDKTESTER1A_NATIVE1_AUTH_RT",
     "SDKTESTER1A_NATIVE1_ID_TOKEN",
-    "SDKTESTER1A_ID_ACCESS_TOKEN"
+    "SDKTESTER1A_ID_ACCESS_TOKEN",
+    "SDKTESTER2B_NATIVE1_TRANSFER_RT"
 ]

--- a/tests/framework/constants.py
+++ b/tests/framework/constants.py
@@ -30,6 +30,10 @@ SDKTESTER1A_NATIVE1_ID_TOKEN = (
 SDKTESTER1A_ID_ACCESS_TOKEN = (
     "AQBYuuk5AAAAAAAEgv9acyfVlpa9Jhe3A1LhzhzofL"
     "tYuM3-yBKxA7yZ6QAN9tosD4xRsxwaQ35pUXGM7dCj")
+# sdktester2b@globusid.org transfer refresh token for Native App 1
+SDKTESTER2B_NATIVE1_TRANSFER_RT = (
+    "AQEAAAAAAATZj3h-kuwerpWbwQYoWECsTrjqoaJv5Q"
+    "zPoq52QBnfxrOszPl714hF6iISZgTe0061E6sQPwjt")
 # ---------- #
 # end tokens #
 # ---------- #

--- a/tests/framework/tools.py
+++ b/tests/framework/tools.py
@@ -26,7 +26,7 @@ def get_client_data():
 def get_user_data():
     dirname = get_fixture_file_dir()
     ret = {}
-    for uname in ("sdktester1a", "go"):
+    for uname in ("sdktester1a", "sdktester2b", "go"):
         with open(os.path.join(dirname,
                                "auth_fixtures",
                                uname + "@globusid.org.json")) as f:

--- a/tests/manual_tools/clean_sdk_test_assets.py
+++ b/tests/manual_tools/clean_sdk_test_assets.py
@@ -17,8 +17,7 @@ def clean():
 
     # create an authorized transfer client
     client = globus_sdk.NativeAppAuthClient(client_id=CLIENT_ID)
-    client.oauth2_start_flow_native_app(requested_scopes=SCOPES,
-                                        refresh_tokens=True)
+    client.oauth2_start_flow(requested_scopes=SCOPES)
     url = client.oauth2_get_authorize_url()
 
     print("Login with SDK Tester: \n{}".format(url))
@@ -72,11 +71,15 @@ def clean():
 
     # clean endpoints owned by SDK Tester
     endpoint_deletions = 0
-    r = tc.endpoint_search(filter_scope="my-endpoints")
-    for ep in r:
-        tc.delete_endpoint(ep["id"])
-        print("deleting endpoint: {}".format(ep["display_name"]))
-        endpoint_deletions += 1
+    cleaning = True
+    while(cleaning):
+        cleaning = False
+        r = tc.endpoint_search(filter_scope="my-endpoints", num_results=None)
+        for ep in r:
+            tc.delete_endpoint(ep["id"])
+            print("deleting endpoint: {}".format(ep["display_name"]))
+            endpoint_deletions += 1
+            cleaning = True
 
     # wait for deletes to complete
     for task_id in task_ids:

--- a/tests/manual_tools/login_native_app1.py
+++ b/tests/manual_tools/login_native_app1.py
@@ -11,8 +11,8 @@ get_input = getattr(__builtins__, 'raw_input', input)
 
 
 client = NativeAppAuthClient(client_id=CLIENT_ID)
-client.oauth2_start_flow_native_app(requested_scopes=SCOPES,
-                                    refresh_tokens=True)
+client.oauth2_start_flow(requested_scopes=SCOPES,
+                         refresh_tokens=True)
 url = client.oauth2_get_authorize_url()
 
 print("Native App Authorization URL: \n{}".format(url))


### PR DESCRIPTION
Resolves #189 

Adds endpoint_manager_task_successful_transfers() to transfer client
Updates the testing framework to add user info and a transfer refresh token for sdktester2b
And adds unit tests for the three endpoint_manager_* methods in transfer client