### PR TITLE
Improvements to environments and base config

### DIFF
--- a/globus_sdk/config.py
+++ b/globus_sdk/config.py
@@ -172,6 +172,8 @@ def get_default_environ():
     which does not explicitly specify its environment will use this value.
     """
     env = os.environ.get('GLOBUS_SDK_ENVIRONMENT', 'default')
+    if env == 'production':
+        env = 'default'
     if env != 'default':
         logger.info(('On lookup, non-default environment: '
                      'GLOBUS_SDK_ENVIRONMENT={}'.format(env)))

--- a/globus_sdk/config.py
+++ b/globus_sdk/config.py
@@ -106,6 +106,7 @@ class GlobusConfigParser(object):
 
         if value is not None:
             value = type_cast(value)
+
         return value
 
 
@@ -131,6 +132,12 @@ def get_service_url(environment, service):
     option = service + "_service"
     # TODO: validate with urlparse?
     url = p.get(option, environment=environment)
+    if url is None:
+        raise ValueError(
+            ('Failed to find a url for service "{}" in environment "{}". '
+             "Please double-check that GLOBUS_SDK_ENVIRONMENT is set "
+             "correctly, or not set at all")
+            .format(service, environment))
     logger.debug("Service URL Lookup Result: \"{}\" is at \"{}\""
                  .format(service, url))
     return url

--- a/globus_sdk/globus.cfg
+++ b/globus_sdk/globus.cfg
@@ -2,10 +2,10 @@
 
 [environment default]
 auth_service = https://auth.globus.org/
-transfer_service = https://transfer.api.globusonline.org/
+transfer_service = https://transfer.api.globus.org/
 nexus_service = https://nexus.api.globusonline.org/
 
-[environment beta]
-auth_service = https://auth.beta.globus.org/
-nexus_service = https://nexus.api.globusonline.org/
-transfer_service = https://transfer.api.beta.globus.org/
+[environment preview]
+auth_service = https://auth.preview.globus.org/
+nexus_service = https://nexus.api.preview.globus.org/
+transfer_service = https://transfer.api.preview.globus.org/

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -116,8 +116,8 @@ class ConfigParserTests(CapturedIOTestCase):
             "https://transfer.api.beta.globus.org/")
 
         # missing values
-        self.assertEqual(
-            globus_sdk.config.get_service_url("nonexistant", "auth"), None)
+        with self.assertRaises(ValueError):
+            globus_sdk.config.get_service_url("nonexistent", "auth")
 
     def test_get_ssl_verify(self):
         """


### PR DESCRIPTION
Improve error for bad envs, per globus/globus-cli#350
Alias `production` to `default`
Replace `beta` with `preview`
Rewrite Transfer API hostname to `.globus.org`