### PR TITLE
Remove 'tests' package from find_packages()

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(name="globus-sdk",
       author="Globus Team",
       author_email="support@globus.org",
       url="https://github.com/globus/globus-sdk-python",
-      packages=find_packages(),
+      packages=find_packages(exclude=['tests', 'tests.*']),
       install_requires=[
           'requests>=2.0.0,<3.0.0',
           'six>=1.10.0,<2.0.0'


### PR DESCRIPTION
We aren't excluding `tests`, which means that installing `globus-sdk` from pypi will also provide a mysterious `tests` package. This can be especially confusing when working with a dependent codebase that has its own top-level `tests` package, as the site-packages dir comes earlier in the pythonpath than `.`, so `import tests` will grab the *sdk* tests package and presumably fail to import properly.

Since this can break client applications' testsuites, I kind of think it's a "big deal" once you notice it, though most people probably won't ever notice.
I noticed while refactoring another application to move its tests from `package_name.tests` to `tests` and my whole testsuite failed strangely.