### PR TITLE
First draft of LocalGlobusConnectPersonal

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,6 +27,7 @@ Table of Contents
    clients
    responses
    exceptions
+   local_endpoints
    oauth
    authorization
    config

--- a/docs/local_endpoints.rst
+++ b/docs/local_endpoints.rst
@@ -1,0 +1,27 @@
+.. _local_endpoints:
+
+Local Endpoints
+===============
+
+Unlike SDK functionality for accessing Globus APIs, the locally available
+Globus Endpoints require special treatment.
+These accesses are not authenticated via Globus Auth, and may rely upon the
+state of the local filesystem, running processes, and the permissions of local
+users.
+
+Globus Connect Server
+---------------------
+
+There are no SDK methods for accessing an installation of Globus Connect
+Server.
+
+Globus Connect Personal
+-----------------------
+
+Globus Connect Personal endpoints belonging to the current user may be accessed
+via instances of the following class:
+
+
+.. autoclass:: globus_sdk.LocalGlobusConnectPersonal
+   :members:
+   :member-order: bysource

--- a/globus_sdk/__init__.py
+++ b/globus_sdk/__init__.py
@@ -22,6 +22,8 @@ from globus_sdk.transfer.data import TransferData, DeleteData
 
 from globus_sdk.search import SearchClient, SearchQuery
 
+from globus_sdk.local_endpoint import LocalGlobusConnectPersonal
+
 
 __all__ = (
     "__version__",
@@ -41,6 +43,8 @@ __all__ = (
     "TransferClient", "TransferData", "DeleteData",
 
     "SearchClient", "SearchQuery",
+
+    'LocalGlobusConnectPersonal',
 )
 
 

--- a/globus_sdk/local_endpoint/__init__.py
+++ b/globus_sdk/local_endpoint/__init__.py
@@ -1,0 +1,3 @@
+from globus_sdk.local_endpoint.personal import LocalGlobusConnectPersonal
+
+__all__ = ('LocalGlobusConnectPersonal',)

--- a/globus_sdk/local_endpoint/personal.py
+++ b/globus_sdk/local_endpoint/personal.py
@@ -1,0 +1,88 @@
+import os
+
+
+def _on_windows():
+    """
+    Per python docs, this is a safe, reliable way of checking the platform.
+    sys.platform offers more detail -- more than we want, in this case.
+    """
+    return os.name == "nt"
+
+
+class LocalGlobusConnectPersonal(object):
+    r"""
+    A LocalGlobusConnectPersonal object represents the available SDK methods
+    for inspecting and controlling a running Globus Connect Personal
+    installation.
+
+    These objects do *not* inherit from BaseClient and do not provide methods
+    for interacting with any Globus Service APIs.
+    """
+    def __init__(self):
+        self._endpoint_id = None
+
+    @property
+    def endpoint_id(self):
+        """
+        :type: string
+
+        The endpoint ID of the local Globus Connect Personal endpoint
+        installation.
+
+        This value is loaded whenever it is first accessed, but saved after
+        that. To reload the endpoint ID, either create a new
+        LocalGlobusConnectPersonal, or delete the property with ``del``.
+
+        Simple usage:
+
+        >>> from globus_sdk import TransferClient, LocalGlobusConnectPersonal
+        >>> local_ep = LocalGlobusConnectPersonal()
+        >>> ep_id = local_ep.endpoint_id
+        >>> tc = TransferClient(...)  # needs auth details
+        >>> for f in tc.operation_ls(ep_id):
+        >>>     print("Local file: ", f["name"])
+
+        Example of using ``del`` to reset the endpoint ID:
+
+        >>> local_ep = LocalGlobusConnectPersonal()
+        >>> x = local_ep.endpoint_id  # endpoint_id is now saved
+        >>>
+        >>> # while code is running, reinstall Globus Connect Personal,
+        >>> # thus generating a new endpoint ID
+        >>>
+        >>> assert x == local_ep.endpoint_id  # the value has not changed
+        >>> del local_ep.endpoint_id  # clear the endpoint_id , allowing it to
+        >>>                           # reload
+        >>>
+        >>> y = local_ep.endpoint_id  # y will now have the new value
+        >>> assert x != y  # and the value has changed, x still has the old val
+        """
+        if self._endpoint_id is None:
+            try:
+                if _on_windows():
+                    appdata = os.getenv("LOCALAPPDATA")
+                    if appdata is None:
+                        raise ValueError(
+                            "LOCALAPPDATA not detected in Windows environment")
+                    fname = os.path.join(
+                        appdata, "Globus Connect\client-id.txt")
+                else:
+                    fname = os.path.expanduser(
+                        "~/.globusonline/lta/client-id.txt")
+                with open(fname) as fp:
+                    self._endpoint_id = fp.read().strip()
+            except IOError as e:
+                # no such file or directory
+                if e.errno == 2:
+                    pass
+                else:
+                    raise
+
+        return self._endpoint_id
+
+    @endpoint_id.deleter
+    def endpoint_id(self):
+        """
+        Deleter for LocalGlobusConnectPersonal.endpoint_id
+        """
+        self._endpoint_id = None

--- a/globus_sdk/local_endpoint/personal.py
+++ b/globus_sdk/local_endpoint/personal.py
@@ -30,10 +30,9 @@ class LocalGlobusConnectPersonal(object):
         installation.
 
         This value is loaded whenever it is first accessed, but saved after
-        that. To reload the endpoint ID, either create a new
-        LocalGlobusConnectPersonal, or delete the property with ``del``.
+        that.
 
-        Simple usage:
+        Usage:
 
         >>> from globus_sdk import TransferClient, LocalGlobusConnectPersonal
         >>> local_ep = LocalGlobusConnectPersonal()
@@ -42,20 +41,8 @@ class LocalGlobusConnectPersonal(object):
         >>> for f in tc.operation_ls(ep_id):
         >>>     print("Local file: ", f["name"])
 
-        Example of using ``del`` to reset the endpoint ID:
-
-        >>> local_ep = LocalGlobusConnectPersonal()
-        >>> x = local_ep.endpoint_id  # endpoint_id is now saved
-        >>>
-        >>> # while code is running, reinstall Globus Connect Personal,
-        >>> # thus generating a new endpoint ID
-        >>>
-        >>> assert x == local_ep.endpoint_id  # the value has not changed
-        >>> del local_ep.endpoint_id  # clear the endpoint_id , allowing it to
-        >>>                           # reload
-        >>>
-        >>> y = local_ep.endpoint_id  # y will now have the new value
-        >>> assert x != y  # and the value has changed, x still has the old val
+        You can also reset the value, causing it to load again on next access,
+        with ``del local_ep.endpoint_id``
         """
         if self._endpoint_id is None:
             try:


### PR DESCRIPTION
This is a new class which describes the local personal endpoint. It has one property: endpoint_id, which gets the endpoint ID as a string.

@jaswilli mentioned maybe not including a deleter for `LocalGlobusConnectPersonal.endpoint_id` -- I don't have much of an opinion on this.
I could also remove it from the docstring for the `endpoint_id` property, to keep the docs simpler and shorter, but I'd leave the actual deleter in place, if we think it might be confusing to novice users.