### PR TITLE
Add symlink support to sdk

### DIFF
--- a/globus_sdk/transfer/client.py
+++ b/globus_sdk/transfer/client.py
@@ -980,9 +980,43 @@ class TransferClient(BaseClient):
         resource_path = self.qjoin_path("operation/endpoint", endpoint_id,
                                         "rename")
         json_body = {
-            'DATA_TYPE': 'mkdir',
+            'DATA_TYPE': 'rename',
             'old_path': oldpath,
             'new_path': newpath
+        }
+        return self.post(resource_path, json_body=json_body, params=params)
+
+    def operation_symlink(self, endpoint_id, symlink_target, path, **params):
+        """
+        ``POST /operation/endpoint/<endpoint_id>/symlink``
+
+        :rtype: :class:`TransferResponse
+                <globus_sdk.transfer.response.TransferResponse>`
+
+        **Examples**
+
+        >>> tc = globus_sdk.TransferClient(...)
+        >>> tc.operation_symlink(ep_id, symlink_target="/~/file1.txt",
+        >>>                     path="/~/file1.txt")
+
+        **External Documentation**
+
+        See
+        `Symlink \
+        <https://docs.globus.org/api/transfer/file_operations/#symlink>`_
+        in the REST documentation for details.
+        """
+        endpoint_id = safe_stringify(endpoint_id)
+        symlink_target = safe_stringify(symlink_target)
+        path = safe_stringify(path)
+        self.logger.info("TransferClient.operation_symlink({}, {}, {}, {})"
+                         .format(endpoint_id, symlink_target, path, params))
+        resource_path = self.qjoin_path("operation/endpoint", endpoint_id,
+                                        "symlink")
+        json_body = {
+            "DATA_TYPE": "symlink",
+            "symlink_target": symlink_target,
+            "path": path
         }
         return self.post(resource_path, json_body=json_body, params=params)
 

--- a/globus_sdk/transfer/client.py
+++ b/globus_sdk/transfer/client.py
@@ -993,11 +993,14 @@ class TransferClient(BaseClient):
         :rtype: :class:`TransferResponse
                 <globus_sdk.transfer.response.TransferResponse>`
 
+        The ``path`` is the name of the symlink, and the ``symlink_target`` is
+        the path referenced by the symlink.
+
         **Examples**
 
         >>> tc = globus_sdk.TransferClient(...)
         >>> tc.operation_symlink(ep_id, symlink_target="/~/file1.txt",
-        >>>                     path="/~/file1.txt")
+        >>>                      path="/~/link-to-file1.txt")
 
         **External Documentation**
 

--- a/tests/framework/__init__.py
+++ b/tests/framework/__init__.py
@@ -3,8 +3,8 @@ from tests.framework.transfer_client_testcase import TransferClientTestCase
 from tests.framework.tools import (get_fixture_file_dir,
                                    get_client_data, get_user_data)
 
-from tests.framework.constants import (GO_EP1_ID, GO_EP2_ID,
-                                       GO_EP1_SERVER_ID,
+from tests.framework.constants import (GO_EP1_ID, GO_EP2_ID, GO_EP3_ID,
+                                       GO_S3_ID, GO_EP1_SERVER_ID,
                                        SDKTESTER1A_NATIVE1_TRANSFER_RT,
                                        SDKTESTER1A_NATIVE1_AUTH_RT,
                                        SDKTESTER1A_NATIVE1_ID_TOKEN,
@@ -21,6 +21,8 @@ __all__ = [
 
     "GO_EP1_ID",
     "GO_EP2_ID",
+    "GO_EP3_ID",
+    "GO_S3_ID",
     "GO_EP1_SERVER_ID",
 
     "SDKTESTER1A_NATIVE1_TRANSFER_RT",

--- a/tests/framework/constants.py
+++ b/tests/framework/constants.py
@@ -1,5 +1,8 @@
 GO_EP1_ID = "ddb59aef-6d04-11e5-ba46-22000b92c6ec"
 GO_EP2_ID = "ddb59af0-6d04-11e5-ba46-22000b92c6ec"
+# TODO: stop using EP3 once EP1 and EP2 support symlinks
+GO_EP3_ID = "4be6107f-634d-11e7-a979-22000bf2d287"
+GO_S3_ID = "cf9bcaa5-6d04-11e5-ba46-22000b92c6ec"
 GO_EP1_SERVER_ID = 207976
 
 # ------ #

--- a/tests/manual_tools/clean_sdk_test_assets.py
+++ b/tests/manual_tools/clean_sdk_test_assets.py
@@ -11,6 +11,8 @@ def clean():
     SDK_USER_ID = "84942ca8-17c4-4080-9036-2f58e0093869"
     GO_EP1_ID = "ddb59aef-6d04-11e5-ba46-22000b92c6ec"
     GO_EP2_ID = "ddb59af0-6d04-11e5-ba46-22000b92c6ec"
+    # TODO: remove EP3 when EP1 and EP2 support symlinks
+    GO_EP3_ID = "4be6107f-634d-11e7-a979-22000bf2d287"
     CLIENT_ID = 'd0f1d9b0-bd81-4108-be74-ea981664453a'
     SCOPES = 'urn:globus:auth:scope:transfer.api.globus.org:all'
     get_input = getattr(__builtins__, 'raw_input', input)
@@ -44,8 +46,8 @@ def clean():
 
     # now clean test assets
 
-    # clean SDK Tester's home /~/ on go#ep1 and go#ep2
-    ep_ids = [GO_EP1_ID, GO_EP2_ID]
+    # clean SDK Tester's home /~/ on go#ep1 go#ep2 and go#ep3
+    ep_ids = [GO_EP1_ID, GO_EP2_ID, GO_EP3_ID]
     task_ids = []
     file_deletions = 0
     for ep_id in ep_ids:

--- a/tests/unit/test_data.py
+++ b/tests/unit/test_data.py
@@ -80,6 +80,21 @@ class DataTests(CapturedIOTestCase):
         self.assertEqual(r_data["destination_path"], dest_path)
         self.assertEqual(r_data["recursive"], True)
 
+    def test_transfer_add_symlink_item(self):
+        """
+        Adds a transfer_symlink_item to TransferData, verifies results
+        """
+        # add item
+        source_path = "source/path/"
+        dest_path = "dest/path/"
+        self.tdata.add_symlink_item(source_path, dest_path)
+        # verify results
+        self.assertEqual(len(self.tdata["DATA"]), 1)
+        data = self.tdata["DATA"][0]
+        self.assertEqual(data["DATA_TYPE"], "transfer_symlink_item")
+        self.assertEqual(data["source_path"], source_path)
+        self.assertEqual(data["destination_path"], dest_path)
+
     def test_delete_init(self):
         """
         Verifies DeleteData field initialization


### PR DESCRIPTION
Resolves #216 and is implemented as described in the issue.

This was passing tests against sandbox, but I would feel a bit safer waiting to merge this until there is a tutorial endpoint that supports symlinks on production so I can add my unit tests to this PR and make sure everything is working as expected. (That said, the CLI supporting symlinks is blocked on this being released so we might want to go ahead and get this out for that reason?)