### PR TITLE
Add reference from Responses to originating Client

### DIFF
--- a/docs/optional_dependencies.rst
+++ b/docs/optional_dependencies.rst
@@ -1,3 +1,5 @@
+.. _optional_dependencies:
+
 Optional Dependencies
 =====================
 

--- a/globus_sdk/auth/token_response.py
+++ b/globus_sdk/auth/token_response.py
@@ -58,9 +58,19 @@ class OAuthTokenResponse(GlobusHTTPResponse):
         """
         return self._by_resource_server
 
-    def decode_id_token(self, auth_client):
+    def decode_id_token(self, auth_client=None):
         """
         A parsed ID Token (OIDC) as a dict.
+
+        Requires the globus-sdk[jwt] optional dependency. For more details, see
+        the :ref:`Optional Dependency Docs <optional_dependencies>`.
+
+        **Parameters**
+
+            ``auth_client`` (:class:`AuthClient <globus_sdk.AuthClient>`)
+              Deprecated parameter for providing the AuthClient used to request
+              this token back to the OAuthTokenResponse. The SDK now tracks
+              this internally, so it is no longer necessary.
         """
         logger.info('Decoding ID Token "{}"'.format(self['id_token']))
         try:
@@ -70,6 +80,16 @@ class OAuthTokenResponse(GlobusHTTPResponse):
             raise GlobusOptionalDependencyError(
                 ["globus_sdk[jwt]"],
                 "JWT Parsing via OAuthTokenResponse.id_token")
+
+        # warn (not error) on older usage pattern, but still respect it
+        # FIXME: should be deprecated and removed in SDK v2
+        if auth_client:
+            logger.warn(
+                'Providing an auth_client to decode_id_token is no '
+                'longer required and may be deprecated in a future version '
+                'of the Globus SDK')
+        else:
+            auth_client = self._client
 
         logger.debug('Fetch JWK Data: Start')
         oidc_conf = auth_client.get('/.well-known/openid-configuration')

--- a/globus_sdk/auth/token_response.py
+++ b/globus_sdk/auth/token_response.py
@@ -62,9 +62,6 @@ class OAuthTokenResponse(GlobusHTTPResponse):
         """
         A parsed ID Token (OIDC) as a dict.
 
-        Requires the globus-sdk[jwt] optional dependency. For more details, see
-        the :ref:`Optional Dependency Docs <optional_dependencies>`.
-
         **Parameters**
 
             ``auth_client`` (:class:`AuthClient <globus_sdk.AuthClient>`)

--- a/globus_sdk/base.py
+++ b/globus_sdk/base.py
@@ -358,9 +358,9 @@ class BaseClient(object):
             self.logger.debug('request completed with response code: {}'
                               .format(r.status_code))
             if response_class is None:
-                return self.default_response_class(r)
+                return self.default_response_class(self, r)
             else:
-                return response_class(r)
+                return response_class(self, r)
 
         self.logger.debug('request completed with (error) response code: {}'
                           .format(r.status_code))

--- a/globus_sdk/base.py
+++ b/globus_sdk/base.py
@@ -358,9 +358,9 @@ class BaseClient(object):
             self.logger.debug('request completed with response code: {}'
                               .format(r.status_code))
             if response_class is None:
-                return self.default_response_class(self, r)
+                return self.default_response_class(r, client=self)
             else:
-                return response_class(self, r)
+                return response_class(r, client=self)
 
         self.logger.debug('request completed with (error) response code: {}'
                           .format(r.status_code))

--- a/globus_sdk/response.py
+++ b/globus_sdk/response.py
@@ -20,11 +20,13 @@ class GlobusResponse(object):
     return to a caller. Most basic actions on a GlobusResponse are
     just ways of interacting with this data.
     """
-    def __init__(self, client, data):
+    def __init__(self, data, client=None):
+        # TODO: In v2, consider making client a required argument
         # client is the originating client object, which can be used by
         # advanced response classes to implement fancy methods which need to
         # interact with the client
         self._client = client
+
         self._data = data
 
     def __str__(self):
@@ -82,10 +84,10 @@ class GlobusHTTPResponse(GlobusResponse):
     :ivar http_status: HTTP status code returned by the server (int)
     :ivar content_type: Content-Type header returned by the server (str)
     """
-    def __init__(self, client, http_response):
+    def __init__(self, http_response, client=None):
         # the API response as some form of HTTP response object will be the
         # underlying data of an API response
-        GlobusResponse.__init__(self, client, http_response)
+        GlobusResponse.__init__(self, http_response, client=client)
         # NB: the word 'code' is confusing because we use it in the
         # error body, and status_code is not much better. http_code, or
         # http_status_code if we wanted to be really explicit, is

