### PR TITLE
Upgrade pip in Makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,13 @@ python:
   - "3.5"
   - "3.6"
   # allow failures on CPython dev and pypy
-  # we want to be warned about these, but they aen't critical
-  - "3.6-dev"
+  # we want to be warned about these, but they aren't critical
+  - "3.7-dev"
   - "pypy"
   - "pypy3"
 matrix:
   allow_failures:
-    - python: "3.6-dev"
+    - python: "3.7-dev"
     - python: "pypy"
     - python: "pypy3"
 cache: pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,5 @@ matrix:
     - python: "pypy"
     - python: "pypy3"
 cache: pip
-install:
-  - pip install -e .[jwt]
-  - pip install -r test-requirements.txt
 script:
-  - flake8
-  - nose2 --verbose
+  - make travis

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,4 @@
-# default to system python
-PYTHON_VERSION ?=
-PYTHON_INTERPRETER=python$(PYTHON_VERSION)
-VIRTUALENV=.venv$(PYTHON_VERSION)
+VIRTUALENV=.venv
 
 .PHONY: docs build upload test test/opts clean help
 
@@ -27,7 +24,9 @@ localdev: $(VIRTUALENV)
 
 
 $(VIRTUALENV): setup.py
-	virtualenv --python $(PYTHON_INTERPRETER) $(VIRTUALENV)
+	virtualenv $(VIRTUALENV)
+	$(VIRTUALENV)/bin/pip install --upgrade pip
+	$(VIRTUALENV)/bin/pip install --upgrade setuptools
 	$(VIRTUALENV)/bin/python setup.py develop
 	# explicit touch to ensure good update time relative to setup.py
 	touch $(VIRTUALENV)
@@ -56,6 +55,13 @@ test/opts: $(VIRTUALENV)
 	$(VIRTUALENV)/bin/pip install -e .[jwt]
 	$(MAKE) test
 
+travis:
+	pip install --upgrade pip
+	pip install --upgrade "setuptools>=29,<30"
+	pip install -r test-requirements.txt
+	pip install -e .[jwt]
+	flake8
+	nose2 --verbose
 
 
 # docs needs full install because sphinx will actually try to do


### PR DESCRIPTION
As seen with the release of `requests` 2.14, old versions of pip can cause problems. Since we're still using one of Ubuntu 12.04 containers on Travis we get a _really_ old version of pip.

**update:** and `setuptools`.