### PR TITLE
Crank up task_wait() limit and period

### DIFF
--- a/tests/framework/__init__.py
+++ b/tests/framework/__init__.py
@@ -9,7 +9,10 @@ from tests.framework.constants import (GO_EP1_ID, GO_EP2_ID, GO_EP3_ID,
                                        SDKTESTER1A_NATIVE1_AUTH_RT,
                                        SDKTESTER1A_NATIVE1_ID_TOKEN,
                                        SDKTESTER1A_ID_ACCESS_TOKEN,
-                                       SDKTESTER2B_NATIVE1_TRANSFER_RT)
+                                       SDKTESTER2B_NATIVE1_TRANSFER_RT,
+
+                                       DEFAULT_TASK_WAIT_TIMEOUT,
+                                       DEFAULT_TASK_WAIT_POLLING_INTERVAL)
 
 __all__ = [
     "CapturedIOTestCase",
@@ -29,5 +32,8 @@ __all__ = [
     "SDKTESTER1A_NATIVE1_AUTH_RT",
     "SDKTESTER1A_NATIVE1_ID_TOKEN",
     "SDKTESTER1A_ID_ACCESS_TOKEN",
-    "SDKTESTER2B_NATIVE1_TRANSFER_RT"
+    "SDKTESTER2B_NATIVE1_TRANSFER_RT",
+
+    "DEFAULT_TASK_WAIT_TIMEOUT",
+    "DEFAULT_TASK_WAIT_POLLING_INTERVAL",
 ]

--- a/tests/framework/constants.py
+++ b/tests/framework/constants.py
@@ -41,3 +41,10 @@ SDKTESTER2B_NATIVE1_TRANSFER_RT = (
 # ---------- #
 # end tokens #
 # ---------- #
+
+
+# TransferClient task_wait parameters
+# 2 minutes
+DEFAULT_TASK_WAIT_TIMEOUT = 120
+# every 3 seconds
+DEFAULT_TASK_WAIT_POLLING_INTERVAL = 3

--- a/tests/integration/test_encoding.py
+++ b/tests/integration/test_encoding.py
@@ -4,7 +4,9 @@ import six
 from random import getrandbits
 
 import globus_sdk
-from tests.framework import TransferClientTestCase, GO_EP1_ID
+from tests.framework import (
+    TransferClientTestCase, GO_EP1_ID,
+    DEFAULT_TASK_WAIT_TIMEOUT, DEFAULT_TASK_WAIT_POLLING_INTERVAL)
 
 
 class EncodingTests(TransferClientTestCase):
@@ -45,7 +47,9 @@ class EncodingTests(TransferClientTestCase):
         tdata.add_item(source_path, new_path, recursive=True)
         transfer_id = self.tc.submit_transfer(tdata)["task_id"]
         self.assertTrue(
-            self.tc.task_wait(transfer_id, timeout=30, polling_interval=1))
+            self.tc.task_wait(
+                transfer_id, timeout=DEFAULT_TASK_WAIT_TIMEOUT,
+                polling_interval=DEFAULT_TASK_WAIT_POLLING_INTERVAL))
         # confirm ls sees files inside the directory
         ls_doc = self.tc.operation_ls(GO_EP1_ID, path=new_path)
         expected = ["file1.txt", "file2.txt", "file3.txt"]

--- a/tests/unit/test_transfer_client.py
+++ b/tests/unit/test_transfer_client.py
@@ -3,7 +3,10 @@ from random import getrandbits
 import globus_sdk
 from tests.framework import (TransferClientTestCase, get_user_data,
                              GO_EP1_ID, GO_EP2_ID, GO_EP3_ID, GO_S3_ID,
-                             GO_EP1_SERVER_ID)
+                             GO_EP1_SERVER_ID,
+
+                             DEFAULT_TASK_WAIT_TIMEOUT,
+                             DEFAULT_TASK_WAIT_POLLING_INTERVAL)
 from globus_sdk.exc import TransferAPIError
 from globus_sdk.transfer.paging import PaginatedResource
 
