### PR TITLE
Improve handling of connection timeouts

### DIFF
--- a/docs/exceptions.rst
+++ b/docs/exceptions.rst
@@ -82,3 +82,7 @@ Error Classes
 .. autoclass:: globus_sdk.exc.GlobusTimeoutError
    :members:
    :show-inheritance:
+
+.. autoclass:: globus_sdk.exc.GlobusConnectionTimeoutError
+   :members:
+   :show-inheritance:

--- a/globus_sdk/__init__.py
+++ b/globus_sdk/__init__.py
@@ -7,7 +7,8 @@ from globus_sdk.response import GlobusResponse, GlobusHTTPResponse
 
 from globus_sdk.exc import (
     GlobusError, GlobusAPIError, TransferAPIError, SearchAPIError,
-    NetworkError, GlobusConnectionError, GlobusTimeoutError)
+    NetworkError, GlobusConnectionError, GlobusTimeoutError,
+    GlobusConnectionTimeoutError)
 
 from globus_sdk.authorizers import (
     NullAuthorizer, BasicAuthorizer, AccessTokenAuthorizer,
@@ -29,6 +30,7 @@ __all__ = (
 
     "GlobusError", "GlobusAPIError", "TransferAPIError", "SearchAPIError",
     "NetworkError", "GlobusConnectionError", "GlobusTimeoutError",
+    "GlobusConnectionTimeoutError",
 
     "NullAuthorizer", "BasicAuthorizer",
     "AccessTokenAuthorizer", "RefreshTokenAuthorizer",

--- a/globus_sdk/base.py
+++ b/globus_sdk/base.py
@@ -45,6 +45,8 @@ class BaseClient(object):
 
        ``http_timeout`` (*float*)
          Number of seconds to wait on HTTP connections. Default is 60.
+         A value of -1 indicates that no timeout should be used (requests can
+         hang indefinitely).
 
     All other parameters are for internal use and should be ignored.
     """
@@ -114,6 +116,9 @@ class BaseClient(object):
         if http_timeout is None:
             http_timeout = config.get_http_timeout(environment)
         self._http_timeout = http_timeout
+        # handle -1 by passing None to requests
+        if self._http_timeout == -1:
+            self._http_timeout = None
 
         # set application name if given
         self.app_name = None

--- a/globus_sdk/config.py
+++ b/globus_sdk/config.py
@@ -147,7 +147,7 @@ def get_http_timeout(environment):
     p = _get_parser()
     value = p.get("http_timeout", environment=environment,
                   failover_to_general=True, check_env=True,
-                  type_cast=int)
+                  type_cast=float)
     if value is None:
         value = 60
     logger.debug('default http_timeout set to {}'.format(value))

--- a/globus_sdk/config.py
+++ b/globus_sdk/config.py
@@ -143,6 +143,17 @@ def get_service_url(environment, service):
     return url
 
 
+def get_http_timeout(environment):
+    p = _get_parser()
+    value = p.get("http_timeout", environment=environment,
+                  failover_to_general=True, check_env=True,
+                  type_cast=int)
+    if value is None:
+        value = 60
+    logger.debug('default http_timeout set to {}'.format(value))
+    return value
+
+
 def get_ssl_verify(environment):
     p = _get_parser()
     value = p.get("ssl_verify", environment=environment,

--- a/globus_sdk/exc.py
+++ b/globus_sdk/exc.py
@@ -218,6 +218,11 @@ class GlobusTimeoutError(NetworkError):
     """The REST request timed out."""
 
 
+class GlobusConnectionTimeoutError(GlobusTimeoutError):
+    """The request timed out during connection establishment.
+    These errors are safe to retry."""
+
+
 class GlobusConnectionError(NetworkError):
     """A connection error occured while making a REST request."""
 
@@ -225,6 +230,9 @@ class GlobusConnectionError(NetworkError):
 def convert_request_exception(exc):
     """Converts incoming requests.Exception to a Globus NetworkError"""
 
+    if isinstance(exc, requests.ConnectTimeout):
+        return GlobusConnectionTimeoutError(
+            "ConnectTimeoutError on request", exc)
     if isinstance(exc, requests.Timeout):
         return GlobusTimeoutError("TimeoutError on request", exc)
     elif isinstance(exc, requests.ConnectionError):


### PR DESCRIPTION
Add a default connection timeout of 60s (settable via env var or config). Default is wait indefinitely, which could hang clients... bad.

Also, improve error propagation so that callers can distinguish connection timeout (waiting for TCP connection establishment) from read timeout (waiting for data back from server). This is just a matter of wrapping some requests errors better.