### PR TITLE
Retry NetworkErrors in testsuite

### DIFF
--- a/tests/framework/__init__.py
+++ b/tests/framework/__init__.py
@@ -1,7 +1,8 @@
 from tests.framework.capturedio_testcase import CapturedIOTestCase
 from tests.framework.transfer_client_testcase import TransferClientTestCase
 from tests.framework.tools import (get_fixture_file_dir,
-                                   get_client_data, get_user_data)
+                                   get_client_data, get_user_data,
+                                   retry_errors)
 
 from tests.framework.constants import (GO_EP1_ID, GO_EP2_ID, GO_EP3_ID,
                                        GO_S3_ID, GO_EP1_SERVER_ID,
@@ -21,6 +22,7 @@ __all__ = [
     "get_fixture_file_dir",
     "get_client_data",
     "get_user_data",
+    "retry_errors",
 
     "GO_EP1_ID",
     "GO_EP2_ID",

--- a/tests/framework/tools.py
+++ b/tests/framework/tools.py
@@ -1,5 +1,9 @@
 import os
 import json
+import time
+from functools import wraps
+
+from globus_sdk.exc import NetworkError
 
 
 def get_fixture_file_dir():
@@ -32,3 +36,33 @@ def get_user_data():
                                uname + "@globusid.org.json")) as f:
             ret[uname] = json.load(f)
     return ret
+
+
+def retry_errors(retries=2, error_classes=(NetworkError,)):
+    """
+    A decorator which wraps tests to make them retry x times after a short
+    sleep (with exponential backoff) when a class of errors occurs.
+
+    Typically good for making tests robust to NetworkErrors
+
+    retries is the number of times to retry
+    error_classes is a tuple of classes of errors to retry
+    """
+    def inner_decorator(f):
+        @wraps(f)
+        def result_func(*args, **kwargs):
+            last_error = None
+            sleep_time = 1
+            count = 0
+            while count <= retries:
+                try:
+                    return f(*args, **kwargs)
+                except error_classes as e:
+                    last_error = e
+                    time.sleep(sleep_time)
+                    sleep_time *= 2
+                    count += 1
+            assert last_error is not None
+            raise last_error
+
+    return inner_decorator

--- a/tests/integration/test_auth_client_flow.py
+++ b/tests/integration/test_auth_client_flow.py
@@ -3,12 +3,13 @@ from six.moves.urllib.parse import quote_plus
 import globus_sdk
 from globus_sdk.auth.oauth2_constants import DEFAULT_REQUESTED_SCOPES
 from globus_sdk.auth.oauth2_native_app import make_native_app_challenge
-from tests.framework import CapturedIOTestCase, get_client_data
+from tests.framework import CapturedIOTestCase, get_client_data, retry_errors
 from globus_sdk.exc import AuthAPIError
 
 
 class AuthClientIntegrationTests(CapturedIOTestCase):
 
+    @retry_errors()
     def test_oauth2_get_authorize_url_native(self):
         """
         Starts an auth flow with a NativeAppFlowManager, gets the authorize url
@@ -59,6 +60,7 @@ class AuthClientIntegrationTests(CapturedIOTestCase):
         for val in expected_vals:
             self.assertIn(val, url_res)
 
+    @retry_errors()
     def test_oauth2_get_authorize_url_confidential(self):
         """
         Starts an auth flow with a NativeAppFlowManager, gets the authorize url
@@ -103,6 +105,7 @@ class AuthClientIntegrationTests(CapturedIOTestCase):
         for val in expected_vals:
             self.assertIn(val, url_res)
 
+    @retry_errors()
     def test_oauth2_exchange_code_for_tokens_native(self):
         """
         Starts a NativeAppFlowManager, Confirms invalid code raises 401
@@ -118,6 +121,7 @@ class AuthClientIntegrationTests(CapturedIOTestCase):
         self.assertEqual(apiErr.exception.http_status, 401)
         self.assertEqual(apiErr.exception.code, "Error")
 
+    @retry_errors()
     def test_oauth2_exchange_code_for_tokens_confidential(self):
         """
         Starts an AuthorizationCodeFlowManager, Confirms bad code raises 401

--- a/tests/integration/test_client_credentials_token_confidential_client.py
+++ b/tests/integration/test_client_credentials_token_confidential_client.py
@@ -4,7 +4,8 @@ except ImportError:
     from unittest import mock
 
 import globus_sdk
-from tests.framework import CapturedIOTestCase, get_client_data, GO_EP1_ID
+from tests.framework import (
+    CapturedIOTestCase, get_client_data, GO_EP1_ID, retry_errors)
 from globus_sdk.exc import GlobusAPIError
 
 
@@ -39,6 +40,7 @@ class ClientCredentialsAuthorizerIntegrationTests(CapturedIOTestCase):
             on_refresh=self.on_refresh)
         self.tc = globus_sdk.TransferClient(authorizer=self.authorizer)
 
+    @retry_errors()
     def test_get_new_access_token(self):
         """
         Has the Authorizer get a new access_token via the ConfidentialAppClient
@@ -53,6 +55,7 @@ class ClientCredentialsAuthorizerIntegrationTests(CapturedIOTestCase):
         get_res = self.tc.get_endpoint(GO_EP1_ID)
         self.assertEqual(get_res["id"], GO_EP1_ID)
 
+    @retry_errors()
     def test_invalid_access_token(self):
         """
         Invalidates the Authorizer's access_token, then makes a request
@@ -67,6 +70,7 @@ class ClientCredentialsAuthorizerIntegrationTests(CapturedIOTestCase):
         self.on_refresh.assert_called_once()
         self.assertNotEqual(self.access_token, self.authorizer.access_token)
 
+    @retry_errors()
     def test_invalid_access_token_no_retry(self):
         """
         Invalidates the Authorizer's access_token, then makes a request
@@ -81,6 +85,7 @@ class ClientCredentialsAuthorizerIntegrationTests(CapturedIOTestCase):
         self.assertEqual(apiErr.exception.http_status, 401)
         self.assertEqual(apiErr.exception.code, "AuthenticationFailed")
 
+    @retry_errors()
     def test_multiple_resource_servers(self):
         """
         Attempts to create a ClientCredentialsAuthorizer with scopes

