### PR TITLE
Add explicit documentation for PaginatedResources

### DIFF
--- a/docs/oauth/resource_servers.rst
+++ b/docs/oauth/resource_servers.rst
@@ -1,5 +1,5 @@
 Resource Servers and Scopes
-==========================
+===========================
 
 What are Resource Servers, and how do they interact with scopes?
 

--- a/docs/responses.rst
+++ b/docs/responses.rst
@@ -21,20 +21,12 @@ Generic Response Classes
    :members:
    :show-inheritance:
 
-Transfer Response Classes
--------------------------
 
-.. automodule:: globus_sdk.transfer.response
-   :members:
-   :show-inheritance:
+Service-Specific Response Classes
+---------------------------------
 
-Auth Response Classes
----------------------
+.. toctree::
+   :maxdepth: 1
 
-.. autoclass:: globus_sdk.auth.token_response.OAuthTokenResponse
-   :members:
-   :show-inheritance:
-
-.. autoclass:: globus_sdk.auth.token_response.OAuthDependentTokenResponse
-   :members:
-   :show-inheritance:
+   responses/transfer
+   responses/auth

--- a/docs/responses/auth.rst
+++ b/docs/responses/auth.rst
@@ -1,0 +1,10 @@
+Auth Responses
+==============
+
+.. autoclass:: globus_sdk.auth.token_response.OAuthTokenResponse
+   :members:
+   :show-inheritance:
+
+.. autoclass:: globus_sdk.auth.token_response.OAuthDependentTokenResponse
+   :members:
+   :show-inheritance:

--- a/docs/responses/transfer.rst
+++ b/docs/responses/transfer.rst
@@ -16,5 +16,5 @@ It is an iterable of ``GlobusRepsonse`` objects.
 
 
 .. autoclass:: globus_sdk.transfer.paging.PaginatedResource
-   :members:
+   :members: data
    :show-inheritance:

--- a/docs/responses/transfer.rst
+++ b/docs/responses/transfer.rst
@@ -1,0 +1,20 @@
+Transfer Responses
+==================
+
+.. automodule:: globus_sdk.transfer.response
+   :members:
+   :show-inheritance:
+
+
+PaginatedResource Responses
+---------------------------
+
+The ``PaginatedResource`` class should not typically be instantiated directly,
+but is returned from several :class:`TransferClient
+<globus_sdk.transfer.client.TransferClient>` methods.
+It is an iterable of ``GlobusRepsonse`` objects.
+
+
+.. autoclass:: globus_sdk.transfer.paging.PaginatedResource
+   :members:
+   :show-inheritance:

--- a/globus_sdk/transfer/client.py
+++ b/globus_sdk/transfer/client.py
@@ -29,6 +29,12 @@ class TransferClient(BaseClient):
     :class:`TransferResponse <globus_sdk.transfer.response.TransferResponse>`
     object.
 
+    Some calls are paginated. If a call returns a :class:`PaginatedResource \
+    <globus_sdk.transfer.paging.PaginatedResource>` object, the result is an
+    iterator which can only be walked *once*. If you need to do multiple passes
+    over the result, call ``list()`` on the ``PaginatedResource`` or call the
+    original method again to get fresh results.
+
     Detailed documentation is available in the official REST API
     documentation, which is linked to from the method documentation. Methods
     that allow arbitrary keyword arguments will pass the extra arguments as
@@ -193,7 +199,9 @@ class TransferClient(BaseClient):
             GET /endpoint_search\
             ?filter_fulltext=<filter_fulltext>&filter_scope=<filter_scope>
 
-        :rtype: iterable of :class:`GlobusResponse
+        :rtype: :class:`PaginatedResource
+                <globus_sdk.transfer.paging.PaginatedResource>`,
+                an iterable of :class:`GlobusResponse
                 <globus_sdk.response.GlobusResponse>`
 
         **Parameters**
@@ -1089,7 +1097,9 @@ class TransferClient(BaseClient):
 
         ``GET /task_list``
 
-        :rtype: iterable of :class:`GlobusResponse
+        :rtype: :class:`PaginatedResource
+                <globus_sdk.transfer.paging.PaginatedResource>`,
+                an iterable of :class:`GlobusResponse
                 <globus_sdk.response.GlobusResponse>`
 
         **Parameters**
@@ -1131,7 +1141,9 @@ class TransferClient(BaseClient):
 
         ``GET /task/<task_id>/event_list``
 
