### PR TITLE
Require cryptography and pyjwt on all installs, deprecate [jwt] target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 language: python
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 VIRTUALENV=.venv
 
-.PHONY: docs build upload test test/opts clean help
+.PHONY: docs build upload test clean help
 
 
 help:
@@ -11,8 +11,6 @@ help:
 	@echo "  localdev:     Setup local development env with a 'setup.py develop'"
 	@echo "  build:        Create the distributions which we like to upload to pypi"
 	@echo "  test:         Run the full suite of tests"
-	@echo "  test/opts:    Run the full suite of tests with optional dependencies installed"
-	@echo "  test/no-opts: Run the full suite of tests with optional dependencies explicitly uninstalled"
 	@echo "  docs:         Clean old HTML docs and rebuild them with sphinx"
 	@echo "  upload:       [build], but also upload to pypi using twine"
 	@echo "  clean:        Remove typically unwanted files, mostly from [build]"
@@ -51,15 +49,12 @@ $(VIRTUALENV)/bin/flake8 $(VIRTUALENV)/bin/nose2: test-requirements.txt $(VIRTUA
 test: $(VIRTUALENV)/bin/flake8 $(VIRTUALENV)/bin/nose2
 	$(VIRTUALENV)/bin/flake8
 	$(VIRTUALENV)/bin/nose2 --verbose
-test/opts: $(VIRTUALENV)
-	$(VIRTUALENV)/bin/pip install -e .[jwt]
-	$(MAKE) test
 
 travis:
 	pip install --upgrade pip
 	pip install --upgrade "setuptools>=29,<30"
 	pip install -r test-requirements.txt
-	pip install -e .[jwt]
+	pip install -e .
 	flake8
 	nose2 --verbose
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,6 @@ environment:
     # See: http://www.appveyor.com/docs/installed-software#python
     - PYTHON: "C:\\Python27"
     - PYTHON: "C:\\Python27-x64"
-    - PYTHON: "C:\\Python33-x64"
     - PYTHON: "C:\\Python34-x64"
     - PYTHON: "C:\\Python35-x64"
     - PYTHON: "C:\\Python36-x64"

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+import warnings
 import os.path
 import sys
 from setuptools import setup, find_packages
@@ -8,6 +9,13 @@ if sys.version_info < (2, 7):
 ##############################################################
 # globus-sdk does not support python versions older than 2.7 #
 ##############################################################""")
+
+# warn on older/untested python3s
+# it's not disallowed, but it could be an issue for some people
+if sys.version_info > (3,) and sys.version_info < (3, 4):
+    warnings.warn(
+        'Installing globus-sdk on Python 3 versions older than 3.4 '
+        'may result in degraded functionality or even errors.')
 
 
 # single source of truth for package version

--- a/setup.py
+++ b/setup.py
@@ -25,11 +25,13 @@ setup(name="globus-sdk",
       packages=find_packages(exclude=['tests', 'tests.*']),
       install_requires=[
           'requests>=2.0.0,<3.0.0',
-          'six>=1.10.0,<2.0.0'
+          'six>=1.10.0,<2.0.0',
+          'pyjwt[crypto]>=1.5.3,<2.0.0'
       ],
 
       extras_require={
-          'jwt': ['pyjwt[crypto]>=1.5.3,<2.0.0']
+          # empty extra included to support older installs
+          'jwt': []
       },
 
       include_package_data=True,
@@ -44,7 +46,6 @@ setup(name="globus-sdk",
           "Operating System :: POSIX",
           "Programming Language :: Python",
           "Programming Language :: Python :: 2.7",
-          "Programming Language :: Python :: 3.3",
           "Programming Language :: Python :: 3.4",
           "Programming Language :: Python :: 3.5",
           "Programming Language :: Python :: 3.6",


### PR DESCRIPTION
Cryptography and pyjwt become required (via `pyjwt[crypto]`), and this removes py3.3 from supported versions (because it breaks on Windows, or at least AppVeyor).

Since this makes a previously supported py3 version unsupported, add a warning at install time as a courtesy.

The `[jwt]` target needs to stay as an empty target so that SDK installs which specify it don't break.

The big tada moment for this is that the tests pass on Windows, so we can probably roll forward.

Per discussions about this:
IF and ONLY IF people run into problems installing `cryptography` on platforms and versions we want to target, we can pursue the addition of an env var which controls setup.py and removes `cryptography` and `pyjwt` from install_requires.