### PR TITLE
Add Content-Type to SearchClient headers

### DIFF
--- a/globus_sdk/search/client.py
+++ b/globus_sdk/search/client.py
@@ -34,6 +34,9 @@ class SearchClient(BaseClient):
 
     def __init__(self, authorizer=None, **kwargs):
         BaseClient.__init__(self, "search", authorizer=authorizer, **kwargs)
+        # a content-type header for JSON payloads is required by the Search API
+        # setting this does not harm GET or DELETE, and makes POST/PUT work
+        self._headers['Content-Type'] = 'application/json'
 
     #
     # Index Management


### PR DESCRIPTION
The Search API is a stickler for correct Content-Type on JSON payloads.
Set this header all the time when talking to the API to keep things happy.