### PR TITLE
Add a (BETA) SearchClient class which provides an interface to the Search API

### DIFF
--- a/docs/clients.rst
+++ b/docs/clients.rst
@@ -30,4 +30,5 @@ very simply::
 
    clients/transfer
    clients/auth
+   clients/search
    clients/base

--- a/docs/clients/search.rst
+++ b/docs/clients/search.rst
@@ -1,0 +1,31 @@
+.. module:: globus_sdk.search
+
+
+Search Client (BETA)
+====================
+
+The SearchClient interface is in Beta, but the Search API is a fully
+supported, production service.
+Its docs are visible here:
+http://globus-search-docs.s3-website-us-east-1.amazonaws.com/stable/
+
+
+.. autoclass:: globus_sdk.SearchClient
+   :members:
+   :member-order: bysource
+   :show-inheritance:
+   :exclude-members: error_class, default_response_class
+
+Helper Objects
+--------------
+
+.. autoclass:: globus_sdk.SearchQuery
+   :members:
+   :show-inheritance:
+
+Specialized Errors
+------------------
+
+.. autoclass:: globus_sdk.exc.SearchAPIError
+   :members:
+   :show-inheritance:

--- a/globus_sdk/__init__.py
+++ b/globus_sdk/__init__.py
@@ -1,39 +1,46 @@
 import logging
 
 
+from globus_sdk.version import __version__
+
 from globus_sdk.response import GlobusResponse, GlobusHTTPResponse
-from globus_sdk.transfer import TransferClient
-from globus_sdk.transfer.data import TransferData, DeleteData
-from globus_sdk.auth import (
-    AuthClient, NativeAppAuthClient, ConfidentialAppAuthClient)
+
+from globus_sdk.exc import (
+    GlobusError, GlobusAPIError, TransferAPIError, SearchAPIError,
+    NetworkError, GlobusConnectionError, GlobusTimeoutError)
 
 from globus_sdk.authorizers import (
     NullAuthorizer, BasicAuthorizer, AccessTokenAuthorizer,
     RefreshTokenAuthorizer, ClientCredentialsAuthorizer)
 
-from globus_sdk.exc import GlobusError, GlobusAPIError, TransferAPIError
-from globus_sdk.exc import (
-    NetworkError, GlobusConnectionError, GlobusTimeoutError)
+from globus_sdk.auth import (
+    AuthClient, NativeAppAuthClient, ConfidentialAppAuthClient)
 
-from globus_sdk.version import __version__
+from globus_sdk.transfer import TransferClient
+from globus_sdk.transfer.data import TransferData, DeleteData
 
-__all__ = ["GlobusResponse", "GlobusHTTPResponse",
+from globus_sdk.search import SearchClient
 
-           "TransferClient", "TransferData", "DeleteData",
 
-           "AuthClient",
-           "NativeAppAuthClient",
-           "ConfidentialAppAuthClient",
+__all__ = (
+    "__version__",
 
-           "NullAuthorizer", "BasicAuthorizer",
-           "AccessTokenAuthorizer", "RefreshTokenAuthorizer",
-           "ClientCredentialsAuthorizer",
+    "GlobusResponse", "GlobusHTTPResponse",
 
-           "GlobusError", "GlobusAPIError", "TransferAPIError",
-           "NetworkError", "GlobusConnectionError", "GlobusTimeoutError",
-           "GlobusOptionalDependencyError",
+    "GlobusError", "GlobusAPIError", "TransferAPIError", "SearchAPIError",
+    "NetworkError", "GlobusConnectionError", "GlobusTimeoutError",
+    "GlobusOptionalDependencyError",
 
-           "__version__"]
+    "NullAuthorizer", "BasicAuthorizer",
+    "AccessTokenAuthorizer", "RefreshTokenAuthorizer",
+    "ClientCredentialsAuthorizer",
+
+    "AuthClient", "NativeAppAuthClient", "ConfidentialAppAuthClient",
+
+    "TransferClient", "TransferData", "DeleteData",
+
+    "SearchClient",
+)
 
 
 # configure logging for a library, per python best practices:

--- a/globus_sdk/__init__.py
+++ b/globus_sdk/__init__.py
@@ -19,7 +19,7 @@ from globus_sdk.auth import (
 from globus_sdk.transfer import TransferClient
 from globus_sdk.transfer.data import TransferData, DeleteData
 
-from globus_sdk.search import SearchClient
+from globus_sdk.search import SearchClient, SearchQuery
 
 
 __all__ = (
@@ -39,7 +39,7 @@ __all__ = (
 
     "TransferClient", "TransferData", "DeleteData",
 
-    "SearchClient",
+    "SearchClient", "SearchQuery",
 )
 
 

--- a/globus_sdk/exc.py
+++ b/globus_sdk/exc.py
@@ -113,6 +113,27 @@ class GlobusAPIError(GlobusError):
         self.message = text
 
 
+class SearchAPIError(GlobusAPIError):
+    """
+    Error class for the Search API client. In addition to the
+    inherited ``code`` and ``message`` instance variables, provides:
+
+    :ivar error_data: Additional object returned in the error response. May be
+                      a dict, list, or None.
+    """
+    def __init__(self, r):
+        self.error_data = None
+        GlobusAPIError.__init__(self, r)
+
+    def _get_args(self):
+        return (self.http_status, self.code, self.message)
+
+    def _load_from_json(self, data):
+        self.code = data["code"]
+        self.message = data["message"]
+        self.error_data = data.get("error_data")
+
+
 class TransferAPIError(GlobusAPIError):
     """
     Error class for the Transfer API client. In addition to the

--- a/globus_sdk/globus.cfg
+++ b/globus_sdk/globus.cfg
@@ -2,30 +2,36 @@
 
 [environment default]
 auth_service = https://auth.globus.org/
-transfer_service = https://transfer.api.globus.org/
 nexus_service = https://nexus.api.globusonline.org/
+transfer_service = https://transfer.api.globus.org/
+search_service = https://search.api.globus.org/
 
 [environment preview]
 auth_service = https://auth.preview.globus.org/
 nexus_service = https://nexus.api.preview.globus.org/
+search_service = https://search.api.preview.globus.org/
 transfer_service = https://transfer.api.preview.globus.org/
 
 [environment sandbox]
 auth_service = https://auth.sandbox.globuscs.info/
-nexus_service = https://graph.api.go.sandbox.globuscs.info/
+nexus_service = https://nexus.api.sandbox.globuscs.info/
+search_service = https://search.api.sandbox.globuscs.info/
 transfer_service = https://transfer.api.sandbox.globuscs.info/
 
 [environment test]
 auth_service = https://auth.test.globuscs.info/
-nexus_service = https://graph.api.test.globuscs.info/
+nexus_service = https://nexus.api.test.globuscs.info/
+search_service = https://search.api.test.globuscs.info/
 transfer_service = https://transfer.test.api.globusonline.org/
 
 [environment integration]
 auth_service = https://auth.integration.globuscs.info/
-nexus_service = https://graph.api.integration.globuscs.info/
+nexus_service = https://nexus.api.integration.globuscs.info/
+search_service = https://search.api.integration.globuscs.info/
 transfer_service = https://transfer.integration.api.globuscs.info/
 
 [environment staging]
 auth_service = https://auth.staging.globuscs.info/
 nexus_service = https://nexus.api.staging.globuscs.info/
+search_service = https://search.api.staging.globuscs.info/
 transfer_service = https://transfer.api.staging.globuscs.info/

--- a/globus_sdk/search/__init__.py
+++ b/globus_sdk/search/__init__.py
@@ -1,0 +1,4 @@
+from globus_sdk.search.client import SearchClient
+
+
+__all__ = ('SearchClient',)

--- a/globus_sdk/search/__init__.py
+++ b/globus_sdk/search/__init__.py
@@ -1,4 +1,5 @@
 from globus_sdk.search.client import SearchClient
+from globus_sdk.search.query import SearchQuery
 
 
-__all__ = ('SearchClient',)
+__all__ = ('SearchClient', 'SearchQuery')

--- a/globus_sdk/search/client.py
+++ b/globus_sdk/search/client.py
@@ -12,14 +12,6 @@ logger = logging.getLogger(__name__)
 
 class SearchClient(BaseClient):
     r"""
-    BETA
-
-    The SearchClient interface is in Beta, but the Search API is a fully
-    supported, production service.
-    Its docs are visible here:
-    http://globus-search-docs.s3-website-us-east-1.amazonaws.com/stable/
-
-
     Client for the Globus Search API
 
     This class provides helper methods for most common resources in the

--- a/globus_sdk/search/client.py
+++ b/globus_sdk/search/client.py
@@ -1,0 +1,402 @@
+from __future__ import unicode_literals
+import logging
+
+from globus_sdk import exc
+from globus_sdk.base import BaseClient, merge_params, safe_stringify
+from globus_sdk.authorizers import (
+    AccessTokenAuthorizer, RefreshTokenAuthorizer, ClientCredentialsAuthorizer)
+from globus_sdk.response import GlobusHTTPResponse
+
+logger = logging.getLogger(__name__)
+
+
+class SearchClient(BaseClient):
+    r"""
+    BETA
+
+    The SearchClient interface is in Beta, but the Search API is a fully
+    supported, production service.
+    Its docs are visible here:
+    http://globus-search-docs.s3-website-us-east-1.amazonaws.com/stable/
+
+
+    Client for the Globus Search API
+
+    This class provides helper methods for most common resources in the
+    API, and basic ``get``, ``put``, ``post``, and ``delete`` methods
+    from the base client that can be used to access any API resource.
+
+    **Parameters**
+
+        ``authorizer`` (:class:`GlobusAuthorizer\
+        <globus_sdk.authorizers.base.GlobusAuthorizer>`)
+
+          An authorizer instance used for all calls to Globus Search
+    """
+    # disallow basic auth
+    allowed_authorizer_types = [AccessTokenAuthorizer,
+                                RefreshTokenAuthorizer,
+                                ClientCredentialsAuthorizer]
+    error_class = exc.SearchAPIError
+    default_response_class = GlobusHTTPResponse
+
+    def __init__(self, authorizer=None, **kwargs):
+        BaseClient.__init__(self, "search", authorizer=authorizer, **kwargs)
+
+    #
+    # Index Management
+    #
+
+    def get_index(self, index_id, **params):
+        """
+        ``GET /v1/index/<index_id>``
+
+        **Examples**
+
+        >>> sc = globus_sdk.SearchClient(...)
+        >>> index = sc.get_index(index_id)
+        >>> assert index['index_id'] == index_id
+        >>> print(index["display_name"],
+        >>>       "(" + index_id + "):",
+        >>>       index["description"])
+        """
+        index_id = safe_stringify(index_id)
+        self.logger.info("SearchClient.get_index({})".format(index_id))
+        path = self.qjoin_path("v1/index", index_id)
+        return self.get(path, params=params)
+
+    #
+    # Search queries
+    #
+
+    def search(self, index_id, q, offset=0, limit=10, query_template=None,
+               advanced=False, **params):
+        """
+        ``GET /v1/index/<index_id>/search``
+
+        **Examples**
+
+        >>> sc = globus_sdk.SearchClient(...)
+        >>> result = sc.search(index_id, 'query string')
+        >>> advanced_result = sc.search(index_id, 'author: "Ada Lovelace"',
+        >>>                             advanced=True)
+        """
+        index_id = safe_stringify(index_id)
+        merge_params(params, q=q, offset=offset, limit=limit,
+                     query_template=query_template, advanced=advanced)
+
+        self.logger.info("SearchClient.search({}, ...)"
+                         .format(index_id))
+        path = self.qjoin_path("v1/index", index_id, "search")
+        return self.get(path, params=params)
+
+    def post_search(self, index_id, data):
+        """
+        ``POST /v1/index/<index_id>/search``
+
+        **Examples**
+
+        >>> sc = globus_sdk.SearchClient(...)
+        >>> query_data = {
+        >>>   "@datatype": "GSearchRequest",
+        >>>   "q": "user query",
+        >>>   "filters": [
+        >>>     {
+        >>>       "type": "range",
+        >>>       "field_name": "path.to.date",
+        >>>       "values": [
+        >>>         {"from": "*",
+        >>>          "to": "2014-11-07"}
+        >>>       ]
+        >>>     }
+        >>>   ],
+        >>>   "facets": [
+        >>>     {"name": "Publication Date",
+        >>>      "field_name": "path.to.date",
+        >>>      "type": "date_histogram",
+        >>>      "date_interval": "year"}
+        >>>   ],
+        >>>   "sort": [
+        >>>     {"field_name": "path.to.date",
+        >>>      "order": "asc"}
+        >>>   ]
+        >>> }
+        >>> search_result = sc.post_search(index_id, query_data)
+        """
+        index_id = safe_stringify(index_id)
+        self.logger.info("SearchClient.post_search({}, ...)"
+                         .format(index_id))
+        path = self.qjoin_path("v1/index", index_id, "search")
+        return self.post(path, data)
+
+    #
+    # Bulk data indexing
+    #
+
+    def ingest(self, index_id, data):
+        """
+        ``POST /v1/index/<index_id>/ingest``
+
+        **Examples**
+
+        >>> sc = globus_sdk.SearchClient(...)
+        >>> ingest_data = {
+        >>>   "ingest_type": "GMetaEntry",
+        >>>   "ingest_data": {
+        >>>     "subject": "https://example.com/foo/bar",
+        >>>     "visible_to": ["public"],
+        >>>     "content": {
+        >>>       "foo/bar": "some val"
+        >>>     }
+        >>>   }
+        >>> }
+        >>> sc.ingest(index_id, ingest_data)
+
+        or with multiple entries at once via a GMetaList:
+
+        >>> sc = globus_sdk.SearchClient(...)
+        >>> ingest_data = {
+        >>>   "ingest_type": "GMetaList",
+        >>>   "ingest_data": {
+        >>>     "gmeta": [
+        >>>       {
+        >>>         "subject": "https://example.com/foo/bar",
+        >>>         "visible_to": ["public"],
+        >>>         "content": {
+        >>>           "foo/bar": "some val"
+        >>>         }
+        >>>       },
+        >>>       {
+        >>>         "subject": "https://example.com/foo/bar",
+        >>>         "id": "otherentry",
+        >>>         "visible_to": ["public"],
+        >>>         "content": {
+        >>>           "foo/bar": "some otherval"
+        >>>         }
+        >>>       }
+        >>>     ]
+        >>>   }
+        >>> }
+        >>> sc.ingest(index_id, ingest_data)
+        """
+        index_id = safe_stringify(index_id)
+        self.logger.info("SearchClient.ingest({}, ...)".format(index_id))
+        path = self.qjoin_path("v1/index", index_id, "ingest")
+        return self.post(path, data)
+
+    #
+    # Bulk delete
+    #
+
+    def delete_by_query(self, index_id, data):
+        """
+        ``POST /v1/index/<index_id>/delete_by_query``
+
+        **Examples**
+
+        >>> sc = globus_sdk.SearchClient(...)
+        >>> query_data = {
+        >>>   "q": "user query",
+        >>>   "filters": [
+        >>>     {
+        >>>       "type": "range",
+        >>>       "field_name": "path.to.date",
+        >>>       "values": [
+        >>>         {"from": "*",
+        >>>          "to": "2014-11-07"}
+        >>>       ]
+        >>>     }
+        >>>   ]
+        >>> }
+        >>> sc.delete_by_query(index_id, query_data)
+        """
+        index_id = safe_stringify(index_id)
+        self.logger.info("SearchClient.delete_by_query({}, ...)"
+                         .format(index_id))
+        path = self.qjoin_path("v1/index", index_id, "delete_by_query")
+        return self.post(path, data)
+
+    #
+    # Subject Operations
+    #
+
+    def get_subject(self, index_id, subject, **params):
+        """
+        ``GET /v1/index/<index_id>/subject``
+
+        **Examples**
+
+        Fetch the data for subject ``http://example.com/abc`` from index
+        ``index_id``:
+
+        >>> sc = globus_sdk.SearchClient(...)
+        >>> subject_data = sc.get_subject(index_id, 'http://example.com/abc')
+        """
+        index_id = safe_stringify(index_id)
+        params = merge_params(params, subject=subject)
+
+        self.logger.info("SearchClient.get_subject({}, {}, ...)"
+                         .format(index_id, subject))
+        path = self.qjoin_path("v1/index", index_id, "subject")
+        return self.get(path, params=params)
+
+    def delete_subject(self, index_id, subject, **params):
+        """
+        ``DELETE /v1/index/<index_id>/subject``
+
+        **Examples**
+
+        Delete all data for subject ``http://example.com/abc`` from index
+        ``index_id``, even data which is not visible to the current user:
+
+        >>> sc = globus_sdk.SearchClient(...)
+        >>> subject_data = sc.get_subject(index_id, 'http://example.com/abc')
+        """
+        index_id = safe_stringify(index_id)
+        params = merge_params(params, subject=subject)
+
+        self.logger.info("SearchClient.delete_subject({}, {}, ...)"
+                         .format(index_id, subject))
+        path = self.qjoin_path("v1/index", index_id, "subject")
+        return self.delete(path, params=params)
+
+    #
+    # Entry Operations
+    #
+
+    def get_entry(self, index_id, subject, entry_id=None, **params):
+        """
+        ``GET /v1/index/<index_id>/entry``
+
+        **Examples**
+
+        Lookup the entry with a subject of ``https://example.com/foo/bar`` and
+        a null entry_id:
+
+        >>> sc = globus_sdk.SearchClient(...)
+        >>> entry_data = sc.get_entry(index_id, 'http://example.com/foo/bar')
+
+        Lookup the entry with a subject of ``https://example.com/foo/bar`` and
+        an entry_id of ``foo/bar``:
+
+        >>> sc = globus_sdk.SearchClient(...)
+        >>> entry_data = sc.get_entry(index_id, 'http://example.com/foo/bar',
+        >>>                           entry_id='foo/bar')
+        """
+        index_id = safe_stringify(index_id)
+        params = merge_params(params, subject=subject, entry_id=entry_id)
+
+        self.logger.info("SearchClient.get_entry({}, {}, {}, ...)"
+                         .format(index_id, subject, entry_id))
+        path = self.qjoin_path("v1/index", index_id, "entry")
+        return self.get(path, params=params)
+
+    def create_entry(self, index_id, data):
+        """
+        ``POST /v1/index/<index_id>/entry``
+
+        **Examples**
+
+        Create an entry with a subject of ``https://example.com/foo/bar`` and
+        a null entry_id:
+
+        >>> sc = globus_sdk.SearchClient(...)
+        >>> sc.create_entry(index_id, {
+        >>>     "subject": "https://example.com/foo/bar",
+        >>>     "visible_to": ["public"],
+        >>>     "content": {
+        >>>         "foo/bar": "some val"
+        >>>     }
+        >>> })
+
+        Create an entry with a subject of ``https://example.com/foo/bar`` and
+        an entry_id of ``foo/bar``:
+
+        >>> sc = globus_sdk.SearchClient(...)
+        >>> sc.create_entry(index_id, {
+        >>>     "subject": "https://example.com/foo/bar",
+        >>>     "visible_to": ["public"],
+        >>>     "id": "foo/bar",
+        >>>     "content": {
+        >>>         "foo/bar": "some val"
+        >>>     }
+        >>> })
+        """
+        index_id = safe_stringify(index_id)
+        self.logger.info("SearchClient.create_entry({}, ...)".format(index_id))
+        path = self.qjoin_path("v1/index", index_id, "entry")
+        return self.post(path, data)
+
+    def update_entry(self, index_id, data):
+        """
+        ``PUT /v1/index/<index_id>/entry``
+
+        **Examples**
+
+        Update an entry with a subject of ``https://example.com/foo/bar`` and
+        a null entry_id:
+
+        >>> sc = globus_sdk.SearchClient(...)
+        >>> sc.update_entry(index_id, {
+        >>>     "subject": "https://example.com/foo/bar",
+        >>>     "visible_to": ["public"],
+        >>>     "content": {
+        >>>         "foo/bar": "some val"
+        >>>     }
+        >>> })
+        """
+        index_id = safe_stringify(index_id)
+        self.logger.info("SearchClient.update_entry({}, ...)".format(index_id))
+        path = self.qjoin_path("v1/index", index_id, "entry")
+        return self.put(path, data)
+
+    def delete_entry(self, index_id, subject, entry_id=None, **params):
+        """
+        ``DELETE  /v1/index/<index_id>/entry``
+
+        **Examples**
+
+        Delete an entry with a subject of ``https://example.com/foo/bar`` and
+        a null entry_id:
+
+        >>> sc = globus_sdk.SearchClient(...)
+        >>> sc.delete_entry(index_id, "https://example.com/foo/bar")
+
+        Delete an entry with a subject of ``https://example.com/foo/bar`` and
+        an entry_id of "foo/bar":
+
+        >>> sc = globus_sdk.SearchClient(...)
+        >>> sc.delete_entry(index_id, "https://example.com/foo/bar",
+        >>>                 entry_id="foo/bar")
+        """
+        index_id = safe_stringify(index_id)
+        params = merge_params(params, subject=subject, entry_id=entry_id)
+        self.logger.info("SearchClient.delete_entry({}, {}, {}, ...)"
+                         .format(index_id, subject, entry_id))
+        path = self.qjoin_path("v1/index", index_id, "entry")
+        return self.delete(path, params=params)
+
+    #
+    # Lookup Query Templates
+    #
+
+    def get_query_template(self, index_id, template_name):
+        """
+        ``GET /v1/index/<index_id>/query_template/<template_name>``
+        """
+        index_id = safe_stringify(index_id)
+        self.logger.info("SearchClient.get_query_template({}, {})"
+                         .format(index_id, template_name))
+        path = self.qjoin_path("v1/index", index_id, "query_template",
+                               template_name)
+        return self.get(path)
+
+    def get_query_template_list(self, index_id):
+        """
+        ``GET /v1/index/<index_id>/query_template``
+        """
+        index_id = safe_stringify(index_id)
+        self.logger.info("SearchClient.get_query_template_list({})"
+                         .format(index_id))
+        path = self.qjoin_path("v1/index", index_id, "query_template")
+        return self.get(path)

--- a/globus_sdk/search/query.py
+++ b/globus_sdk/search/query.py
@@ -1,0 +1,81 @@
+class SearchQuery(dict):
+    """
+    A specialized dict which has helpers for creating and modifying a Search
+    Query document.
+
+    Example usage:
+
+    >>> from globus_sdk import SearchClient, SearchQuery
+    >>> sc = SearchClient(...)
+    >>> index_id = ...
+    >>> query = (SearchQuery(q='example query')
+    >>>          .set_limit(100).set_offset(10)
+    >>>          .add_filter('path.to.field1', ['foo', 'bar']))
+    >>> result = sc.post_search(index_id, query)
+    """
+    def set_query(self, query):
+        self['q'] = query
+        return self
+
+    def set_limit(self, limit):
+        self['limit'] = limit
+        return self
+
+    def set_offset(self, offset):
+        self['offset'] = offset
+        return self
+
+    def set_advanced(self, advanced):
+        self['advanced'] = advanced
+        return self
+
+    def add_facet(self, name, field_name, type='terms', size=None,
+                  date_interval=None, histogram_range=None, **kwargs):
+        self['facets'] = self.get('facets', [])
+        facet = {
+            'name': name,
+            'field_name': field_name,
+            'type': type,
+        }
+        facet.update(kwargs)
+        if size is not None:
+            facet['size'] = size
+        if date_interval is not None:
+            facet['date_interval'] = date_interval
+        if histogram_range is not None:
+            low, high = histogram_range
+            facet['histogram_range'] = {'low': low, 'high': high}
+        self['facets'].append(facet)
+        return self
+
+    def add_filter(self, field_name, values, type='match_all', **kwargs):
+        self['filters'] = self.get('filters', [])
+        new_filter = {
+            'field_name': field_name,
+            'values': values,
+            'type': type
+        }
+        new_filter.update(kwargs)
+        self['filters'].append(new_filter)
+        return self
+
+    def add_boost(self, field_name, factor, **kwargs):
+        self['boosts'] = self.get('boosts', [])
+        boost = {
+            'field_name': field_name,
+            'factor': factor
+        }
+        boost.update(kwargs)
+        self['boosts'].append(boost)
+        return self
+
+    def add_sort(self, field_name, order=None, **kwargs):
+        self['sort'] = self.get('sort', [])
+        sort = {
+            'field_name': field_name,
+        }
+        sort.update(kwargs)
+        if order is not None:
+            sort['order'] = order
+        self['sort'].append(sort)
+        return self


### PR DESCRIPTION
Even though Search is a production service, creating an index is not publicly exposed. As such, it's hard for people in our team to function independently with respect to it and gain familiarity.
We're considering basic review to be the best we can hope for at present.

@corpulentcoffee has kindly offered to review this for obvious errors.
If you would like me to create an index for you to toy with, we can do that too -- it's very little effort.

This contains the following components
- SearchClient class
- SearchQuery object which helps you build structured queries to send to `SearchClient.post_search()`
- SearchAPIError class for API errors
- Docs for the above

Because the docs are still in progress towards docs.globus.org (but not there yet!) there are no `External Documentation` linkages in the docstrings.