-        :rtype: iterable of :class:`GlobusResponse
+        :rtype: :class:`PaginatedResource
+                <globus_sdk.transfer.paging.PaginatedResource>`,
+                an iterable of :class:`GlobusResponse
                 <globus_sdk.response.GlobusResponse>`
 
         **Parameters**
@@ -1351,7 +1363,9 @@ class TransferClient(BaseClient):
 
         ``GET /task/<task_id>/successful_transfers``
 
-        :rtype: iterable of :class:`GlobusResponse
+        :rtype: :class:`PaginatedResource
+                <globus_sdk.transfer.paging.PaginatedResource>`,
+                an iterable of :class:`GlobusResponse
                 <globus_sdk.response.GlobusResponse>`
 
         **Parameters**
@@ -1499,7 +1513,9 @@ class TransferClient(BaseClient):
 
         ``GET endpoint_manager/task_list``
 
-        :rtype: iterable of :class:`GlobusResponse
+        :rtype: :class:`PaginatedResource
+                <globus_sdk.transfer.paging.PaginatedResource>`,
+                an iterable of :class:`GlobusResponse
                 <globus_sdk.response.GlobusResponse>`
 
         **Parameters**
@@ -1577,7 +1593,9 @@ class TransferClient(BaseClient):
 
         ``GET /task/<task_id>/event_list``
 
-        :rtype: iterable of :class:`GlobusResponse
+        :rtype: :class:`PaginatedResource
+                <globus_sdk.transfer.paging.PaginatedResource>`,
+                an iterable of :class:`GlobusResponse
                 <globus_sdk.response.GlobusResponse>`
 
         **Parameters**
@@ -1641,7 +1659,9 @@ class TransferClient(BaseClient):
 
         ``GET /endpoint_manager/task/<task_id>/successful_transfers``
 