--- a/globus_sdk/response.py
+++ b/globus_sdk/response.py
@@ -15,13 +15,16 @@ class GlobusResponse(object):
     ``TypeError``.
 
     >>> print("Response ID": r["id"]) # alias for r.data["id"]
+
+    ``GlobusResponse`` objects *always* wrap some kind of data to
+    return to a caller. Most basic actions on a GlobusResponse are
+    just ways of interacting with this data.
     """
-    def __init__(self, data):
-        """
-        ``GlobusResponse`` objects *always* wrap some kind of data to
-        return to a caller. Most basic actions on a GlobusResponse are
-        just ways of interacting with this data.
-        """
+    def __init__(self, client, data):
+        # client is the originating client object, which can be used by
+        # advanced response classes to implement fancy methods which need to
+        # interact with the client
+        self._client = client
         self._data = data
 
     def __str__(self):
@@ -79,10 +82,10 @@ class GlobusHTTPResponse(GlobusResponse):
     :ivar http_status: HTTP status code returned by the server (int)
     :ivar content_type: Content-Type header returned by the server (str)
     """
-    def __init__(self, http_response):
+    def __init__(self, client, http_response):
         # the API response as some form of HTTP response object will be the
         # underlying data of an API response
-        GlobusResponse.__init__(self, http_response)
+        GlobusResponse.__init__(self, client, http_response)
         # NB: the word 'code' is confusing because we use it in the
         # error body, and status_code is not much better. http_code, or
         # http_status_code if we wanted to be really explicit, is

--- a/globus_sdk/transfer/paging.py
+++ b/globus_sdk/transfer/paging.py
@@ -304,7 +304,7 @@ class PaginatedResource(GlobusResponse, six.Iterator):
             # dicts, so these handle well
             res = self.client_method(self.client_path, **self.client_kwargs)
             for item in res:
-                yield GlobusResponse(self.client_object, item)
+                yield GlobusResponse(item, client=self.client_object)
                 # increment the "num results" counter
                 self.num_results_fetched += 1
 

--- a/globus_sdk/transfer/paging.py
+++ b/globus_sdk/transfer/paging.py
@@ -144,6 +144,11 @@ class PaginatedResource(GlobusResponse, six.Iterator):
 
         # what function call does this class instance wrap up?
         self.client_method = client_method
+        if six.PY2:
+            self.client_object = client_method.im_self
+        else:
+            self.client_object = client_method.__self__
+
         self.client_path = path
         self.client_kwargs = client_kwargs
         self.client_kwargs['response_class'] = IterableTransferResponse
@@ -299,7 +304,7 @@ class PaginatedResource(GlobusResponse, six.Iterator):
             # dicts, so these handle well
             res = self.client_method(self.client_path, **self.client_kwargs)
             for item in res:
-                yield GlobusResponse(item)
+                yield GlobusResponse(self.client_object, item)
                 # increment the "num results" counter
                 self.num_results_fetched += 1
 

--- a/tests/unit/responses/test_activation_response.py
+++ b/tests/unit/responses/test_activation_response.py
@@ -21,7 +21,7 @@ class ActivationRequirementsResponseTests(CapturedIOTestCase):
         response = requests.Response()
         response.headers["Content-Type"] = "application/json"
         response._content = six.b(json.dumps(data))
-        return ActivationRequirementsResponse(None, response)
+        return ActivationRequirementsResponse(response)
 
     def test_expires_at(self):
         """

--- a/tests/unit/responses/test_activation_response.py
+++ b/tests/unit/responses/test_activation_response.py
@@ -21,7 +21,7 @@ class ActivationRequirementsResponseTests(CapturedIOTestCase):
         response = requests.Response()
         response.headers["Content-Type"] = "application/json"
         response._content = six.b(json.dumps(data))
-        return ActivationRequirementsResponse(response)
+        return ActivationRequirementsResponse(None, response)
 
     def test_expires_at(self):
         """

--- a/tests/unit/responses/test_response.py
+++ b/tests/unit/responses/test_response.py
@@ -14,10 +14,10 @@ class GlobusResponseTests(CapturedIOTestCase):
         """
         super(GlobusResponseTests, self).setUp()
         self.dict_data = {"label1": "value1", "label2": "value2"}
-        self.dict_response = GlobusResponse(self.dict_data)
+        self.dict_response = GlobusResponse(None, self.dict_data)
 
         self.list_data = ["value1", "value2", "value3"]
-        self.list_response = GlobusResponse(self.list_data)
+        self.list_response = GlobusResponse(None, self.list_data)
 
     def test_data(self):
         """
