### PR TITLE
Fix handling of `environment="production"`

### DIFF
--- a/globus_sdk/config.py
+++ b/globus_sdk/config.py
@@ -175,17 +175,25 @@ def _bool_cast(value):
     raise ValueError("Invalid config bool")
 
 
-def get_default_environ():
+def get_globus_environ(inputenv=None):
     """
-    Get the default environment to look for in the config, as a string.
+    Get the environment to look for in the config, as a string.
+
     Typically just "default", but it can be overridden with
     `GLOBUS_SDK_ENVIRONMENT` in the shell environment. In that case, any client
     which does not explicitly specify its environment will use this value.
+
+    :param inputenv: An environment which was passed, e.g. to a client
+                     instantiation
     """
-    env = os.environ.get('GLOBUS_SDK_ENVIRONMENT', 'default')
+    if inputenv is None:
+        env = os.environ.get('GLOBUS_SDK_ENVIRONMENT', 'default')
+    else:
+        env = inputenv
+
     if env == 'production':
         env = 'default'
     if env != 'default':
         logger.info(('On lookup, non-default environment: '
-                     'GLOBUS_SDK_ENVIRONMENT={}'.format(env)))
+                     'globus_environment={}'.format(env)))
     return env

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -148,7 +148,7 @@ class ConfigParserTests(CapturedIOTestCase):
         with self.assertRaises(ValueError):
             globus_sdk.config._bool_cast("invalid")
 
-    def test_get_default_environ(self):
+    def test_get_globus_environ(self):
         """
         Confirms returns "default", or the value of GLOBUS_SDK_ENVIRONMENT
         """
@@ -157,10 +157,10 @@ class ConfigParserTests(CapturedIOTestCase):
         if "GLOBUS_SDK_ENVIRONMENT" in os.environ:
             prev_setting = os.environ["GLOBUS_SDK_ENVIRONMENT"]
             del os.environ["GLOBUS_SDK_ENVIRONMENT"]
-        self.assertEqual(globus_sdk.config.get_default_environ(), "default")
+        self.assertEqual(globus_sdk.config.get_globus_environ(), "default")
         # otherwise environ value
         os.environ["GLOBUS_SDK_ENVIRONMENT"] = "beta"
-        self.assertEqual(globus_sdk.config.get_default_environ(), "beta")
+        self.assertEqual(globus_sdk.config.get_globus_environ(), "beta")
 
         # cleanup for other tests
         if prev_setting:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -152,18 +152,31 @@ class ConfigParserTests(CapturedIOTestCase):
         """
         Confirms returns "default", or the value of GLOBUS_SDK_ENVIRONMENT
         """
-        # default if no environ value exists
-        prev_setting = None
-        if "GLOBUS_SDK_ENVIRONMENT" in os.environ:
-            prev_setting = os.environ["GLOBUS_SDK_ENVIRONMENT"]
-            del os.environ["GLOBUS_SDK_ENVIRONMENT"]
-        self.assertEqual(globus_sdk.config.get_globus_environ(), "default")
-        # otherwise environ value
-        os.environ["GLOBUS_SDK_ENVIRONMENT"] = "beta"
-        self.assertEqual(globus_sdk.config.get_globus_environ(), "beta")
+        # mock environ to ensure it gets reset
+        with mock.patch.dict(os.environ):
+            # set an environment value, ensure that it's returned
+            os.environ["GLOBUS_SDK_ENVIRONMENT"] = "beta"
+            self.assertEqual(globus_sdk.config.get_globus_environ(), "beta")
 
-        # cleanup for other tests
-        if prev_setting:
-            os.environ["GLOBUS_SDK_ENVIRONMENT"] = prev_setting
-        else:
+            # clear that value, "default" should be returned
             del os.environ["GLOBUS_SDK_ENVIRONMENT"]
+            self.assertEqual(globus_sdk.config.get_globus_environ(), "default")
+
+            # ensure that passing a value returns that value
+            self.assertEqual(
+                globus_sdk.config.get_globus_environ("beta"), "beta")
+
+    def test_get_globus_environ_production(self):
+        """
+        Confirms that get_globus_environ translates "production" to "default",
+        including when special values are passed
+        """
+        # mock environ to ensure it gets reset
+        with mock.patch.dict(os.environ):
+            os.environ["GLOBUS_SDK_ENVIRONMENT"] = "production"
+            self.assertEqual(globus_sdk.config.get_globus_environ(), "default")
+
+            del os.environ["GLOBUS_SDK_ENVIRONMENT"]
+            # ensure that passing a value returns that value
+            self.assertEqual(
+                globus_sdk.config.get_globus_environ("production"), "default")


### PR DESCRIPTION
When passed explicitly, this value bypassed the check we do while looking up the environment variable, and then results in failed config lookups.
Force the given `environment` through that config lookup code which translates `production` to `default` and logs the use of non-production environments.

Minor note: the logging used to say `GLOBUS_SDK_ENVIRONMENT=...` with a strong implication that it matched the env var. Since this is no longer always taken from there, I've modified it to just say `globus_environment=...`

closes #306