### PR TITLE
Improve docs by listing methods of clients

### DIFF
--- a/docs/_templates/globaltoc.html
+++ b/docs/_templates/globaltoc.html
@@ -1,0 +1,13 @@
+<div class="sidebar-block">
+  <div class="sidebar-wrapper">
+    <h2>{{ _('Table Of Contents') }}</h2>
+  </div>
+  <div class="sidebar-toc">
+    {% set toctree = toctree(includehidden=True) %}
+    {% if toctree %}
+      {{ toctree }}
+    {% else %}
+      {{ toc }}
+    {% endif %}
+  </div>
+</div>

--- a/docs/clients.rst
+++ b/docs/clients.rst
@@ -26,8 +26,6 @@ very simply::
 .. rubric:: Client Types
 
 .. toctree::
-   :maxdepth: 1
-
    clients/transfer
    clients/auth
    clients/search

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -6,8 +6,6 @@ Globus SDK Examples
 Each of these pages contains an example of a piece of SDK functionality.
 
 .. toctree::
-   :maxdepth: 1
-
    examples/authorization
    examples/native_app
    examples/client_credentials

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,7 +20,7 @@ Source code is available at https://github.com/globus/globus-sdk-python.
 Table of Contents
 =================
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 3
 
    installation
    tutorial

--- a/docs/oauth.rst
+++ b/docs/oauth.rst
@@ -32,7 +32,5 @@ perform actions for **bar@example.com** on systems authenticated via Globus.
 .. rubric:: OAuth2 Documentation
 
 .. toctree::
-   :maxdepth: 1
-
    oauth/flows
    oauth/resource_servers

--- a/docs/optional_dependencies.rst
+++ b/docs/optional_dependencies.rst
@@ -1,7 +1,0 @@
-Optional Dependencies
-=====================
-
-The Globus SDK no longer has optional dependencies.
-
-If you are seeing an ``OptionalDependencyError``, please consider upgrading to
-the latest version of the SDK.

--- a/docs/responses.rst
+++ b/docs/responses.rst
@@ -26,7 +26,5 @@ Service-Specific Response Classes
 ---------------------------------
 
 .. toctree::
-   :maxdepth: 1
-
    responses/transfer
    responses/auth

--- a/globus_sdk/auth/client_types/base.py
+++ b/globus_sdk/auth/client_types/base.py
@@ -42,6 +42,18 @@ class AuthClient(BaseClient):
 
     You can, of course, use other kinds of Authorizers (notably the
     ``RefreshTokenAuthorizer``).
+
+    **Methods**
+
+    *  :py:meth:`.get_identities`
+    *  :py:meth:`.oauth2_get_authorize_url`
+    *  :py:meth:`.oauth2_exchange_code_for_tokens`
+    *  :py:meth:`.AuthClient.oauth2_refresh_token`
+    *  :py:meth:`.oauth2_validate_token`
+    *  :py:meth:`.oauth2_revoke_token`
+    *  :py:meth:`.oauth2_token`
+    *  :py:meth:`.oauth2_userinfo`
+
     """
     error_class = exc.AuthAPIError
 

--- a/globus_sdk/auth/client_types/confidential_client.py
+++ b/globus_sdk/auth/client_types/confidential_client.py
@@ -29,6 +29,14 @@ class ConfidentialAppAuthClient(AuthClient):
 
     Any keyword arguments given are passed through to the ``AuthClient``
     constructor.
+
+    **Methods**
+
+    *  :py:meth:`.oauth2_client_credentials_tokens`
+    *  :py:meth:`.ConfidentialAppAuthClient.oauth2_start_flow`
+    *  :py:meth:`.oauth2_get_dependent_tokens`
+    *  :py:meth:`.oauth2_token_introspect`
+
     """
     # checked by BaseClient to see what authorizers are allowed for this client
     # subclass

--- a/globus_sdk/auth/client_types/native_client.py
+++ b/globus_sdk/auth/client_types/native_client.py
@@ -21,6 +21,12 @@ class NativeAppAuthClient(AuthClient):
 
     Any keyword arguments given are passed through to the ``AuthClient``
     constructor.