-        :rtype: iterable of :class:`GlobusResponse
+        :rtype: :class:`PaginatedResource
+                <globus_sdk.transfer.paging.PaginatedResource>`,
+                an iterable of :class:`GlobusResponse
                 <globus_sdk.response.GlobusResponse>`
 
         **Parameters**
@@ -1717,8 +1737,8 @@ class TransferClient(BaseClient):
 
     def endpoint_manager_cancel_status(self, admin_cancel_id, **params):
         """
-        Get the status of an an admin cancel (result of endpoint_manager_
-        cancel_tasks).
+        Get the status of an an admin cancel (result of
+        endpoint_manager_cancel_tasks).
 
         ``GET /endpoint_manager/admin_cancel/<admin_cancel_id>``
 

--- a/globus_sdk/transfer/paging.py
+++ b/globus_sdk/transfer/paging.py
@@ -16,24 +16,27 @@ class PaginatedResource(GlobusResponse, six.Iterator):
 
     This is a class and not a function because it needs to enforce distinct
     actions between initialization and iteration. If defined as a generator
-    function with the `yield` syntax, python won't let us distinguish between
+    function with the ``yield`` syntax, python won't let us distinguish between
     creating the iterable object and iterating it.
     To eagerly trigger errors from the first call, we need to wrap it up in a
     class.
 
     Expectations about Paginated Transfer API Resources:
-    - They support `limit` and `offset` query params, with `limit` being a
-      count of elements to return, and offset being an offset into the result
+
+    - They support ``limit`` and ``offset`` query params, with ``limit`` being
+      a count of elements to return, and offset being an offset into the result
       set (as opposed to a page number), 0-based
       OR
-      They support a `marker` query param, which is an opaque value
-    - They return a JSON result with `has_next_page` as a boolean key,
+      They support a ``marker`` query param, which is an opaque value
+
+    - They return a JSON result with ``has_next_page`` as a boolean key,
       indicating whether or not there are more results available -- even if the
       hard limit for the API forbids requesting these results
       OR
-      They return a JSON result with `marker` as a key indicating whether or
+      They return a JSON result with ``marker`` as a key indicating whether or
       not there are more results available
-    - Individual results are JSON objects inside of an array named `DATA` in
+
+    - Individual results are JSON objects inside of an array named ``DATA`` in
       the returned JSON document
     """
 
@@ -153,6 +156,10 @@ class PaginatedResource(GlobusResponse, six.Iterator):
         """
         To get the "data" on a PaginatedResource, fetch all pages and convert
         them into the only python data structure that makes sense: a list.
+
+        Note that this forces iteration/evaluation of all pages from the API.
+        It therefore may cause singificant IO spikes when used. You should
+        avoid using ``PaginatedResource.data`` property whenever possible.
         """
         return list(self)
 

--- a/globus_sdk/transfer/paging.py
+++ b/globus_sdk/transfer/paging.py
@@ -9,35 +9,17 @@ logger = logging.getLogger(__name__)
 
 class PaginatedResource(GlobusResponse, six.Iterator):
     """
-    A class that describes paginated Transfer API resources.
-    This is not a top level helper func because it depends upon the pagination
-    implementation of the Transfer API, which may not be the implementation
-    chosen by other, future APIs.
+    A ``PaginatedResource`` is an iterable response which implements the Python
+    iterator interface. As such, **you can only iterate over
+    PaginatedResources once**. Future iterations will be empty.
 
-    This is a class and not a function because it needs to enforce distinct
-    actions between initialization and iteration. If defined as a generator
-    function with the ``yield`` syntax, python won't let us distinguish between
-    creating the iterable object and iterating it.
-    To eagerly trigger errors from the first call, we need to wrap it up in a
-    class.
+    If you need fresh results, make a call for a new ``PaginatedResource``, and
+    if you want to cache and reuse results, convert to a list or other
+    structure. You may also want to read the docs on the :py:attr:`~data`
+    property.
 
-    Expectations about Paginated Transfer API Resources:
-
-    - They support ``limit`` and ``offset`` query params, with ``limit`` being
-      a count of elements to return, and offset being an offset into the result
-      set (as opposed to a page number), 0-based
-      OR
-      They support a ``marker`` query param, which is an opaque value
-
-    - They return a JSON result with ``has_next_page`` as a boolean key,
-      indicating whether or not there are more results available -- even if the
-      hard limit for the API forbids requesting these results
-      OR
-      They return a JSON result with ``marker`` as a key indicating whether or
-      not there are more results available
-
-    - Individual results are JSON objects inside of an array named ``DATA`` in
-      the returned JSON document
+    Because paginated data can be large, you will tend to get the best
+    performance by being sure to only iterate over the results once.
     """
 
     # pages have 'has_next_page', 'offset', and 'limit'
@@ -64,6 +46,36 @@ class PaginatedResource(GlobusResponse, six.Iterator):
                  max_total_results=None, offset=0,
                  paging_style=PAGING_STYLE_HAS_NEXT):
         """
+        A class that describes paginated Transfer API resources.
+        This is not a top level helper func because it depends upon the
+        pagination implementation of the Transfer API, which may not be the
+        implementation chosen by other, future APIs.
+
+        This is a class and not a function because it needs to enforce distinct
+        actions between initialization and iteration. If defined as a generator
+        function with the ``yield`` syntax, python won't let us distinguish
+        between creating the iterable object and iterating it.
+        To eagerly trigger errors from the first call, we need to wrap it up in
+        a class.
+
+        Expectations about Paginated Transfer API Resources:
+
+        - They support ``limit`` and ``offset`` query params, with ``limit``
+          being a count of elements to return, and offset being an offset into
+          the result set (as opposed to a page number), 0-based
+          OR
+          They support a ``marker`` query param, which is an opaque value
+
+        - They return a JSON result with ``has_next_page`` as a boolean key,
+          indicating whether or not there are more results available -- even if
+          the hard limit for the API forbids requesting these results
+          OR
+          They return a JSON result with ``marker`` as a key indicating whether
+          or not there are more results available
+
+        - Individual results are JSON objects inside of an array named ``DATA``
+          in the returned JSON document
+
         Takes a TransferClient method, a selection of its arguments, a variety
         of limits on result sizes, an offest into the result set, and a
         "paging style", which defines which kind of Transfer paging behavior
@@ -159,7 +171,7 @@ class PaginatedResource(GlobusResponse, six.Iterator):
 
         Note that this forces iteration/evaluation of all pages from the API.
         It therefore may cause singificant IO spikes when used. You should
-        avoid using ``PaginatedResource.data`` property whenever possible.
+        avoid using the ``PaginatedResource.data`` property whenever possible.
         """
         return list(self)
 


### PR DESCRIPTION
Previously, the docs just said "an iterable of GlobusResponses", which led to confusion by consumers between `IterableTransferResponse` and `PaginatedResource`.

Now, call out the use of `PaginatedResource` explicitly, and document the fact that it acts as a typical iterator only allowing callers to walk its contents once.

Closes #215 

Thoughts on how this is done? Directing people to the `PaginatedResource` doc feels a bit like throwing them to the wolves -- it's very much an internal class and documented as such -- but it's maybe better than doing nothing?