### PR TITLE
Better handle UTF-8 inupts

### DIFF
--- a/globus_sdk/auth/client_types/base.py
+++ b/globus_sdk/auth/client_types/base.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import six
 import collections

--- a/globus_sdk/base.py
+++ b/globus_sdk/base.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import json
 import logging
 

--- a/globus_sdk/transfer/client.py
+++ b/globus_sdk/transfer/client.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import logging
 import time
 
@@ -846,6 +847,7 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/endpoint_bookmarks/#get_bookmark_by_id>`_
         in the REST documentation for details.
         """
+        bookmark_id = safe_stringify(bookmark_id)
         self.logger.info("TransferClient.get_bookmark({})".format(bookmark_id))
         path = self.qjoin_path('bookmark', bookmark_id)
         return self.get(path, params=params)
@@ -939,6 +941,7 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
+        path = safe_stringify(path)
         self.logger.info("TransferClient.operation_mkdir({}, {}, {})"
                          .format(endpoint_id, path, params))
         resource_path = self.qjoin_path("operation/endpoint", endpoint_id,
@@ -970,6 +973,8 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
+        oldpath = safe_stringify(oldpath)
+        newpath = safe_stringify(newpath)
         self.logger.info("TransferClient.operation_rename({}, {}, {}, {})"
                          .format(endpoint_id, oldpath, newpath, params))
         resource_path = self.qjoin_path("operation/endpoint", endpoint_id,
@@ -1699,11 +1704,13 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/advanced_endpoint_management/#admin_cancel>`_
         in the REST documentation for details.
         """
+        task_ids = [safe_stringify(i) for i in task_ids]
+        message = safe_stringify(message)
         self.logger.info(("TransferClient.endpoint_manager_"
                           "cancel_tasks({},{})".format(task_ids, message)))
         json_body = {
             "message": safe_stringify(message),
-            "task_id_list": [safe_stringify(i) for i in task_ids]
+            "task_id_list": task_ids
         }
         path = self.qjoin_path("endpoint_manager", "admin_cancel")
         return self.post(path, json_body=json_body, params=params)
@@ -1767,11 +1774,13 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/advanced_endpoint_management/#pause_tasks_as_admin>`_
         in the REST documentation for details.
         """
+        task_ids = [safe_stringify(i) for i in task_ids]
+        message = safe_stringify(message)
         self.logger.info(("TransferClient.endpoint_manager_"
                           "pause_tasks({},{})".format(task_ids, message)))
         json_body = {
             "message": safe_stringify(message),
-            "task_id_list": [safe_stringify(i) for i in task_ids]
+            "task_id_list": task_ids
         }
         path = self.qjoin_path("endpoint_manager", "admin_pause")
         return self.post(path, json_body=json_body, params=params)
@@ -1804,11 +1813,13 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/advanced_endpoint_management/#admin_cancel>`_
         in the REST documentation for details.
         """
+        task_ids = [safe_stringify(i) for i in task_ids]
+        message = safe_stringify(message)
         self.logger.info(("TransferClient.endpoint_manager_"
                           "resume_tasks({},{})".format(task_ids, message)))
         json_body = {
             "message": safe_stringify(message),
-            "task_id_list": [safe_stringify(i) for i in task_ids]
+            "task_id_list": task_ids
         }
         path = self.qjoin_path("endpoint_manager", "admin_resume")
         return self.post(path, json_body=json_body, params=params)
@@ -1914,6 +1925,7 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/advanced_endpoint_management/#get_pause_rule>`_
         in the REST documentation for details.
         """
+        pause_rule_id = safe_stringify(pause_rule_id)
         self.logger.info(("TransferClient.endpoint_manager_"
                           "get_pause_rule({})".format(pause_rule_id)))
         path = self.qjoin_path("endpoint_manager", "pause_rule", pause_rule_id)
@@ -1947,6 +1959,7 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/advanced_endpoint_management/#update_pause_rule>`_
         in the REST documentation for details.
         """
+        pause_rule_id = safe_stringify(pause_rule_id)
         self.logger.info(("TransferClient.endpoint_manager_"
                           "update_pause_rule({})".format(pause_rule_id)))
         path = self.qjoin_path("endpoint_manager", "pause_rule", pause_rule_id)
