### PR TITLE
Update doc string for add_endpoint_acl_rule

### DIFF
--- a/globus_sdk/transfer/client.py
+++ b/globus_sdk/transfer/client.py
@@ -748,6 +748,9 @@ class TransferClient(BaseClient):
         >>> result = tc.add_endpoint_acl_rule(endpoint_id, rule_data)
         >>> rule_id = result["access_id"]
 
+        Note that if this rule is being created on a shared endpoint
+        the "path" field is relative to the "host_path" of the shared endpoint.
+
         **External Documentation**
 
         See


### PR DESCRIPTION
Updating doc string as requested by a user on developer discuss.

Original request:

> Would you please update the globus sdk documentation to clarify that the path specified when creating an acl on a shared endpoint is relative to the host_path of that endpoint?