### PR TITLE
make work with python 2.6.9

### DIFF
--- a/docs/examples/advanced_transfer.rst
+++ b/docs/examples/advanced_transfer.rst
@@ -103,7 +103,7 @@ retry logic from the core task submission logic.
                     must be run inside an exception handler
             """
             if retries < 1:
-                logger.error('Retried {} too many times.'
+                logger.error('Retried {0} too many times.'
                              .format(func_name))
                 raise
 
@@ -112,12 +112,12 @@ retry logic from the core task submission logic.
         except NetworkError:
             # log with exc_info=True to capture a full stacktrace as a
             # debug-level log
-            logger.debug(('Globus func {} experienced a network error'
+            logger.debug(('Globus func {0} experienced a network error'
                           .format(func_name)), exc_info=True)
             check_for_reraise()
         except GlobusAPIError:
             # again, log with exc_info=True to capture a full stacktrace
-            logger.warn(('Globus func {} experienced a network error'
+            logger.warn(('Globus func {0} experienced a network error'
                          .format(func_name)), exc_info=True)
             check_for_reraise()
 

--- a/docs/examples/client_credentials.rst
+++ b/docs/examples/client_credentials.rst
@@ -71,10 +71,10 @@ For example, after running the code above,
 
     authorizer = globus_sdk.AccessTokenAuthorizer(globus_transfer_token)
     tc = globus_sdk.TransferClient(authorizer=authorizer)
-    print("Endpoints Belonging to {}@clients.auth.globus.org:"
+    print("Endpoints Belonging to {0}@clients.auth.globus.org:"
           .format(CLIENT_ID))
     for ep in tc.endpoint_search(filter_scope="my-endpoints"):
-        print("[{}] {}".format(ep["id"], ep["display_name"]))
+        print("[{0}] {1}".format(ep["id"], ep["display_name"]))
 
 Note that we're doing a search for "my endpoints", but we refer to the results
 as belonging to ``<CLIENT_ID>@clients.auth.globus.org``. The "current user" is
@@ -121,7 +121,7 @@ Use it like so:
     transfer_client = globus_sdk.TransferClient(authorizer=cc_authorizer)
 
     # usage is still the same
-    print("Endpoints Belonging to {}@clients.auth.globus.org:"
+    print("Endpoints Belonging to {0}@clients.auth.globus.org:"
           .format(CLIENT_ID))
     for ep in tc.endpoint_search(filter_scope="my-endpoints"):
-        print("[{}] {}".format(ep["id"], ep["display_name"]))
+        print("[{0}] {1}".format(ep["id"], ep["display_name"]))

--- a/docs/examples/three_legged_oauth.rst
+++ b/docs/examples/three_legged_oauth.rst
@@ -179,8 +179,8 @@ Globus Auth beforehand:
         # there is no tool to help build this (yet!)
         globus_logout_url = (
             'https://auth.globus.org/v2/web/logout' +
-            '?client={}'.format(app.config['PORTAL_CLIENT_ID']) +
-            '&redirect_uri={}'.format(redirect_uri) +
+            '?client={0}'.format(app.config['PORTAL_CLIENT_ID']) +
+            '&redirect_uri={0}'.format(redirect_uri) +
             '&redirect_name=Globus Example App')
 
         # Redirect the user to the Globus Auth logout page
@@ -202,4 +202,4 @@ For example, one might do the following:
 
     print("Endpoints belonging to the current logged-in user:")
     for ep in transfer_client.endpoint_search(filter_scope="my-endpoints"):
-        print("[{}] {}".format(ep["id"], ep["display_name"]))
+        print("[{0}] {1}".format(ep["id"], ep["display_name"]))

--- a/docs/exceptions.rst
+++ b/docs/exceptions.rst
@@ -40,8 +40,8 @@ unexpected API conditions, you'll want to look for ``NetworkError`` and
         # Error response from the REST service, check the code and message for
         # details.
         logging.error(("Got a Globus API Error\n"
-                       "Error Code: {}\n"
-                       "Error Message: {}").format(e.code, e.message))
+                       "Error Code: {0}\n"
+                       "Error Message: {0}").format(e.code, e.message))
         raise e
     except NetworkError:
         logging.error(("Network Failure. "

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -136,7 +136,7 @@ the Globus Transfer service.
     # high level interface; provides iterators for list responses
     print("My Endpoints:")
     for ep in tc.endpoint_search(filter_scope="my-endpoints"):
-        print("[{}] {}".format(ep["id"], ep["display_name"]))
+        print("[{0}] {1}".format(ep["id"], ep["display_name"]))
 
 
 Note that the ``TRANSFER_TOKEN`` is only valid for a limited time. You'll have

--- a/globus_sdk/__init__.py
+++ b/globus_sdk/__init__.py
@@ -53,4 +53,18 @@ __all__ = (
 # configure logging for a library, per python best practices:
 # https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library
 # NB: this won't work on py2.6 because `logging.NullHandler` wasn't added yet
-logging.getLogger('globus_sdk').addHandler(logging.NullHandler())
+try:
+    nullhandler = logging.NullHandler()
+except AttributeError:
+    class MyNullHandler(logging.Handler):
+        def emit(self, record):
+            pass
+
+        def handle(self, record):
+            pass
+
+        def createLock(self):
+            self.lock = None
+
+    nullhandler = MyNullHandler()
+logging.getLogger('globus_sdk').addHandler(nullhandler)

--- a/globus_sdk/auth/client_types/base.py
+++ b/globus_sdk/auth/client_types/base.py
@@ -136,7 +136,7 @@ class AuthClient(BaseClient):
         if ids:
             params['ids'] = _convert_listarg(ids)
 
-        self.logger.debug('params={}'.format(params))
+        self.logger.debug('params={0}'.format(params))
 
         if 'usernames' in params and 'ids' in params:
             self.logger.warn(('get_identities call with both usernames and '
@@ -168,7 +168,7 @@ class AuthClient(BaseClient):
                  'AuthClient to resolve'))
         auth_url = self.current_oauth2_flow_manager.get_authorize_url(
             additional_params=additional_params)
-        self.logger.info('Got authorization URL: {}'.format(auth_url))
+        self.logger.info('Got authorization URL: {0}'.format(auth_url))
         return auth_url
 
     def oauth2_exchange_code_for_tokens(self, auth_code):
@@ -381,8 +381,9 @@ class AuthClient(BaseClient):
 
         >>> ac = AuthClient(...)
         >>> info = ac.oauth2_userinfo()
-        >>> print('Effective Identity "{}" has Full Name "{}" and Email "{}"'
-        >>>       .format(info["sub"], info["name"], info["email"]))
+        >>> print(
+        >>>     'Effective Identity "{0}" has Full Name "{1}" and Email "{2}"'
+        >>>     .format(info["sub"], info["name"], info["email"]))
 
         **External Documentation**
 

--- a/globus_sdk/auth/client_types/confidential_client.py
+++ b/globus_sdk/auth/client_types/confidential_client.py
@@ -45,7 +45,7 @@ class ConfidentialAppAuthClient(AuthClient):
             self, client_id=client_id,
             authorizer=BasicAuthorizer(client_id, client_secret),
             **kwargs)
-        self.logger.info('Finished initializing client, client_id={}'
+        self.logger.info('Finished initializing client, client_id={0}'
                          .format(client_id))
 
     def oauth2_client_credentials_tokens(self, requested_scopes=None):

--- a/globus_sdk/auth/client_types/native_client.py
+++ b/globus_sdk/auth/client_types/native_client.py
@@ -34,7 +34,7 @@ class NativeAppAuthClient(AuthClient):
 
         AuthClient.__init__(
             self, client_id=client_id, authorizer=NullAuthorizer(), **kwargs)
-        self.logger.info('Finished initializing client, client_id={}'
+        self.logger.info('Finished initializing client, client_id={0}'
                          .format(client_id))
 
     def oauth2_start_flow(

--- a/globus_sdk/auth/oauth2_authorization_code.py
+++ b/globus_sdk/auth/oauth2_authorization_code.py
@@ -68,11 +68,11 @@ class GlobusAuthorizationCodeFlowManager(GlobusOAuthFlowManager):
         self.state = state
 
         logger.debug('Starting Authorization Code Flow with params:')
-        logger.debug('auth_client.client_id={}'.format(auth_client.client_id))
-        logger.debug('redirect_uri={}'.format(redirect_uri))
-        logger.debug('refresh_tokens={}'.format(refresh_tokens))
-        logger.debug('state={}'.format(state))
-        logger.debug('requested_scopes={}'.format(self.requested_scopes))
+        logger.debug('auth_client.client_id={0}'.format(auth_client.client_id))
+        logger.debug('redirect_uri={0}'.format(redirect_uri))
+        logger.debug('refresh_tokens={0}'.format(refresh_tokens))
+        logger.debug('state={0}'.format(state))
+        logger.debug('requested_scopes={0}'.format(self.requested_scopes))
 
     def get_authorize_url(self, additional_params=None):
         """
