### PR TITLE
Updates for v1.5.0, and new badge images

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,16 +2,28 @@
     :alt: build status
     :target: https://travis-ci.org/globus/globus-sdk-python
 
+.. image:: https://img.shields.io/pypi/v/globus-sdk.svg
+    :alt: Latest Released Version
+    :target: https://pypi.org/project/globus-sdk/
+
+.. image:: https://img.shields.io/pypi/pyversions/globus-sdk.svg
+    :alt: Supported Python Versions
+    :target: https://pypi.org/project/globus-sdk/
+
+.. image:: https://img.shields.io/github/license/globus/globus-sdk-python.svg
+    :alt: License
+
+
 Globus SDK for Python
 =====================
 
 This SDK provides a convenient Pythonic interface to
-`Globus <https://www.globus.org>`_ REST APIs,
-including the Transfer API and the Globus Auth API.
+`Globus <https://www.globus.org>`_ APIs.
 
 Documentation
 -------------
 
 | Full Documentation: http://globus-sdk-python.readthedocs.io/
 | Source Code: https://github.com/globus/globus-sdk-python
-| REST Documentation: https://docs.globus.org
+| API Documentation: https://docs.globus.org/api/
+| Release History + Changelog: https://github.com/globus/globus-sdk-python/releases

--- a/globus_sdk/version.py
+++ b/globus_sdk/version.py
@@ -1,3 +1,3 @@
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "1.4.1"
+__version__ = "1.5.0"


### PR DESCRIPTION
Just as a little bit of fun, add badges for latest PyPi version, PyPi python version trove classifiers, and GitHub license.

Version is 1.5.0 because of the addition of LocalGlobusConnectPersonal

I'd like to do a release to push out the fix for SearchClient