--- a/tests/integration/test_confidential_client_flow.py
+++ b/tests/integration/test_confidential_client_flow.py
@@ -2,7 +2,7 @@ from six.moves.urllib.parse import quote_plus
 
 import globus_sdk
 from globus_sdk.auth.oauth2_constants import DEFAULT_REQUESTED_SCOPES
-from tests.framework import CapturedIOTestCase, get_client_data
+from tests.framework import CapturedIOTestCase, get_client_data, retry_errors
 from globus_sdk.auth import GlobusAuthorizationCodeFlowManager
 from globus_sdk.exc import AuthAPIError
 
@@ -19,6 +19,7 @@ class ConfidentialAppAuthClientIntegrationTests(CapturedIOTestCase):
             client_id=client_data["id"],
             client_secret=client_data["secret"])
 
+    @retry_errors()
     def test_oauth2_start_flow_default(self):
         """
         Starts a default GlobusAuthorizationCodeFlowManager,
@@ -54,6 +55,7 @@ class ConfidentialAppAuthClientIntegrationTests(CapturedIOTestCase):
         self.assertEqual(apiErr.exception.http_status, 401)
         self.assertEqual(apiErr.exception.code, "Error")
 
+    @retry_errors()
     def test_oauth2_start_flow_specified(self):
         """
         Starts a GlobusAuthorizationCodeFlowManager with specified parameters,

--- a/tests/integration/test_encoding.py
+++ b/tests/integration/test_encoding.py
@@ -6,7 +6,8 @@ from random import getrandbits
 import globus_sdk
 from tests.framework import (
     TransferClientTestCase, GO_EP1_ID,
-    DEFAULT_TASK_WAIT_TIMEOUT, DEFAULT_TASK_WAIT_POLLING_INTERVAL)
+    DEFAULT_TASK_WAIT_TIMEOUT, DEFAULT_TASK_WAIT_POLLING_INTERVAL,
+    retry_errors)
 
 
 class EncodingTests(TransferClientTestCase):
@@ -99,6 +100,7 @@ class EncodingTests(TransferClientTestCase):
         else:
             self.assertEqual(type("literal"), six.text_type)
 
+    @retry_errors()
     def test_ascii_url_encoding(self):
         """
         Tests operations with an ASCII name that includes ' ' and '%"
@@ -108,6 +110,7 @@ class EncodingTests(TransferClientTestCase):
         self.dir_operations(name)
         self.ep_operations(name)
 
+    @retry_errors()
     def test_non_ascii_utf8(self):
         """
         Tests operations with a UTF-8 name containing non ASCII characters with
@@ -118,6 +121,7 @@ class EncodingTests(TransferClientTestCase):
         self.ep_operations(name)
 
     @unittest.skipIf(six.PY3, "test run with Python 3")
+    @retry_errors()
     def test_non_ascii_utf8_bytes(self):
         """
         Tests operations with a byte string encoded from non ASCII UTF-8.
@@ -129,6 +133,7 @@ class EncodingTests(TransferClientTestCase):
         self.dir_operations(byte_name, expected_name=uni_name)
         self.ep_operations(byte_name, expected_name=uni_name)
 
+    @retry_errors()
     def test_latin1(self):
         """
         Tests operations with latin-1 name that is not valid UTF-8.
@@ -143,6 +148,7 @@ class EncodingTests(TransferClientTestCase):
         self.ep_operations(name)
 
     @unittest.skipIf(six.PY3, "test run with Python 3")
+    @retry_errors()
     def test_invalid_utf8_bytes(self):
         """
         Tests operations with byte string that can be decoded with

--- a/tests/integration/test_native_client_flow.py
+++ b/tests/integration/test_native_client_flow.py
@@ -3,7 +3,7 @@ from six.moves.urllib.parse import quote_plus
 import globus_sdk
 from globus_sdk.auth.oauth2_constants import DEFAULT_REQUESTED_SCOPES
 from globus_sdk.auth.oauth2_native_app import make_native_app_challenge
-from tests.framework import CapturedIOTestCase, get_client_data
+from tests.framework import CapturedIOTestCase, get_client_data, retry_errors
 from globus_sdk.auth import GlobusNativeAppFlowManager
 from globus_sdk.exc import AuthAPIError
 
@@ -18,6 +18,7 @@ class NativeAppAuthClientIntegrationTests(CapturedIOTestCase):
         self.nac = globus_sdk.NativeAppAuthClient(
             client_id=get_client_data()["native_app_client1"]["id"])
 
+    @retry_errors()
     def test_oauth2_start_flow_default(self):
         """
         Starts a default GlobusNativeAppFlowManager,
@@ -56,6 +57,7 @@ class NativeAppAuthClientIntegrationTests(CapturedIOTestCase):
         self.assertEqual(apiErr.exception.http_status, 401)
         self.assertEqual(apiErr.exception.code, "Error")
 
+    @retry_errors()
     def test_oauth2_start_flow_specified(self):
         """
         Starts a GlobusNativeAppFlowManager with specified parameters,

--- a/tests/integration/test_refresh_token_auth_client.py
+++ b/tests/integration/test_refresh_token_auth_client.py
@@ -6,7 +6,8 @@ except ImportError:
 import globus_sdk
 from tests.framework import (CapturedIOTestCase,
                              get_client_data, GO_EP1_ID,
-                             SDKTESTER1A_NATIVE1_TRANSFER_RT)
+                             SDKTESTER1A_NATIVE1_TRANSFER_RT,
+                             retry_errors)
 from globus_sdk.exc import GlobusAPIError
 
 
@@ -41,6 +42,7 @@ class RefreshTokenAuthorizerIntegrationTests(CapturedIOTestCase):
             on_refresh=self.on_refresh)
         self.tc = globus_sdk.TransferClient(authorizer=self.authorizer)
 
+    @retry_errors()
     def test_get_new_access_token(self):
         """
         Has the Authorizer get a new access_token via the AuthClient