@@ -32,7 +32,7 @@ class GlobusResponseTests(CapturedIOTestCase):
         """
         for item in self.dict_data:
             self.assertTrue(item in self.dict_response)
-        self.assertFalse("nonexistant" in self.dict_response)
+        self.assertFalse("nonexistent" in self.dict_response)
 
         for item in self.list_data:
             self.assertTrue(item in self.list_response)
@@ -87,20 +87,21 @@ class GlobusHTTPResponseTests(CapturedIOTestCase):
         json_response = requests.Response()
         json_response._content = six.b(json.dumps(self.json_data))
         json_response.headers["Content-Type"] = "application/json"
-        self.globus_json_response = GlobusHTTPResponse(json_response)
+        self.globus_json_response = GlobusHTTPResponse(None, json_response)
 
         # malformed json
         malformed_response = requests.Response()
         malformed_response._content = six.b("{")
         malformed_response.headers["Content-Type"] = "application/json"
-        self.globus_malformed_response = GlobusHTTPResponse(malformed_response)
+        self.globus_malformed_response = GlobusHTTPResponse(
+            None, malformed_response)
 
         # text
         self.text_data = "text data"
         text_response = requests.Response()
         text_response._content = six.b(self.text_data)
         text_response.headers["Content-Type"] = "text/plain"
-        self.globus_text_response = GlobusHTTPResponse(text_response)
+        self.globus_text_response = GlobusHTTPResponse(None, text_response)
 
     def test_data(self):
         """

--- a/tests/unit/responses/test_response.py
+++ b/tests/unit/responses/test_response.py
@@ -14,10 +14,10 @@ class GlobusResponseTests(CapturedIOTestCase):
         """
         super(GlobusResponseTests, self).setUp()
         self.dict_data = {"label1": "value1", "label2": "value2"}
-        self.dict_response = GlobusResponse(None, self.dict_data)
+        self.dict_response = GlobusResponse(self.dict_data)
 
         self.list_data = ["value1", "value2", "value3"]
-        self.list_response = GlobusResponse(None, self.list_data)
+        self.list_response = GlobusResponse(self.list_data)
 
     def test_data(self):
         """
@@ -87,21 +87,20 @@ class GlobusHTTPResponseTests(CapturedIOTestCase):
         json_response = requests.Response()
         json_response._content = six.b(json.dumps(self.json_data))
         json_response.headers["Content-Type"] = "application/json"
-        self.globus_json_response = GlobusHTTPResponse(None, json_response)
+        self.globus_json_response = GlobusHTTPResponse(json_response)
 
         # malformed json
         malformed_response = requests.Response()
         malformed_response._content = six.b("{")
         malformed_response.headers["Content-Type"] = "application/json"
-        self.globus_malformed_response = GlobusHTTPResponse(
-            None, malformed_response)
+        self.globus_malformed_response = GlobusHTTPResponse(malformed_response)
 
         # text
         self.text_data = "text data"
         text_response = requests.Response()
         text_response._content = six.b(self.text_data)
         text_response.headers["Content-Type"] = "text/plain"
-        self.globus_text_response = GlobusHTTPResponse(None, text_response)
+        self.globus_text_response = GlobusHTTPResponse(text_response)
 
     def test_data(self):
         """

--- a/tests/unit/responses/test_token_response.py
+++ b/tests/unit/responses/test_token_response.py
@@ -60,7 +60,7 @@ class OAuthTokenResponseTests(CapturedIOTestCase):
         http_response = requests.Response()
         http_response._content = six.b(json.dumps(self.top_token))
         http_response.headers["Content-Type"] = "application/json"
-        self.response = OAuthTokenResponse(self.ac, http_response)
+        self.response = OAuthTokenResponse(http_response)
 
     def test_convert_token_info_dict(self):
         """
@@ -141,7 +141,7 @@ class OAuthTokenResponseTests(CapturedIOTestCase):
         http_response = requests.Response()
         http_response._content = six.b(json.dumps(self.other_token1))
         http_response.headers["Content-Type"] = "application/json"
-        id_response = OAuthTokenResponse(self.ac, http_response)
+        id_response = OAuthTokenResponse(http_response)
 
         with self.assertRaises(jwt.exceptions.InvalidTokenError):
             id_response.decode_id_token()
@@ -186,7 +186,7 @@ class OAuthDependentTokenResponseTests(CapturedIOTestCase):
         data = [self.token1, self.token2, self.token3]
         http_response._content = six.b(json.dumps(data))
         http_response.headers["Content-Type"] = "application/json"
