### PR TITLE
Fix retry_errors() bug which breaks test discovery

### DIFF
--- a/tests/framework/tools.py
+++ b/tests/framework/tools.py
@@ -65,4 +65,6 @@ def retry_errors(retries=2, error_classes=(NetworkError,)):
             assert last_error is not None
             raise last_error
 
+        return result_func
+
     return inner_decorator

--- a/tests/unit/responses/test_token_response.py
+++ b/tests/unit/responses/test_token_response.py
@@ -60,7 +60,7 @@ class OAuthTokenResponseTests(CapturedIOTestCase):
         http_response = requests.Response()
         http_response._content = six.b(json.dumps(self.top_token))
         http_response.headers["Content-Type"] = "application/json"
-        self.response = OAuthTokenResponse(http_response)
+        self.response = OAuthTokenResponse(http_response, client=self.ac)
 
     def test_convert_token_info_dict(self):
         """
@@ -141,7 +141,7 @@ class OAuthTokenResponseTests(CapturedIOTestCase):
         http_response = requests.Response()
         http_response._content = six.b(json.dumps(self.other_token1))
         http_response.headers["Content-Type"] = "application/json"
-        id_response = OAuthTokenResponse(http_response)
+        id_response = OAuthTokenResponse(http_response, client=self.ac)
 
         with self.assertRaises(jwt.exceptions.InvalidTokenError):
             id_response.decode_id_token()


### PR DESCRIPTION
As discussed in chat, it's somewhat surprising that test discovery doesn't hardfail due to this bug, but as a result, a large portion of the testsuite has been suppressed by mistake.

Rectify the bug and fix the two minor errors that had crept in since its introduction.