@@ -55,6 +57,7 @@ class RefreshTokenAuthorizerIntegrationTests(CapturedIOTestCase):
         get_res = self.tc.get_endpoint(GO_EP1_ID)
         self.assertEqual(get_res["id"], GO_EP1_ID)
 
+    @retry_errors()
     def test_invalid_access_token(self):
         """
         Invalidates the Authorizer's access_token, then makes a request
@@ -69,6 +72,7 @@ class RefreshTokenAuthorizerIntegrationTests(CapturedIOTestCase):
         self.on_refresh.assert_called_once()
         self.assertNotEqual(self.access_token, self.authorizer.access_token)
 
+    @retry_errors()
     def test_invalid_access_token_no_retry(self):
         """
         Invalidates the Authorizer's access_token, then makes a request
@@ -83,6 +87,7 @@ class RefreshTokenAuthorizerIntegrationTests(CapturedIOTestCase):
         self.assertEqual(apiErr.exception.http_status, 401)
         self.assertEqual(apiErr.exception.code, "AuthenticationFailed")
 
+    @retry_errors()
     def test_invalid_tokens(self):
         """
         Invalidates the Authorizer's refresh_token and access_tokens,

--- a/tests/unit/responses/test_token_response.py
+++ b/tests/unit/responses/test_token_response.py
@@ -14,7 +14,8 @@ except ImportError:
     from unittest import mock
 
 from tests.framework import (CapturedIOTestCase, SDKTESTER1A_NATIVE1_ID_TOKEN,
-                             SDKTESTER1A_ID_ACCESS_TOKEN, get_client_data)
+                             SDKTESTER1A_ID_ACCESS_TOKEN, get_client_data,
+                             retry_errors)
 from globus_sdk.auth.token_response import (
     OAuthTokenResponse, OAuthDependentTokenResponse, _convert_token_info_dict)
 from globus_sdk.exc import GlobusOptionalDependencyError
@@ -127,6 +128,7 @@ class OAuthTokenResponseTests(CapturedIOTestCase):
         with self.assertRaises(GlobusOptionalDependencyError):
             self.response.decode_id_token(self.ac)
 
+    @retry_errors()
     @unittest.skipIf(not JWT_FLAG, "pyjwt not imported")
     def test_decode_id_token_invalid_id(self):
         """
@@ -141,6 +143,7 @@ class OAuthTokenResponseTests(CapturedIOTestCase):
         with self.assertRaises(jwt.exceptions.InvalidTokenError):
             id_response.decode_id_token(self.ac)
 
+    @retry_errors()
     @unittest.skipIf(not JWT_FLAG, "pyjwt not imported")
     def test_decode_id_token_expired(self):
         """

--- a/tests/unit/test_auth_client.py
+++ b/tests/unit/test_auth_client.py
@@ -6,7 +6,8 @@ except ImportError:
 import globus_sdk
 from tests.framework import (CapturedIOTestCase,
                              get_client_data, get_user_data,
-                             SDKTESTER1A_NATIVE1_AUTH_RT)
+                             SDKTESTER1A_NATIVE1_AUTH_RT,
+                             retry_errors)
 from globus_sdk.exc import AuthAPIError
 
 
@@ -31,6 +32,7 @@ class AuthClientTests(CapturedIOTestCase):
             authorizer=globus_sdk.AccessTokenAuthorizer(self.access_token),
             client_id=client_id)
 
+    @retry_errors()
     def test_get_identities_singleton(self):
         """
         gets identities with single username and id values, validates results.
@@ -60,6 +62,7 @@ class AuthClientTests(CapturedIOTestCase):
                 return identity
         return None
 
+    @retry_errors()
     def test_get_identites_ids(self):
         """
         gets identities with a list of ids, validates results
@@ -87,6 +90,7 @@ class AuthClientTests(CapturedIOTestCase):
         # confirm unused id isn't returned
         self.assertIsNone(unused_identity)
 
+    @retry_errors()
     def test_get_identities_usernames(self):
         """
         gets identities with a list of usernames, validates results.
@@ -117,6 +121,7 @@ class AuthClientTests(CapturedIOTestCase):
         self.assertEqual(unused_identity["name"], None)
         self.assertEqual(unused_identity["status"], "unused")
 
+    @retry_errors()
     def test_get_identities_errors(self):
         """
         Confirms bad and unauthorized requests to get_identities throw errors
@@ -133,6 +138,7 @@ class AuthClientTests(CapturedIOTestCase):
         self.assertEqual(apiErr.exception.http_status, 401)
         self.assertEqual(apiErr.exception.code, "UNAUTHORIZED")
 
+    @retry_errors()
     def test_oauth2_get_authorize_url(self):
         """
         Gets an authorize url with no auth flow and a mock auth flow.
@@ -153,6 +159,7 @@ class AuthClientTests(CapturedIOTestCase):
         self.assertEqual(url_res, mock_url)
         mock_flow.get_authorize_url.assert_called_once()
 
+    @retry_errors()
     def test_oauth2_exchange_code_for_tokens(self):
         """
         Confirms flow required to exchange code,
@@ -176,6 +183,7 @@ class AuthClientTests(CapturedIOTestCase):
         self.assertEqual(token_res, mock_tokens)
         mock_flow.exchange_code_for_tokens.assert_called_once_with(mock_code)
 
+    @retry_errors()
     def test_oauth2_refresh_token(self):
         """
         Gets an access token from the testing Refresh Token, validates results
@@ -195,6 +203,7 @@ class AuthClientTests(CapturedIOTestCase):
         self.assertEqual(apiErr.exception.http_status, 401)
         self.assertEqual(apiErr.exception.code, "Error")  # json is malformed?
 
+    @retry_errors()
     def test_oauth2_revoke_token(self):
         """
         Revokes the access_token used in test AuthClient's authorizer
@@ -210,6 +219,7 @@ class AuthClientTests(CapturedIOTestCase):
         self.assertEqual(apiErr.exception.http_status, 401)
         self.assertEqual(apiErr.exception.code, "UNAUTHORIZED")
 
+    @retry_errors()
     def test_oauth2_token(self):
         """
         Gets an access_token using oauth2/token directly, validates results.
