### PR TITLE
Fix linting errors caught by new pycodestyle

### DIFF
--- a/globus_sdk/config.py
+++ b/globus_sdk/config.py
@@ -62,7 +62,7 @@ class GlobusConfigParser(object):
             section=None, environment=None,
             failover_to_general=False, check_env=False,
             type_cast=str):
-        """
+        r"""
         Attempt to lookup an option in the config file. Optionally failover to
         the general section if the option is not found.
 

--- a/globus_sdk/local_endpoint/personal.py
+++ b/globus_sdk/local_endpoint/personal.py
@@ -54,7 +54,7 @@ class LocalGlobusConnectPersonal(object):
                         raise GlobusSDKUsageError(
                             "LOCALAPPDATA not detected in Windows environment")
                     fname = os.path.join(
-                        appdata, "Globus Connect\client-id.txt")
+                        appdata, "Globus Connect\\client-id.txt")
                 else:
                     fname = os.path.expanduser(
                         "~/.globusonline/lta/client-id.txt")


### PR DESCRIPTION
* Fixes the `W605` warnings caught by a new release of `flake8`.

It's worth noting that the error in `personal.py` is probably a legitimate bug.