@@ -95,9 +95,9 @@ class GlobusAuthorizationCodeFlowManager(GlobusOAuthFlowManager):
         """
         authorize_base_url = slash_join(self.auth_client.base_url,
                                         '/v2/oauth2/authorize')
-        logger.debug('Building authorization URI. Base URL: {}'
+        logger.debug('Building authorization URI. Base URL: {0}'
                      .format(authorize_base_url))
-        logger.debug('additional_params={}'.format(additional_params))
+        logger.debug('additional_params={0}'.format(additional_params))
 
         params = {
             'client_id': self.client_id,

--- a/globus_sdk/auth/oauth2_native_app.py
+++ b/globus_sdk/auth/oauth2_native_app.py
@@ -37,7 +37,7 @@ def make_native_app_challenge(verifier=None):
     if verifier:
         if not 43 <= len(verifier) <= 128:
             raise GlobusSDKUsageError(
-                'verifier must be 43-128 characters long: {}'.format(
+                'verifier must be 43-128 characters long: {0}'.format(
                     len(verifier)))
         if bool(re.search(r'[^a-zA-Z0-9~_.-]', verifier)):
             raise GlobusSDKUsageError('verifier contained invalid characters')
@@ -113,7 +113,7 @@ class GlobusNativeAppFlowManager(GlobusOAuthFlowManager):
         # set client_id, then check for validity
         self.client_id = auth_client.client_id
         if not self.client_id:
-            logger.error('Invalid auth_client ID to start Native App Flow: {}'
+            logger.error('Invalid auth_client ID to start Native App Flow: {0}'
                          .format(self.client_id))
             raise GlobusSDKUsageError(
                 'Invalid value for client_id. Got "{0}"'
@@ -141,15 +141,16 @@ class GlobusNativeAppFlowManager(GlobusOAuthFlowManager):
         self.prefill_named_grant = prefill_named_grant
 
         logger.debug('Starting Native App Flow with params:')
-        logger.debug('auth_client.client_id={}'.format(auth_client.client_id))
-        logger.debug('redirect_uri={}'.format(self.redirect_uri))
-        logger.debug('refresh_tokens={}'.format(refresh_tokens))
-        logger.debug('state={}'.format(state))
-        logger.debug('requested_scopes={}'.format(self.requested_scopes))
-        logger.debug('verifier=<REDACTED>,challenge={}'.format(self.challenge))
+        logger.debug('auth_client.client_id={0}'.format(auth_client.client_id))
+        logger.debug('redirect_uri={0}'.format(self.redirect_uri))
+        logger.debug('refresh_tokens={0}'.format(refresh_tokens))
+        logger.debug('state={0}'.format(state))
+        logger.debug('requested_scopes={0}'.format(self.requested_scopes))
+        logger.debug('verifier=<REDACTED>,challenge={0}'
+                     .format(self.challenge))
 
         if prefill_named_grant is not None:
-            logger.debug('prefill_named_grant={}'.format(
+            logger.debug('prefill_named_grant={0}'.format(
                 self.prefill_named_grant))
 
     def get_authorize_url(self, additional_params=None):
@@ -173,9 +174,9 @@ class GlobusNativeAppFlowManager(GlobusOAuthFlowManager):
         """
         authorize_base_url = slash_join(self.auth_client.base_url,
                                         '/v2/oauth2/authorize')