@@ -224,6 +234,7 @@ class AuthClientTests(CapturedIOTestCase):
         self.assertIn("expires_in", token_res)
         self.assertIn("scope", token_res)
 
+    @retry_errors()
     def test_oauth2_userinfo(self):
         """
         Gets userinfo, validates results

--- a/tests/unit/test_base_client.py
+++ b/tests/unit/test_base_client.py
@@ -6,7 +6,7 @@ import globus_sdk
 from globus_sdk.base import (BaseClient, safe_stringify,
                              slash_join, merge_params)
 from tests.framework import (CapturedIOTestCase, get_client_data,
-                             SDKTESTER1A_NATIVE1_TRANSFER_RT)
+                             SDKTESTER1A_NATIVE1_TRANSFER_RT, retry_errors)
 from globus_sdk.exc import GlobusAPIError
 
 
@@ -94,6 +94,7 @@ class BaseClientTests(CapturedIOTestCase):
         path = self.bc.qjoin_path(*parts)
         self.assertEqual(path, "/SDK/Test/Path/Items")
 
+    @retry_errors()
     def test_get(self):
         """
         Gets test endpoint, verifies results
@@ -121,6 +122,7 @@ class BaseClientTests(CapturedIOTestCase):
         self.assertEqual(apiErr.exception.http_status, 405)
         self.assertEqual(apiErr.exception.code, "ClientError.BadMethod")
 
+    @retry_errors()
     def test_post(self):
         """
         Makes a test endpoint, verifies results
@@ -159,6 +161,7 @@ class BaseClientTests(CapturedIOTestCase):
         self.assertEqual(apiErr.exception.http_status, 405)
         self.assertEqual(apiErr.exception.code, "ClientError.BadMethod")
 
+    @retry_errors()
     def test_delete(self):
         """
         Deletes the test endpoint, verifies results
@@ -198,6 +201,7 @@ class BaseClientTests(CapturedIOTestCase):
         self.assertEqual(apiErr.exception.http_status, 405)
         self.assertEqual(apiErr.exception.code, "ClientError.BadMethod")
 
+    @retry_errors()
     def test_put(self):
         """
         Updates test endpoint, verifies results

--- a/tests/unit/test_confidential_client.py
+++ b/tests/unit/test_confidential_client.py
@@ -4,7 +4,7 @@ except ImportError:
     from unittest import mock
 
 import globus_sdk
-from tests.framework import CapturedIOTestCase, get_client_data
+from tests.framework import CapturedIOTestCase, get_client_data, retry_errors
 from globus_sdk.exc import AuthAPIError
 
 
@@ -27,6 +27,7 @@ class ConfidentialAppAuthClientTests(CapturedIOTestCase):
             client_id=client_data["id"],
             client_secret=client_data["secret"])
 
+    @retry_errors()
     def test_oauth2_client_credentials_tokens(self):
         """
         Get client credentials tokens, validate results
@@ -57,6 +58,7 @@ class ConfidentialAppAuthClientTests(CapturedIOTestCase):
             userinfo_res["sub"],
             get_client_data()["confidential_app_client1"]["id"])
 
+    @retry_errors()
     def test_oauth2_get_dependent_tokens(self):
         """
         Gets dependent tokens for a client access_token, validates results
@@ -99,6 +101,7 @@ class ConfidentialAppAuthClientTests(CapturedIOTestCase):
         self.assertEqual(apiErr.exception.http_status, 401)
         self.assertEqual(apiErr.exception.code, "Error")
 
+    @retry_errors()
     def test_oauth2_token_introspect(self):
         """
         Introspects a client access_token, validates results

--- a/tests/unit/test_native_client.py
+++ b/tests/unit/test_native_client.py
@@ -1,7 +1,7 @@
 import globus_sdk
 from tests.framework import (CapturedIOTestCase,
                              get_client_data, get_user_data,
-                             SDKTESTER1A_NATIVE1_AUTH_RT)
+                             SDKTESTER1A_NATIVE1_AUTH_RT, retry_errors)
 from globus_sdk.exc import AuthAPIError
 
 
@@ -25,6 +25,7 @@ class NativeAppAuthClientTests(CapturedIOTestCase):
                 client_id=get_client_data()["native_app_client1"]["id"],
                 authorizer=globus_sdk.AccessTokenAuthorizer(""))
 
+    @retry_errors()
     def test_get_identities(self):
         """
         Confirms native apps aren't authorized to get_identities on their own
@@ -34,6 +35,7 @@ class NativeAppAuthClientTests(CapturedIOTestCase):
         self.assertEqual(apiErr.exception.http_status, 401)
         self.assertEqual(apiErr.exception.code, "UNAUTHORIZED")
 
+    @retry_errors()
     def test_oauth2_refresh_token(self):
         """
         Sends a refresh_token grant, validates results
@@ -60,6 +62,7 @@ class NativeAppAuthClientTests(CapturedIOTestCase):
         # return access_token
         return access_token
 
+    @retry_errors()
     def test_oauth2_revoke_token(self):
         """
         Gets an access_token from test_oauth2_refresh_token, then revokes it

--- a/tests/unit/test_transfer_client.py
+++ b/tests/unit/test_transfer_client.py
@@ -6,7 +6,9 @@ from tests.framework import (TransferClientTestCase, get_user_data,
                              GO_EP1_SERVER_ID,
 
                              DEFAULT_TASK_WAIT_TIMEOUT,
-                             DEFAULT_TASK_WAIT_POLLING_INTERVAL)
+                             DEFAULT_TASK_WAIT_POLLING_INTERVAL,
+
+                             retry_errors)
 from globus_sdk.exc import TransferAPIError
 from globus_sdk.transfer.paging import PaginatedResource
 
@@ -18,6 +20,7 @@ class TransferClientTests(TransferClientTestCase):
 
     __test__ = True  # marks sub-class as having tests
 
+    @retry_errors()
     def test_get_endpoint(self):
         """
         Gets endpoint on go#ep1 and go#ep2, validate results
