### PR TITLE
Fix ClientCredentials authorization docs

### DIFF
--- a/docs/examples/client_credentials.rst
+++ b/docs/examples/client_credentials.rst
@@ -94,4 +94,34 @@ When your tokens are expired, you should just request new ones by making
 another Client Credentials request.
 Depending on your needs, you may need to track the expiration times along with
 your tokens.
-The SDK does not offer any special facilities for doing this.
+
+Using ClientCredentialsAuthorizer
+---------------------------------
+
+The SDK also provides a specialized Authorizer which can be used to
+automatically handle token expiration.
+
+Use it like so:
+
+.. code-block:: python
+
+    import globus_sdk
+
+    # you must have a client ID
+    CLIENT_ID = '...'
+    # the secret, loaded from wherever you store it
+    CLIENT_SECRET = '...'
+
+    confidential_client = globus_sdk.ConfidentialAppAuthClient(
+        client_id=CLIENT_ID, client_secret=CLIENT_SECRET)
+    scopes = "urn:globus:auth:scopes:transfer.api.globus.org:all"
+    cc_authorizer = globus_sdk.ClientCredentialsAuthorizer(
+        confidential_client, scopes)
+    # create a new client
+    transfer_client = globus_sdk.TransferClient(authorizer=cc_authorizer)
+
+    # usage is still the same
+    print("Endpoints Belonging to {}@clients.auth.globus.org:"
+          .format(CLIENT_ID))
+    for ep in tc.endpoint_search(filter_scope="my-endpoints"):
+        print("[{}] {}".format(ep["id"], ep["display_name"]))

--- a/globus_sdk/authorizers/client_credentials.py
+++ b/globus_sdk/authorizers/client_credentials.py
@@ -14,10 +14,11 @@ class ClientCredentialsAuthorizer(RenewingAuthorizer):
     Example usage looks something like this:
 
     >>> import globus_sdk
-    >>> confidential_client = globus_sdk.ConfidentiallAppAuthClient(
-        client_id=..., client_secret=..., scopes=...)
+    >>> confidential_client = globus_sdk.ConfidentialAppAuthClient(
+        client_id=..., client_secret=...)
+    >>> scopes = "..."
     >>> cc_authorizer = globus_sdk.ClientCredentialsAuthorizer(
-    >>>     confidential_client)
+    >>>     confidential_client, scopes)
     >>> # create a new client
     >>> transfer_client = globus_sdk.TransferClient(authorizer=cc_authorizer)
 


### PR DESCRIPTION
Resolves #244, #243 

Some minor fixes to a docstring, and replace some erroneous text with an example of `ClientCredentialsAuthorizer`