-        self.response = OAuthDependentTokenResponse(None, http_response)
+        self.response = OAuthDependentTokenResponse(http_response)
 
     def test_by_resource_server(self):
         """

--- a/tests/unit/responses/test_token_response.py
+++ b/tests/unit/responses/test_token_response.py
@@ -47,12 +47,6 @@ class OAuthTokenResponseTests(CapturedIOTestCase):
             "access_token": "invalid_access_token"}
         self.top_token["other_tokens"] = [self.other_token1, self.other_token2]
 
-        # create the response
-        http_response = requests.Response()
-        http_response._content = six.b(json.dumps(self.top_token))
-        http_response.headers["Content-Type"] = "application/json"
-        self.response = OAuthTokenResponse(http_response)
-
         # mock AuthClient
         self.ac = mock.Mock()
         self.ac.client_id = get_client_data()["native_app_client1"]["id"]
@@ -61,6 +55,12 @@ class OAuthTokenResponseTests(CapturedIOTestCase):
             "jwks_uri": "https://auth.globus.org/jwk.json",
             "id_token_signing_alg_values_supported": ["RS512"]
         })
+
+        # create the response
+        http_response = requests.Response()
+        http_response._content = six.b(json.dumps(self.top_token))
+        http_response.headers["Content-Type"] = "application/json"
+        self.response = OAuthTokenResponse(self.ac, http_response)
 
     def test_convert_token_info_dict(self):
         """
@@ -126,6 +126,9 @@ class OAuthTokenResponseTests(CapturedIOTestCase):
         If pyjwt was not imported, confirms OptionalDependencyError
         """
         with self.assertRaises(GlobusOptionalDependencyError):
+            self.response.decode_id_token()
+        # test with deprecated usage pattern too
+        with self.assertRaises(GlobusOptionalDependencyError):
             self.response.decode_id_token(self.ac)
 
     @retry_errors()
@@ -138,8 +141,11 @@ class OAuthTokenResponseTests(CapturedIOTestCase):
         http_response = requests.Response()
         http_response._content = six.b(json.dumps(self.other_token1))
         http_response.headers["Content-Type"] = "application/json"
-        id_response = OAuthTokenResponse(http_response)
+        id_response = OAuthTokenResponse(self.ac, http_response)
 
+        with self.assertRaises(jwt.exceptions.InvalidTokenError):
+            id_response.decode_id_token()
+        # test with deprecated usage pattern too
         with self.assertRaises(jwt.exceptions.InvalidTokenError):
             id_response.decode_id_token(self.ac)
 
@@ -150,6 +156,9 @@ class OAuthTokenResponseTests(CapturedIOTestCase):
         Attempt to decode an expired id_token, confirms that the token is
         decoded, but errors out on the expired signature.
         """
+        with self.assertRaises(jwt.exceptions.ExpiredSignatureError):
+            self.response.decode_id_token()
+        # test with deprecated usage pattern too
         with self.assertRaises(jwt.exceptions.ExpiredSignatureError):
             self.response.decode_id_token(self.ac)
 
@@ -177,7 +186,7 @@ class OAuthDependentTokenResponseTests(CapturedIOTestCase):
         data = [self.token1, self.token2, self.token3]
         http_response._content = six.b(json.dumps(data))
         http_response.headers["Content-Type"] = "application/json"
-        self.response = OAuthDependentTokenResponse(http_response)
+        self.response = OAuthDependentTokenResponse(None, http_response)
 
     def test_by_resource_server(self):
         """

--- a/tests/unit/test_paging.py
+++ b/tests/unit/test_paging.py
@@ -34,7 +34,7 @@ class PagingSimulator(object):
         response = requests.Response()
         response._content = six.b(json.dumps(data))
         response.headers["Content-Type"] = "application/json"
-        return IterableTransferResponse(None, response)
+        return IterableTransferResponse(response)
 
 
 class PaginatedResourceTests(CapturedIOTestCase):

--- a/tests/unit/test_paging.py
+++ b/tests/unit/test_paging.py
@@ -34,7 +34,7 @@ class PagingSimulator(object):
         response = requests.Response()
         response._content = six.b(json.dumps(data))
         response.headers["Content-Type"] = "application/json"
-        return IterableTransferResponse(response)
+        return IterableTransferResponse(None, response)
 
 
 class PaginatedResourceTests(CapturedIOTestCase):


### PR DESCRIPTION
Motivated largely by #252 , where an otherwise clean explanation of `decode_id_token` seemed encumbered a little bit by the ugly detail of having to pass an `AuthClient`.
This has also always been a bit of a wart on the SDK, and maybe it's time that we cleaned it up a bit.

Give every GlobusResponse object a ref to the client object which created it. Use this newfound power to simplify the OAuthTokenResponse.decode_id_token method to not require that you pass the client object back into it (which is confusing for both naive and experienced users).
This may have implications for other response classes in the future.

Updates in only a few places: the response definitions which don't consume `*args, **kwargs`, and the base client _request method (which instantiates the response objects).

This is carefully compatible with current usage, but deprecates passing `auth_client` into `decode_id_token` and starts logging a warning under that usage.

Also improves docstring for `decode_id_token`.