@@ -38,6 +41,7 @@ class TransferClientTests(TransferClientTestCase):
         self.assertEqual(ep1_doc["canonical_name"], "go#ep1")
         self.assertEqual(ep2_doc["canonical_name"], "go#ep2")
 
+    @retry_errors()
     def test_update_endpoint(self):
         """
         Updates test endpoint, validate results,
@@ -78,6 +82,7 @@ class TransferClientTests(TransferClientTestCase):
                          update_data2["display_name"])
         self.assertEqual(get_doc2["description"], update_data2["description"])
 
+    @retry_errors()
     def test_create_endpoint(self):
         """
         Creates an endpoint, validates results
@@ -102,6 +107,7 @@ class TransferClientTests(TransferClientTestCase):
         self.asset_cleanup.append({"function": self.tc.delete_endpoint,
                                    "args": [create_doc["id"]]})
 
+    @retry_errors()
     def test_delete_endpoint(self):
         """
         Deletes the test endpoint, validates results
@@ -131,6 +137,7 @@ class TransferClientTests(TransferClientTestCase):
     # def test_endpoint_activate(self):
         # TODO: test against an endpoint that uses MyProxy
 
+    @retry_errors()
     def test_endpoint_get_activation_requirements(self):
         """
         Gets activation requirements on tutorial endpoint, validates results
@@ -154,6 +161,7 @@ class TransferClientTests(TransferClientTestCase):
         self.assertTrue(reqs_doc.supports_web_activation)
         self.assertTrue(reqs_doc.always_activated)
 
+    @retry_errors()
     def test_create_shared_endpoint(self):
         """
         Creates a shared endpoint, validates results,
@@ -188,6 +196,7 @@ class TransferClientTests(TransferClientTestCase):
         self.asset_cleanup.append({"function": self.deleteHelper,
                                    "args": [GO_EP1_ID, share_path]})
 
+    @retry_errors()
     def test_endpoint_server_list(self):
         """
         Gets endpoint server list for go#ep1, validates results
@@ -204,6 +213,7 @@ class TransferClientTests(TransferClientTestCase):
             self.assertEqual(server["DATA_TYPE"], "server")
             self.assertIn("id", server)
 
+    @retry_errors()
     def test_get_endpoint_server(self):
         """
         Gets the go#ep1 server by id, validates results
@@ -217,6 +227,7 @@ class TransferClientTests(TransferClientTestCase):
         self.assertIn("hostname", get_doc)
         self.assertIn("port", get_doc)
 
+    @retry_errors()
     def test_add_endpoint_server(self):
         """
         Adds a new server with a dummy hostname, validate results
@@ -240,6 +251,7 @@ class TransferClientTests(TransferClientTestCase):
         # return server id
         return server_id
 
+    @retry_errors()
     def test_update_endpoint_server(self):
         """
         Adds a new server, updates server data, validates results,
@@ -265,6 +277,7 @@ class TransferClientTests(TransferClientTestCase):
         self.assertEqual(get_doc["hostname"], update_data["hostname"])
         self.assertEqual(get_doc["port"], update_data["port"])
 
+    @retry_errors()
     def test_delete_endpoint_server(self):
         """
         Adds a new server, deletes it, validates results,
@@ -289,6 +302,7 @@ class TransferClientTests(TransferClientTestCase):
         self.assertEqual(apiErr.exception.code,
                          "ClientError.NotFound.ServerNotFound")
 
+    @retry_errors()
     def test_endpoint_role_list(self):
         """
         Gets the endpoint role list from the test endpoint, validates results
@@ -308,6 +322,7 @@ class TransferClientTests(TransferClientTestCase):
             self.assertIn("principal", role)
             self.assertIn("role", role)
 
+    @retry_errors()
     def test_bookmark_list(self):
         """
         Gets SDK user's bookmark list, validates results
@@ -327,6 +342,7 @@ class TransferClientTests(TransferClientTestCase):
             self.assertIn("endpoint_id", bookmark)
             self.assertIn("path", bookmark)
 
+    @retry_errors()
     def test_create_bookmark(self):
         """
         Creates a bookmark, validates results, confirms get sees bookmark,
@@ -361,6 +377,7 @@ class TransferClientTests(TransferClientTestCase):
         # return bookmark_id
         return bookmark_id
 
+    @retry_errors()
     def test_get_bookmark(self):
         """
         Creates a bookmark, gets it, validates results
@@ -379,6 +396,7 @@ class TransferClientTests(TransferClientTestCase):
         self.assertIn("endpoint_id", get_doc)
         self.assertIn("path", get_doc)
 
+    @retry_errors()
     def test_update_bookmark(self):
         """
         Creates a bookmark, updates it, validates results,
@@ -402,6 +420,7 @@ class TransferClientTests(TransferClientTestCase):
         get_doc = self.tc.get_bookmark(bookmark_id)
         self.assertEqual(get_doc["name"], update_data["name"])
 
+    @retry_errors()
     def test_delete_bookmark(self):
         """
         Creates a bookmark, deletes it, validates results,
@@ -431,6 +450,7 @@ class TransferClientTests(TransferClientTestCase):
                 self.asset_cleanup.remove(cleanup)
                 break
 
+    @retry_errors()
     def test_operation_ls(self):
         """
         Performs ls operations on go#ep1, tests path, show_hidden, limit,
@@ -502,6 +522,7 @@ class TransferClientTests(TransferClientTestCase):
         self.assertEqual(file_data["name"], file_name)
         self.assertTrue(file_data["size"] > min_size)
 
+    @retry_errors()
     def test_operation_mkdir(self):
         """
         Performs mkdir operation in go#ep1/~/, validates results,
@@ -529,6 +550,7 @@ class TransferClientTests(TransferClientTestCase):
         self.asset_cleanup.append({"function": self.deleteHelper,
                                    "args": [GO_EP1_ID, path]})
 
