### PR TITLE
Fix endpoint manager resume and stop skipping pause and resume tests

### DIFF
--- a/globus_sdk/transfer/client.py
+++ b/globus_sdk/transfer/client.py
@@ -1842,7 +1842,7 @@ class TransferClient(BaseClient):
         path = self.qjoin_path("endpoint_manager", "admin_pause")
         return self.post(path, json_body=json_body, params=params)
 
-    def endpoint_manager_resume_tasks(self, task_ids, message, **params):
+    def endpoint_manager_resume_tasks(self, task_ids, **params):
         """
         Resume a list of tasks as an admin. Requires activity manager effective
         role on the task(s) source or destination endpoint(s).
@@ -1857,25 +1857,20 @@ class TransferClient(BaseClient):
             ``task_ids`` (*list of string*)
               List of task ids to resume.
 
-            ``message`` (*string*)
-              Message given to all users who's tasks have been canceled.
-
             ``params``
               Any additional parameters will be passed through as query params.
 
         **External Documentation**
 
         See
-        `Cancel tasks as admin \
-        <https://docs.globus.org/api/transfer/advanced_endpoint_management/#admin_cancel>`_
+        `Resume tasks as admin \
+        <https://docs.globus.org/api/transfer/advanced_endpoint_management/#resume_tasks_as_admin>`_
         in the REST documentation for details.
         """
         task_ids = [safe_stringify(i) for i in task_ids]
-        message = safe_stringify(message)
         self.logger.info(("TransferClient.endpoint_manager_"
-                          "resume_tasks({},{})".format(task_ids, message)))
+                          "resume_tasks({})".format(task_ids)))
         json_body = {
-            "message": safe_stringify(message),
             "task_id_list": task_ids
         }
         path = self.qjoin_path("endpoint_manager", "admin_resume")

--- a/tests/unit/test_transfer_client_manager.py
+++ b/tests/unit/test_transfer_client_manager.py
@@ -1,6 +1,5 @@
 import re
 import time
-import unittest
 from random import getrandbits
 
 import globus_sdk
@@ -367,10 +366,6 @@ class ManagerTransferClientTests(TransferClientTestCase):
             self.assertEqual(task_doc["canceled_by_admin"], "SOURCE")
             self.assertEqual(task_doc["canceled_by_admin_message"], message)
 
-    # TODO: stop skipping these tests when
-    # https://github.com/globusonline/koa/issues/49
-    # is resolved.
-    @unittest.skipIf(True, "github.com/globusonline/koa/issues/49")
     def test_endpoint_manager_pause_tasks(self):
         """
         Has sdktester2b submit three unauthorized transfers,
@@ -398,7 +393,6 @@ class ManagerTransferClientTests(TransferClientTestCase):
         self.assertEqual(apiErr.exception.http_status, 403)
         self.assertEqual(apiErr.exception.code, "PermissionDenied")
 
-    @unittest.skipIf(True, "github.com/globusonline/koa/issues/49")
     def test_endpoint_manager_resume_tasks(self):
         """
         Has sdktester2b submit three unauthorized transfers,
@@ -415,7 +409,7 @@ class ManagerTransferClientTests(TransferClientTestCase):
             self.assertTrue(task_doc["is_paused"])
 
         # resume the tasks and validate results
-        resume_doc = self.tc.endpoint_manager_resume_tasks(task_ids, message)
+        resume_doc = self.tc.endpoint_manager_resume_tasks(task_ids)
         self.assertEqual(resume_doc["DATA_TYPE"], "result")
         self.assertEqual(resume_doc["code"], "ResumeAccepted")
 
@@ -426,6 +420,6 @@ class ManagerTransferClientTests(TransferClientTestCase):
 
         # 403 for non managers
         with self.assertRaises(TransferAPIError) as apiErr:
-            self.tc2.endpoint_manager_resume_tasks(task_ids, message)
+            self.tc2.endpoint_manager_resume_tasks(task_ids)
         self.assertEqual(apiErr.exception.http_status, 403)
         self.assertEqual(apiErr.exception.code, "PermissionDenied")


### PR DESCRIPTION
Since https://github.com/globusonline/koa/issues/49 is now on prod, we can stop skipping the endpoint manager pause and resume tests.

Also removes the message field from endpoint_manager_resume_tasks which I never caught as an error since the unit tests were being skipped.