### PR TITLE
Make clients safe(r) to un/pickle

### DIFF
--- a/globus_sdk/base.py
+++ b/globus_sdk/base.py
@@ -63,11 +63,7 @@ class BaseClient(object):
                  base_path=None, authorizer=None, app_name=None,
                  http_timeout=None,
                  *args, **kwargs):
-        # get the fully qualified name of the client class, so that it's a
-        # child of globus_sdk
-        self.logger = ClientLogAdapter(
-            logging.getLogger(self.__module__ + '.' + self.__class__.__name__),
-            {'client': self})
+        self._init_logger_adapter()
         self.logger.info('Creating client of type {} for service "{}"'
                          .format(type(self), service))
         # if restrictions have been placed by a child class on the allowed
@@ -124,6 +120,40 @@ class BaseClient(object):
         self.app_name = None
         if app_name is not None:
             self.set_app_name(app_name)
+
+    def _init_logger_adapter(self):
+        """
+        Create & assign the self.logger LoggerAdapter
+        Used when initializing a new client, or unpickling.
+
+        Technically, this could result in a state change across a
+        pickle/unpickle -- file handles and other handlers could be detached,
+        etc.
+        However, that's better than a hard-fail on pickle.dump(s) calls.
+
+        Also, so long as loggers are attached at the module level -- as they
+        really ought to be -- everything will be fine.
+        """
+        # get the fully qualified name of the client class, so that it's a
+        # child of globus_sdk
+        self.logger = ClientLogAdapter(
+            logging.getLogger(self.__module__ + '.' + self.__class__.__name__),
+            {'client': self})
+
+    def __getstate__(self):
+        """
+        Render to a serializable dict for pickle.dump(s)
+        """
+        d = dict(self.__dict__)  # copy
+        del d['logger']
+        return d
+
+    def __setstate__(self, d):
+        """
+        Load from a serialized format, as in pickle.load(s)
+        """
+        self._init_logger_adapter()
+        self.__dict__.update(d)
 
     def set_app_name(self, app_name):
         """

--- a/globus_sdk/base.py
+++ b/globus_sdk/base.py
@@ -144,6 +144,7 @@ class BaseClient(object):
         """
         Render to a serializable dict for pickle.dump(s)
         """
+        self.logger.info('__getstate__() called; client being pickled')
         d = dict(self.__dict__)  # copy
         del d['logger']
         return d
@@ -154,6 +155,7 @@ class BaseClient(object):
         """
         self._init_logger_adapter()
         self.__dict__.update(d)
+        self.logger.info('__setstate__() finished; client unpickled')
 
     def set_app_name(self, app_name):
         """

--- a/tests/integration/test_token_response_pickleability.py
+++ b/tests/integration/test_token_response_pickleability.py
@@ -1,0 +1,79 @@
+import logging
+import os
+import pickle
+import tempfile
+
+import globus_sdk
+from tests.framework import (CapturedIOTestCase,
+                             get_client_data, GO_EP1_ID,
+                             SDKTESTER1A_NATIVE1_TRANSFER_RT,
+                             retry_errors)
+
+
+class RefreshTokenResponsePickleTests(CapturedIOTestCase):
+
+    def setUp(self):
+        """
+        Do a refresh_token grant token call to get token responses, test with
+        those results that.
+        """
+        super(RefreshTokenResponsePickleTests, self).setUp()
+
+        client_id = get_client_data()["native_app_client1"]["id"]
+        form_data = {'refresh_token': SDKTESTER1A_NATIVE1_TRANSFER_RT,
+                     'grant_type': 'refresh_token',
+                     'client_id': client_id}
+        self.ac = globus_sdk.AuthClient()
+        # add a logger with an open file handle to ensure that the client
+        # cannot be pickled -- this is the common way that pickleability is
+        # broken
+        # also, this looks odd -- logger.logger -- but it's correct, "logger"
+        # is what we named our LoggerAdapter, and "logger" is the name of the
+        # underlying logger object on a LoggerAdapter
+        tmplog_handle, self.tmplog = tempfile.mkstemp()
+        self.ac.logger.logger.addHandler(logging.FileHandler(self.tmplog))
+        self.token_response = self.ac.oauth2_token(form_data)
+
+    def tearDown(self):
+        """
+        Clean up the temp log file
+        """
+        try:
+            os.remove(self.tmplog)
+        except OSError:
+            pass
+
+    def mint_new_transfer_client(self, response=None):
+        response = response or self.token_response
+
+        access_token = response.by_resource_server[
+            'transfer.api.globus.org']['access_token']
+
+        authorizer = globus_sdk.AccessTokenAuthorizer(access_token)
+        return globus_sdk.TransferClient(authorizer=authorizer)
+
+    def test_pickle_and_unpickle_no_usage(self):
+        """
+        Test pickle and unpickle, with no usage of the result,
+        for all pickle protocol versions supported by the current interpreter.
+        """
+        pickled_versions = [pickle.dumps(self.token_response, protocol=n)
+                            for n in range(pickle.HIGHEST_PROTOCOL + 1)]
+        unpickled_versions = [pickle.loads(x) for x in pickled_versions]
+        for x in unpickled_versions:
+            self.assertDictEqual(x.by_resource_server,
+                                 self.token_response.by_resource_server)
+
+    @retry_errors()
+    def test_pickle_unpickle_and_ls(self):
+        """
+        Pickle a response, unpickle it, use it to build an authorizer and do an
+        `ls`, verify against the "straight" version which builds the authorizer
+        without a pickle/unpickle pass
+        """
+        sour_tc = self.mint_new_transfer_client(
+            response=pickle.loads(pickle.dumps(self.token_response)))
+
+        # confirm the resulting client still works!
+        get_res = sour_tc.get_endpoint(GO_EP1_ID)
+        self.assertEqual(get_res["id"], GO_EP1_ID)


### PR DESCRIPTION
A response should be safe to pickle and unpickle, thus guaranteeing that we have some ready mode of support for simple caching of response objects. Users can, of course, add attributes and break this themselves, but that's not supported usage.

Pickling responses is currently often unsafe, as the client object referenced by a response object has a logger attached to it with open file handles (which themselves cannot be pickled, obviously).

To resolve, implement `__getstate__` and `__setstate__` which scrub and recreate the LoggerAdapter used by client objects. This isn't quite the same as preserving that object -- it could have handlers and other data directly attached to it which will be lost/reinitialized -- but it is close.

So long as the logger isn't being directly modified by a user, this will continue to work. If it is modified, there's not much we can do.

Closes #280

I don't think we need to make pickleability part of the publicly documented interface for the SDK's various objects, but taking small efforts to support it where possible seems reasonable.