+    @retry_errors()
     def test_operation_rename(self):
         """
         Performs mkdir operation, renames the directory,
@@ -567,6 +589,7 @@ class TransferClientTests(TransferClientTestCase):
         self.asset_cleanup.append({"function": self.deleteHelper,
                                    "args": [GO_EP1_ID, new_path]})
 
+    @retry_errors()
     def test_operation_symlink(self):
         """
         Performs operation symlink creating valid and invalid symlinks
@@ -610,6 +633,7 @@ class TransferClientTests(TransferClientTestCase):
         self.assertEqual(apiErr.exception.http_status, 409)
         self.assertEqual(apiErr.exception.code, "NotSupported")
 
+    @retry_errors()
     def test_operation_get_submission_id(self):
         """
         Gets a submission_id, validates results, checks UUID looks reasonable
@@ -630,6 +654,7 @@ class TransferClientTests(TransferClientTestCase):
         self.assertEqual(uuid[18], "-")
         self.assertEqual(uuid[23], "-")
 
+    @retry_errors()
     def test_submit_transfer(self):
         """
         Submits transfer requests, validates results, confirms tasks completed
@@ -711,6 +736,7 @@ class TransferClientTests(TransferClientTestCase):
             timeout=DEFAULT_TASK_WAIT_TIMEOUT,
             polling_interval=DEFAULT_TASK_WAIT_POLLING_INTERVAL))
 
+    @retry_errors()
     def test_submit_transfer_keep_recursive_symlinks(self):
         """
         Submits transfer tasks from go#ep3:/share/symlinks/good/
@@ -741,6 +767,7 @@ class TransferClientTests(TransferClientTestCase):
         for item in ls_doc:
             self.assertIsNotNone(item["link_target"])
 
+    @retry_errors()
     def test_submit_transfer_copy_recursive_symlinks(self):
         """
         Submits transfer tasks from go#ep3:/share/symlinks/good/
@@ -771,6 +798,7 @@ class TransferClientTests(TransferClientTestCase):
         for item in ls_doc:
             self.assertIsNone(item["link_target"])
 
+    @retry_errors()
     def test_submit_transfer_ignore_recursive_symlinks(self):
         # dir for testing transfers to, name randomized to prevent collision
         ignore_dir = "ignore_symlink_dest_dir-" + str(getrandbits(128))
@@ -794,6 +822,7 @@ class TransferClientTests(TransferClientTestCase):
         ls_doc = self.tc.operation_ls(GO_EP3_ID, path=ignore_path)
         self.assertEqual(len(ls_doc["DATA"]), 0)
 
+    @retry_errors()
     def test_submit_transfer_symlink(self):
         """
         Transfers a symlink on go#ep3:/share/symlinks/good to go#ep3:~/
@@ -833,6 +862,7 @@ class TransferClientTests(TransferClientTestCase):
         ls_doc = self.tc.operation_ls(GO_EP3_ID, filter="name:" + file_name)
         self.assertIsNone(ls_doc["DATA"][0]["link_target"])
 
+    @retry_errors()
     def test_submit_delete(self):
         """
         Transfers a file and makes a dir in go#ep1, then deletes them,
@@ -901,6 +931,7 @@ class TransferClientTests(TransferClientTestCase):
         self.assertEqual(resub_delete_doc["submission_id"], sub_id)
         self.assertEqual(resub_delete_doc["task_id"], task_id)
 
+    @retry_errors()
     def test_task_list(self):
         """
         Gets task list, validates results, tests num_results and filter params
@@ -937,6 +968,7 @@ class TransferClientTests(TransferClientTestCase):
             self.assertEqual(task["type"], "DELETE")
             self.assertEqual(task["status"], "SUCCEEDED")
 
+    @retry_errors()
     def test_task_event_list(self):
         """
         Gets the task event list for a completed transfer,
@@ -961,6 +993,7 @@ class TransferClientTests(TransferClientTestCase):
         for event in filter_doc:
             self.assertEqual(event["is_error"], True)
 
+    @retry_errors()
     def test_get_task(self):
         """
         Submits a transfer, waits for transfer to complete, gets transfer task
@@ -1003,6 +1036,7 @@ class TransferClientTests(TransferClientTestCase):
         # return task_id
         return task_id
 
+    @retry_errors()
     def test_update_task(self):
         """
         Submits an un-allowed transfer task, updates task, validates results,
@@ -1039,6 +1073,7 @@ class TransferClientTests(TransferClientTestCase):
         self.assertEqual(apiErr.exception.http_status, 409)
         self.assertEqual(apiErr.exception.code, "Conflict")
 
+    @retry_errors()
     def test_cancel_task(self):
         """
         Submits an un-allowed transfer task, cancels task, validates results,
@@ -1075,6 +1110,7 @@ class TransferClientTests(TransferClientTestCase):
             complete_doc["message"],
             "The task completed before the cancel request was processed.")
 
+    @retry_errors()
     def test_task_wait(self):
         """
         Waits on complete, and never completing tasks, confirms results
@@ -1102,6 +1138,7 @@ class TransferClientTests(TransferClientTestCase):
         self.asset_cleanup.append({"function": self.tc.cancel_task,
                                    "args": [never_id]})
 
+    @retry_errors()
     def test_task_successful_transfers(self):
         """
         Gets the successful transfers from a completed task, validates results

--- a/tests/unit/test_transfer_client_manager.py
+++ b/tests/unit/test_transfer_client_manager.py
@@ -7,7 +7,9 @@ from tests.framework import (TransferClientTestCase, get_user_data,
                              GO_EP1_ID, GO_EP2_ID,
 
                              DEFAULT_TASK_WAIT_TIMEOUT,
-                             DEFAULT_TASK_WAIT_POLLING_INTERVAL)
+                             DEFAULT_TASK_WAIT_POLLING_INTERVAL,
+
+                             retry_errors)
 from globus_sdk.exc import TransferAPIError
 from globus_sdk.transfer.paging import PaginatedResource
 
@@ -60,6 +62,7 @@ class ManagerTransferClientTests(TransferClientTestCase):
             else:
                 raise e
 
+    @retry_errors()
     def test_endpoint_manager_monitored_endpoints(self):
         """
         Gets a list of all endpoints sdktester1a is an activity_manager on,