-        logger.debug('Building authorization URI. Base URL: {}'
+        logger.debug('Building authorization URI. Base URL: {0}'
                      .format(authorize_base_url))
-        logger.debug('additional_params={}'.format(additional_params))
+        logger.debug('additional_params={0}'.format(additional_params))
 
         params = {
             'client_id': self.client_id,

--- a/globus_sdk/auth/token_response.py
+++ b/globus_sdk/auth/token_response.py
@@ -50,7 +50,7 @@ class _ByScopesGetter(object):
 
     def __getitem__(self, scopename):
         if not isinstance(scopename, six.string_types):
-            raise KeyError('by_scopes cannot contain non-string value "{}"'
+            raise KeyError('by_scopes cannot contain non-string value "{0}"'
                            .format(scopename))
 
         # split on spaces
@@ -64,13 +64,13 @@ class _ByScopesGetter(object):
                 rs_names.add(self.scope_map[scope]['resource_server'])
                 toks.append(self.scope_map[scope])
             except KeyError:
-                raise KeyError(('Scope specifier "{}" contains scope "{}" '
+                raise KeyError(('Scope specifier "{0}" contains scope "{1}" '
                                 "which was not found"
                                 ).format(scopename, scope))
         # if there isn't exactly 1 token, it's an error
         if len(rs_names) != 1:
             raise KeyError(
-                'Scope specifier "{}" did not match exactly one token!'
+                'Scope specifier "{0}" did not match exactly one token!'
                 .format(scopename))
         # pop the only element in the set
         return toks.pop()
@@ -164,7 +164,7 @@ class OAuthTokenResponse(GlobusHTTPResponse):
               this token back to the OAuthTokenResponse. The SDK now tracks
               this internally, so it is no longer necessary.
         """
-        logger.info('Decoding ID Token "{}"'.format(self['id_token']))
+        logger.info('Decoding ID Token "{0}"'.format(self['id_token']))
 
         # warn (not error) on older usage pattern, but still respect it
         # FIXME: should be deprecated and removed in SDK v2

--- a/globus_sdk/authorizers/access_token.py
+++ b/globus_sdk/authorizers/access_token.py
@@ -19,7 +19,7 @@ class AccessTokenAuthorizer(GlobusAuthorizer):
     def __init__(self, access_token):
         logger.info(("Setting up an AccessTokenAuthorizer. It will use an "
                      "auth type of Bearer and cannot handle 401s."))
-        logger.debug('Bearer token ends in "...{}" (last 5 chars)'
+        logger.debug('Bearer token ends in "...{0}" (last 5 chars)'
                      .format(access_token[-5:]))
         self.access_token = access_token
         self.header_val = "Bearer %s" % access_token
@@ -30,6 +30,6 @@ class AccessTokenAuthorizer(GlobusAuthorizer):
         "Bearer <access_token>"
         """
         logger.debug(("Setting AccessToken Authorization Header: "
-                      '"Bearer ...{}" (last 5 chars)')
+                      '"Bearer ...{0}" (last 5 chars)')
                      .format(self.header_val[-5:]))
         header_dict['Authorization'] = self.header_val

--- a/globus_sdk/authorizers/basic.py
+++ b/globus_sdk/authorizers/basic.py
@@ -25,7 +25,7 @@ class BasicAuthorizer(GlobusAuthorizer):
     def __init__(self, username, password):
         logger.info(("Setting up a BasicAuthorizer. It will use an "
                      "auth type of Basic and cannot handle 401s."))
-        logger.info("BasicAuthorizer.username = {}".format(username))
+        logger.info("BasicAuthorizer.username = {0}".format(username))
         self.username = username
         self.password = password
 
@@ -38,5 +38,5 @@ class BasicAuthorizer(GlobusAuthorizer):
         "Basic <base64 encoded username:password>"
         """
         logger.debug(("Setting Basic Authorization Header: "
-                      '"Basic <{}:SECRET>"').format(self.username))
+                      '"Basic <{0}:SECRET>"').format(self.username))
         header_dict['Authorization'] = self.header_val

--- a/globus_sdk/authorizers/client_credentials.py
+++ b/globus_sdk/authorizers/client_credentials.py
@@ -55,8 +55,8 @@ class ClientCredentialsAuthorizer(RenewingAuthorizer):
                  access_token=None, expires_at=None, on_refresh=None):
         logger.info((
             "Setting up ClientCredentialsAuthorizer with confidential_client ="
-            " instance:{} and scopes = "
-            "{}".format(id(confidential_client), scopes)))
+            " instance:{0} and scopes = "
+            "{0}".format(id(confidential_client), scopes)))
 
         # values for _get_token_data
         self.confidential_client = confidential_client
@@ -82,6 +82,6 @@ class ClientCredentialsAuthorizer(RenewingAuthorizer):
             raise ValueError(
                 "Attempting get new access token for client credentials "
                 "authorizer didn't return exactly one token. Ensure scopes "
-                "{} are for only one resource server.".format(self.scopes))
+                "{0} are for only one resource server.".format(self.scopes))
 
         return next(iter(token_data))

--- a/globus_sdk/authorizers/refresh_token.py
+++ b/globus_sdk/authorizers/refresh_token.py
@@ -50,7 +50,7 @@ class RefreshTokenAuthorizer(RenewingAuthorizer):
                  access_token=None, expires_at=None, on_refresh=None):
         logger.info((
             "Setting up RefreshTokenAuthorizer with auth_client = "
-            "instance: {}".format(id(auth_client))))
+            "instance: {0}".format(id(auth_client))))
 
         # required for _get_token_data
         self.refresh_token = refresh_token

--- a/globus_sdk/authorizers/renewing.py
+++ b/globus_sdk/authorizers/renewing.py
@@ -50,7 +50,7 @@ class RenewingAuthorizer(GlobusAuthorizer):
         if expires_at is not None and self.access_token is not None:
             logger.info(("Got both expires_at and access_token. "
                          "Will start by using "
-                         "RenewingAuthorizer.access_token = ...{} "
+                         "RenewingAuthorizer.access_token = ...{0} "
                          "(last 5 chars)")
                         .format(self.access_token[-5:]))
             self._set_expiration_time(expires_at)
@@ -82,7 +82,7 @@ class RenewingAuthorizer(GlobusAuthorizer):
         Set the expiration time adjusting for potential network delays.
         """
         self.expires_at = expires_at - EXPIRES_ADJUST_SECONDS
-        logger.debug(("Adjusted expiration time down to {} to account for "
+        logger.debug(("Adjusted expiration time down to {0} to account for "
                       "potential delays.")
                      .format(self.expires_at))
 
@@ -99,7 +99,7 @@ class RenewingAuthorizer(GlobusAuthorizer):
         self.access_token = token_data['access_token']
 
         logger.info(("RenewingAuthorizer.access_token updated to "
-                     '"...{}" (last 5 chars)')
+                     '"...{0}" (last 5 chars)')
                     .format(self.access_token[-5:]))
 
         if callable(self.on_refresh):
@@ -128,7 +128,7 @@ class RenewingAuthorizer(GlobusAuthorizer):
         """
         self._check_expiration_time()
         logger.debug(("Setting RefreshToken Authorization Header:"
-                      '"Bearer ...{}" (last 5 chars)')
+                      '"Bearer ...{0}" (last 5 chars)')
                      .format(self.access_token[-5:]))
         header_dict['Authorization'] = "Bearer %s" % self.access_token
 

--- a/globus_sdk/base.py
+++ b/globus_sdk/base.py
@@ -16,7 +16,8 @@ class ClientLogAdapter(logging.LoggerAdapter):
     Stuff in the memory location of the client to make log records unambiguous.
     """
     def process(self, msg, kwargs):
-        return '[instance:{}] {}'.format(id(self.extra['client']), msg), kwargs
+        return ('[instance:{0}] {1}'.format(id(self.extra['client']), msg),
+                kwargs)
 
     def warn(self, *args, **kwargs):
         return self.warning(*args, **kwargs)
@@ -68,7 +69,7 @@ class BaseClient(object):
         self.logger = ClientLogAdapter(
             logging.getLogger(self.__module__ + '.' + self.__class__.__name__),
             {'client': self})
-        self.logger.info('Creating client of type {} for service "{}"'
+        self.logger.info('Creating client of type {0} for service "{1}"'
                          .format(type(self), service))
         # if restrictions have been placed by a child class on the allowed
         # authorizer types, make sure we are not in violation of those
@@ -76,7 +77,7 @@ class BaseClient(object):
         if self.allowed_authorizer_types is not None and (
                 authorizer is not None and
                 type(authorizer) not in self.allowed_authorizer_types):
-            self.logger.error("{} doesn't support authorizer={}"
+            self.logger.error("{0} doesn't support authorizer={1}"
                               .format(type(self), type(authorizer)))
             raise exc.GlobusSDKUsageError(
                 ("{0} can only take authorizers from {1}, "
@@ -168,7 +169,7 @@ class BaseClient(object):
         :return: :class:`GlobusHTTPResponse \
         <globus_sdk.response.GlobusHTTPResponse>` object
         """
-        self.logger.debug('GET to {} with params {}'.format(path, params))
+        self.logger.debug('GET to {0} with params {1}'.format(path, params))
         return self._request("GET", path, params=params, headers=headers,
                              response_class=response_class,
                              retry_401=retry_401)
@@ -207,7 +208,7 @@ class BaseClient(object):
         :return: :class:`GlobusHTTPResponse \
         <globus_sdk.response.GlobusHTTPResponse>` object
         """
-        self.logger.debug('POST to {} with params {}'.format(path, params))
+        self.logger.debug('POST to {0} with params {1}'.format(path, params))
         return self._request("POST", path, json_body=json_body, params=params,
                              headers=headers, text_body=text_body,
                              response_class=response_class,
@@ -240,7 +241,7 @@ class BaseClient(object):
         :return: :class:`GlobusHTTPResponse \
         <globus_sdk.response.GlobusHTTPResponse>` object
         """
-        self.logger.debug('DELETE to {} with params {}'.format(path, params))
+        self.logger.debug('DELETE to {0} with params {1}'.format(path, params))
         return self._request("DELETE", path, params=params,
                              headers=headers,
                              response_class=response_class,
@@ -280,7 +281,7 @@ class BaseClient(object):
         :return: :class:`GlobusHTTPResponse \
         <globus_sdk.response.GlobusHTTPResponse>` object
         """
-        self.logger.debug('PUT to {} with params {}'.format(path, params))
+        self.logger.debug('PUT to {0} with params {1}'.format(path, params))
         return self._request("PUT", path, json_body=json_body, params=params,
                              headers=headers, text_body=text_body,
                              response_class=response_class,
@@ -338,12 +339,12 @@ class BaseClient(object):
         # add Authorization header, or (if it's a NullAuthorizer) possibly
         # explicitly remove the Authorization header
         if self.authorizer is not None:
-            self.logger.debug('request will have authorization of type {}'
+            self.logger.debug('request will have authorization of type {0}'
                               .format(type(self.authorizer)))
             self.authorizer.set_authorization_header(rheaders)
 
         url = slash_join(self.base_url, path)
-        self.logger.debug('request will hit URL:{}'.format(url))
+        self.logger.debug('request will hit URL:{0}'.format(url))
 
         # because a 401 can trigger retry, we need to wrap the retry-able thing
         # in a method
@@ -360,7 +361,7 @@ class BaseClient(object):
         # initial request
         r = send_request()
 
-        self.logger.debug('Request made to URL: {}'.format(r.url))
+        self.logger.debug('Request made to URL: {0}'.format(r.url))
 
         # potential 401 retry handling
         if r.status_code == 401 and retry_401 and self.authorizer is not None:
@@ -375,14 +376,14 @@ class BaseClient(object):
                 r = send_request()
 
         if 200 <= r.status_code < 400:
-            self.logger.debug('request completed with response code: {}'
+            self.logger.debug('request completed with response code: {0}'
                               .format(r.status_code))
             if response_class is None:
                 return self.default_response_class(r, client=self)
             else:
                 return response_class(r, client=self)
 
-        self.logger.debug('request completed with (error) response code: {}'
+        self.logger.debug('request completed with (error) response code: {0}'
                           .format(r.status_code))
         raise self.error_class(r)
 

--- a/globus_sdk/config.py
+++ b/globus_sdk/config.py
@@ -87,10 +87,10 @@ class GlobusConfigParser(object):
         # *first* for a value -- env values have higher precedence than config
         # files so that you can locally override the behavior of a command in a
         # given shell or subshell
-        env_option_name = 'GLOBUS_SDK_{}'.format(option.upper())
+        env_option_name = 'GLOBUS_SDK_{0}'.format(option.upper())
         value = None
         if check_env and env_option_name in os.environ:
-            logger.debug("Getting config value from environment: {}={}"
+            logger.debug("Getting config value from environment: {0}={1}"
                          .format(env_option_name, value))
             value = os.environ[env_option_name]
         else:
@@ -98,7 +98,7 @@ class GlobusConfigParser(object):
                 value = self._parser.get(section, option)
             except (NoOptionError, NoSectionError):
                 if failover_to_general:
-                    logger.debug("Config lookup of [{}]:{} failed, checking "
+                    logger.debug("Config lookup of [{0}]:{1} failed, checking "
                                  "[general] for a value as well"
                                  .format(section, option))
                     value = self.get(option,
@@ -126,7 +126,7 @@ _parser = None
 
 
 def get_service_url(environment, service):
-    logger.debug("Service URL Lookup for \"{}\" under env \"{}\""
+    logger.debug("Service URL Lookup for \"{0}\" under env \"{1}\""
                  .format(service, environment))
     p = _get_parser()
     option = service + "_service"
@@ -134,11 +134,11 @@ def get_service_url(environment, service):
     url = p.get(option, environment=environment)
     if url is None:
         raise GlobusSDKUsageError(
-            ('Failed to find a url for service "{}" in environment "{}". '
+            ('Failed to find a url for service "{0}" in environment "{1}". '
              "Please double-check that GLOBUS_SDK_ENVIRONMENT is set "
              "correctly, or not set at all")
             .format(service, environment))
-    logger.debug("Service URL Lookup Result: \"{}\" is at \"{}\""
+    logger.debug("Service URL Lookup Result: \"{0}\" is at \"{1}\""
                  .format(service, url))
     return url
 
@@ -150,7 +150,7 @@ def get_http_timeout(environment):
                   type_cast=float)
     if value is None:
         value = 60
-    logger.debug('default http_timeout set to {}'.format(value))
+    logger.debug('default http_timeout set to {0}'.format(value))
     return value
 
 
@@ -161,7 +161,7 @@ def get_ssl_verify(environment):
                   type_cast=_bool_cast)
     if value is None:
         return True
-    logger.debug('ssl_verify set to {}'.format(value))
+    logger.debug('ssl_verify set to {0}'.format(value))
     return value
 
 
@@ -171,7 +171,7 @@ def _bool_cast(value):
         return True
     elif value in ("0", "no", "false", "off"):
         return False
-    logger.error('Value "{}" can\'t cast to bool'.format(value))
+    logger.error('Value "{0}" can\'t cast to bool'.format(value))
     raise ValueError("Invalid config bool")
 
 
@@ -187,5 +187,5 @@ def get_default_environ():
         env = 'default'
     if env != 'default':
         logger.info(('On lookup, non-default environment: '
-                     'GLOBUS_SDK_ENVIRONMENT={}'.format(env)))
+                     'GLOBUS_SDK_ENVIRONMENT={0}'.format(env)))
     return env

--- a/globus_sdk/exc.py
+++ b/globus_sdk/exc.py
@@ -100,7 +100,7 @@ class GlobusAPIError(GlobusError):
             if len(data["errors"]) != 1:
                 logger.warn(("Doing JSON load of error response with multiple "
                              "errors. Exception data will only include the "
-                             "first error, but there are really {} errors")
+                             "first error, but there are really {0} errors")
                             .format(len(data["errors"])))
             # TODO: handle responses with more than one error
             data = data["errors"][0]
@@ -185,7 +185,7 @@ class AuthAPIError(GlobusAPIError):
             if len(data["errors"]) != 1:
                 logger.warn(("Doing JSON load of error response with multiple "
                              "errors. Exception data will only include the "
-                             "first error, but there are really {} errors")
+                             "first error, but there are really {0} errors")
                             .format(len(data["errors"])))
             # TODO: handle responses with more than one error
             data = data["errors"][0]

--- a/globus_sdk/response.py
+++ b/globus_sdk/response.py
@@ -43,7 +43,7 @@ class GlobusResponse(object):
         try:
             return data[key]
         except TypeError:
-            logger.error("Can't index into responses of type {}"
+            logger.error("Can't index into responses of type {0}"
                          .format(type(self)))
             # re-raise with an altered message -- the issue is that whatever
             # type of GlobusResponse you're working with doesn't support

--- a/globus_sdk/search/client.py
+++ b/globus_sdk/search/client.py
@@ -60,7 +60,7 @@ class SearchClient(BaseClient):
         in the API documentation for details.
         """
         index_id = safe_stringify(index_id)
-        self.logger.info("SearchClient.get_index({})".format(index_id))
+        self.logger.info("SearchClient.get_index({0})".format(index_id))
         path = self.qjoin_path("v1/index", index_id)
         return self.get(path, params=params)
 
@@ -91,7 +91,7 @@ class SearchClient(BaseClient):
         merge_params(params, q=q, offset=offset, limit=limit,
                      query_template=query_template, advanced=advanced)
 
-        self.logger.info("SearchClient.search({}, ...)"
+        self.logger.info("SearchClient.search({0}, ...)"
                          .format(index_id))
         path = self.qjoin_path("v1/index", index_id, "search")
         return self.get(path, params=params)
@@ -137,7 +137,7 @@ class SearchClient(BaseClient):
         in the API documentation for details.
         """
         index_id = safe_stringify(index_id)
-        self.logger.info("SearchClient.post_search({}, ...)"
+        self.logger.info("SearchClient.post_search({0}, ...)"
                          .format(index_id))
         path = self.qjoin_path("v1/index", index_id, "search")
         return self.post(path, data)
@@ -200,7 +200,7 @@ class SearchClient(BaseClient):
         in the API documentation for details.
         """
         index_id = safe_stringify(index_id)
-        self.logger.info("SearchClient.ingest({}, ...)".format(index_id))
+        self.logger.info("SearchClient.ingest({0}, ...)".format(index_id))
         path = self.qjoin_path("v1/index", index_id, "ingest")
         return self.post(path, data)
 
@@ -238,7 +238,7 @@ class SearchClient(BaseClient):
         in the API documentation for details.
         """
         index_id = safe_stringify(index_id)
-        self.logger.info("SearchClient.delete_by_query({}, ...)"
+        self.logger.info("SearchClient.delete_by_query({0}, ...)"
                          .format(index_id))
         path = self.qjoin_path("v1/index", index_id, "delete_by_query")
         return self.post(path, data)
@@ -269,7 +269,7 @@ class SearchClient(BaseClient):
         index_id = safe_stringify(index_id)
         merge_params(params, subject=subject)
 
-        self.logger.info("SearchClient.get_subject({}, {}, ...)"
+        self.logger.info("SearchClient.get_subject({0}, {1}, ...)"
                          .format(index_id, subject))
         path = self.qjoin_path("v1/index", index_id, "subject")
         return self.get(path, params=params)
@@ -296,7 +296,7 @@ class SearchClient(BaseClient):
         index_id = safe_stringify(index_id)
         merge_params(params, subject=subject)
 
-        self.logger.info("SearchClient.delete_subject({}, {}, ...)"
+        self.logger.info("SearchClient.delete_subject({0}, {1}, ...)"
                          .format(index_id, subject))
         path = self.qjoin_path("v1/index", index_id, "subject")
         return self.delete(path, params=params)
@@ -334,7 +334,7 @@ class SearchClient(BaseClient):
         index_id = safe_stringify(index_id)
         merge_params(params, subject=subject, entry_id=entry_id)
 
-        self.logger.info("SearchClient.get_entry({}, {}, {}, ...)"
+        self.logger.info("SearchClient.get_entry({0}, {1}, {2}, ...)"
                          .format(index_id, subject, entry_id))
         path = self.qjoin_path("v1/index", index_id, "entry")
         return self.get(path, params=params)
@@ -378,7 +378,8 @@ class SearchClient(BaseClient):
         in the API documentation for details.
         """
         index_id = safe_stringify(index_id)
-        self.logger.info("SearchClient.create_entry({}, ...)".format(index_id))
+        self.logger.info("SearchClient.create_entry({0}, ...)"
+                         .format(index_id))
         path = self.qjoin_path("v1/index", index_id, "entry")
         return self.post(path, data)
 
@@ -408,7 +409,8 @@ class SearchClient(BaseClient):
         in the API documentation for details.
         """
         index_id = safe_stringify(index_id)
-        self.logger.info("SearchClient.update_entry({}, ...)".format(index_id))
+        self.logger.info("SearchClient.update_entry({0}, ...)"
+                         .format(index_id))
         path = self.qjoin_path("v1/index", index_id, "entry")
         return self.put(path, data)
 
@@ -440,7 +442,7 @@ class SearchClient(BaseClient):
         """
         index_id = safe_stringify(index_id)
         merge_params(params, subject=subject, entry_id=entry_id)
-        self.logger.info("SearchClient.delete_entry({}, {}, {}, ...)"
+        self.logger.info("SearchClient.delete_entry({0}, {1}, {2}, ...)"
                          .format(index_id, subject, entry_id))
         path = self.qjoin_path("v1/index", index_id, "entry")
         return self.delete(path, params=params)
@@ -461,7 +463,7 @@ class SearchClient(BaseClient):
         in the API documentation for details.
         """
         index_id = safe_stringify(index_id)
-        self.logger.info("SearchClient.get_query_template({}, {})"
+        self.logger.info("SearchClient.get_query_template({0}, {1})"
                          .format(index_id, template_name))
         path = self.qjoin_path("v1/index", index_id, "query_template",
                                template_name)
@@ -479,7 +481,7 @@ class SearchClient(BaseClient):
         in the API documentation for details.
         """
         index_id = safe_stringify(index_id)
-        self.logger.info("SearchClient.get_query_template_list({})"
+        self.logger.info("SearchClient.get_query_template_list({0})"
                          .format(index_id))
         path = self.qjoin_path("v1/index", index_id, "query_template")
         return self.get(path)

--- a/globus_sdk/transfer/client.py
+++ b/globus_sdk/transfer/client.py
@@ -87,7 +87,8 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info("TransferClient.get_endpoint({})".format(endpoint_id))
+        self.logger.info("TransferClient.get_endpoint({0})"
+                         .format(endpoint_id))
         path = self.qjoin_path("endpoint", endpoint_id)
         return self.get(path, params=params)
 
@@ -124,7 +125,7 @@ class TransferClient(BaseClient):
             data['myproxy_server'] = None
 
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info("TransferClient.update_endpoint({}, ...)"
+        self.logger.info("TransferClient.update_endpoint({0}, ...)"
                          .format(endpoint_id))
         path = self.qjoin_path("endpoint", endpoint_id)
         return self.put(path, data, params=params)
@@ -188,7 +189,7 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info("TransferClient.delete_endpoint({})"
+        self.logger.info("TransferClient.delete_endpoint({0})"
                          .format(endpoint_id))
         path = self.qjoin_path("endpoint", endpoint_id)
         return self.delete(path)
@@ -266,7 +267,7 @@ class TransferClient(BaseClient):
         merge_params(params, filter_scope=filter_scope,
                      filter_fulltext=filter_fulltext)
         self.logger.info(
-            "TransferClient.endpoint_manager_monitored_endpoints({})"
+            "TransferClient.endpoint_manager_monitored_endpoints({0})"
             .format(params))
         return PaginatedResource(
             self.get, "endpoint_search", {'params': params},
@@ -314,17 +315,17 @@ class TransferClient(BaseClient):
         >>> tc = globus_sdk.TransferClient(...)
         >>> r = tc.endpoint_autoactivate(ep_id, if_expires_in=3600)
         >>> if r['code'] == 'AutoActivationFailed':
-        >>>     print('Endpoint({}) Not Active! Error! Source message: {}'
+        >>>     print('Endpoint({0}) Not Active! Error! Source message: {1}'
         >>>           .format(ep_id, r['message']))
         >>>     sys.exit(1)
         >>> elif r['code'] == 'AutoActivated.CachedCredential':
-        >>>     print('Endpoint({}) autoactivated using a cached credential.'
+        >>>     print('Endpoint({0}) autoactivated using a cached credential.'
         >>>           .format(ep_id))
         >>> elif r['code'] == 'AutoActivated.GlobusOnlineCredential':
-        >>>     print(('Endpoint({}) autoactivated using a built-in Globus '
+        >>>     print(('Endpoint({0}) autoactivated using a built-in Globus '
         >>>            'credential.').format(ep_id))
         >>> elif r['code'] = 'AlreadyActivated':
-        >>>     print('Endpoint({}) already active until at least {}'
+        >>>     print('Endpoint({0}) already active until at least {1}'
         >>>           .format(ep_id, 3600))
 
         **External Documentation**
@@ -335,7 +336,7 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info("TransferClient.endpoint_autoactivate({})"
+        self.logger.info("TransferClient.endpoint_autoactivate({0})"
                          .format(endpoint_id))
         path = self.qjoin_path("endpoint", endpoint_id, "autoactivate")
         return self.post(path, params=params)
@@ -355,7 +356,7 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info("TransferClient.endpoint_deactivate({})"
+        self.logger.info("TransferClient.endpoint_deactivate({0})"
                          .format(endpoint_id))
         path = self.qjoin_path("endpoint", endpoint_id, "deactivate")
         return self.post(path, params=params)
@@ -379,7 +380,7 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info("TransferClient.endpoint_activate({})"
+        self.logger.info("TransferClient.endpoint_activate({0})"
                          .format(endpoint_id))
         path = self.qjoin_path("endpoint", endpoint_id, "activate")
         return self.post(path, json_body=requirements_data, params=params)
@@ -419,8 +420,9 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info("TransferClient.my_effective_pause_rule_list({}, ...)"
-                         .format(endpoint_id))
+        self.logger.info(
+            "TransferClient.my_effective_pause_rule_list({0}, ...)"
+            .format(endpoint_id))
         path = self.qjoin_path('endpoint', endpoint_id,
                                'my_effective_pause_rule_list')
         return self.get(path, params=params,
@@ -443,7 +445,7 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info("TransferClient.my_shared_endpoint_list({}, ...)"
+        self.logger.info("TransferClient.my_shared_endpoint_list({0}, ...)"
                          .format(endpoint_id))
         path = self.qjoin_path('endpoint', endpoint_id,
                                'my_shared_endpoint_list')
@@ -503,7 +505,7 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info("TransferClient.endpoint_server_list({}, ...)"
+        self.logger.info("TransferClient.endpoint_server_list({0}, ...)"
                          .format(endpoint_id))
         path = self.qjoin_path('endpoint', endpoint_id, 'server_list')
         return self.get(path, params=params,
@@ -524,7 +526,7 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info("TransferClient.get_endpoint_server({}, {}, ...)"
+        self.logger.info("TransferClient.get_endpoint_server({0}, {1}, ...)"
                          .format(endpoint_id, server_id))
         path = self.qjoin_path("endpoint", endpoint_id,
                                "server", str(server_id))
@@ -545,7 +547,7 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info("TransferClient.add_endpoint_server({}, ...)"
+        self.logger.info("TransferClient.add_endpoint_server({0}, ...)"
                          .format(endpoint_id))
         path = self.qjoin_path("endpoint", endpoint_id, "server")
         return self.post(path, server_data)
@@ -565,7 +567,7 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info("TransferClient.update_endpoint_server({}, {}, ...)"
+        self.logger.info("TransferClient.update_endpoint_server({0}, {1}, ...)"
                          .format(endpoint_id, server_id))
         path = self.qjoin_path("endpoint", endpoint_id,
                                "server", str(server_id))
@@ -586,7 +588,7 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info("TransferClient.delete_endpoint_server({}, {})"
+        self.logger.info("TransferClient.delete_endpoint_server({0}, {1})"
                          .format(endpoint_id, server_id))
         path = self.qjoin_path("endpoint", endpoint_id,
                                "server", str(server_id))
@@ -611,7 +613,7 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info("TransferClient.endpoint_role_list({}, ...)"
+        self.logger.info("TransferClient.endpoint_role_list({0}, ...)"
                          .format(endpoint_id))
         path = self.qjoin_path('endpoint', endpoint_id, 'role_list')
         return self.get(path, params=params,
@@ -632,7 +634,7 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info("TransferClient.add_endpoint_role({}, ...)"
+        self.logger.info("TransferClient.add_endpoint_role({0}, ...)"
                          .format(endpoint_id))
         path = self.qjoin_path('endpoint', endpoint_id, 'role')
         return self.post(path, role_data)
@@ -652,7 +654,7 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info("TransferClient.get_endpoint_role({}, {}, ...)"
+        self.logger.info("TransferClient.get_endpoint_role({0}, {1}, ...)"
                          .format(endpoint_id, role_id))
         path = self.qjoin_path('endpoint', endpoint_id, 'role', role_id)
         return self.get(path, params=params)
@@ -672,7 +674,7 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info("TransferClient.delete_endpoint_role({}, {})"
+        self.logger.info("TransferClient.delete_endpoint_role({0}, {1})"
                          .format(endpoint_id, role_id))
         path = self.qjoin_path('endpoint', endpoint_id, 'role', role_id)
         return self.delete(path)
@@ -696,7 +698,7 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info("TransferClient.endpoint_acl_list({}, ...)"
+        self.logger.info("TransferClient.endpoint_acl_list({0}, ...)"
                          .format(endpoint_id))
         path = self.qjoin_path('endpoint', endpoint_id, 'access_list')
         return self.get(path, params=params,
@@ -717,7 +719,7 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info("TransferClient.get_endpoint_acl_rule({}, {}, ...)"
+        self.logger.info("TransferClient.get_endpoint_acl_rule({0}, {1}, ...)"
                          .format(endpoint_id, rule_id))
         path = self.qjoin_path('endpoint', endpoint_id, 'access', rule_id)
         return self.get(path, params=params)
@@ -761,7 +763,7 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info("TransferClient.add_endpoint_acl_rule({}, ...)"
+        self.logger.info("TransferClient.add_endpoint_acl_rule({0}, ...)"
                          .format(endpoint_id))
         path = self.qjoin_path('endpoint', endpoint_id, 'access')
         return self.post(path, rule_data)
@@ -781,8 +783,9 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info("TransferClient.update_endpoint_acl_rule({}, {}, ...)"
-                         .format(endpoint_id, rule_id))
+        self.logger.info(
+            "TransferClient.update_endpoint_acl_rule({0}, {1}, ...)"
+            .format(endpoint_id, rule_id))
         path = self.qjoin_path('endpoint', endpoint_id, 'access', rule_id)
         return self.put(path, rule_data)
 
@@ -801,7 +804,7 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info("TransferClient.delete_endpoint_acl_rule({}, {})"
+        self.logger.info("TransferClient.delete_endpoint_acl_rule({0}, {1})"
                          .format(endpoint_id, rule_id))
         path = self.qjoin_path('endpoint', endpoint_id, 'access', rule_id)
         return self.delete(path)
@@ -824,7 +827,7 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/endpoint_bookmarks/#get_list_of_bookmarks>`_
         in the REST documentation for details.
         """
-        self.logger.info("TransferClient.bookmark_list({})".format(params))
+        self.logger.info("TransferClient.bookmark_list({0})".format(params))
         return self.get('bookmark_list', params=params,
                         response_class=IterableTransferResponse)
 
@@ -842,7 +845,7 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/endpoint_bookmarks/#create_bookmark>`_
         in the REST documentation for details.
         """
-        self.logger.info("TransferClient.create_bookmark({})"
+        self.logger.info("TransferClient.create_bookmark({0})"
                          .format(bookmark_data))
         return self.post('bookmark', bookmark_data)
 
@@ -861,7 +864,8 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         bookmark_id = safe_stringify(bookmark_id)
-        self.logger.info("TransferClient.get_bookmark({})".format(bookmark_id))
+        self.logger.info("TransferClient.get_bookmark({0})"
+                         .format(bookmark_id))
         path = self.qjoin_path('bookmark', bookmark_id)
         return self.get(path, params=params)
 
@@ -879,7 +883,7 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/endpoint_bookmarks/#update_bookmark>`_
         in the REST documentation for details.
         """
-        self.logger.info("TransferClient.update_bookmark({})"
+        self.logger.info("TransferClient.update_bookmark({0})"
                          .format(bookmark_id))
         path = self.qjoin_path('bookmark', bookmark_id)
         return self.put(path, bookmark_data)
@@ -898,7 +902,7 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/endpoint_bookmarks/#delete_bookmark_by_id>`_
         in the REST documentation for details.
         """
-        self.logger.info("TransferClient.delete_bookmark({})"
+        self.logger.info("TransferClient.delete_bookmark({0})"
                          .format(bookmark_id))
         path = self.qjoin_path('bookmark', bookmark_id)
         return self.delete(path)
@@ -928,7 +932,7 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info("TransferClient.operation_ls({}, {})"
+        self.logger.info("TransferClient.operation_ls({0}, {1})"
                          .format(endpoint_id, params))
         path = self.qjoin_path("operation/endpoint", endpoint_id, "ls")
         return self.get(path, params=params,
@@ -955,7 +959,7 @@ class TransferClient(BaseClient):
         """
         endpoint_id = safe_stringify(endpoint_id)
         path = safe_stringify(path)
-        self.logger.info("TransferClient.operation_mkdir({}, {}, {})"
+        self.logger.info("TransferClient.operation_mkdir({0}, {1}, {2})"
                          .format(endpoint_id, path, params))
         resource_path = self.qjoin_path("operation/endpoint", endpoint_id,
                                         "mkdir")
@@ -988,7 +992,7 @@ class TransferClient(BaseClient):
         endpoint_id = safe_stringify(endpoint_id)
         oldpath = safe_stringify(oldpath)
         newpath = safe_stringify(newpath)
-        self.logger.info("TransferClient.operation_rename({}, {}, {}, {})"
+        self.logger.info("TransferClient.operation_rename({0}, {1}, {2}, {3})"
                          .format(endpoint_id, oldpath, newpath, params))
         resource_path = self.qjoin_path("operation/endpoint", endpoint_id,
                                         "rename")
@@ -1025,7 +1029,7 @@ class TransferClient(BaseClient):
         endpoint_id = safe_stringify(endpoint_id)
         symlink_target = safe_stringify(symlink_target)
         path = safe_stringify(path)
-        self.logger.info("TransferClient.operation_symlink({}, {}, {}, {})"
+        self.logger.info("TransferClient.operation_symlink({0}, {1}, {2}, {3})"
                          .format(endpoint_id, symlink_target, path, params))
         resource_path = self.qjoin_path("operation/endpoint", endpoint_id,
                                         "symlink")
@@ -1063,7 +1067,8 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/task_submit/#get_submission_id>`_
         in the REST documentation for more details.
         """
-        self.logger.info("TransferClient.get_submission_id({})".format(params))
+        self.logger.info("TransferClient.get_submission_id({0})"
+                         .format(params))
         return self.get("submission_id", params=params)
 
     def submit_transfer(self, data):
@@ -1160,7 +1165,7 @@ class TransferClient(BaseClient):
 
         >>> tc = TransferClient(...)
         >>> for task in tc.task_list():
-        >>>     print("Task({}): {} -> {}".format(
+        >>>     print("Task({0}): {1} -> {2}".format(
         >>>         task["task_id"], task["source_endpoint"],
         >>>         task["destination_endpoint"))
 
@@ -1208,7 +1213,7 @@ class TransferClient(BaseClient):
         >>> tc = TransferClient(...)
         >>> task_id = ...
         >>> for event in tc.task_event_list(task_id):
-        >>>     print("Event on Task({}) at {}:\n{}".format(
+        >>>     print("Event on Task({0}) at {1}:\n{2}".format(
         >>>         task_id, event["time"], event["description"])
 
         **External Documentation**
@@ -1218,7 +1223,7 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/task/#get_event_list>`_
         in the REST documentation for details.
         """
-        self.logger.info("TransferClient.task_event_list({}, ...)"
+        self.logger.info("TransferClient.task_event_list({0}, ...)"
                          .format(task_id))
         path = self.qjoin_path('task', task_id, 'event_list')
         return PaginatedResource(
@@ -1240,7 +1245,7 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/task/#get_task_by_id>`_
         in the REST documentation for details.
         """
-        self.logger.info("TransferClient.get_task({}, ...)".format(task_id))
+        self.logger.info("TransferClient.get_task({0}, ...)".format(task_id))
         resource_path = self.qjoin_path("task", task_id)
         return self.get(resource_path, params=params)
 
@@ -1258,7 +1263,8 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/task/#update_task_by_id>`_
         in the REST documentation for details.
         """
-        self.logger.info("TransferClient.update_task({}, ...)".format(task_id))
+        self.logger.info("TransferClient.update_task({0}, ...)"
+                         .format(task_id))
         resource_path = self.qjoin_path("task", task_id)
         return self.put(resource_path, data, params=params)
 
@@ -1276,7 +1282,7 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/task/#cancel_task_by_id>`_
         in the REST documentation for details.
         """
-        self.logger.info("TransferClient.cancel_task({})".format(task_id))
+        self.logger.info("TransferClient.cancel_task({0})".format(task_id))
         resource_path = self.qjoin_path("task", task_id, "cancel")
         return self.post(resource_path)
 
@@ -1327,19 +1333,19 @@ class TransferClient(BaseClient):
         >>>     print(".", end="")
         >>> print("\n{0} completed!".format(task_id))
         """
-        self.logger.info("TransferClient.task_wait({}, {}, {})"
+        self.logger.info("TransferClient.task_wait({0}, {1}, {2})"
                          .format(task_id, timeout, polling_interval))
 
         # check valid args
         if timeout < 1:
             self.logger.error(
-                "task_wait() timeout={} is less than minimum of 1s"
+                "task_wait() timeout={0} is less than minimum of 1s"
                 .format(timeout))
             raise exc.GlobusSDKUsageError(
                 "TransferClient.task_wait timeout has a minimum of 1")
         if polling_interval < 1:
             self.logger.error(
-                "task_wait() polling_interval={} is less than minimum of 1s"
+                "task_wait() polling_interval={0} is less than minimum of 1s"
                 .format(polling_interval))
             raise exc.GlobusSDKUsageError(
                 "TransferClient.task_wait polling_interval has a minimum of 1")
@@ -1362,7 +1368,7 @@ class TransferClient(BaseClient):
             status = task['status']
             if status != 'ACTIVE':
                 self.logger.debug(
-                    "task_wait(task_id={}) terminated with status={}"
+                    "task_wait(task_id={0}) terminated with status={1}"
                     .format(task_id, status))
                 return True
 
@@ -1371,11 +1377,11 @@ class TransferClient(BaseClient):
             waited_time += polling_interval
             if timed_out(waited_time):
                 self.logger.debug(
-                    "task_wait(task_id={}) timed out".format(task_id))
+                    "task_wait(task_id={0}) timed out".format(task_id))
                 return False
 
             self.logger.debug(
-                "task_wait(task_id={}) waiting {}s"
+                "task_wait(task_id={0}) waiting {1}s"
                 .format(task_id, polling_interval))
             time.sleep(polling_interval)
         # unreachable -- end of task_wait
@@ -1394,7 +1400,7 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/task/#get_task_pause_info>`_
         in the REST documentation for details.
         """
-        self.logger.info("TransferClient.task_pause_info({}, ...)"
+        self.logger.info("TransferClient.task_pause_info({0}, ...)"
                          .format(task_id))
         resource_path = self.qjoin_path("task", task_id, "pause_info")
         return self.get(resource_path, params=params)
@@ -1431,7 +1437,7 @@ class TransferClient(BaseClient):
         >>> tc = TransferClient(...)
         >>> task_id = ...
         >>> for info in tc.task_successful_transfers(task_id):
-        >>>     print("{} -> {}".format(
+        >>>     print("{0} -> {1}".format(
         >>>         info["source_path"], info["destination_path"))
 
         **External Documentation**
@@ -1441,7 +1447,7 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/task/#get_task_successful_transfers>`_
         in the REST documentation for details.
         """
-        self.logger.info("TransferClient.task_successful_transfers({}, ...)"
+        self.logger.info("TransferClient.task_successful_transfers({0}, ...)"
                          .format(task_id))
 
         resource_path = self.qjoin_path("task", task_id,
@@ -1470,7 +1476,7 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         self.logger.info(
-            "TransferClient.endpoint_manager_monitored_endpoints({})"
+            "TransferClient.endpoint_manager_monitored_endpoints({0})"
             .format(params))
         path = self.qjoin_path('endpoint_manager', 'monitored_endpoints')
         return self.get(path, params=params,
@@ -1492,7 +1498,7 @@ class TransferClient(BaseClient):
         """
         endpoint_id = safe_stringify(endpoint_id)
         self.logger.info(("TransferClient.endpoint_manager_"
-                          "hosted_endpoint_list({})".format(endpoint_id)))
+                          "hosted_endpoint_list({0})".format(endpoint_id)))
         path = self.qjoin_path("endpoint_manager", "endpoint",
                                endpoint_id, "hosted_endpoint_list")
         return self.get(path, params=params,
@@ -1516,7 +1522,7 @@ class TransferClient(BaseClient):
         """
         endpoint_id = safe_stringify(endpoint_id)
         self.logger.info(("TransferClient.endpoint_manager_"
-                          "get_endpoint({})".format(endpoint_id)))
+                          "get_endpoint({0})".format(endpoint_id)))
         path = self.qjoin_path("endpoint_manager", "endpoint", endpoint_id)
         return self.get(path, params=params)
 
@@ -1538,7 +1544,7 @@ class TransferClient(BaseClient):
         """
         endpoint_id = safe_stringify(endpoint_id)
         self.logger.info(("TransferClient.endpoint_manager_"
-                          "endpoint_acl_list({}, ...)".format(endpoint_id)))
+                          "endpoint_acl_list({0}, ...)".format(endpoint_id)))
         path = self.qjoin_path("endpoint_manager", "endpoint",
                                endpoint_id, "access_list")
         return self.get(path, params=params,
@@ -1576,18 +1582,18 @@ class TransferClient(BaseClient):
 
         >>> tc = TransferClient(...)
         >>> for task in tc.endpoint_manager_task_list():
-        >>>     print("Task({}): {} -> {}\n  was submitted by\n  {}".format(
-        >>>         task["task_id"], task["source_endpoint"],
-        >>>         task["destination_endpoint"), task["owner_string"])
+        >>>     print("Task({0}): {1} -> {2}\n  was submitted by\n  {3}"
+        >>>         .format(task["task_id"], task["source_endpoint"],
+        >>>                 task["destination_endpoint"), task["owner_string"])
 
         Do that same operation on *all* tasks visible via ``activity_monitor``
         status:
 
         >>> tc = TransferClient(...)
         >>> for task in tc.endpoint_manager_task_list(num_results=None):
-        >>>     print("Task({}): {} -> {}\n  was submitted by\n  {}".format(
-        >>>         task["task_id"], task["source_endpoint"],
-        >>>         task["destination_endpoint"), task["owner_string"])
+        >>>     print("Task({0}): {1} -> {2}\n  was submitted by\n  {3}"
+        >>>         .format(task["task_id"], task["source_endpoint"],
+        >>>                 task["destination_endpoint"), task["owner_string"])
 
         **External Documentation**
 
@@ -1622,7 +1628,7 @@ class TransferClient(BaseClient):
         """
         task_id = safe_stringify(task_id)
         self.logger.info(("TransferClient.endpoint_manager_"
-                          "get_task({}, ...)".format(task_id)))
+                          "get_task({0}, ...)".format(task_id)))
         path = self.qjoin_path("endpoint_manager", "task", task_id)
         return self.get(path, params=params)
 
@@ -1662,7 +1668,7 @@ class TransferClient(BaseClient):
         """
         task_id = safe_stringify(task_id)
         self.logger.info(("TransferClient.endpoint_manager_"
-                          "task_event_list({}, ...)".format(task_id)))
+                          "task_event_list({0}, ...)".format(task_id)))
         path = self.qjoin_path("endpoint_manager", "task",
                                task_id, "event_list")
         return PaginatedResource(
@@ -1689,7 +1695,7 @@ class TransferClient(BaseClient):
         """
         task_id = safe_stringify(task_id)
         self.logger.info(("TransferClient.endpoint_manager_"
-                         "task_pause_info({}, ...)".format(task_id)))
+                         "task_pause_info({0}, ...)".format(task_id)))
         path = self.qjoin_path("endpoint_manager", "task",
                                task_id, "pause_info")
         return self.get(path, params=params)
@@ -1729,7 +1735,7 @@ class TransferClient(BaseClient):
         """
         task_id = safe_stringify(task_id)
         self.logger.info(("TransferClient.endpoint_manager_task_"
-                          "successful_transfers({}, ...)".format(task_id)))
+                          "successful_transfers({0}, ...)".format(task_id)))
 
         resource_path = self.qjoin_path("endpoint_manager", "task", task_id,
                                         "successful_transfers")
@@ -1769,7 +1775,7 @@ class TransferClient(BaseClient):
         task_ids = [safe_stringify(i) for i in task_ids]
         message = safe_stringify(message)
         self.logger.info(("TransferClient.endpoint_manager_"
-                          "cancel_tasks({},{})".format(task_ids, message)))
+                          "cancel_tasks({0},{1})".format(task_ids, message)))
         json_body = {
             "message": safe_stringify(message),
             "task_id_list": task_ids
@@ -1803,7 +1809,7 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         self.logger.info(("TransferClient.endpoint_manager_"
-                          "cancel_status({})".format(admin_cancel_id)))
+                          "cancel_status({0})".format(admin_cancel_id)))
         path = self.qjoin_path("endpoint_manager", "admin_cancel",
                                admin_cancel_id)
         return self.get(path, params=params)
@@ -1839,7 +1845,7 @@ class TransferClient(BaseClient):
         task_ids = [safe_stringify(i) for i in task_ids]
         message = safe_stringify(message)
         self.logger.info(("TransferClient.endpoint_manager_"
-                          "pause_tasks({},{})".format(task_ids, message)))
+                          "pause_tasks({0},{1})".format(task_ids, message)))
         json_body = {
             "message": safe_stringify(message),
             "task_id_list": task_ids
@@ -1874,7 +1880,7 @@ class TransferClient(BaseClient):
         """
         task_ids = [safe_stringify(i) for i in task_ids]
         self.logger.info(("TransferClient.endpoint_manager_"
-                          "resume_tasks({})".format(task_ids)))
+                          "resume_tasks({0})".format(task_ids)))
         json_body = {
             "task_id_list": task_ids
         }
@@ -1984,7 +1990,7 @@ class TransferClient(BaseClient):
         """
         pause_rule_id = safe_stringify(pause_rule_id)
         self.logger.info(("TransferClient.endpoint_manager_"
-                          "get_pause_rule({})".format(pause_rule_id)))
+                          "get_pause_rule({0})".format(pause_rule_id)))
         path = self.qjoin_path("endpoint_manager", "pause_rule", pause_rule_id)
         return self.get(path, params=params)
 
@@ -2018,7 +2024,7 @@ class TransferClient(BaseClient):
         """
         pause_rule_id = safe_stringify(pause_rule_id)
         self.logger.info(("TransferClient.endpoint_manager_"
-                          "update_pause_rule({})".format(pause_rule_id)))
+                          "update_pause_rule({0})".format(pause_rule_id)))
         path = self.qjoin_path("endpoint_manager", "pause_rule", pause_rule_id)
         return self.put(path, data)
 
@@ -2050,6 +2056,6 @@ class TransferClient(BaseClient):
         """
         pause_rule_id = safe_stringify(pause_rule_id)
         self.logger.info(("TransferClient.endpoint_manager_"
-                          "delete_pause_rule({})".format(pause_rule_id)))
+                          "delete_pause_rule({0})".format(pause_rule_id)))
         path = self.qjoin_path("endpoint_manager", "pause_rule", pause_rule_id)
         return self.delete(path, params=params)

--- a/globus_sdk/transfer/data.py
+++ b/globus_sdk/transfer/data.py
@@ -103,34 +103,34 @@ class TransferData(dict):
         self["DATA_TYPE"] = "transfer"
         self["submission_id"] = submission_id or \
             transfer_client.get_submission_id()["value"]
-        logger.info("TransferData.submission_id = {}"
+        logger.info("TransferData.submission_id = {0}"
                     .format(self["submission_id"]))
         self["source_endpoint"] = source_endpoint
-        logger.info("TransferData.source_endpoint = {}"
+        logger.info("TransferData.source_endpoint = {0}"
                     .format(source_endpoint))
         self["destination_endpoint"] = destination_endpoint
-        logger.info("TransferData.destination_endpoint = {}"
+        logger.info("TransferData.destination_endpoint = {0}"
                     .format(destination_endpoint))
         self["verify_checksum"] = verify_checksum
-        logger.info("TransferData.verify_checksum = {}"
+        logger.info("TransferData.verify_checksum = {0}"
                     .format(verify_checksum))
         self["preserve_timestamp"] = preserve_timestamp
-        logger.info("TransferData.preserve_timestamp = {}"
+        logger.info("TransferData.preserve_timestamp = {0}"
                     .format(preserve_timestamp))
         self["encrypt_data"] = encrypt_data
-        logger.info("TransferData.encrypt_data = {}"
+        logger.info("TransferData.encrypt_data = {0}"
                     .format(encrypt_data))
         self["recursive_symlinks"] = recursive_symlinks
-        logger.info("TransferData.recursive_symlinks = {}"
+        logger.info("TransferData.recursive_symlinks = {0}"
                     .format(recursive_symlinks))
 
         if label is not None:
             self["label"] = label
-            logger.debug("TransferData.label = {}".format(label))
+            logger.debug("TransferData.label = {0}".format(label))
 
         if deadline is not None:
             self["deadline"] = str(deadline)
-            logger.debug("TransferData.deadline = {}".format(deadline))
+            logger.debug("TransferData.deadline = {0}".format(deadline))
 
         # map the sync_level (if it's a nice string) to one of the known int
         # values
@@ -141,14 +141,14 @@ class TransferData(dict):
         if sync_level is not None:
             sync_dict = {"exists": 0, "size": 1, "mtime": 2, "checksum": 3}
             self['sync_level'] = sync_dict.get(sync_level, sync_level)
-            logger.info("TransferData.sync_level = {} ({})"
+            logger.info("TransferData.sync_level = {0} ({1})"
                         .format(self['sync_level'], sync_level))
 
         self["DATA"] = []
 
         self.update(kwargs)
         for option, value in kwargs.items():
-            logger.info("TransferData.{} = {} (option passed in via kwargs)"
+            logger.info("TransferData.{0} = {1} (option passed in via kwargs)"
                         .format(option, value))
 
     def add_item(self, source_path, destination_path, recursive=False):
@@ -168,7 +168,7 @@ class TransferData(dict):
             "destination_path": destination_path,
             "recursive": recursive,
         }
-        logger.debug('TransferData[{}, {}].add_item: "{}"->"{}"'
+        logger.debug('TransferData[{0}, {1}].add_item: "{2}"->"{3}"'
                      .format(self["source_endpoint"],
                              self["destination_endpoint"],
                              source_path, destination_path))
@@ -189,7 +189,7 @@ class TransferData(dict):
             "source_path": source_path,
             "destination_path": destination_path,
         }
-        logger.debug('TransferData[{}, {}].add_symlink_item: "{}"->"{}"'
+        logger.debug('TransferData[{0}, {1}].add_symlink_item: "{2}"->"{3}"'
                      .format(self["source_endpoint"],
                              self["destination_endpoint"],
                              source_path, destination_path))
@@ -254,28 +254,28 @@ class DeleteData(dict):
         self["DATA_TYPE"] = "delete"
         self["submission_id"] = submission_id or \
             transfer_client.get_submission_id()["value"]
-        logger.info("DeleteData.submission_id = {}"
+        logger.info("DeleteData.submission_id = {0}"
                     .format(self["submission_id"]))
         self["endpoint"] = endpoint
-        logger.info("DeleteData.endpoint = {}"
+        logger.info("DeleteData.endpoint = {0}"
                     .format(endpoint))
         self["recursive"] = recursive
-        logger.info("DeleteData.recursive = {}"
+        logger.info("DeleteData.recursive = {0}"
                     .format(recursive))
 
         if label is not None:
             self["label"] = label
-            logger.debug("DeleteData.label = {}".format(label))
+            logger.debug("DeleteData.label = {0}".format(label))
 
         if deadline is not None:
             self["deadline"] = str(deadline)
-            logger.debug("DeleteData.deadline = {}".format(deadline))
+            logger.debug("DeleteData.deadline = {0}".format(deadline))
 
         self["DATA"] = []
 
         self.update(kwargs)
         for option, value in kwargs.items():
-            logger.info("DeleteData.{} = {} (option passed in via kwargs)"
+            logger.info("DeleteData.{0} = {1} (option passed in via kwargs)"
                         .format(option, value))
 
     def add_item(self, path):
@@ -292,6 +292,6 @@ class DeleteData(dict):
             "DATA_TYPE": "delete_item",
             "path": path,
         }
-        logger.debug('DeleteData[{}].add_item: "{}"'
+        logger.debug('DeleteData[{0}].add_item: "{1}"'
                      .format(self["endpoint"], path))
         self["DATA"].append(item_data)

--- a/globus_sdk/transfer/paging.py
+++ b/globus_sdk/transfer/paging.py
@@ -113,11 +113,12 @@ class PaginatedResource(GlobusResponse, six.Iterator):
             An value from an enum on this class which tells us how paging works
             for this API.
         """
-        logger.info("Creating PaginatedResource({}) on {}(instance:{}):{}:{}"
-                    .format(paging_style,
-                            client_method.__self__.__class__.__name__,
-                            id(client_method.__self__),
-                            client_method.__name__, path))
+        logger.info(
+            "Creating PaginatedResource({0}) on {1}(instance:{2}):{3}:{4}"
+            .format(paging_style,
+                    client_method.__self__.__class__.__name__,
+                    id(client_method.__self__),
+                    client_method.__name__, path))
         self.max_results_per_call = max_results_per_call
         self.max_total_results = max_total_results
         self.offset = offset
@@ -288,7 +289,7 @@ class PaginatedResource(GlobusResponse, six.Iterator):
             if self.paging_style == self.PAGING_STYLE_TOTAL:
                 return self.offset < res['total']
 
-            logger.error("PaginatedResource.paging_style={} is invalid"
+            logger.error("PaginatedResource.paging_style={0} is invalid"
                          .format(self.paging_style))
             raise GlobusSDKUsageError(
                 'Invalid Paging Style Given to PaginatedResource')

--- a/globus_sdk/transfer/response/activation.py
+++ b/globus_sdk/transfer/response/activation.py
@@ -45,7 +45,7 @@ class ActivationRequirementsResponse(TransferResponse):
         >>>     # use `from __future__ import print_function` in py2
         >>>     print(("This endpoint requires web activation. "
         >>>            "Please login and activate the endpoint here:\n"
-        >>>            "https://www.globus.org/app/endpoints/{}/activate")
+        >>>            "https://www.globus.org/app/endpoints/{0}/activate")
         >>>           .format(endpoint_id), file=sys.stderr)
         >>>     # py3 calls it `input()` in py2, use `raw_input()`
         >>>     input("Please Hit Enter When You Are Done")

--- a/tests/manual_tools/clean_sdk_test_assets.py
+++ b/tests/manual_tools/clean_sdk_test_assets.py
@@ -22,7 +22,7 @@ def clean():
     client.oauth2_start_flow(requested_scopes=SCOPES)
     url = client.oauth2_get_authorize_url()
 
-    print("Login with SDK Tester: \n{}".format(url))
+    print("Login with SDK Tester: \n{0}".format(url))
     auth_code = get_input("Enter auth code: ").strip()
 
     # get tokens and make a transfer client
@@ -57,7 +57,7 @@ def clean():
         r = tc.operation_ls(ep_id)
         for item in r:
             ddata.add_item("/~/" + item["name"])
-            print("deleting {}: {}".format(item["type"], item["name"]))
+            print("deleting {0}: {1}".format(item["type"], item["name"]))
             file_deletions += 1
         if len(ddata["DATA"]):
             r = tc.submit_delete(ddata)
@@ -68,7 +68,7 @@ def clean():
     r = tc.bookmark_list()
     for bookmark in r:
         tc.delete_bookmark(bookmark["id"])
-        print("deleting bookmark: {}".format(bookmark["name"]))
+        print("deleting bookmark: {0}".format(bookmark["name"]))
         bookmark_deletions += 1
 
     # clean endpoints owned by SDK Tester
@@ -79,7 +79,7 @@ def clean():
         r = tc.endpoint_search(filter_scope="my-endpoints", num_results=None)
         for ep in r:
             tc.delete_endpoint(ep["id"])
-            print("deleting endpoint: {}".format(ep["display_name"]))
+            print("deleting endpoint: {0}".format(ep["display_name"]))
             endpoint_deletions += 1
             cleaning = True
 
@@ -87,9 +87,9 @@ def clean():
     for task_id in task_ids:
         tc.task_wait(task_id, polling_interval=1)
 
-    print("{} files or folders cleaned".format(file_deletions))
-    print("{} endpoints cleaned".format(endpoint_deletions))
-    print("{} bookmarks cleaned".format(bookmark_deletions))
+    print("{0} files or folders cleaned".format(file_deletions))
+    print("{0} endpoints cleaned".format(endpoint_deletions))
+    print("{0} bookmarks cleaned".format(bookmark_deletions))
 
 
 if __name__ == "__main__":

--- a/tests/manual_tools/login_native_app1.py
+++ b/tests/manual_tools/login_native_app1.py
@@ -15,7 +15,7 @@ client.oauth2_start_flow(requested_scopes=SCOPES,
                          refresh_tokens=True)
 url = client.oauth2_get_authorize_url()
 
-print("Native App Authorization URL: \n{}".format(url))
+print("Native App Authorization URL: \n{0}".format(url))
 auth_code = get_input("Enter the auth code: ").strip()
 
 token_res = client.oauth2_exchange_code_for_tokens(auth_code)
@@ -26,7 +26,7 @@ auth_token = tokens["auth.globus.org"]["refresh_token"]
 id_token = token_res["id_token"]
 access_token = token_res["access_token"]
 
-print("Transfer Refresh Token: {}".format(transfer_token))
-print("Auth Refresh Token    : {}".format(auth_token))
-print("Openid id_token       : {}".format(id_token))
-print("Access Token          : {}".format(access_token))
+print("Transfer Refresh Token: {0}".format(transfer_token))
+print("Auth Refresh Token    : {0}".format(auth_token))
+print("Openid id_token       : {0}".format(id_token))
+print("Access Token          : {0}".format(access_token))

--- a/tests/unit/test_base_client.py
+++ b/tests/unit/test_base_client.py
@@ -68,7 +68,7 @@ class BaseClientTests(CapturedIOTestCase):
         self.bc.logger.info(in_msg)
         # confirm results
         out_msg = memory_handler.buffer[0].getMessage()
-        expected_msg = "[instance:{}] {}".format(id(self.bc), in_msg)
+        expected_msg = "[instance:{0}] {1}".format(id(self.bc), in_msg)
         self.assertEqual(expected_msg, out_msg)
 
         memory_handler.close()

--- a/tests/unit/test_imports.py
+++ b/tests/unit/test_imports.py
@@ -18,7 +18,7 @@ class TestImports(unittest.TestCase):
     """
 
     def _check_import_str(self, s):
-        proc = subprocess.Popen('{} -c "{}"'.format(PYTHON_BINARY, s),
+        proc = subprocess.Popen('{0} -c "{1}"'.format(PYTHON_BINARY, s),
                                 shell=True, stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE)
         status = proc.wait()


### PR DESCRIPTION
This makes the module usable with python 2.6.9 as found eg on Blue Waters. 

There are basically two changes:

1. I need to use `{0}` and `{1}` etc. in all string.format() calls and cannot use just `{}`
2. `logging.NullHandler` does not yet exist so I have to provide a substitute