+
+    **Methods**
+
+    *  :py:meth:`.NativeAppAuthClient.oauth2_start_flow`
+    *  :py:meth:`.NativeAppAuthClient.oauth2_refresh_token`
+
     """
     # don't allow any authorizer to be used on a native app client
     # it can't authorize it's calls, and shouldn't try to

--- a/globus_sdk/search/client.py
+++ b/globus_sdk/search/client.py
@@ -18,12 +18,26 @@ class SearchClient(BaseClient):
     API, and basic ``get``, ``put``, ``post``, and ``delete`` methods
     from the base client that can be used to access any API resource.
 
-    **Parameters**
+    :param authorizer: An authorizer instance used for all calls to
+                       Globus Search
+    :type authorizer: :class:`GlobusAuthorizer \
+                      <globus_sdk.authorizers.base.GlobusAuthorizer>`
 
-        ``authorizer`` (:class:`GlobusAuthorizer\
-        <globus_sdk.authorizers.base.GlobusAuthorizer>`)
+    **Methods**
 
-          An authorizer instance used for all calls to Globus Search
+    *  :py:meth:`.get_index`
+    *  :py:meth:`.search`
+    *  :py:meth:`.post_search`
+    *  :py:meth:`.ingest`
+    *  :py:meth:`.delete_by_query`
+    *  :py:meth:`.get_subject`
+    *  :py:meth:`.delete_subject`
+    *  :py:meth:`.get_entry`
+    *  :py:meth:`.create_entry`
+    *  :py:meth:`.update_entry`
+    *  :py:meth:`.delete_entry`
+    *  :py:meth:`.get_query_template`
+    *  :py:meth:`.get_query_template_list`
     """
     # disallow basic auth
     allowed_authorizer_types = [AccessTokenAuthorizer,

--- a/globus_sdk/transfer/client.py
+++ b/globus_sdk/transfer/client.py
@@ -40,12 +40,78 @@ class TransferClient(BaseClient):
     that allow arbitrary keyword arguments will pass the extra arguments as
     query parameters.
 
-    **Parameters**
+    :param authorizer: An authorizer instance used for all calls to
+                       Globus Transfer
+    :type authorizer: :class:`GlobusAuthorizer\
+                      <globus_sdk.authorizers.base.GlobusAuthorizer>`
 
-        ``authorizer`` (:class:`GlobusAuthorizer\
-        <globus_sdk.authorizers.base.GlobusAuthorizer>`)
+    **Methods**
 
-          An authorizer instance used for all calls to Globus Transfer
+    *  :py:meth:`.get_endpoint`
+    *  :py:meth:`.update_endpoint`
+    *  :py:meth:`.create_endpoint`
+    *  :py:meth:`.delete_endpoint`
+    *  :py:meth:`.endpoint_search`
+    *  :py:meth:`.endpoint_autoactivate`
+    *  :py:meth:`.endpoint_deactivate`
+    *  :py:meth:`.endpoint_activate`
+    *  :py:meth:`.endpoint_get_activation_requirements`
+    *  :py:meth:`.my_effective_pause_rule_list`
+    *  :py:meth:`.my_shared_endpoint_list`
+    *  :py:meth:`.create_shared_endpoint`
+    *  :py:meth:`.endpoint_server_list`
+    *  :py:meth:`.get_endpoint_server`
+    *  :py:meth:`.add_endpoint_server`
+    *  :py:meth:`.update_endpoint_server`
+    *  :py:meth:`.delete_endpoint_server`
+    *  :py:meth:`.endpoint_role_list`
+    *  :py:meth:`.add_endpoint_role`
+    *  :py:meth:`.get_endpoint_role`
+    *  :py:meth:`.delete_endpoint_role`
+    *  :py:meth:`.endpoint_acl_list`
+    *  :py:meth:`.get_endpoint_acl_rule`
+    *  :py:meth:`.add_endpoint_acl_rule`
+    *  :py:meth:`.update_endpoint_acl_rule`
+    *  :py:meth:`.delete_endpoint_acl_rule`
+    *  :py:meth:`.bookmark_list`
+    *  :py:meth:`.create_bookmark`
+    *  :py:meth:`.get_bookmark`
+    *  :py:meth:`.update_bookmark`
+    *  :py:meth:`.delete_bookmark`
+    *  :py:meth:`.operation_ls`
+    *  :py:meth:`.operation_mkdir`
+    *  :py:meth:`.operation_rename`
+    *  :py:meth:`.operation_symlink`
+    *  :py:meth:`.get_submission_id`
+    *  :py:meth:`.submit_transfer`
+    *  :py:meth:`.submit_delete`
+    *  :py:meth:`.task_list`
+    *  :py:meth:`.task_event_list`
+    *  :py:meth:`.get_task`
+    *  :py:meth:`.update_task`
+    *  :py:meth:`.cancel_task`
+    *  :py:meth:`.task_wait`
+    *  :py:meth:`.task_pause_info`
+    *  :py:meth:`.task_successful_transfers`
+    *  :py:meth:`.endpoint_manager_monitored_endpoints`
+    *  :py:meth:`.endpoint_manager_hosted_endpoint_list`
+    *  :py:meth:`.endpoint_manager_get_endpoint`
+    *  :py:meth:`.endpoint_manager_acl_list`
+    *  :py:meth:`.endpoint_manager_task_list`
+    *  :py:meth:`.endpoint_manager_get_task`
+    *  :py:meth:`.endpoint_manager_task_event_list`
+    *  :py:meth:`.endpoint_manager_task_pause_info`
+    *  :py:meth:`.endpoint_manager_task_successful_transfers`
+    *  :py:meth:`.endpoint_manager_cancel_tasks`
+    *  :py:meth:`.endpoint_manager_cancel_status`
+    *  :py:meth:`.endpoint_manager_pause_tasks`
+    *  :py:meth:`.endpoint_manager_resume_tasks`
+    *  :py:meth:`.endpoint_manager_pause_rule_list`
+    *  :py:meth:`.endpoint_manager_create_pause_rule`
+    *  :py:meth:`.endpoint_manager_get_pause_rule`
+    *  :py:meth:`.endpoint_manager_update_pause_rule`
+    *  :py:meth:`.endpoint_manager_delete_pause_rule`
+
     """
     # disallow basic auth
     allowed_authorizer_types = [AccessTokenAuthorizer,


### PR DESCRIPTION
Also improve some cosmetics by making the sidebar TOC capable of expanding to one level deeper. (Done with an override for the globaltoc.html template)

Some other minor edits:
- remove dead optional deps page
- switch `**Parameters**` to use `:param:` syntax for client constructors

Not changing the parameter style everywhere, but I think the result is a little bit cleaner. If we like it here, we can gradually shift everything to using `:param:` and `:type:`