@@ -78,6 +81,7 @@ class ManagerTransferClientTests(TransferClientTestCase):
         else:
             self.assertFalse("managed endpoint not found")
 
+    @retry_errors()
     def test_endpoint_manager_get_endpoint(self):
         """
         Gets the managed endpoint, confirms expected results
@@ -95,6 +99,7 @@ class ManagerTransferClientTests(TransferClientTestCase):
         self.assertEqual(apiErr.exception.code, "PermissionDenied")
 
     # TODO: test against a non shared endpoint we have the manager role on
+    @retry_errors()
     def test_endpoint_manager_hosted_endpoint_list(self):
         """
         Attempts to gets the list of shares hosted on the managed endpoint.
@@ -114,6 +119,7 @@ class ManagerTransferClientTests(TransferClientTestCase):
         self.assertEqual(apiErr.exception.http_status, 403)
         self.assertEqual(apiErr.exception.code, "PermissionDenied")
 
+    @retry_errors()
     def test_endpoint_manager_acl_list(self):
         """
         Gets ACL list from managed endpoint, validates results
@@ -134,6 +140,7 @@ class ManagerTransferClientTests(TransferClientTestCase):
         self.assertEqual(apiErr.exception.http_status, 403)
         self.assertEqual(apiErr.exception.code, "PermissionDenied")
 
+    @retry_errors()
     def test_endpoint_manager_task_list(self):
         """
         Has sdktester2b submit transfer and delete task to the managed_ep
@@ -190,6 +197,7 @@ class ManagerTransferClientTests(TransferClientTestCase):
         # fail if both not found
         self.assertTrue(delete_found and transfer_found)
 
+    @retry_errors()
     def test_endpoint_manager_get_task(self):
         """
         Has sdktester2b submit a no-op task on the managed endpoint
@@ -217,6 +225,7 @@ class ManagerTransferClientTests(TransferClientTestCase):
         self.assertEqual(apiErr.exception.http_status, 403)
         self.assertEqual(apiErr.exception.code, "PermissionDenied")
 
+    @retry_errors()
     def test_endpoint_manager_task_event_list(self):
         """
         Has sdktester2b submit a no-op task on the managed endpoint.
@@ -250,6 +259,7 @@ class ManagerTransferClientTests(TransferClientTestCase):
         self.assertEqual(apiErr.exception.http_status, 403)
         self.assertEqual(apiErr.exception.code, "PermissionDenied")
 
+    @retry_errors()
     def test_endpoint_manager_task_successful_transfers(self):
         """
         Has sdktester2b submit a recursive transfer of share/godata to the
@@ -314,6 +324,7 @@ class ManagerTransferClientTests(TransferClientTestCase):
 
         return task_ids
 
+    @retry_errors()
     def test_endpoint_manager_cancel_tasks(self):
         """
         Get task ids from _unauthorized transfers, and has sdktester1a cancel
@@ -336,6 +347,7 @@ class ManagerTransferClientTests(TransferClientTestCase):
         self.assertEqual(apiErr.exception.http_status, 403)
         self.assertEqual(apiErr.exception.code, "PermissionDenied")
 
+    @retry_errors()
     def test_endpoint_manager_cancel_status(self):
         """
         Has sdktester2b submit three unauthorized transfers from the managed
@@ -366,6 +378,7 @@ class ManagerTransferClientTests(TransferClientTestCase):
             self.assertEqual(task_doc["canceled_by_admin"], "SOURCE")
             self.assertEqual(task_doc["canceled_by_admin_message"], message)
 
+    @retry_errors()
     def test_endpoint_manager_pause_tasks(self):
         """
         Has sdktester2b submit three unauthorized transfers,
@@ -393,6 +406,7 @@ class ManagerTransferClientTests(TransferClientTestCase):
         self.assertEqual(apiErr.exception.http_status, 403)
         self.assertEqual(apiErr.exception.code, "PermissionDenied")
 
+    @retry_errors()
     def test_endpoint_manager_resume_tasks(self):
         """
         Has sdktester2b submit three unauthorized transfers,

--- a/tests/unit/test_transfer_client_shared.py
+++ b/tests/unit/test_transfer_client_shared.py
@@ -1,7 +1,8 @@
 from random import getrandbits
 
 import globus_sdk
-from tests.framework import TransferClientTestCase, get_user_data, GO_EP1_ID
+from tests.framework import (
+    TransferClientTestCase, get_user_data, GO_EP1_ID, retry_errors)
 from globus_sdk.exc import TransferAPIError
 from globus_sdk.transfer.paging import PaginatedResource
 
@@ -41,6 +42,7 @@ class SharedTransferClientTests(TransferClientTestCase):
         self.asset_cleanup.append({"function": self.deleteHelper,
                                    "args": [GO_EP1_ID, share_path]})
 
+    @retry_errors()
     def test_endpoint_search(self):
         """
         Searches by fulltext, owner_id, and scopes, validates results
@@ -85,6 +87,7 @@ class SharedTransferClientTests(TransferClientTestCase):
             self.assertIsNotNone(ep["sharing_target_root_path"])
             self.assertIsNotNone(ep["host_endpoint_id"])
 
+    @retry_errors()
     def test_endpoint_autoactivate(self):
         """
         Deactivates, then auto-activates shared endpoint,
@@ -111,6 +114,7 @@ class SharedTransferClientTests(TransferClientTestCase):
 
         # TODO: test against an endpoint we are not allowed to activate
 
+    @retry_errors()
     def test_endpoint_deactivate(self):
         """
         Auto-activates, then deactivates shared endpoint,
@@ -128,6 +132,7 @@ class SharedTransferClientTests(TransferClientTestCase):
         get_doc = self.tc.get_endpoint(self.test_share_ep_id)
         self.assertFalse(get_doc["activated"])
 
+    @retry_errors()
     def test_my_shared_endpoint_list(self):
         """
         Gets my shared endpoint list, validates results
@@ -144,6 +149,7 @@ class SharedTransferClientTests(TransferClientTestCase):
         else:
             self.assertFalse("test share not found")
 
+    @retry_errors()
     def test_endpoint_acl_list(self):
         """
         Gets endpoint access rule list from test_share_ep, validates results