@@ -1978,6 +1991,7 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/advanced_endpoint_management/#delete_pause_rule>`_
         in the REST documentation for details.
         """
+        pause_rule_id = safe_stringify(pause_rule_id)
         self.logger.info(("TransferClient.endpoint_manager_"
                           "delete_pause_rule({})".format(pause_rule_id)))
         path = self.qjoin_path("endpoint_manager", "pause_rule", pause_rule_id)

--- a/globus_sdk/transfer/data.py
+++ b/globus_sdk/transfer/data.py
@@ -4,6 +4,7 @@ extend ``dict``, so they can be passed seemlesly to
 :class:`TransferClient <globus_sdk.TransferClient>` methods without
 conversion.
 """
+from __future__ import unicode_literals
 import logging
 
 from globus_sdk.base import safe_stringify
@@ -96,6 +97,8 @@ class TransferData(dict):
         Appends a transfer_item document to the DATA key of the transfer
         document.
         """
+        source_path = safe_stringify(source_path)
+        destination_path = safe_stringify(destination_path)
         item_data = {
             "DATA_TYPE": "transfer_item",
             "source_path": source_path,
@@ -166,6 +169,7 @@ class DeleteData(dict):
         Appends a delete_item document to the DATA key of the delete
         document.
         """
+        path = safe_stringify(path)
         item_data = {
             "DATA_TYPE": "delete_item",
             "path": path,

--- a/tests/integration/test_encoding.py
+++ b/tests/integration/test_encoding.py
@@ -1,0 +1,155 @@
+# -*- coding: utf8 -*-
+import unittest
+import six
+from random import getrandbits
+
+import globus_sdk
+from tests.framework import TransferClientTestCase, GO_EP1_ID
+
+
+class EncodingTests(TransferClientTestCase):
+
+    __test__ = True  # marks sub-class as having tests
+
+    def dir_operations(self, input_name, expected_name=None):
+        """
+        Given an input directory name, makes, renames, and ls's that directory
+        transfers files into that directory, and deletes the directory.
+        If an expected_name is given, confirms output matches that name
+        rather than the input_name.
+        """
+        # mkdir
+        # name randomized to prevent collision
+        rand = str(getrandbits(128))
+        path = "/~/" + input_name + rand
+        mkdir_doc = self.tc.operation_mkdir(GO_EP1_ID, path)
+        self.assertEqual(mkdir_doc["code"], "DirectoryCreated")
+        # confirm ls sees dir
+        ls_doc = self.tc.operation_ls(GO_EP1_ID, path="/~/")
+        expected = (expected_name or input_name) + rand
+        self.assertIn(expected, [x["name"] for x in ls_doc])
+
+        # rename
+        new_rand = str(getrandbits(128))
+        new_path = "/~/" + input_name + new_rand
+        rename_doc = self.tc.operation_rename(GO_EP1_ID, path, new_path)
+        self.assertEqual(rename_doc["code"], "FileRenamed")
+        # confirm ls sees new dir name
+        expected = (expected_name or input_name) + new_rand
+        ls_doc = self.tc.operation_ls(GO_EP1_ID, path="/~/")
+        self.assertIn(expected, [x["name"] for x in ls_doc])
+
+        # transfer
+        source_path = "/share/godata/"
+        tdata = globus_sdk.TransferData(self.tc, GO_EP1_ID, GO_EP1_ID)
+        tdata.add_item(source_path, new_path, recursive=True)
+        transfer_id = self.tc.submit_transfer(tdata)["task_id"]
+        self.assertTrue(
+            self.tc.task_wait(transfer_id, timeout=30, polling_interval=1))
+        # confirm ls sees files inside the directory
+        ls_doc = self.tc.operation_ls(GO_EP1_ID, path=new_path)
+        expected = ["file1.txt", "file2.txt", "file3.txt"]
+        self.assertEqual(expected, [x["name"] for x in ls_doc])
+
+        # delete
+        ddata = globus_sdk.DeleteData(self.tc, GO_EP1_ID, recursive=True)
+        ddata.add_item(new_path)
+        delete_doc = self.tc.submit_delete(ddata)
+        self.assertEqual(delete_doc["code"], "Accepted")
+
+    def ep_operations(self, input_name, expected_name=None):
+        """
+        Given an input_name, creates, updates, gets, and deletes an endpoint
+        using the input_name as a display_name. If an expected_name is given,
+        confirms output matches that name rather than the input_name.
+        """
+        # create
+        create_data = {"display_name": input_name}
+        create_doc = self.tc.create_endpoint(create_data)
+        self.assertEqual(create_doc["code"], "Created")
+        ep_id = create_doc["id"]
+        # confirm get sees ep
+        get_doc = self.tc.get_endpoint(ep_id)
+        self.assertEqual((expected_name or input_name),
+                         get_doc["display_name"])
+
+        # update
+        update_data = {"description": input_name}
+        update_doc = self.tc.update_endpoint(ep_id, update_data)
+        self.assertEqual(update_doc["code"], "Updated")
+        # confirm get sees updated description
+        get_doc = self.tc.get_endpoint(ep_id)
+        self.assertEqual((expected_name or input_name), get_doc["description"])
+
+        # delete
+        delete_doc = self.tc.delete_endpoint(ep_id)
+        self.assertEqual(delete_doc["code"], "Deleted")
+
+    def test_literal_str_encoding(self):
+        """
+        Sanity check that importing unicode_literals in the globus_sdk
+        doesn't affect the encoding of literals in code that imports the sdk.
+        """
+        if (six.PY2):
+            self.assertEqual(type("literal"), six.binary_type)
+        else:
+            self.assertEqual(type("literal"), six.text_type)
+
+    def test_ascii_url_encoding(self):
+        """
+        Tests operations with an ASCII name that includes ' ' and '%"
+        characters that will need to be encoded for use in a url.
+        """
+        name = "a% b"
+        self.dir_operations(name)
+        self.ep_operations(name)
+
+    def test_non_ascii_utf8(self):
+        """
+        Tests operations with a UTF-8 name containing non ASCII characters with
+        code points requiring multiple bytes.
+        """
+        name = u"テスト"
+        self.dir_operations(name)
+        self.ep_operations(name)
+
+    @unittest.skipIf(six.PY3, "test run with Python 3")
+    def test_non_ascii_utf8_bytes(self):
+        """
+        Tests operations with a byte string encoded from non ASCII UTF-8.
+        This test is only run on Python 2 as bytes are not strings in Python 3.
+        """
+        uni_name = u"テスト"
+        byte_name = uni_name.encode("utf8")
+        # we expect uni_name back since the API returns unicode strings
+        self.dir_operations(byte_name, expected_name=uni_name)
+        self.ep_operations(byte_name, expected_name=uni_name)
+
+    def test_latin1(self):
+        """
+        Tests operations with latin-1 name that is not valid UTF-8.
+        """
+        # the encoding for 'é' in latin-1 is a continuation byte in utf-8
+        byte_name = b"\xe9"  # é's latin-1 encoding
+        name = byte_name.decode("latin-1")
+        with self.assertRaises(UnicodeDecodeError):
+            byte_name.decode("utf-8")
+
+        self.dir_operations(name)
+        self.ep_operations(name)
+
+    @unittest.skipIf(six.PY3, "test run with Python 3")
+    def test_invalid_utf8_bytes(self):
+        """
+        Tests operations with byte string that can be decoded with
+        latin-1 but not with UTF-8. Confirms that this raises a
+        UnicodeDecodeError, as the SDK/APIs can't handle decoding non UTF-8.
+        This test is only run on Python 2 as bytes are not strings in Python 3.
+        """
+        # the encoding for 'é' in latin-1 is a continuation byte in utf-8
+        byte_name = b"\xe9"  # é's latin-1 encoding
+
+        with self.assertRaises(UnicodeDecodeError):
+            self.dir_operations(byte_name)
+        with self.assertRaises(UnicodeDecodeError):
+            self.ep_operations(byte_name)

--- a/tests/manual_tools/clean_sdk_test_assets.py
+++ b/tests/manual_tools/clean_sdk_test_assets.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-
+from __future__ import unicode_literals
 import globus_sdk
 
 


### PR DESCRIPTION
Fixes #207 and adds integration tests that test operations using non url-safe ascii names, non-ascii utf-8 names, and non-utf-8 latin-1 names.

It seems latin-1 works fine as long as it doesn't need to be decoded from a byte string internally. I attempted to do what the APIs do and fall back to latin-1 if decoding with utf-8 fails, but this caused errors in the json library and got a 500 back from transfer, so I figured it best to only support decoding utf-8 for now.

Should we raise some kind of `GlobusError` when `safe_stringify` fails on an input, or would this mask the original error too much?