@@ -663,7 +666,9 @@ class TransferClientTests(TransferClientTestCase):
         # confirm the task completed and the files were transfered
         task_id = transfer_doc["task_id"]
         self.assertTrue(
-            self.tc.task_wait(task_id, timeout=30, polling_interval=1))
+            self.tc.task_wait(
+                task_id, timeout=DEFAULT_TASK_WAIT_TIMEOUT,
+                polling_interval=DEFAULT_TASK_WAIT_POLLING_INTERVAL))
         # confirm file and dir are visible by ls
         filter_string = "name:" + file_name + "," + dir_name
         params = {"path": dest_path, "filter": filter_string}
@@ -701,8 +706,10 @@ class TransferClientTests(TransferClientTestCase):
         self.assertEqual(resub_transfer_doc["task_id"], sub_task_id)
 
         # wait for submission to finish before moving on to cleanup
-        self.assertTrue(self.tc.task_wait(sub_transfer_doc["task_id"],
-                                          timeout=30, polling_interval=1))
+        self.assertTrue(self.tc.task_wait(
+            sub_transfer_doc["task_id"],
+            timeout=DEFAULT_TASK_WAIT_TIMEOUT,
+            polling_interval=DEFAULT_TASK_WAIT_POLLING_INTERVAL))
 
     def test_submit_transfer_keep_recursive_symlinks(self):
         """
@@ -726,7 +733,9 @@ class TransferClientTests(TransferClientTestCase):
 
         # confirm the symlinks are kept as symlinks
         self.assertTrue(
-            self.tc.task_wait(task_id, timeout=30, polling_interval=1))
+            self.tc.task_wait(
+                task_id, timeout=DEFAULT_TASK_WAIT_TIMEOUT,
+                polling_interval=DEFAULT_TASK_WAIT_POLLING_INTERVAL))
         ls_doc = self.tc.operation_ls(GO_EP3_ID, path=keep_path)
         self.assertEqual(len(ls_doc["DATA"]), 4)
         for item in ls_doc:
@@ -754,7 +763,9 @@ class TransferClientTests(TransferClientTestCase):
 
         # confirm the symlinks have their targets copied
         self.assertTrue(
-            self.tc.task_wait(task_id, timeout=30, polling_interval=1))
+            self.tc.task_wait(
+                task_id, timeout=DEFAULT_TASK_WAIT_TIMEOUT,
+                polling_interval=DEFAULT_TASK_WAIT_POLLING_INTERVAL))
         ls_doc = self.tc.operation_ls(GO_EP3_ID, path=copy_path)
         self.assertEqual(len(ls_doc["DATA"]), 4)
         for item in ls_doc:
@@ -777,7 +788,9 @@ class TransferClientTests(TransferClientTestCase):
 
         # confirm the symlinks have their targets copied
         self.assertTrue(
-            self.tc.task_wait(task_id, timeout=30, polling_interval=1))
+            self.tc.task_wait(
+                task_id, timeout=DEFAULT_TASK_WAIT_TIMEOUT,
+                polling_interval=DEFAULT_TASK_WAIT_POLLING_INTERVAL))
         ls_doc = self.tc.operation_ls(GO_EP3_ID, path=ignore_path)
         self.assertEqual(len(ls_doc["DATA"]), 0)
 
@@ -803,7 +816,9 @@ class TransferClientTests(TransferClientTestCase):
         # submit the task
         task_id = self.tc.submit_transfer(tdata)["task_id"]
         self.assertTrue(
-            self.tc.task_wait(task_id, timeout=30, polling_interval=1))
+            self.tc.task_wait(
+                task_id, timeout=DEFAULT_TASK_WAIT_TIMEOUT,
+                polling_interval=DEFAULT_TASK_WAIT_POLLING_INTERVAL))
         # track assets for cleanup
         self.asset_cleanup.append({"function": self.deleteHelper,
                                    "args": [GO_EP1_ID, link_dest]})
@@ -848,8 +863,10 @@ class TransferClientTests(TransferClientTestCase):
         self.tc.operation_mkdir(GO_EP1_ID, path)
 
         # wait for transfer to complete
-        self.assertTrue(self.tc.task_wait(transfer_doc["task_id"],
-                                          timeout=30, polling_interval=1))
+        self.assertTrue(self.tc.task_wait(
+            transfer_doc["task_id"],
+            timeout=DEFAULT_TASK_WAIT_TIMEOUT,
+            polling_interval=DEFAULT_TASK_WAIT_POLLING_INTERVAL))
 
         # delete the items
         ddata = globus_sdk.DeleteData(self.tc, GO_EP1_ID,
@@ -868,8 +885,9 @@ class TransferClientTests(TransferClientTestCase):
 
         # confirm the task completed and the files were deleted
         # wait for transfer to complete
-        self.assertTrue(self.tc.task_wait(task_id, timeout=30,
-                                          polling_interval=1))
+        self.assertTrue(self.tc.task_wait(
+            task_id, timeout=DEFAULT_TASK_WAIT_TIMEOUT,
+            polling_interval=DEFAULT_TASK_WAIT_POLLING_INTERVAL))
         # confirm file and dir are no longer visible by ls
         filter_string = "name:" + file_name + "," + dir_name
         params = {"path": dest_path, "filter": filter_string}
@@ -969,8 +987,9 @@ class TransferClientTests(TransferClientTestCase):
 
         # wait for task to complete
         task_id = transfer_doc["task_id"]
-        self.assertTrue(self.tc.task_wait(task_id, timeout=30,
-                                          polling_interval=1))
+        self.assertTrue(self.tc.task_wait(
+            task_id, timeout=DEFAULT_TASK_WAIT_TIMEOUT,
+            polling_interval=DEFAULT_TASK_WAIT_POLLING_INTERVAL))
 
         # get the task by id
         get_doc = self.tc.get_task(task_id)

--- a/tests/unit/test_transfer_client_manager.py
+++ b/tests/unit/test_transfer_client_manager.py
@@ -5,7 +5,10 @@ from random import getrandbits
 
 import globus_sdk
 from tests.framework import (TransferClientTestCase, get_user_data,
-                             GO_EP1_ID, GO_EP2_ID)
+                             GO_EP1_ID, GO_EP2_ID,
+
+                             DEFAULT_TASK_WAIT_TIMEOUT,
+                             DEFAULT_TASK_WAIT_POLLING_INTERVAL)
 from globus_sdk.exc import TransferAPIError
 from globus_sdk.transfer.paging import PaginatedResource
 
@@ -228,7 +231,9 @@ class ManagerTransferClientTests(TransferClientTestCase):
         ddata.add_item("no-op.txt")
         task_id = self.tc2.submit_delete(ddata)["task_id"]
         self.assertTrue(
-            self.tc2.task_wait(task_id, timeout=30, polling_interval=1))
+            self.tc2.task_wait(
+                task_id, timeout=DEFAULT_TASK_WAIT_TIMEOUT,
+                polling_interval=DEFAULT_TASK_WAIT_POLLING_INTERVAL))
 
         # sdktester1a gets the task event list as admin
         events_doc = self.tc.endpoint_manager_task_event_list(task_id)
@@ -270,7 +275,9 @@ class ManagerTransferClientTests(TransferClientTestCase):
                                    "args": [self.managed_ep_id, dest_path]})
         # wait for task to complete
         self.assertTrue(
-            self.tc2.task_wait(task_id, timeout=30, polling_interval=1))
+            self.tc2.task_wait(
+                task_id, timeout=DEFAULT_TASK_WAIT_TIMEOUT,
+                polling_interval=DEFAULT_TASK_WAIT_POLLING_INTERVAL))
 
         # sdktester1a gets successful transfers as admin
         success_doc = self.tc.endpoint_manager_task_successful_transfers(


### PR DESCRIPTION
Puts a couple of ints into the test constants so that we can adjust the "default" task_wait() behavior in the future without a slew of file-by-file edits.
I wanted to increase the limits here to reduce the number of spurious build failures. It should pair nicely with whatever we do for #221

Many of our tests run with a timeout of 30s and a polling interval of 1s, but there's no guarantee that tests will complete within that period of time. Rather than trying to make the tests truly robust to an arbitrary number of concurrent runs, it's simpler to tune things up for now. If want more robustness in the future, we'll need to find a way of running the testsuite under arbitrary users, and letting people run it as their own test accounts.

The default behavior for task_wait() is now to wait a full 2 minutes and poll on 3 a second interval. This means that builds could take a longer time, but in practice they probably won't. Worst case test run times increase by 6x90s = 540s = 9 minutes per environment in the build matrix, but we'll rarely see such bad behavior.