@@ -163,6 +169,7 @@ class SharedTransferClientTests(TransferClientTestCase):
             self.assertIn("principal", access)
             self.assertIn("permissions", access)
 
+    @retry_errors()
     def test_get_endpoint_acl_rule(self):
         """
         Adds access rule to test_share_ep, gets it by id, validates results
@@ -179,6 +186,7 @@ class SharedTransferClientTests(TransferClientTestCase):
         self.assertEqual(get_doc["DATA_TYPE"], "access")
         self.assertEqual(get_doc["id"], access_id)
 
+    @retry_errors()
     def test_add_endpoint_acl_rule(self):
         """
         Adds access rule to test_share_ep, validates results,
@@ -214,6 +222,7 @@ class SharedTransferClientTests(TransferClientTestCase):
         # return access_id
         return access_id
 
+    @retry_errors()
     def test_update_endpoint_acl_rule(self):
         """
         Adds access rule to test_share_ep, updates that access rule,
@@ -239,6 +248,7 @@ class SharedTransferClientTests(TransferClientTestCase):
                                                 access_id)
         self.assertEqual(get_doc["permissions"], update_data["permissions"])
 
+    @retry_errors()
     def test_delete_endpoint_acl_rule(self):
         """
         Adds access rule to test_share_ep, deletes that access rule,
@@ -263,6 +273,7 @@ class SharedTransferClientTests(TransferClientTestCase):
         self.assertEqual(apiErr.exception.http_status, 404)
         self.assertEqual(apiErr.exception.code, "AccessRuleNotFound")
 
+    @retry_errors()
     def test_endpoint_manager_create_pause_rule(self):
         """
         Creates a pause rule on the shared endpoint, validates results.
@@ -302,6 +313,7 @@ class SharedTransferClientTests(TransferClientTestCase):
         # return id for use in other tests
         return rule_id
 
+    @retry_errors()
     def test_endpoint_manager_pause_rule_list(self):
         """
         Gets a pause_rule id from test_endpoint_manager_create_pause_rule.
@@ -332,6 +344,7 @@ class SharedTransferClientTests(TransferClientTestCase):
         self.assertEqual(apiErr.exception.http_status, 403)
         self.assertEqual(apiErr.exception.code, "PermissionDenied")
 
+    @retry_errors()
     def test_endpoint_manager_get_pause_rule(self):
         """
         Gets a pause rule created by test_endpoint_manager_create_pause_rule.
@@ -360,6 +373,7 @@ class SharedTransferClientTests(TransferClientTestCase):
         self.assertEqual(apiErr.exception.http_status, 403)
         self.assertEqual(apiErr.exception.code, "PermissionDenied")
 
+    @retry_errors()
     def test_endpoint_manager_update_pause_rule(self):
         """
         Updates a pause rule created by test_endpoint_manager_create_pause_rule
@@ -392,6 +406,7 @@ class SharedTransferClientTests(TransferClientTestCase):
         self.assertEqual(apiErr.exception.http_status, 403)
         self.assertEqual(apiErr.exception.code, "PermissionDenied")
 
+    @retry_errors()
     def test_endpoint_manager_delete_pause_rule(self):
         """
         Deletes a pause rule created by test_endpoint_manager_create_pause_rule
@@ -423,6 +438,7 @@ class SharedTransferClientTests(TransferClientTestCase):
                 self.asset_cleanup.remove(cleanup)
                 break
 
+    @retry_errors()
     def test_task_pause_info(self):
         """
         Creates a pause rule on the shared endpoint, then submits a task
@@ -454,6 +470,7 @@ class SharedTransferClientTests(TransferClientTestCase):
         self.assertNotIn("modified_by", rule)
         self.assertNotIn("modified_by_id", rule)
 
+    @retry_errors()
     def test_my_effective_pause_rule_list(self):
         """
         Creates a pause rule on the shared endpoint, then gets pause rule list.
@@ -476,6 +493,7 @@ class SharedTransferClientTests(TransferClientTestCase):
         self.assertNotIn("modified_by", rule)
         self.assertNotIn("modified_by_id", rule)
 
+    @retry_errors()
     def test_endpoint_manager_task_pause_info(self):
         """
         Creates a pause rule on the shared endpoint, then
@@ -514,6 +532,7 @@ class SharedTransferClientTests(TransferClientTestCase):
         self.assertEqual(apiErr.exception.http_status, 403)
         self.assertEqual(apiErr.exception.code, "PermissionDenied")
 
+    @retry_errors()
     def test_add_endpoint_role(self):
         """
         Adds a role to the test share endpoint, validates results
@@ -539,6 +558,7 @@ class SharedTransferClientTests(TransferClientTestCase):
         # return role id
         return role_id
 
+    @retry_errors()
     def test_get_endpoint_role(self):
         """
         Gets role created in test_add_endpoint_role, validates results.
@@ -554,6 +574,7 @@ class SharedTransferClientTests(TransferClientTestCase):
                          get_user_data()["go"]["id"])
         self.assertEqual(get_doc["role"], "access_manager")
 
+    @retry_errors()
     def test_delete_endpoint_role(self):
         """
         Deletes role created in test_add_endpoint_role, validates results.


### PR DESCRIPTION
It's quite common to get spurious failures in the testsuite because one GET somewhere along the line times out. These should all be retried, but we don't want to put painstaking retry logic into each testcase.

Add a decorator which sets up retry behavior to the tests.framework package, and decorate every network-sensitive test with it. It is possible to write a test such that the retry will fail, potentially worse than it would have failed without the retry, but (1) that's not the common case and (2) you can use `retry_errors` on a locally defined function to restrict its behavior if you're writing a sensitive test.

Although this is pretty much universally applied, it should be a per-test decision, so keep the decorator pattern very simple to shuffle around and re-apply (at the cost of some redundancy).

This worked for me locally, but I'm concerned that across pythons and platforms we might see some weirdness.