### PR TITLE
Fix minor error in testsuite

### DIFF
--- a/tests/unit/test_confidential_client.py
+++ b/tests/unit/test_confidential_client.py
@@ -98,8 +98,8 @@ class ConfidentialAppAuthClientTests(CapturedIOTestCase):
         invalid_token = tokens["auth.globus.org"]["access_token"]
         with self.assertRaises(AuthAPIError) as apiErr:
             self.cac.oauth2_get_dependent_tokens(invalid_token)
-        self.assertEqual(apiErr.exception.http_status, 401)
-        self.assertEqual(apiErr.exception.code, "Error")
+        self.assertEqual(apiErr.exception.http_status, 400)
+        self.assertEqual(apiErr.exception.code, "UNAUTHORIZED_CLIENT")
 
     @retry_errors()
     def test_oauth2_token_introspect(self):


### PR DESCRIPTION
This test checks that using the wrong client type for dependent tokens gets back a 401. That *was* the behavior of Auth, but it was not spec compliant, so it changed in a recent release.
~The spec says to return 400, so check for that instead.~
EDIT More precisely: the spec doesn't specify which type of 4xx to return, and 401 is clearly weird/wrong.

I'm not 100% convinced that we should be testing this, but it's easier to adjust the test and move on than to think about removing/replacing it.