### PR TITLE
Recursive operation_ls

### DIFF
--- a/globus_sdk/transfer/client.py
+++ b/globus_sdk/transfer/client.py
@@ -7,7 +7,8 @@ from globus_sdk.base import BaseClient, merge_params, safe_stringify
 from globus_sdk.authorizers import (
     AccessTokenAuthorizer, RefreshTokenAuthorizer, ClientCredentialsAuthorizer)
 from globus_sdk.transfer.response import (
-    TransferResponse, IterableTransferResponse, ActivationRequirementsResponse)
+    TransferResponse, IterableTransferResponse, ActivationRequirementsResponse,
+    RecursiveLsResponse)
 from globus_sdk.transfer.paging import PaginatedResource
 
 logger = logging.getLogger(__name__)
@@ -920,6 +921,55 @@ class TransferClient(BaseClient):
         path = self.qjoin_path("operation/endpoint", endpoint_id, "ls")
         return self.get(path, params=params,
                         response_class=IterableTransferResponse)
+
+    def recursive_operation_ls(self, endpoint_id,
+                               depth=3, filter_after_first=True, **params):
+        """
+        Makes recursive calls to ``GET /operation/endpoint/<endpoint_id>/ls``
+
+        Does not preserve access to top level operation_ls fields, but
+        adds a "path" field for every item that represents the full
+        path to that item.
+
+        :rtype: iterable of :class:`GlobusResponse
+                <globus_sdk.response.GlobusResponse>`
+
+        **Parameters**
+
+            ``endpoint_id`` (*string*)
+              The endpoint being recursively ls'ed. If no "path" is given in
+              params, the start path is determined by this endpoint.
+
+            ``depth`` (*int*)
+              The maximum file depth the recursive ls will go to.
+
+            ``filter_after_first`` (*bool*)
+              If False, any "filter" in params will only be applied to the
+              first, top level ls, all results beyond that will be unfiltered.
+
+            ``params``
+              Parameters that will be passed through as query params.
+
+        **Examples**
+
+        >>> tc = globus_sdk.TransferClient(...)
+        >>> for entry in tc.recursive_operation_ls(ep_id, path="/~/project1/"):
+        >>>     print(entry["path"], entry["type"])
+
+        **External Documentation**
+
+        See
+        `List Directory Contents \
+        <https://docs.globus.org/api/transfer/file_operations/#list_directory_contents>`_
+        in the REST documentation for details, but note that top level data
+        fields are no longer available and an additional per item
+        "path" field is added.
+        """
+        endpoint_id = safe_stringify(endpoint_id)
+        self.logger.info("TransferClient.recursive_operation_ls({}, {}, {})"
+                         .format(endpoint_id, depth, params))
+        return RecursiveLsResponse(self, endpoint_id,
+                                   depth, filter_after_first, params)
 
     def operation_mkdir(self, endpoint_id, path, **params):
         """

--- a/globus_sdk/transfer/response/__init__.py
+++ b/globus_sdk/transfer/response/__init__.py
@@ -2,10 +2,12 @@ from globus_sdk.transfer.response.base import TransferResponse
 from globus_sdk.transfer.response.iterable import IterableTransferResponse
 from globus_sdk.transfer.response.activation import (
     ActivationRequirementsResponse)
+from globus_sdk.transfer.response.recursive_ls import RecursiveLsResponse
 
 
 __all__ = [
     'TransferResponse',
     'IterableTransferResponse',
-    'ActivationRequirementsResponse'
+    'ActivationRequirementsResponse',
+    'RecursiveLsResponse'
 ]

--- a/globus_sdk/transfer/response/recursive_ls.py
+++ b/globus_sdk/transfer/response/recursive_ls.py
@@ -1,0 +1,135 @@
+import logging
+import time
+from collections import deque
+
+from globus_sdk.response import GlobusResponse
+from globus_sdk.transfer.paging import PaginatedResource
+
+logger = logging.getLogger(__name__)
+
+# constants for controlling rate limiting
+SLEEP_FREQUENCY = 25
+SLEEP_LEN = 1
+
+
+class RecursiveLsResponse(PaginatedResource):
+    """
+    Response class for recursive_operation_ls
+
+    Uses PaginatedResource logic for iterating over potentially very
+    large file systems without keeping the whole filesystem in memory,
+    but rather than using Globus paging uses an internal queue
+    for BFS of the filesystem.
+
+    Rate limits calls to prevent getting back connection errors.
+    """
+    def __init__(self, client, endpoint_id,
+                 max_depth, filter_after_first, ls_params):
+        """
+        **Parameters**
+
+          ``client``
+            A `TransferClient`` used for making the operation_ls calls.
+
+          ``endpoint_id``
+            The endpoint that will be recursively ls'ed.
+
+          ``max_depth``
+            The maximum depth the recursive ls will go into the file system.
+
+          ``filter_after_first``
+            If True, any filter in ``ls_params`` will be applied to all calls
+            If False, any filter in ``ls_params`` will only be applied to the
+            first ls.
+
+          ``ls_params``
+            Query params sent to operation_ls, see operation_ls for more
+            details.
+
+        """
+        logger.info("Creating RecursiveLsResponse on path {} of endpoint {}"
+                    .format(ls_params.get("path"), endpoint_id))
+
+        self.client = client
+        self.endpoint_id = endpoint_id
+        self.ls_params = ls_params
+        self.max_depth = max_depth
+        self.filter_after_first = filter_after_first
+        self.filtering = True
+        self.ls_count = 0
+
+        # queue of (path, depth) tuples.
+        self.queue = deque()
+        # initialized with the start path (if any) and a depth of 0
+        self.queue.append((self.ls_params.get("path"), 0))
+
+        # call the iterable_func method to convert it to a generator expression
+        self.generator = self.iterable_func()
+
+        # grab the first element out of the internal iteration function
+        # because this could raise a StopIteration exception, we need to be
+        # careful and make sure that such a condition is respected (and
+        # replicated as an iterable of length 0)
+        try:
+            self.first_elem = next(self.generator)
+        except StopIteration:
+            # express this internally as "generator is null" -- just need some
+            # way of making sure that it's clear
+            self.generator = None
+
+    def iterable_func(self):
+        """
+        An internal function which has generator semantics. Defined using the
+        `yield` syntax.
+        Used to grab the first element during class initialization, and
+        subsequently on calls to `next()` to get the remaining elements.
+        We rely on the implicit StopIteration built into this type of function
+        to propagate through the final `next()` call.
+        """
+        # BFS is not done until the queue is empty
+        while self.queue:
+            logger.debug(("recursive_operation_ls BFS queue not empty, "
+                          "getting next path now."))
+
+            # rate limit based on number of ls calls we have made
+            self.ls_count += 1
+            if self.ls_count % SLEEP_FREQUENCY == 0:
+                logger.debug(("recursive_operation_ls sleeping {} seconds to "
+                              "rate limit itself.".format(SLEEP_LEN)))
+                time.sleep(SLEEP_LEN)
+
+            # get path and current depth from the queue
+            path, depth = self.queue.pop()
+
+            # set the target path to the popped path if it exists
+            if path:
+                self.ls_params["path"] = path
+
+            # if filter_after_first is False, stop filtering after the first
+            # ls call has been made
+            if not self.filter_after_first:
+                if self.filtering:
+                    self.filtering = False
+                else:
+                    try:
+                        self.ls_params.pop("filter")
+                    except KeyError:
+                        pass
+
+            # do the operation_ls with the updated params
+            res = self.client.operation_ls(self.endpoint_id, **self.ls_params)
+            res_data = res["DATA"]
+
+            # for each item in the response data include the item's path with
+            # the response data since top level fields are no longer visible,
+            # and yield the item
+            for item in res_data:
+                item["path"] = res["path"] + item["name"]
+                yield GlobusResponse(item)
+
+            # if we aren't at the depth limit, add dir entries to the queue.
+            # data is reversed to maintain any "orderby" ordering
+            if depth < self.max_depth:
+                self.queue.extend([(i["path"], depth + 1)
+                                   for i in reversed(res_data)
+                                   if i["type"] == "dir"])


### PR DESCRIPTION
Needed for https://github.com/globus/globus-cli/issues/46. Unless we want to just wait for endpoint level support, in which case I'll just add this to the CLI.

Uses BFS, rate-limiting, and dosen't buffer the whole response in memory.

I decided the simplest way to handle non-buffered output was to make a `RecursiveLsResponse` response class that inherits from `PaginatedResource` so we can return an iterator.

Since this gets rid of access to top level fields and changed the response class I made this a separate `recursive_operation_ls` method in the transfer client rather than requiring `recursive=True` for the normal `operation_ls` method. I also re-added the top level path field to each item.

The `filter_after_first` paramater is to help the CLI match the behavior of a batch ls while using filter to simulate globbing.