### PR TITLE
Very noisy cosmetic cleanup

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,0 @@
-[flake8]
-exclude = .git,__pycache__,.eggs,dist,venv,.venv*,venv27,virtualenv,docs,docs-source,build
-# explicitly set flake8 to not ignore any rules
-ignore = W503,W504

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -14,8 +14,8 @@ Reporting Bugs & Requesting Features
 Linting & Testing
 -----------------
 
-- All code is autoformatted with [`black`](https://github.com/ambv/black) and
-    [`isort`](https://github.com/timothycrosley/isort). You may run
+- All code is autoformatted with https://github.com/ambv/black[black] and
+   https://github.com/timothycrosley/isort[isort]. You may run
     `make autoformat` to do this or configure these tools for use in your
     editor.
 - Code must pass `make lint`, which checks that autoformatting is clean and

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -3,128 +3,52 @@ Contributing to the Globus SDK
 
 First off, thank you so much for taking the time to contribute! :+1:
 
-This document is a set of guidelines for making modifications to the SDK, not a
-set of strict rules.
-Sometimes it's okay to go off-book if you have a good reason, so use your best
-judgement.
-Feel free to propose changes to this document in a pull request.
+Reporting Bugs & Requesting Features
+------------------------------------
 
-QuickStart
-----------
-
-Impatient? Want to get hacking on this right away?
-A few quick rules if you don't want to read this full document:
-
-  - All of your code *must* pass `flake8`. We won't consider merging code which
-      doesn't pass `flake8`
   - Check if there's a matching
       https://github.com/globus/globus-sdk-python/issues[issue]
       before opening a new issue or pull request
-  - Any features which change the public API of the SDK must include
-      documentation updates
-  - `make test` must pass
+  - When possible, provide a code sample to reproduce bugs
 
-Reporting Bugs
---------------
+Linting & Testing
+-----------------
 
-We welcome any and all bugs on the
-https://github.com/globus/globus-sdk-python/issues[GitHub Issue Tracker].
+- All code is autoformatted with [`black`](https://github.com/ambv/black) and
+    [`isort`](https://github.com/timothycrosley/isort). You may run
+    `make autoformat` to do this or configure these tools for use in your
+    editor.
+- Code must pass `make lint`, which checks that autoformatting is clean and
+    that `flake8` passes
+- All code must pass `make test`
 
-However, the best bug reports are ones which follow the following rules:
+NOTE: `black` requires python3.6, so you may find it necessary to
+`make clean autoformat PYTHON_VERSION=python3.6` or equivalent.
 
-  - *Check for duplicates*. You don't have to scour our issue tracker, but do a
-      quick search to try to make sure you aren't reporting a known bug.
-  - *Use a clear descriptive title* for the issue you are reporting. The best
-      titles are short, but also uniquely describe the problem.
-  - *Provide a specific example of how to reproduce*. Example code is best, but
-      even a vague description is better than no description.
-  - *Explain what behavior you expected* and why. Not everything unexpected is
-      a bug -- what appears to you as a defect may in fact be faulty
-      documentation, for example, which needs to be updated.
-  - *Include a stacktrace* where applicable. If you're getting an error from
-      within the SDK code itself, stacktraces often help us figure out what's
-      going on much faster.
-
-You can also help us a lot by including the following information:
-
-  - *What version of python are you running?* The SDK supports a wide variety
-      of python versions, and a wide class of bugs are results of version
-      incompatibilities between those versions.
-  - *What OS and OS version are you running?* `uname -a` is the easiest way to
-      give us this info, but additional description like "Ubuntu Linux 15.10"
-      may help.
-  - *What other python packages do you have installed?* The best thing in this
-      case is to show us the results of `pip freeze`
-
-
-Requesting Enhancements
------------------------
-
-When requesting new features, there are a few things we ask you to do in order
-to help us prioritize.
-
-  - *Describe the end result you want*. You might have good (or great!) ideas
-      about how a feature can be implemented, but we ask that you give us a bit
-      more information. This lets us have a conversation about what you want
-      and the best way for us to support it among our other concerns.
-  - *Tell us why you want it*. If you request a feature, but we don't know what
-      you want it for, it's hard for us to know how critical the request is.
-      Tell us as much of the *why* as you can, not just the *what*.
-  - *How important is this feature to you?* Clearly describe to us how
-      important this feature is for your use case. Obviously, this is not the
-      only thing we weigh when prioritizing features, but it is important for
-      us to know.
-
-Submitting Pull Requests
-------------------------
-
-The most important thing about a pull request is that it meets the standards
-defined in this document's <<style-guide,Style Guide>>.
-
-Beyond that, we have a few recommendations:
+Expectations for Pull Requests
+------------------------------
 
   - *Make sure it merges cleanly*. We may request that you rebase if your PR
       has merge conflicts.
-  - *List any issues closed by the pull request*.
-  - *Squash intermediate commits*. Help us keep our git history clean by doing
-      a `git rebase --interactive` and squashing typo fixes, aborted
-      implementations, and other cruft.
+  - *List any issues closed by the pull request*
+  - *Squash intermediate and fixup commits*. We recommend running
+    `git rebase --interactive` prior to submitting a pull request.
 
-Additionally, make sure you follow our rules for
-<<commit-messages, Commit Messages>>
-
-Commit Messages
----------------
-
-A few basic ground rules for what ideal commits should look like.
+These are our guidelines for good commit messages:
 
   - No lines over 72 characters
   - No GitHub emoji -- use your words
   - Reference issues and pull requests where appropriate
   - Present tense and imperative mood
 
-Style Guide
------------
+Additional Recommendations
+--------------------------
 
-Some rules and tips for the python and documentation in this project.
-
-  - All code must pass `flake8`. That means PEP8 compliant and passing pyflakes
   - Try to use raw strings for docstrings -- ensures that ReST won't be
       confused by characters like `\\`
-  - For complex functionality, include sample usage in docstrings
-  - Comment liberally
-  - Use double-quotes for strings, except when quoting a string containing
-      double-quotes but not containing single quotes
-  - Use examples very liberally in documentation, and show where you imported
-      from within the SDK. Start at least one example with
+  - Use examples very liberally in documentation
+  - Show where you imported from within the SDK. Start at least one example with
       `from globus_sdk.modulename import ClassName` on a page with docs for
       `ClassName`
-  - Use absolute imports everywhere
-  - Avoid circular imports whenever possible -- given the choice between adding
-      a new module or adding a circular import, add the new module
-  - Import non-`globus_sdk` modules and packages before importing from within
-      `globus_sdk`
-  - Ensure all public API methods return a `GlobusResponse` or subclass thereof,
-      or explicitly document their exceptional status
   - Think very hard before adding a new dependency -- keep the dependencies of
       `globus_sdk` as lightweight as possible

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ help:
 	@echo "  help:         Show this helptext"
 	@echo "  localdev:     Setup local development env with a 'setup.py develop'"
 	@echo "  build:        Create the distributions which we like to upload to pypi"
-	@echo "  lint:         All linting steps other than 'black'"
+	@echo "  lint:         All linting steps (may be limited by what your python version supports)"
 	@echo "  autoformat:   Run code autoformatters"
 	@echo "  test:         Run the full suite of tests"
 	@echo "  docs:         Clean old HTML docs and rebuild them with sphinx"
@@ -54,8 +54,8 @@ autoformat: $(VIRTUALENV)
 
 lint: $(VIRTUALENV)
 	if [ -f "$(VIRTUALENV)/bin/black" ]; then $(VIRTUALENV)/bin/black --check $(AUTOFORMAT_TARGETS); fi
-	$(VIRTUALENV)/bin/flake8
 	$(VIRTUALENV)/bin/isort --recursive --check-only $(AUTOFORMAT_TARGETS)
+	$(VIRTUALENV)/bin/flake8
 
 
 test: $(VIRTUALENV)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,14 @@
-VIRTUALENV=.venv
+# allow specification of python version and venv loc for devs, so you can
+#    make test PYTHON_VERSION=python3.6 VIRTUALENV=.venv36
+#    make test PYTHON_VERSION=python2.7 VIRTUALENV=.venv27
+# and be happy
+# we don't need tox just to do this (though it might make life easier in the
+# future, especially now that tests are fast)
+PYTHON_VERSION?=python3
+VIRTUALENV?=.venv
+AUTOFORMAT_TARGETS=tests/ globus_sdk/ setup.py
 
-.PHONY: docs build upload test clean help
+.PHONY: docs build upload test lint autoformat clean help
 
 
 help:
@@ -10,6 +18,8 @@ help:
 	@echo "  help:         Show this helptext"
 	@echo "  localdev:     Setup local development env with a 'setup.py develop'"
 	@echo "  build:        Create the distributions which we like to upload to pypi"
+	@echo "  lint:         All linting steps other than 'black'"
+	@echo "  autoformat:   Run code autoformatters"
 	@echo "  test:         Run the full suite of tests"
 	@echo "  docs:         Clean old HTML docs and rebuild them with sphinx"
 	@echo "  upload:       [build], but also upload to pypi using twine"
@@ -23,7 +33,7 @@ localdev: $(VIRTUALENV)
 
 $(VIRTUALENV): setup.py
 	# don't recreate it if it already exists -- just run the setup steps
-	if [ ! -d "$(VIRTUALENV)" ]; then virtualenv $(VIRTUALENV); fi
+	if [ ! -d "$(VIRTUALENV)" ]; then virtualenv --python=$(PYTHON_VERSION) $(VIRTUALENV); fi
 	$(VIRTUALENV)/bin/pip install -U pip setuptools
 	$(VIRTUALENV)/bin/pip install -e '.[development]'
 	# explicit touch to ensure good update time relative to setup.py
@@ -36,18 +46,32 @@ build: $(VIRTUALENV)
 upload: build
 	$(VIRTUALENV)/bin/twine upload dist/*
 
-test: $(VIRTUALENV)
+
+autoformat: $(VIRTUALENV)
+	$(VIRTUALENV)/bin/isort --recursive $(AUTOFORMAT_TARGETS)
+	if [ -f "$(VIRTUALENV)/bin/black" ]; then $(VIRTUALENV)/bin/black $(AUTOFORMAT_TARGETS); fi
+
+
+lint: $(VIRTUALENV)
+	if [ -f "$(VIRTUALENV)/bin/black" ]; then $(VIRTUALENV)/bin/black --check $(AUTOFORMAT_TARGETS); fi
 	$(VIRTUALENV)/bin/flake8
+	$(VIRTUALENV)/bin/isort --recursive --check-only $(AUTOFORMAT_TARGETS)
+
+
+test: $(VIRTUALENV)
 	$(VIRTUALENV)/bin/pytest -v --cov=globus_sdk
+
 
 travis:
 	pip install -U pip setuptools
 	pip install -e '.[development]'
-	flake8
+	$(MAKE) lint
 	pytest -v tests/
+
 
 docs: $(VIRTUALENV)
 	. $(VIRTUALENV)/bin/activate && $(MAKE) -C docs/ clean html
+
 
 clean:
 	-rm -r $(VIRTUALENV)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,9 +17,7 @@ install:
 
 test_script:
   # explicitly invoke under the build environment's python
-  - "set GLOBUS_TEST_PY=%PYTHON%\\python.exe"
-  - "%GLOBUS_TEST_PY% -m flake8"
-  - "%GLOBUS_TEST_PY% -m pytest -v  --cov=globus_sdk"
+  - "%PYTHON%\\python.exe -m pytest -v --cov=globus_sdk"
 
 build: off
 deploy: off

--- a/globus_sdk/__init__.py
+++ b/globus_sdk/__init__.py
@@ -6,17 +6,27 @@ from globus_sdk.version import __version__
 from globus_sdk.response import GlobusResponse, GlobusHTTPResponse
 
 from globus_sdk.exc import (
-    GlobusError, GlobusSDKUsageError,
-    GlobusAPIError, AuthAPIError, TransferAPIError, SearchAPIError,
-    NetworkError, GlobusConnectionError, GlobusTimeoutError,
-    GlobusConnectionTimeoutError)
+    GlobusError,
+    GlobusSDKUsageError,
+    GlobusAPIError,
+    AuthAPIError,
+    TransferAPIError,
+    SearchAPIError,
+    NetworkError,
+    GlobusConnectionError,
+    GlobusTimeoutError,
+    GlobusConnectionTimeoutError,
+)
 
 from globus_sdk.authorizers import (
-    NullAuthorizer, BasicAuthorizer, AccessTokenAuthorizer,
-    RefreshTokenAuthorizer, ClientCredentialsAuthorizer)
+    NullAuthorizer,
+    BasicAuthorizer,
+    AccessTokenAuthorizer,
+    RefreshTokenAuthorizer,
+    ClientCredentialsAuthorizer,
+)
 
-from globus_sdk.auth import (
-    AuthClient, NativeAppAuthClient, ConfidentialAppAuthClient)
+from globus_sdk.auth import AuthClient, NativeAppAuthClient, ConfidentialAppAuthClient
 
 from globus_sdk.transfer import TransferClient
 from globus_sdk.transfer.data import TransferData, DeleteData
@@ -28,29 +38,36 @@ from globus_sdk.local_endpoint import LocalGlobusConnectPersonal
 
 __all__ = (
     "__version__",
-
-    "GlobusResponse", "GlobusHTTPResponse",
-
-    "GlobusError", "GlobusSDKUsageError",
-    "GlobusAPIError", "AuthAPIError", "TransferAPIError", "SearchAPIError",
-    "NetworkError", "GlobusConnectionError", "GlobusTimeoutError",
+    "GlobusResponse",
+    "GlobusHTTPResponse",
+    "GlobusError",
+    "GlobusSDKUsageError",
+    "GlobusAPIError",
+    "AuthAPIError",
+    "TransferAPIError",
+    "SearchAPIError",
+    "NetworkError",
+    "GlobusConnectionError",
+    "GlobusTimeoutError",
     "GlobusConnectionTimeoutError",
-
-    "NullAuthorizer", "BasicAuthorizer",
-    "AccessTokenAuthorizer", "RefreshTokenAuthorizer",
+    "NullAuthorizer",
+    "BasicAuthorizer",
+    "AccessTokenAuthorizer",
+    "RefreshTokenAuthorizer",
     "ClientCredentialsAuthorizer",
-
-    "AuthClient", "NativeAppAuthClient", "ConfidentialAppAuthClient",
-
-    "TransferClient", "TransferData", "DeleteData",
-
-    "SearchClient", "SearchQuery",
-
-    'LocalGlobusConnectPersonal',
+    "AuthClient",
+    "NativeAppAuthClient",
+    "ConfidentialAppAuthClient",
+    "TransferClient",
+    "TransferData",
+    "DeleteData",
+    "SearchClient",
+    "SearchQuery",
+    "LocalGlobusConnectPersonal",
 )
 
 
 # configure logging for a library, per python best practices:
 # https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library
 # NB: this won't work on py2.6 because `logging.NullHandler` wasn't added yet
-logging.getLogger('globus_sdk').addHandler(logging.NullHandler())
+logging.getLogger("globus_sdk").addHandler(logging.NullHandler())

--- a/globus_sdk/__init__.py
+++ b/globus_sdk/__init__.py
@@ -1,40 +1,31 @@
 import logging
 
-
-from globus_sdk.version import __version__
-
-from globus_sdk.response import GlobusResponse, GlobusHTTPResponse
-
+from globus_sdk.auth import AuthClient, ConfidentialAppAuthClient, NativeAppAuthClient
+from globus_sdk.authorizers import (
+    AccessTokenAuthorizer,
+    BasicAuthorizer,
+    ClientCredentialsAuthorizer,
+    NullAuthorizer,
+    RefreshTokenAuthorizer,
+)
 from globus_sdk.exc import (
+    AuthAPIError,
+    GlobusAPIError,
+    GlobusConnectionError,
+    GlobusConnectionTimeoutError,
     GlobusError,
     GlobusSDKUsageError,
-    GlobusAPIError,
-    AuthAPIError,
-    TransferAPIError,
-    SearchAPIError,
-    NetworkError,
-    GlobusConnectionError,
     GlobusTimeoutError,
-    GlobusConnectionTimeoutError,
+    NetworkError,
+    SearchAPIError,
+    TransferAPIError,
 )
-
-from globus_sdk.authorizers import (
-    NullAuthorizer,
-    BasicAuthorizer,
-    AccessTokenAuthorizer,
-    RefreshTokenAuthorizer,
-    ClientCredentialsAuthorizer,
-)
-
-from globus_sdk.auth import AuthClient, NativeAppAuthClient, ConfidentialAppAuthClient
-
-from globus_sdk.transfer import TransferClient
-from globus_sdk.transfer.data import TransferData, DeleteData
-
-from globus_sdk.search import SearchClient, SearchQuery
-
 from globus_sdk.local_endpoint import LocalGlobusConnectPersonal
-
+from globus_sdk.response import GlobusHTTPResponse, GlobusResponse
+from globus_sdk.search import SearchClient, SearchQuery
+from globus_sdk.transfer import TransferClient
+from globus_sdk.transfer.data import DeleteData, TransferData
+from globus_sdk.version import __version__
 
 __all__ = (
     "__version__",

--- a/globus_sdk/auth/__init__.py
+++ b/globus_sdk/auth/__init__.py
@@ -1,11 +1,10 @@
 from globus_sdk.auth.client_types import (
     AuthClient,
-    NativeAppAuthClient,
     ConfidentialAppAuthClient,
+    NativeAppAuthClient,
 )
-from globus_sdk.auth.oauth2_native_app import GlobusNativeAppFlowManager
 from globus_sdk.auth.oauth2_authorization_code import GlobusAuthorizationCodeFlowManager
-
+from globus_sdk.auth.oauth2_native_app import GlobusNativeAppFlowManager
 
 __all__ = [
     "AuthClient",

--- a/globus_sdk/auth/__init__.py
+++ b/globus_sdk/auth/__init__.py
@@ -1,15 +1,16 @@
 from globus_sdk.auth.client_types import (
-    AuthClient, NativeAppAuthClient, ConfidentialAppAuthClient)
+    AuthClient,
+    NativeAppAuthClient,
+    ConfidentialAppAuthClient,
+)
 from globus_sdk.auth.oauth2_native_app import GlobusNativeAppFlowManager
-from globus_sdk.auth.oauth2_authorization_code import (
-    GlobusAuthorizationCodeFlowManager)
+from globus_sdk.auth.oauth2_authorization_code import GlobusAuthorizationCodeFlowManager
 
 
 __all__ = [
     "AuthClient",
     "NativeAppAuthClient",
     "ConfidentialAppAuthClient",
-
     "GlobusNativeAppFlowManager",
-    "GlobusAuthorizationCodeFlowManager"
+    "GlobusAuthorizationCodeFlowManager",
 ]

--- a/globus_sdk/auth/client_types/__init__.py
+++ b/globus_sdk/auth/client_types/__init__.py
@@ -1,6 +1,5 @@
 from globus_sdk.auth.client_types.base import AuthClient
-from globus_sdk.auth.client_types.native_client import NativeAppAuthClient
 from globus_sdk.auth.client_types.confidential_client import ConfidentialAppAuthClient
-
+from globus_sdk.auth.client_types.native_client import NativeAppAuthClient
 
 __all__ = ["AuthClient", "NativeAppAuthClient", "ConfidentialAppAuthClient"]

--- a/globus_sdk/auth/client_types/__init__.py
+++ b/globus_sdk/auth/client_types/__init__.py
@@ -1,11 +1,6 @@
 from globus_sdk.auth.client_types.base import AuthClient
 from globus_sdk.auth.client_types.native_client import NativeAppAuthClient
-from globus_sdk.auth.client_types.confidential_client import (
-    ConfidentialAppAuthClient)
+from globus_sdk.auth.client_types.confidential_client import ConfidentialAppAuthClient
 
 
-__all__ = [
-    'AuthClient',
-    'NativeAppAuthClient',
-    'ConfidentialAppAuthClient'
-]
+__all__ = ["AuthClient", "NativeAppAuthClient", "ConfidentialAppAuthClient"]

--- a/globus_sdk/auth/client_types/base.py
+++ b/globus_sdk/auth/client_types/base.py
@@ -154,7 +154,7 @@ class AuthClient(BaseClient):
         self.logger.debug("params={}".format(params))
 
         if "usernames" in params and "ids" in params:
-            self.logger.warn(
+            self.logger.warning(
                 (
                     "get_identities call with both usernames and "
                     "identities set! Expected to result in errors"

--- a/globus_sdk/auth/client_types/confidential_client.py
+++ b/globus_sdk/auth/client_types/confidential_client.py
@@ -1,14 +1,14 @@
 import logging
+
 import six
 
-from globus_sdk.exc import GlobusSDKUsageError
-from globus_sdk.base import merge_params
-from globus_sdk.authorizers import BasicAuthorizer
-from globus_sdk.auth.oauth2_constants import DEFAULT_REQUESTED_SCOPES
 from globus_sdk.auth.client_types.base import AuthClient
-from globus_sdk.auth.oauth2_authorization_code import (
-    GlobusAuthorizationCodeFlowManager)
+from globus_sdk.auth.oauth2_authorization_code import GlobusAuthorizationCodeFlowManager
+from globus_sdk.auth.oauth2_constants import DEFAULT_REQUESTED_SCOPES
 from globus_sdk.auth.token_response import OAuthDependentTokenResponse
+from globus_sdk.authorizers import BasicAuthorizer
+from globus_sdk.base import merge_params
+from globus_sdk.exc import GlobusSDKUsageError
 
 logger = logging.getLogger(__name__)
 
@@ -38,6 +38,7 @@ class ConfidentialAppAuthClient(AuthClient):
     *  :py:meth:`.oauth2_token_introspect`
 
     """
+
     # checked by BaseClient to see what authorizers are allowed for this client
     # subclass
     # only allow basic auth -- anything else means you're misusing the client
@@ -45,16 +46,18 @@ class ConfidentialAppAuthClient(AuthClient):
 
     def __init__(self, client_id, client_secret, **kwargs):
         if "authorizer" in kwargs:
-            logger.error('ArgumentError(ConfidentialAppClient.authorizer)')
+            logger.error("ArgumentError(ConfidentialAppClient.authorizer)")
             raise GlobusSDKUsageError(
-                "Cannot give a ConfidentialAppAuthClient an authorizer")
+                "Cannot give a ConfidentialAppAuthClient an authorizer"
+            )
 
         AuthClient.__init__(
-            self, client_id=client_id,
+            self,
+            client_id=client_id,
             authorizer=BasicAuthorizer(client_id, client_secret),
-            **kwargs)
-        self.logger.info('Finished initializing client, client_id={}'
-                         .format(client_id))
+            **kwargs
+        )
+        self.logger.info("Finished initializing client, client_id={}".format(client_id))
 
     def oauth2_client_credentials_tokens(self, requested_scopes=None):
         r"""
@@ -81,19 +84,23 @@ class ConfidentialAppAuthClient(AuthClient):
         ...     tokens.by_resource_server["transfer.api.globus.org"])
         >>> transfer_token = transfer_token_info["access_token"]
         """
-        self.logger.info('Fetching token(s) using client credentials')
+        self.logger.info("Fetching token(s) using client credentials")
         requested_scopes = requested_scopes or DEFAULT_REQUESTED_SCOPES
         # convert scopes iterable to string immediately on load
         if not isinstance(requested_scopes, six.string_types):
             requested_scopes = " ".join(requested_scopes)
 
-        return self.oauth2_token({
-            'grant_type': 'client_credentials',
-            'scope': requested_scopes})
+        return self.oauth2_token(
+            {"grant_type": "client_credentials", "scope": requested_scopes}
+        )
 
     def oauth2_start_flow(
-            self, redirect_uri, requested_scopes=None,
-            state='_default', refresh_tokens=False):
+        self,
+        redirect_uri,
+        requested_scopes=None,
+        state="_default",
+        refresh_tokens=False,
+    ):
         """
         Starts or resumes an Authorization Code OAuth2 flow.
 
@@ -133,10 +140,14 @@ class ConfidentialAppAuthClient(AuthClient):
         `in the Globus Auth Specification \
         <https://docs.globus.org/api/auth/developer-guide/#obtaining-authorization>`_
         """
-        self.logger.info('Starting OAuth2 Authorization Code Grant Flow')
+        self.logger.info("Starting OAuth2 Authorization Code Grant Flow")
         self.current_oauth2_flow_manager = GlobusAuthorizationCodeFlowManager(
-            self, redirect_uri, requested_scopes=requested_scopes,
-            state=state, refresh_tokens=refresh_tokens)
+            self,
+            redirect_uri,
+            requested_scopes=requested_scopes,
+            state=state,
+            refresh_tokens=refresh_tokens,
+        )
         return self.current_oauth2_flow_manager
 
     def oauth2_get_dependent_tokens(self, token, additional_params=None):
@@ -173,16 +184,16 @@ class ConfidentialAppAuthClient(AuthClient):
         :rtype: :class:`OAuthTokenResponse
                 <globus_sdk.auth.token_response.OAuthTokenResponse>`
         """
-        self.logger.info('Getting dependent tokens from access token')
-        self.logger.debug('additional_params={}'.format(additional_params))
+        self.logger.info("Getting dependent tokens from access token")
+        self.logger.debug("additional_params={}".format(additional_params))
         form_data = {
-            'grant_type': 'urn:globus:auth:grant_type:dependent_token',
-            'token': token}
+            "grant_type": "urn:globus:auth:grant_type:dependent_token",
+            "token": token,
+        }
         if additional_params:
             form_data.update(additional_params)
 
-        return self.oauth2_token(
-            form_data, response_class=OAuthDependentTokenResponse)
+        return self.oauth2_token(form_data, response_class=OAuthDependentTokenResponse)
 
     def oauth2_token_introspect(self, token, include=None):
         """
@@ -221,7 +232,7 @@ class ConfidentialAppAuthClient(AuthClient):
         #token_introspection_post_v2_oauth2_token_introspect>`_
         in the API documentation for details.
         """
-        self.logger.info('Checking token validity (introspect)')
-        body = {'token': token}
+        self.logger.info("Checking token validity (introspect)")
+        body = {"token": token}
         merge_params(body, include=include)
         return self.post("/v2/oauth2/token/introspect", text_body=body)

--- a/globus_sdk/auth/client_types/native_client.py
+++ b/globus_sdk/auth/client_types/native_client.py
@@ -1,9 +1,9 @@
 import logging
 
-from globus_sdk.exc import GlobusSDKUsageError
-from globus_sdk.authorizers import NullAuthorizer
 from globus_sdk.auth.client_types.base import AuthClient
 from globus_sdk.auth.oauth2_native_app import GlobusNativeAppFlowManager
+from globus_sdk.authorizers import NullAuthorizer
+from globus_sdk.exc import GlobusSDKUsageError
 
 logger = logging.getLogger(__name__)
 
@@ -28,25 +28,30 @@ class NativeAppAuthClient(AuthClient):
     *  :py:meth:`.NativeAppAuthClient.oauth2_refresh_token`
 
     """
+
     # don't allow any authorizer to be used on a native app client
     # it can't authorize it's calls, and shouldn't try to
     allowed_authorizer_types = [NullAuthorizer]
 
     def __init__(self, client_id, **kwargs):
         if "authorizer" in kwargs:
-            logger.error('ArgumentError(NativeAppClient.authorizer)')
-            raise GlobusSDKUsageError(
-                "Cannot give a NativeAppAuthClient an authorizer")
+            logger.error("ArgumentError(NativeAppClient.authorizer)")
+            raise GlobusSDKUsageError("Cannot give a NativeAppAuthClient an authorizer")
 
         AuthClient.__init__(
-            self, client_id=client_id, authorizer=NullAuthorizer(), **kwargs)
-        self.logger.info('Finished initializing client, client_id={}'
-                         .format(client_id))
+            self, client_id=client_id, authorizer=NullAuthorizer(), **kwargs
+        )
+        self.logger.info("Finished initializing client, client_id={}".format(client_id))
 
     def oauth2_start_flow(
-            self, requested_scopes=None, redirect_uri=None,
-            state='_default', verifier=None, refresh_tokens=False,
-            prefill_named_grant=None):
+        self,
+        requested_scopes=None,
+        redirect_uri=None,
+        state="_default",
+        verifier=None,
+        refresh_tokens=False,
+        prefill_named_grant=None,
+    ):
         """
         Starts a Native App OAuth2 flow.
 
@@ -102,12 +107,16 @@ class NativeAppAuthClient(AuthClient):
         `The PKCE Security Protocol \
         <https://docs.globus.org/api/auth/developer-guide/#pkce>`_
         """
-        self.logger.info('Starting Native App Grant Flow')
+        self.logger.info("Starting Native App Grant Flow")
         self.current_oauth2_flow_manager = GlobusNativeAppFlowManager(
-            self, requested_scopes=requested_scopes,
-            redirect_uri=redirect_uri, state=state, verifier=verifier,
+            self,
+            requested_scopes=requested_scopes,
+            redirect_uri=redirect_uri,
+            state=state,
+            verifier=verifier,
             refresh_tokens=refresh_tokens,
-            prefill_named_grant=prefill_named_grant)
+            prefill_named_grant=prefill_named_grant,
+        )
         return self.current_oauth2_flow_manager
 
     def oauth2_refresh_token(self, refresh_token):
@@ -117,9 +126,11 @@ class NativeAppAuthClient(AuthClient):
         It needs this specialization because it cannot authenticate the refresh
         grant call with client credentials, as is normal.
         """
-        self.logger.info('Executing token refresh without client credentials')
-        form_data = {'refresh_token': refresh_token,
-                     'grant_type': 'refresh_token',
-                     'client_id': self.client_id}
+        self.logger.info("Executing token refresh without client credentials")
+        form_data = {
+            "refresh_token": refresh_token,
+            "grant_type": "refresh_token",
+            "client_id": self.client_id,
+        }
 
         return self.oauth2_token(form_data)

--- a/globus_sdk/auth/oauth2_authorization_code.py
+++ b/globus_sdk/auth/oauth2_authorization_code.py
@@ -1,10 +1,11 @@
 import logging
+
 import six
 from six.moves.urllib.parse import urlencode
 
-from globus_sdk.base import slash_join
 from globus_sdk.auth.oauth2_constants import DEFAULT_REQUESTED_SCOPES
 from globus_sdk.auth.oauth2_flow_manager import GlobusOAuthFlowManager
+from globus_sdk.base import slash_join
 
 logger = logging.getLogger(__name__)
 
@@ -51,9 +52,14 @@ class GlobusAuthorizationCodeFlowManager(GlobusOAuthFlowManager):
           When True, request refresh tokens in addition to access tokens
     """
 
-    def __init__(self, auth_client, redirect_uri,
-                 requested_scopes=None, state='_default',
-                 refresh_tokens=False):
+    def __init__(
+        self,
+        auth_client,
+        redirect_uri,
+        requested_scopes=None,
+        state="_default",
+        refresh_tokens=False,
+    ):
         # default to the default requested scopes
         self.requested_scopes = requested_scopes or DEFAULT_REQUESTED_SCOPES
         # convert scopes iterable to string immediately on load
@@ -67,12 +73,12 @@ class GlobusAuthorizationCodeFlowManager(GlobusOAuthFlowManager):
         self.refresh_tokens = refresh_tokens
         self.state = state
 
-        logger.debug('Starting Authorization Code Flow with params:')
-        logger.debug('auth_client.client_id={}'.format(auth_client.client_id))
-        logger.debug('redirect_uri={}'.format(redirect_uri))
-        logger.debug('refresh_tokens={}'.format(refresh_tokens))
-        logger.debug('state={}'.format(state))
-        logger.debug('requested_scopes={}'.format(self.requested_scopes))
+        logger.debug("Starting Authorization Code Flow with params:")
+        logger.debug("auth_client.client_id={}".format(auth_client.client_id))
+        logger.debug("redirect_uri={}".format(redirect_uri))
+        logger.debug("refresh_tokens={}".format(refresh_tokens))
+        logger.debug("state={}".format(state))
+        logger.debug("requested_scopes={}".format(self.requested_scopes))
 
     def get_authorize_url(self, additional_params=None):
         """
@@ -93,25 +99,27 @@ class GlobusAuthorizationCodeFlowManager(GlobusOAuthFlowManager):
         either to your provided ``redirect_uri`` or to the default location,
         with the ``auth_code`` embedded in a query parameter.
         """
-        authorize_base_url = slash_join(self.auth_client.base_url,
-                                        '/v2/oauth2/authorize')
-        logger.debug('Building authorization URI. Base URL: {}'
-                     .format(authorize_base_url))
-        logger.debug('additional_params={}'.format(additional_params))
+        authorize_base_url = slash_join(
+            self.auth_client.base_url, "/v2/oauth2/authorize"
+        )
+        logger.debug(
+            "Building authorization URI. Base URL: {}".format(authorize_base_url)
+        )
+        logger.debug("additional_params={}".format(additional_params))
 
         params = {
-            'client_id': self.client_id,
-            'redirect_uri': self.redirect_uri,
-            'scope': self.requested_scopes,
-            'state': self.state,
-            'response_type': 'code',
-            'access_type': (self.refresh_tokens and 'offline') or 'online'
+            "client_id": self.client_id,
+            "redirect_uri": self.redirect_uri,
+            "scope": self.requested_scopes,
+            "state": self.state,
+            "response_type": "code",
+            "access_type": (self.refresh_tokens and "offline") or "online",
         }
         if additional_params:
             params.update(additional_params)
 
         params = urlencode(params)
-        return '{0}?{1}'.format(authorize_base_url, params)
+        return "{0}?{1}".format(authorize_base_url, params)
 
     def exchange_code_for_tokens(self, auth_code):
         """
@@ -121,9 +129,16 @@ class GlobusAuthorizationCodeFlowManager(GlobusOAuthFlowManager):
         :rtype: :class:`OAuthTokenResponse \
         <globus_sdk.auth.token_response.OAuthTokenResponse>`
         """
-        logger.debug(('Performing Authorization Code auth_code exchange. '
-                      'Sending client_id and client_secret'))
+        logger.debug(
+            (
+                "Performing Authorization Code auth_code exchange. "
+                "Sending client_id and client_secret"
+            )
+        )
         return self.auth_client.oauth2_token(
-            {'grant_type': 'authorization_code',
-             'code': auth_code.encode('utf-8'),
-             'redirect_uri': self.redirect_uri})
+            {
+                "grant_type": "authorization_code",
+                "code": auth_code.encode("utf-8"),
+                "redirect_uri": self.redirect_uri,
+            }
+        )

--- a/globus_sdk/auth/oauth2_constants.py
+++ b/globus_sdk/auth/oauth2_constants.py
@@ -1,6 +1,9 @@
-__all__ = ['DEFAULT_REQUESTED_SCOPES']
+__all__ = ["DEFAULT_REQUESTED_SCOPES"]
 
 
 DEFAULT_REQUESTED_SCOPES = (
-    'openid', 'profile', 'email',
-    'urn:globus:auth:scope:transfer.api.globus.org:all')
+    "openid",
+    "profile",
+    "email",
+    "urn:globus:auth:scope:transfer.api.globus.org:all",
+)

--- a/globus_sdk/auth/oauth2_flow_manager.py
+++ b/globus_sdk/auth/oauth2_flow_manager.py
@@ -16,6 +16,7 @@ class GlobusOAuthFlowManager(object):
     have to wrap it in order to provide a clean API surface anyway, we
     implement our own set of Flow objects.
     """
+
     def get_authorize_url(self):
         """
         This method consumes no arguments or keyword arguments, and produces a
@@ -29,7 +30,8 @@ class GlobusOAuthFlowManager(object):
         :rtype: ``string``
         """
         raise NotImplementedError(
-            '{0} does not implement get_authorize_url()'.format(type(self)))
+            "{0} does not implement get_authorize_url()".format(type(self))
+        )
 
     def exchange_code_for_tokens(self, auth_code):
         """
@@ -50,5 +52,5 @@ class GlobusOAuthFlowManager(object):
         :rtype: :class:`OAuthTokenResponse <globus_sdk.OAuthTokenResponse>`
         """
         raise NotImplementedError(
-            '{0} does not implement exchange_code_for_tokens()'
-            .format(type(self)))
+            "{0} does not implement exchange_code_for_tokens()".format(type(self))
+        )

--- a/globus_sdk/auth/oauth2_native_app.py
+++ b/globus_sdk/auth/oauth2_native_app.py
@@ -1,15 +1,16 @@
-import logging
-import hashlib
 import base64
-import re
+import hashlib
+import logging
 import os
+import re
+
 import six
 from six.moves.urllib.parse import urlencode
 
-from globus_sdk.exc import GlobusSDKUsageError
-from globus_sdk.base import slash_join
 from globus_sdk.auth.oauth2_constants import DEFAULT_REQUESTED_SCOPES
 from globus_sdk.auth.oauth2_flow_manager import GlobusOAuthFlowManager
+from globus_sdk.base import slash_join
+from globus_sdk.exc import GlobusSDKUsageError
 
 logger = logging.getLogger(__name__)
 
@@ -37,22 +38,27 @@ def make_native_app_challenge(verifier=None):
     if verifier:
         if not 43 <= len(verifier) <= 128:
             raise GlobusSDKUsageError(
-                'verifier must be 43-128 characters long: {}'.format(
-                    len(verifier)))
-        if bool(re.search(r'[^a-zA-Z0-9~_.-]', verifier)):
-            raise GlobusSDKUsageError('verifier contained invalid characters')
+                "verifier must be 43-128 characters long: {}".format(len(verifier))
+            )
+        if bool(re.search(r"[^a-zA-Z0-9~_.-]", verifier)):
+            raise GlobusSDKUsageError("verifier contained invalid characters")
     else:
-        logger.info(('Autogenerating verifier secret. On low-entropy systems '
-                     'this may be insecure'))
+        logger.info(
+            (
+                "Autogenerating verifier secret. On low-entropy systems "
+                "this may be insecure"
+            )
+        )
 
-    code_verifier = (verifier or
-                     base64.urlsafe_b64encode(
-                         os.urandom(32)).decode('utf-8').rstrip('='))
+    code_verifier = verifier or base64.urlsafe_b64encode(os.urandom(32)).decode(
+        "utf-8"
+    ).rstrip("=")
     # hash it, pull out a digest
-    hashed_verifier = hashlib.sha256(code_verifier.encode('utf-8')).digest()
+    hashed_verifier = hashlib.sha256(code_verifier.encode("utf-8")).digest()
     # urlsafe base64 encode that hash and strip the padding
-    code_challenge = base64.urlsafe_b64encode(
-        hashed_verifier).decode('utf-8').rstrip('=')
+    code_challenge = (
+        base64.urlsafe_b64encode(hashed_verifier).decode("utf-8").rstrip("=")
+    )
 
     # return the verifier and the encoded hash
     return code_verifier, code_challenge
@@ -105,19 +111,29 @@ class GlobusNativeAppFlowManager(GlobusOAuthFlowManager):
           Optionally prefill the named grant label on the consent page
     """
 
-    def __init__(self, auth_client, requested_scopes=None,
-                 redirect_uri=None, state='_default', verifier=None,
-                 refresh_tokens=False, prefill_named_grant=None):
+    def __init__(
+        self,
+        auth_client,
+        requested_scopes=None,
+        redirect_uri=None,
+        state="_default",
+        verifier=None,
+        refresh_tokens=False,
+        prefill_named_grant=None,
+    ):
         self.auth_client = auth_client
 
         # set client_id, then check for validity
         self.client_id = auth_client.client_id
         if not self.client_id:
-            logger.error('Invalid auth_client ID to start Native App Flow: {}'
-                         .format(self.client_id))
+            logger.error(
+                "Invalid auth_client ID to start Native App Flow: {}".format(
+                    self.client_id
+                )
+            )
             raise GlobusSDKUsageError(
-                'Invalid value for client_id. Got "{0}"'
-                .format(self.client_id))
+                'Invalid value for client_id. Got "{0}"'.format(self.client_id)
+            )
 
         # default to the default requested scopes
         self.requested_scopes = requested_scopes or DEFAULT_REQUESTED_SCOPES
@@ -128,7 +144,8 @@ class GlobusNativeAppFlowManager(GlobusOAuthFlowManager):
         # default to `/v2/web/auth-code` on whatever environment we're looking
         # at -- most typically it will be `https://auth.globus.org/`
         self.redirect_uri = redirect_uri or (
-            slash_join(auth_client.base_url, '/v2/web/auth-code'))
+            slash_join(auth_client.base_url, "/v2/web/auth-code")
+        )
 
         # make a challenge and secret to keep
         # if the verifier is provided, it will just be passed back to us, and
@@ -140,17 +157,16 @@ class GlobusNativeAppFlowManager(GlobusOAuthFlowManager):
         self.state = state
         self.prefill_named_grant = prefill_named_grant
 
-        logger.debug('Starting Native App Flow with params:')
-        logger.debug('auth_client.client_id={}'.format(auth_client.client_id))
-        logger.debug('redirect_uri={}'.format(self.redirect_uri))
-        logger.debug('refresh_tokens={}'.format(refresh_tokens))
-        logger.debug('state={}'.format(state))
-        logger.debug('requested_scopes={}'.format(self.requested_scopes))
-        logger.debug('verifier=<REDACTED>,challenge={}'.format(self.challenge))
+        logger.debug("Starting Native App Flow with params:")
+        logger.debug("auth_client.client_id={}".format(auth_client.client_id))
+        logger.debug("redirect_uri={}".format(self.redirect_uri))
+        logger.debug("refresh_tokens={}".format(refresh_tokens))
+        logger.debug("state={}".format(state))
+        logger.debug("requested_scopes={}".format(self.requested_scopes))
+        logger.debug("verifier=<REDACTED>,challenge={}".format(self.challenge))
 
         if prefill_named_grant is not None:
-            logger.debug('prefill_named_grant={}'.format(
-                self.prefill_named_grant))
+            logger.debug("prefill_named_grant={}".format(self.prefill_named_grant))
 
     def get_authorize_url(self, additional_params=None):
         """
@@ -171,29 +187,31 @@ class GlobusNativeAppFlowManager(GlobusOAuthFlowManager):
         either to your provided ``redirect_uri`` or to the default location,
         with the ``auth_code`` embedded in a query parameter.
         """
-        authorize_base_url = slash_join(self.auth_client.base_url,
-                                        '/v2/oauth2/authorize')
-        logger.debug('Building authorization URI. Base URL: {}'
-                     .format(authorize_base_url))
-        logger.debug('additional_params={}'.format(additional_params))
+        authorize_base_url = slash_join(
+            self.auth_client.base_url, "/v2/oauth2/authorize"
+        )
+        logger.debug(
+            "Building authorization URI. Base URL: {}".format(authorize_base_url)
+        )
+        logger.debug("additional_params={}".format(additional_params))
 
         params = {
-            'client_id': self.client_id,
-            'redirect_uri': self.redirect_uri,
-            'scope': self.requested_scopes,
-            'state': self.state,
-            'response_type': 'code',
-            'code_challenge': self.challenge,
-            'code_challenge_method': 'S256',
-            'access_type': (self.refresh_tokens and 'offline') or 'online'
+            "client_id": self.client_id,
+            "redirect_uri": self.redirect_uri,
+            "scope": self.requested_scopes,
+            "state": self.state,
+            "response_type": "code",
+            "code_challenge": self.challenge,
+            "code_challenge_method": "S256",
+            "access_type": (self.refresh_tokens and "offline") or "online",
         }
         if self.prefill_named_grant is not None:
-            params['prefill_named_grant'] = self.prefill_named_grant
+            params["prefill_named_grant"] = self.prefill_named_grant
         if additional_params:
             params.update(additional_params)
 
         params = urlencode(params)
-        return '{0}?{1}'.format(authorize_base_url, params)
+        return "{0}?{1}".format(authorize_base_url, params)
 
     def exchange_code_for_tokens(self, auth_code):
         """
@@ -203,11 +221,18 @@ class GlobusNativeAppFlowManager(GlobusOAuthFlowManager):
         :rtype: :class:`OAuthTokenResponse \
         <globus_sdk.auth.token_response.OAuthTokenResponse>`
         """
-        logger.debug(('Performing Native App auth_code exchange. '
-                      'Sending verifier and client_id'))
+        logger.debug(
+            (
+                "Performing Native App auth_code exchange. "
+                "Sending verifier and client_id"
+            )
+        )
         return self.auth_client.oauth2_token(
-            {'client_id': self.client_id,
-             'grant_type': 'authorization_code',
-             'code': auth_code.encode('utf-8'),
-             'code_verifier': self.verifier,
-             'redirect_uri': self.redirect_uri})
+            {
+                "client_id": self.client_id,
+                "grant_type": "authorization_code",
+                "code": auth_code.encode("utf-8"),
+                "code_verifier": self.verifier,
+                "redirect_uri": self.redirect_uri,
+            }
+        )

--- a/globus_sdk/auth/token_response.py
+++ b/globus_sdk/auth/token_response.py
@@ -1,10 +1,10 @@
-import logging
 import json
-import requests
+import logging
 import time
-import six
 
 import jwt
+import requests
+import six
 
 from globus_sdk.response import GlobusHTTPResponse
 
@@ -18,15 +18,15 @@ def _convert_token_info_dict(source_dict):
         - "refresh_token"
         - "token_type"
     """
-    expires_in = source_dict.get('expires_in', 0)
+    expires_in = source_dict.get("expires_in", 0)
 
     return {
-        'scope': source_dict['scope'],
-        'access_token': source_dict['access_token'],
-        'refresh_token': source_dict.get('refresh_token'),
-        'token_type': source_dict.get('token_type'),
-        'expires_at_seconds': int(time.time() + expires_in),
-        'resource_server': source_dict['resource_server']
+        "scope": source_dict["scope"],
+        "access_token": source_dict["access_token"],
+        "refresh_token": source_dict.get("refresh_token"),
+        "token_type": source_dict.get("token_type"),
+        "expires_at_seconds": int(time.time() + expires_in),
+        "resource_server": source_dict["resource_server"],
     }
 
 
@@ -38,6 +38,7 @@ class _ByScopesGetter(object):
     >>> tokens = OAuthTokenResponse(...)
     >>> tok = tokens.by_scopes['openid profile']['access_token']
     """
+
     def __init__(self, scope_map):
         self.scope_map = scope_map
 
@@ -50,8 +51,9 @@ class _ByScopesGetter(object):
 
     def __getitem__(self, scopename):
         if not isinstance(scopename, six.string_types):
-            raise KeyError('by_scopes cannot contain non-string value "{}"'
-                           .format(scopename))
+            raise KeyError(
+                'by_scopes cannot contain non-string value "{}"'.format(scopename)
+            )
 
         # split on spaces
         scopes = scopename.split()
@@ -61,17 +63,22 @@ class _ByScopesGetter(object):
         toks = []
         for scope in scopes:
             try:
-                rs_names.add(self.scope_map[scope]['resource_server'])
+                rs_names.add(self.scope_map[scope]["resource_server"])
                 toks.append(self.scope_map[scope])
             except KeyError:
-                raise KeyError(('Scope specifier "{}" contains scope "{}" '
-                                "which was not found"
-                                ).format(scopename, scope))
+                raise KeyError(
+                    (
+                        'Scope specifier "{}" contains scope "{}" '
+                        "which was not found"
+                    ).format(scopename, scope)
+                )
         # if there isn't exactly 1 token, it's an error
         if len(rs_names) != 1:
             raise KeyError(
-                'Scope specifier "{}" did not match exactly one token!'
-                .format(scopename))
+                'Scope specifier "{}" did not match exactly one token!'.format(
+                    scopename
+                )
+            )
         # pop the only element in the set
         return toks.pop()
 
@@ -95,6 +102,7 @@ class OAuthTokenResponse(GlobusHTTPResponse):
     Class for responses from the OAuth2 code for tokens exchange used in
     3-legged OAuth flows.
     """
+
     def __init__(self, *args, **kwargs):
         GlobusHTTPResponse.__init__(self, *args, **kwargs)
         self._init_rs_dict()
@@ -102,7 +110,7 @@ class OAuthTokenResponse(GlobusHTTPResponse):
 
     def _init_scopes_getter(self):
         scope_map = {}
-        for rs, tok_data in self._by_resource_server.items():
+        for _rs, tok_data in self._by_resource_server.items():
             for s in tok_data["scope"].split():
                 scope_map[s] = tok_data
         self._by_scopes = _ByScopesGetter(scope_map)
@@ -110,13 +118,18 @@ class OAuthTokenResponse(GlobusHTTPResponse):
     def _init_rs_dict(self):
         # call the helper at the top level
         self._by_resource_server = {
-            self['resource_server']: _convert_token_info_dict(self)
+            self["resource_server"]: _convert_token_info_dict(self)
         }
         # call the helper on everything in 'other_tokens'
-        self._by_resource_server.update(dict(
-            (unprocessed_item['resource_server'],
-             _convert_token_info_dict(unprocessed_item))
-            for unprocessed_item in self['other_tokens']))
+        self._by_resource_server.update(
+            dict(
+                (
+                    unprocessed_item["resource_server"],
+                    _convert_token_info_dict(unprocessed_item),
+                )
+                for unprocessed_item in self["other_tokens"]
+            )
+        )
 
     @property
     def by_resource_server(self):
@@ -164,33 +177,38 @@ class OAuthTokenResponse(GlobusHTTPResponse):
               this token back to the OAuthTokenResponse. The SDK now tracks
               this internally, so it is no longer necessary.
         """
-        logger.info('Decoding ID Token "{}"'.format(self['id_token']))
+        logger.info('Decoding ID Token "{}"'.format(self["id_token"]))
 
         # warn (not error) on older usage pattern, but still respect it
         # FIXME: should be deprecated and removed in SDK v2
         if auth_client:
             logger.warn(
-                'Providing an auth_client to decode_id_token is no '
-                'longer required and may be deprecated in a future version '
-                'of the Globus SDK')
+                "Providing an auth_client to decode_id_token is no "
+                "longer required and may be deprecated in a future version "
+                "of the Globus SDK"
+            )
         else:
             auth_client = self._client
 
-        logger.debug('Fetch JWK Data: Start')
-        oidc_conf = auth_client.get('/.well-known/openid-configuration')
-        jwks_uri = oidc_conf['jwks_uri']
-        signing_algos = oidc_conf['id_token_signing_alg_values_supported']
+        logger.debug("Fetch JWK Data: Start")
+        oidc_conf = auth_client.get("/.well-known/openid-configuration")
+        jwks_uri = oidc_conf["jwks_uri"]
+        signing_algos = oidc_conf["id_token_signing_alg_values_supported"]
 
         # use the auth_client's decision on ssl_verify=yes/no
         jwk_data = requests.get(jwks_uri, verify=auth_client._verify).json()
-        logger.debug('Fetch JWK Data: Complete')
+        logger.debug("Fetch JWK Data: Complete")
         # decode from JWK to an RSA PEM key for JWT decoding
         jwk_as_pem = jwt.algorithms.RSAAlgorithm.from_jwk(
-            json.dumps(jwk_data['keys'][0]))
+            json.dumps(jwk_data["keys"][0])
+        )
 
         return jwt.decode(
-            self['id_token'], jwk_as_pem,
-            algorithms=signing_algos, audience=auth_client.client_id)
+            self["id_token"],
+            jwk_as_pem,
+            algorithms=signing_algos,
+            audience=auth_client.client_id,
+        )
 
     def __str__(self):
         # Make printing responses more convenient by only showing the
@@ -205,16 +223,23 @@ class OAuthDependentTokenResponse(OAuthTokenResponse):
     :meth:`oauth2_get_dependent_tokens \
     <globus_sdk.ConfidentialAppAuthClient.oauth2_get_dependent_tokens>`
     """
+
     def _init_rs_dict(self):
         # call the helper on everything in the response array
         self._by_resource_server = dict(
-            (unprocessed_item['resource_server'],
-             _convert_token_info_dict(unprocessed_item))
-            for unprocessed_item in self.data)
+            (
+                unprocessed_item["resource_server"],
+                _convert_token_info_dict(unprocessed_item),
+            )
+            for unprocessed_item in self.data
+        )
 
     def decode_id_token(self, auth_client):
         # just in case
         raise NotImplementedError(
-            ('OAuthDependentTokenResponse.decode_id_token() is not and cannot '
-             'be implemented. Dependent Tokens data does not include an '
-             'id_token'))
+            (
+                "OAuthDependentTokenResponse.decode_id_token() is not and cannot "
+                "be implemented. Dependent Tokens data does not include an "
+                "id_token"
+            )
+        )

--- a/globus_sdk/auth/token_response.py
+++ b/globus_sdk/auth/token_response.py
@@ -182,7 +182,7 @@ class OAuthTokenResponse(GlobusHTTPResponse):
         # warn (not error) on older usage pattern, but still respect it
         # FIXME: should be deprecated and removed in SDK v2
         if auth_client:
-            logger.warn(
+            logger.warning(
                 "Providing an auth_client to decode_id_token is no "
                 "longer required and may be deprecated in a future version "
                 "of the Globus SDK"

--- a/globus_sdk/authorizers/__init__.py
+++ b/globus_sdk/authorizers/__init__.py
@@ -1,10 +1,9 @@
-from globus_sdk.authorizers.base import GlobusAuthorizer
-from globus_sdk.authorizers.null import NullAuthorizer
-from globus_sdk.authorizers.basic import BasicAuthorizer
 from globus_sdk.authorizers.access_token import AccessTokenAuthorizer
-from globus_sdk.authorizers.refresh_token import RefreshTokenAuthorizer
+from globus_sdk.authorizers.base import GlobusAuthorizer
+from globus_sdk.authorizers.basic import BasicAuthorizer
 from globus_sdk.authorizers.client_credentials import ClientCredentialsAuthorizer
-
+from globus_sdk.authorizers.null import NullAuthorizer
+from globus_sdk.authorizers.refresh_token import RefreshTokenAuthorizer
 
 __all__ = [
     "GlobusAuthorizer",

--- a/globus_sdk/authorizers/__init__.py
+++ b/globus_sdk/authorizers/__init__.py
@@ -3,15 +3,14 @@ from globus_sdk.authorizers.null import NullAuthorizer
 from globus_sdk.authorizers.basic import BasicAuthorizer
 from globus_sdk.authorizers.access_token import AccessTokenAuthorizer
 from globus_sdk.authorizers.refresh_token import RefreshTokenAuthorizer
-from globus_sdk.authorizers.client_credentials import (
-    ClientCredentialsAuthorizer)
+from globus_sdk.authorizers.client_credentials import ClientCredentialsAuthorizer
 
 
 __all__ = [
-    'GlobusAuthorizer',
-    'NullAuthorizer',
-    'BasicAuthorizer',
-    'AccessTokenAuthorizer',
-    'RefreshTokenAuthorizer',
-    'ClientCredentialsAuthorizer',
+    "GlobusAuthorizer",
+    "NullAuthorizer",
+    "BasicAuthorizer",
+    "AccessTokenAuthorizer",
+    "RefreshTokenAuthorizer",
+    "ClientCredentialsAuthorizer",
 ]

--- a/globus_sdk/authorizers/access_token.py
+++ b/globus_sdk/authorizers/access_token.py
@@ -17,22 +17,29 @@ class AccessTokenAuthorizer(GlobusAuthorizer):
         ``access_token`` (*string*)
           An access token for Globus Auth
     """
+
     def __init__(self, access_token):
-        logger.info(("Setting up an AccessTokenAuthorizer. It will use an "
-                     "auth type of Bearer and cannot handle 401s."))
+        logger.info(
+            (
+                "Setting up an AccessTokenAuthorizer. It will use an "
+                "auth type of Bearer and cannot handle 401s."
+            )
+        )
         self.access_token = access_token
         self.header_val = "Bearer %s" % access_token
 
         self.access_token_hash = sha256_string(self.access_token)
-        logger.debug('Bearer token has hash "{}"'
-                     .format(self.access_token_hash))
+        logger.debug('Bearer token has hash "{}"'.format(self.access_token_hash))
 
     def set_authorization_header(self, header_dict):
         """
         Sets the ``Authorization`` header to
         "Bearer <access_token>"
         """
-        logger.debug(("Setting AccessToken Authorization Header: "
-                      '"Bearer token has hash "{}"')
-                     .format(self.access_token_hash))
-        header_dict['Authorization'] = self.header_val
+        logger.debug(
+            (
+                "Setting AccessToken Authorization Header: "
+                '"Bearer token has hash "{}"'
+            ).format(self.access_token_hash)
+        )
+        header_dict["Authorization"] = self.header_val

--- a/globus_sdk/authorizers/base.py
+++ b/globus_sdk/authorizers/base.py
@@ -1,4 +1,5 @@
 import abc
+
 import six
 
 
@@ -10,6 +11,7 @@ class GlobusAuthorizer(object):
     It may also have handling for responses that indicate that it has provided
     an invalid Authorization header.
     """
+
     @abc.abstractmethod
     def set_authorization_header(header_dict):
         """

--- a/globus_sdk/authorizers/basic.py
+++ b/globus_sdk/authorizers/basic.py
@@ -22,14 +22,19 @@ class BasicAuthorizer(GlobusAuthorizer):
         ``password`` (*string*)
           Password component for Basic Auth
     """
+
     def __init__(self, username, password):
-        logger.info(("Setting up a BasicAuthorizer. It will use an "
-                     "auth type of Basic and cannot handle 401s."))
+        logger.info(
+            (
+                "Setting up a BasicAuthorizer. It will use an "
+                "auth type of Basic and cannot handle 401s."
+            )
+        )
         logger.info("BasicAuthorizer.username = {}".format(username))
         self.username = username
         self.password = password
 
-        to_b64 = '{0}:{1}'.format(username, password)
+        to_b64 = "{0}:{1}".format(username, password)
         self.header_val = "Basic %s" % safe_b64encode(to_b64)
 
     def set_authorization_header(self, header_dict):
@@ -37,6 +42,9 @@ class BasicAuthorizer(GlobusAuthorizer):
         Sets the ``Authorization`` header to
         "Basic <base64 encoded username:password>"
         """
-        logger.debug(("Setting Basic Authorization Header: "
-                      '"Basic <{}:SECRET>"').format(self.username))
-        header_dict['Authorization'] = self.header_val
+        logger.debug(
+            ("Setting Basic Authorization Header: " '"Basic <{}:SECRET>"').format(
+                self.username
+            )
+        )
+        header_dict["Authorization"] = self.header_val

--- a/globus_sdk/authorizers/client_credentials.py
+++ b/globus_sdk/authorizers/client_credentials.py
@@ -59,26 +59,38 @@ class ClientCredentialsAuthorizer(RenewingAuthorizer):
           ``on_refresh`` callback can be used to update the Access Tokens and
           their expiration times.
     """
-    def __init__(self, confidential_client, scopes,
-                 access_token=None, expires_at=None, on_refresh=None):
-        logger.info((
-            "Setting up ClientCredentialsAuthorizer with confidential_client ="
-            " instance:{} and scopes = "
-            "{}".format(id(confidential_client), scopes)))
+
+    def __init__(
+        self,
+        confidential_client,
+        scopes,
+        access_token=None,
+        expires_at=None,
+        on_refresh=None,
+    ):
+        logger.info(
+            (
+                "Setting up ClientCredentialsAuthorizer with confidential_client ="
+                " instance:{} and scopes = "
+                "{}".format(id(confidential_client), scopes)
+            )
+        )
 
         # values for _get_token_data
         self.confidential_client = confidential_client
         self.scopes = scopes
 
         super(ClientCredentialsAuthorizer, self).__init__(
-            access_token, expires_at, on_refresh)
+            access_token, expires_at, on_refresh
+        )
 
     def _get_token_response(self):
         """
         Make a client credentials grant
         """
         return self.confidential_client.oauth2_client_credentials_tokens(
-            requested_scopes=self.scopes)
+            requested_scopes=self.scopes
+        )
 
     def _extract_token_data(self, res):
         """
@@ -90,6 +102,7 @@ class ClientCredentialsAuthorizer(RenewingAuthorizer):
             raise ValueError(
                 "Attempting get new access token for client credentials "
                 "authorizer didn't return exactly one token. Ensure scopes "
-                "{} are for only one resource server.".format(self.scopes))
+                "{} are for only one resource server.".format(self.scopes)
+            )
 
         return next(iter(token_data))

--- a/globus_sdk/authorizers/null.py
+++ b/globus_sdk/authorizers/null.py
@@ -10,10 +10,11 @@ class NullAuthorizer(GlobusAuthorizer):
     This Authorizer implements No Authentication -- as in, it ensures that
     there is no Authorization header.
     """
+
     def set_authorization_header(self, header_dict):
         """
         Removes the Authorization header from the given header dict if one was
         present.
         """
         logger.debug("NullAuthorizer: ensuring there is no Authorization")
-        header_dict.pop('Authorization', None)
+        header_dict.pop("Authorization", None)

--- a/globus_sdk/authorizers/refresh_token.py
+++ b/globus_sdk/authorizers/refresh_token.py
@@ -2,7 +2,6 @@ import logging
 
 from globus_sdk.authorizers.renewing import RenewingAuthorizer
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -54,18 +53,29 @@ class RefreshTokenAuthorizer(RenewingAuthorizer):
           ``on_refresh`` callback can be used to update the Access Tokens and
           their expiration times.
     """
-    def __init__(self, refresh_token, auth_client,
-                 access_token=None, expires_at=None, on_refresh=None):
-        logger.info((
-            "Setting up RefreshTokenAuthorizer with auth_client = "
-            "instance: {}".format(id(auth_client))))
+
+    def __init__(
+        self,
+        refresh_token,
+        auth_client,
+        access_token=None,
+        expires_at=None,
+        on_refresh=None,
+    ):
+        logger.info(
+            (
+                "Setting up RefreshTokenAuthorizer with auth_client = "
+                "instance: {}".format(id(auth_client))
+            )
+        )
 
         # required for _get_token_data
         self.refresh_token = refresh_token
         self.auth_client = auth_client
 
         super(RefreshTokenAuthorizer, self).__init__(
-            access_token, expires_at, on_refresh)
+            access_token, expires_at, on_refresh
+        )
 
     def _get_token_response(self):
         """
@@ -82,6 +92,7 @@ class RefreshTokenAuthorizer(RenewingAuthorizer):
         if len(token_data) != 1:
             raise ValueError(
                 "Attempting refresh for refresh token authorizer "
-                "didn't return exactly one token. Possible service error.")
+                "didn't return exactly one token. Possible service error."
+            )
 
         return next(iter(token_data))

--- a/globus_sdk/authorizers/renewing.py
+++ b/globus_sdk/authorizers/renewing.py
@@ -60,7 +60,7 @@ class RenewingAuthorizer(GlobusAuthorizer):
             )
         )
         if access_token is not None and expires_at is None:
-            logger.warn(
+            logger.warning(
                 (
                     "Initializing a RenewingAuthorizer with an "
                     "access_token and no expires_at time means that this "

--- a/globus_sdk/authorizers/renewing.py
+++ b/globus_sdk/authorizers/renewing.py
@@ -1,11 +1,11 @@
 import abc
-import six
 import logging
 import time
 
+import six
+
 from globus_sdk.authorizers.base import GlobusAuthorizer
 from globus_sdk.utils.string_hashing import sha256_string
-
 
 logger = logging.getLogger(__name__)
 # Provides a buffer for token expiration time to account for
@@ -53,14 +53,21 @@ class RenewingAuthorizer(GlobusAuthorizer):
     """
 
     def __init__(self, access_token=None, expires_at=None, on_refresh=None):
-        logger.info(("Setting up a RenewingAuthorizer. It will use an "
-                     "auth type of Bearer and can handle 401s."))
+        logger.info(
+            (
+                "Setting up a RenewingAuthorizer. It will use an "
+                "auth type of Bearer and can handle 401s."
+            )
+        )
         if access_token is not None and expires_at is None:
             logger.warn(
-                ("Initializing a RenewingAuthorizer with an "
-                 "access_token and no expires_at time means that this "
-                 "access_token will be discarded. You should either pass "
-                 "expires_at or not pass an access_token at all"))
+                (
+                    "Initializing a RenewingAuthorizer with an "
+                    "access_token and no expires_at time means that this "
+                    "access_token will be discarded. You should either pass "
+                    "expires_at or not pass an access_token at all"
+                )
+            )
             # coerce to None for simplicity / consistency
             access_token = None
 
@@ -72,16 +79,21 @@ class RenewingAuthorizer(GlobusAuthorizer):
         # expiration without an access token
         if expires_at is not None and self.access_token is not None:
             self.access_token_hash = sha256_string(self.access_token)
-            logger.info(("Got both expires_at and access_token. "
-                         "Will start by using "
-                         'RenewingAuthorizer.access_token with hash "{}"')
-                        .format(self.access_token_hash))
+            logger.info(
+                (
+                    "Got both expires_at and access_token. "
+                    "Will start by using "
+                    'RenewingAuthorizer.access_token with hash "{}"'
+                ).format(self.access_token_hash)
+            )
             self._set_expiration_time(expires_at)
 
         # if these were unspecified, fetch a new access token
         if self.access_token is None and self.expires_at is None:
-            logger.info("Creating RenewingAuthorizer without Access "
-                        "Token. Fetching initial token now.")
+            logger.info(
+                "Creating RenewingAuthorizer without Access "
+                "Token. Fetching initial token now."
+            )
             self._get_new_access_token()
 
     @abc.abstractmethod
@@ -105,9 +117,12 @@ class RenewingAuthorizer(GlobusAuthorizer):
         Set the expiration time adjusting for potential network delays.
         """
         self.expires_at = expires_at - EXPIRES_ADJUST_SECONDS
-        logger.debug(("Adjusted expiration time down to {} to account for "
-                      "potential delays.")
-                     .format(self.expires_at))
+        logger.debug(
+            (
+                "Adjusted expiration time down to {} to account for "
+                "potential delays."
+            ).format(self.expires_at)
+        )
 
     def _get_new_access_token(self):
         """
@@ -119,13 +134,15 @@ class RenewingAuthorizer(GlobusAuthorizer):
         res = self._get_token_response()
         token_data = self._extract_token_data(res)
 
-        self._set_expiration_time(token_data['expires_at_seconds'])
-        self.access_token = token_data['access_token']
+        self._set_expiration_time(token_data["expires_at_seconds"])
+        self.access_token = token_data["access_token"]
         self.access_token_hash = sha256_string(self.access_token)
 
-        logger.info(("RenewingAuthorizer.access_token updated to token "
-                     "with hash" '"{}"')
-                    .format(self.access_token_hash))
+        logger.info(
+            (
+                "RenewingAuthorizer.access_token updated to token " "with hash" '"{}"'
+            ).format(self.access_token_hash)
+        )
 
         if callable(self.on_refresh):
             self.on_refresh(res)
@@ -142,13 +159,17 @@ class RenewingAuthorizer(GlobusAuthorizer):
         """
         logger.debug("RenewingAuthorizer checking expiration time")
         if self.access_token is None or (
-                self.expires_at is None or time.time() > self.expires_at):
-            logger.debug(("RenewingAuthorizer determined time has "
-                          "expired. Fetching new Access Token"))
+            self.expires_at is None or time.time() > self.expires_at
+        ):
+            logger.debug(
+                (
+                    "RenewingAuthorizer determined time has "
+                    "expired. Fetching new Access Token"
+                )
+            )
             self._get_new_access_token()
         else:
-            logger.debug(("RenewingAuthorizer determined time has "
-                          "not yet expired"))
+            logger.debug(("RenewingAuthorizer determined time has " "not yet expired"))
 
     def set_authorization_header(self, header_dict):
         """
@@ -157,10 +178,13 @@ class RenewingAuthorizer(GlobusAuthorizer):
         "Bearer <access_token>"
         """
         self.check_expiration_time()
-        logger.debug(("Setting RefreshToken Authorization Header:"
-                      'Bearer token has hash "{}"')
-                     .format(self.access_token_hash))
-        header_dict['Authorization'] = "Bearer %s" % self.access_token
+        logger.debug(
+            (
+                "Setting RefreshToken Authorization Header:"
+                'Bearer token has hash "{}"'
+            ).format(self.access_token_hash)
+        )
+        header_dict["Authorization"] = "Bearer %s" % self.access_token
 
     def handle_missing_authorization(self, *args, **kwargs):
         """
@@ -169,8 +193,12 @@ class RenewingAuthorizer(GlobusAuthorizer):
         to ``set_authorization_header()`` will result in a new Access Token
         being fetched.
         """
-        logger.debug(("RenewingAuthorizer seeing 401. Invalidating "
-                      "token and preparing for refresh."))
+        logger.debug(
+            (
+                "RenewingAuthorizer seeing 401. Invalidating "
+                "token and preparing for refresh."
+            )
+        )
         # None for expires_at invalidates any current token
         self.expires_at = None
         # respond True, as in "we took some action, the 401 *may* be resolved"

--- a/globus_sdk/base.py
+++ b/globus_sdk/base.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+
 import json
 import logging
 
@@ -7,16 +8,17 @@ import six
 from six.moves.urllib.parse import quote
 
 from globus_sdk import config, exc
-from globus_sdk.version import __version__
 from globus_sdk.response import GlobusHTTPResponse
+from globus_sdk.version import __version__
 
 
 class ClientLogAdapter(logging.LoggerAdapter):
     """
     Stuff in the memory location of the client to make log records unambiguous.
     """
+
     def process(self, msg, kwargs):
-        return '[instance:{}] {}'.format(id(self.extra['client']), msg), kwargs
+        return "[instance:{}] {}".format(id(self.extra["client"]), msg), kwargs
 
     def warn(self, *args, **kwargs):
         return self.warning(*args, **kwargs)
@@ -57,28 +59,40 @@ class BaseClient(object):
     # a collection of authorizer types, or None to indicate "any"
     allowed_authorizer_types = None
 
-    BASE_USER_AGENT = 'globus-sdk-py-{0}'.format(__version__)
+    BASE_USER_AGENT = "globus-sdk-py-{0}".format(__version__)
 
-    def __init__(self, service, environment=None, base_url=None,
-                 base_path=None, authorizer=None, app_name=None,
-                 http_timeout=None,
-                 *args, **kwargs):
+    def __init__(
+        self,
+        service,
+        environment=None,
+        base_url=None,
+        base_path=None,
+        authorizer=None,
+        app_name=None,
+        http_timeout=None,
+        *args,
+        **kwargs
+    ):
         self._init_logger_adapter()
-        self.logger.info('Creating client of type {} for service "{}"'
-                         .format(type(self), service))
+        self.logger.info(
+            'Creating client of type {} for service "{}"'.format(type(self), service)
+        )
         # if restrictions have been placed by a child class on the allowed
         # authorizer types, make sure we are not in violation of those
         # constraints
         if self.allowed_authorizer_types is not None and (
-                authorizer is not None and
-                type(authorizer) not in self.allowed_authorizer_types):
-            self.logger.error("{} doesn't support authorizer={}"
-                              .format(type(self), type(authorizer)))
+            authorizer is not None
+            and type(authorizer) not in self.allowed_authorizer_types
+        ):
+            self.logger.error(
+                "{} doesn't support authorizer={}".format(type(self), type(authorizer))
+            )
             raise exc.GlobusSDKUsageError(
-                ("{0} can only take authorizers from {1}, "
-                 "but you have provided {2}").format(
-                    type(self), self.allowed_authorizer_types,
-                    type(authorizer)))
+                (
+                    "{0} can only take authorizers from {1}, "
+                    "but you have provided {2}"
+                ).format(type(self), self.allowed_authorizer_types, type(authorizer))
+            )
 
         # if an environment was passed, it will be used, but otherwise lookup
         # the env var -- and in the special case of `production` translate to
@@ -99,8 +113,8 @@ class BaseClient(object):
         # including basics for internal header dict
         self._session = requests.Session()
         self._headers = {
-            'Accept': 'application/json',
-            'User-Agent': self.BASE_USER_AGENT
+            "Accept": "application/json",
+            "User-Agent": self.BASE_USER_AGENT,
         }
 
         # verify SSL? Usually true
@@ -137,16 +151,17 @@ class BaseClient(object):
         # get the fully qualified name of the client class, so that it's a
         # child of globus_sdk
         self.logger = ClientLogAdapter(
-            logging.getLogger(self.__module__ + '.' + self.__class__.__name__),
-            {'client': self})
+            logging.getLogger(self.__module__ + "." + self.__class__.__name__),
+            {"client": self},
+        )
 
     def __getstate__(self):
         """
         Render to a serializable dict for pickle.dump(s)
         """
-        self.logger.info('__getstate__() called; client being pickled')
+        self.logger.info("__getstate__() called; client being pickled")
         d = dict(self.__dict__)  # copy
-        del d['logger']
+        del d["logger"]
         return d
 
     def __setstate__(self, d):
@@ -155,7 +170,7 @@ class BaseClient(object):
         """
         self._init_logger_adapter()
         self.__dict__.update(d)
-        self.logger.info('__setstate__() finished; client unpickled')
+        self.logger.info("__setstate__() finished; client unpickled")
 
     def set_app_name(self, app_name):
         """
@@ -167,14 +182,12 @@ class BaseClient(object):
         interacting with Globus Support.
         """
         self.app_name = app_name
-        self._headers['User-Agent'] = '{0}/{1}'.format(self.BASE_USER_AGENT,
-                                                       app_name)
+        self._headers["User-Agent"] = "{0}/{1}".format(self.BASE_USER_AGENT, app_name)
 
     def qjoin_path(self, *parts):
         return "/" + "/".join(quote(part) for part in parts)
 
-    def get(self, path, params=None, headers=None,
-            response_class=None, retry_401=True):
+    def get(self, path, params=None, headers=None, response_class=None, retry_401=True):
         """
         Make a GET request to the specified path.
 
@@ -200,13 +213,26 @@ class BaseClient(object):
         :return: :class:`GlobusHTTPResponse \
         <globus_sdk.response.GlobusHTTPResponse>` object
         """
-        self.logger.debug('GET to {} with params {}'.format(path, params))
-        return self._request("GET", path, params=params, headers=headers,
-                             response_class=response_class,
-                             retry_401=retry_401)
+        self.logger.debug("GET to {} with params {}".format(path, params))
+        return self._request(
+            "GET",
+            path,
+            params=params,
+            headers=headers,
+            response_class=response_class,
+            retry_401=retry_401,
+        )
 
-    def post(self, path, json_body=None, params=None, headers=None,
-             text_body=None, response_class=None, retry_401=True):
+    def post(
+        self,
+        path,
+        json_body=None,
+        params=None,
+        headers=None,
+        text_body=None,
+        response_class=None,
+        retry_401=True,
+    ):
         """
         Make a POST request to the specified path.
 
@@ -239,14 +265,21 @@ class BaseClient(object):
         :return: :class:`GlobusHTTPResponse \
         <globus_sdk.response.GlobusHTTPResponse>` object
         """
-        self.logger.debug('POST to {} with params {}'.format(path, params))
-        return self._request("POST", path, json_body=json_body, params=params,
-                             headers=headers, text_body=text_body,
-                             response_class=response_class,
-                             retry_401=retry_401)
+        self.logger.debug("POST to {} with params {}".format(path, params))
+        return self._request(
+            "POST",
+            path,
+            json_body=json_body,
+            params=params,
+            headers=headers,
+            text_body=text_body,
+            response_class=response_class,
+            retry_401=retry_401,
+        )
 
-    def delete(self, path, params=None, headers=None,
-               response_class=None, retry_401=True):
+    def delete(
+        self, path, params=None, headers=None, response_class=None, retry_401=True
+    ):
         """
         Make a DELETE request to the specified path.
 
@@ -272,14 +305,26 @@ class BaseClient(object):
         :return: :class:`GlobusHTTPResponse \
         <globus_sdk.response.GlobusHTTPResponse>` object
         """
-        self.logger.debug('DELETE to {} with params {}'.format(path, params))
-        return self._request("DELETE", path, params=params,
-                             headers=headers,
-                             response_class=response_class,
-                             retry_401=retry_401)
+        self.logger.debug("DELETE to {} with params {}".format(path, params))
+        return self._request(
+            "DELETE",
+            path,
+            params=params,
+            headers=headers,
+            response_class=response_class,
+            retry_401=retry_401,
+        )
 
-    def put(self, path, json_body=None, params=None, headers=None,
-            text_body=None, response_class=None, retry_401=True):
+    def put(
+        self,
+        path,
+        json_body=None,
+        params=None,
+        headers=None,
+        text_body=None,
+        response_class=None,
+        retry_401=True,
+    ):
         """
         Make a PUT request to the specified path.
 
@@ -312,14 +357,28 @@ class BaseClient(object):
         :return: :class:`GlobusHTTPResponse \
         <globus_sdk.response.GlobusHTTPResponse>` object
         """
-        self.logger.debug('PUT to {} with params {}'.format(path, params))
-        return self._request("PUT", path, json_body=json_body, params=params,
-                             headers=headers, text_body=text_body,
-                             response_class=response_class,
-                             retry_401=retry_401)
+        self.logger.debug("PUT to {} with params {}".format(path, params))
+        return self._request(
+            "PUT",
+            path,
+            json_body=json_body,
+            params=params,
+            headers=headers,
+            text_body=text_body,
+            response_class=response_class,
+            retry_401=retry_401,
+        )
 
-    def patch(self, path, json_body=None, params=None, headers=None,
-              text_body=None, response_class=None, retry_401=True):
+    def patch(
+        self,
+        path,
+        json_body=None,
+        params=None,
+        headers=None,
+        text_body=None,
+        response_class=None,
+        retry_401=True,
+    ):
         """
         Make a PATCH request to the specified path.
 
@@ -352,15 +411,29 @@ class BaseClient(object):
         :return: :class:`GlobusHTTPResponse \
         <globus_sdk.response.GlobusHTTPResponse>` object
         """
-        self.logger.debug('PATCH to {} with params {}'.format(path, params))
-        return self._request("PATCH", path, json_body=json_body, params=params,
-                             headers=headers, text_body=text_body,
-                             response_class=response_class,
-                             retry_401=retry_401)
+        self.logger.debug("PATCH to {} with params {}".format(path, params))
+        return self._request(
+            "PATCH",
+            path,
+            json_body=json_body,
+            params=params,
+            headers=headers,
+            text_body=text_body,
+            response_class=response_class,
+            retry_401=retry_401,
+        )
 
-    def _request(self, method, path, params=None, headers=None,
-                 json_body=None, text_body=None,
-                 response_class=None, retry_401=True):
+    def _request(
+        self,
+        method,
+        path,
+        params=None,
+        headers=None,
+        json_body=None,
+        text_body=None,
+        response_class=None,
+        retry_401=True,
+    ):
         """
 
         **Parameters**
@@ -405,26 +478,34 @@ class BaseClient(object):
             assert text_body is None
             text_body = json.dumps(json_body)
             # set appropriate content-type header
-            rheaders.update({'Content-Type': 'application/json'})
+            rheaders.update({"Content-Type": "application/json"})
 
         # add Authorization header, or (if it's a NullAuthorizer) possibly
         # explicitly remove the Authorization header
         if self.authorizer is not None:
-            self.logger.debug('request will have authorization of type {}'
-                              .format(type(self.authorizer)))
+            self.logger.debug(
+                "request will have authorization of type {}".format(
+                    type(self.authorizer)
+                )
+            )
             self.authorizer.set_authorization_header(rheaders)
 
         url = slash_join(self.base_url, path)
-        self.logger.debug('request will hit URL:{}'.format(url))
+        self.logger.debug("request will hit URL:{}".format(url))
 
         # because a 401 can trigger retry, we need to wrap the retry-able thing
         # in a method
         def send_request():
             try:
                 return self._session.request(
-                    method=method, url=url, headers=rheaders, params=params,
-                    data=text_body, verify=self._verify,
-                    timeout=self._http_timeout)
+                    method=method,
+                    url=url,
+                    headers=rheaders,
+                    params=params,
+                    data=text_body,
+                    verify=self._verify,
+                    timeout=self._http_timeout,
+                )
             except requests.RequestException as e:
                 self.logger.error("NetworkError on request")
                 raise exc.convert_request_exception(e)
@@ -432,30 +513,32 @@ class BaseClient(object):
         # initial request
         r = send_request()
 
-        self.logger.debug('Request made to URL: {}'.format(r.url))
+        self.logger.debug("Request made to URL: {}".format(r.url))
 
         # potential 401 retry handling
         if r.status_code == 401 and retry_401 and self.authorizer is not None:
-            self.logger.debug('request got 401, checking retry-capability')
+            self.logger.debug("request got 401, checking retry-capability")
             # note that although handle_missing_authorization returns a T/F
             # value, it may actually mutate the state of the authorizer and
             # therefore change the value set by the `set_authorization_header`
             # method
             if self.authorizer.handle_missing_authorization():
-                self.logger.debug('request can be retried')
+                self.logger.debug("request can be retried")
                 self.authorizer.set_authorization_header(rheaders)
                 r = send_request()
 
         if 200 <= r.status_code < 400:
-            self.logger.debug('request completed with response code: {}'
-                              .format(r.status_code))
+            self.logger.debug(
+                "request completed with response code: {}".format(r.status_code)
+            )
             if response_class is None:
                 return self.default_response_class(r, client=self)
             else:
                 return response_class(r, client=self)
 
-        self.logger.debug('request completed with (error) response code: {}'
-                          .format(r.status_code))
+        self.logger.debug(
+            "request completed with (error) response code: {}".format(r.status_code)
+        )
         raise self.error_class(r)
 
 
@@ -525,6 +608,6 @@ def safe_stringify(value):
     if isinstance(value, six.text_type):
         return value
     if isinstance(value, bytes):
-        return value.decode('utf-8')
+        return value.decode("utf-8")
     else:
-        return six.b(str(value)).decode('utf-8')
+        return six.b(str(value)).decode("utf-8")

--- a/globus_sdk/base.py
+++ b/globus_sdk/base.py
@@ -21,6 +21,17 @@ class ClientLogAdapter(logging.LoggerAdapter):
         return "[instance:{}] {}".format(id(self.extra["client"]), msg), kwargs
 
     def warn(self, *args, **kwargs):
+        """
+        NOTE: although Logger.warn() is deprecated in python, we've now made
+        it part of the interface for clients. We should only remove this
+        carefully, as someone may be leveraging something like
+
+        >>> TransferClient.logger.warn(...)
+
+        even though that would be a bad idea. At the very least, removing it
+        should be a considered move, not just thrown in with warn() ->
+        warning() cleanup.
+        """
         return self.warning(*args, **kwargs)
 
 

--- a/globus_sdk/exc.py
+++ b/globus_sdk/exc.py
@@ -118,7 +118,7 @@ class GlobusAPIError(GlobusError):
         """
         if "errors" in data:
             if len(data["errors"]) != 1:
-                logger.warn(
+                logger.warning(
                     (
                         "Doing JSON load of error response with multiple "
                         "errors. Exception data will only include the "
@@ -213,7 +213,7 @@ class AuthAPIError(GlobusAPIError):
         """
         if "errors" in data:
             if len(data["errors"]) != 1:
-                logger.warn(
+                logger.warning(
                     (
                         "Doing JSON load of error response with multiple "
                         "errors. Exception data will only include the "

--- a/globus_sdk/exc.py
+++ b/globus_sdk/exc.py
@@ -1,6 +1,7 @@
 import logging
-import six
+
 import requests
+import six
 
 logger = logging.getLogger(__name__)
 
@@ -33,23 +34,37 @@ class GlobusAPIError(GlobusError):
                    useful to developers, but there may be cases where it's
                    suitable for display to end users.
     """
+
     def __init__(self, r, *args, **kw):
         self._underlying_response = r
         self.http_status = r.status_code
         if "Content-Type" in r.headers and (
-                "application/json" in r.headers["Content-Type"]):
-            logger.debug(('Content-Type on error is application/json. '
-                          'Doing error load from JSON'))
+            "application/json" in r.headers["Content-Type"]
+        ):
+            logger.debug(
+                (
+                    "Content-Type on error is application/json. "
+                    "Doing error load from JSON"
+                )
+            )
             try:
                 self._load_from_json(r.json())
             except (KeyError, ValueError):
-                logger.error(('Error body could not be JSON decoded! '
-                              'This means the Content-Type is wrong, or the '
-                              'body is malformed!'))
+                logger.error(
+                    (
+                        "Error body could not be JSON decoded! "
+                        "This means the Content-Type is wrong, or the "
+                        "body is malformed!"
+                    )
+                )
                 self._load_from_text(r.text)
         else:
-            logger.debug(('Content-Type on error is unknown. '
-                          'Failing over to error load as text (default)'))
+            logger.debug(
+                (
+                    "Content-Type on error is unknown. "
+                    "Failing over to error load as text (default)"
+                )
+            )
             # fallback to using the entire body as the message for all
             # other types
             self._load_from_text(r.text)
@@ -66,13 +81,18 @@ class GlobusAPIError(GlobusError):
         """
         r = self._underlying_response
         if "Content-Type" in r.headers and (
-                "application/json" in r.headers["Content-Type"]):
+            "application/json" in r.headers["Content-Type"]
+        ):
             try:
                 return r.json()
             except ValueError:
-                logger.error(('Error body could not be JSON decoded! '
-                              'This means the Content-Type is wrong, or the '
-                              'body is malformed!'))
+                logger.error(
+                    (
+                        "Error body could not be JSON decoded! "
+                        "This means the Content-Type is wrong, or the "
+                        "body is malformed!"
+                    )
+                )
                 return None
         else:
             return None
@@ -98,17 +118,24 @@ class GlobusAPIError(GlobusError):
         """
         if "errors" in data:
             if len(data["errors"]) != 1:
-                logger.warn(("Doing JSON load of error response with multiple "
-                             "errors. Exception data will only include the "
-                             "first error, but there are really {} errors")
-                            .format(len(data["errors"])))
+                logger.warn(
+                    (
+                        "Doing JSON load of error response with multiple "
+                        "errors. Exception data will only include the "
+                        "first error, but there are really {} errors"
+                    ).format(len(data["errors"]))
+                )
             # TODO: handle responses with more than one error
             data = data["errors"][0]
         self.code = data["code"]
         if "message" in data:
-            logger.debug(("Doing JSON load of error response with 'message' "
-                          "field. There may also be a useful 'detail' field "
-                          "to inspect"))
+            logger.debug(
+                (
+                    "Doing JSON load of error response with 'message' "
+                    "field. There may also be a useful 'detail' field "
+                    "to inspect"
+                )
+            )
             self.message = data["message"]
         else:
             self.message = data["detail"]
@@ -130,6 +157,7 @@ class SearchAPIError(GlobusAPIError):
     :ivar error_data: Additional object returned in the error response. May be
                       a dict, list, or None.
     """
+
     def __init__(self, r):
         self.error_data = None
         GlobusAPIError.__init__(self, r)
@@ -151,6 +179,7 @@ class TransferAPIError(GlobusAPIError):
     :ivar request_id: Unique identifier for the request, which should be
                       provided when contacting support@globus.org.
     """
+
     def __init__(self, r):
         self.request_id = None
         GlobusAPIError.__init__(self, r)
@@ -170,6 +199,7 @@ class AuthAPIError(GlobusAPIError):
 
     Customizes JSON parsing.
     """
+
     def _load_from_json(self, data):
         """
         Load error data from a JSON document.
@@ -183,10 +213,13 @@ class AuthAPIError(GlobusAPIError):
         """
         if "errors" in data:
             if len(data["errors"]) != 1:
-                logger.warn(("Doing JSON load of error response with multiple "
-                             "errors. Exception data will only include the "
-                             "first error, but there are really {} errors")
-                            .format(len(data["errors"])))
+                logger.warn(
+                    (
+                        "Doing JSON load of error response with multiple "
+                        "errors. Exception data will only include the "
+                        "first error, but there are really {} errors"
+                    ).format(len(data["errors"]))
+                )
             # TODO: handle responses with more than one error
             data = data["errors"][0]
 
@@ -219,6 +252,7 @@ class NetworkError(GlobusError):
     Holds onto original exception data, but also takes a message
     to explain potentially confusing or inconsistent exceptions passed to us
     """
+
     def __init__(self, msg, exc, *args, **kw):
         super(NetworkError, self).__init__(msg)
         self.underlying_exception = exc
@@ -241,8 +275,7 @@ def convert_request_exception(exc):
     """Converts incoming requests.Exception to a Globus NetworkError"""
 
     if isinstance(exc, requests.ConnectTimeout):
-        return GlobusConnectionTimeoutError(
-            "ConnectTimeoutError on request", exc)
+        return GlobusConnectionTimeoutError("ConnectTimeoutError on request", exc)
     if isinstance(exc, requests.Timeout):
         return GlobusTimeoutError("TimeoutError on request", exc)
     elif isinstance(exc, requests.ConnectionError):

--- a/globus_sdk/local_endpoint/__init__.py
+++ b/globus_sdk/local_endpoint/__init__.py
@@ -1,3 +1,3 @@
 from globus_sdk.local_endpoint.personal import LocalGlobusConnectPersonal
 
-__all__ = ('LocalGlobusConnectPersonal',)
+__all__ = ("LocalGlobusConnectPersonal",)

--- a/globus_sdk/local_endpoint/personal.py
+++ b/globus_sdk/local_endpoint/personal.py
@@ -20,6 +20,7 @@ class LocalGlobusConnectPersonal(object):
     These objects do *not* inherit from BaseClient and do not provide methods
     for interacting with any Globus Service APIs.
     """
+
     def __init__(self):
         self._endpoint_id = None
 
@@ -52,12 +53,11 @@ class LocalGlobusConnectPersonal(object):
                     appdata = os.getenv("LOCALAPPDATA")
                     if appdata is None:
                         raise GlobusSDKUsageError(
-                            "LOCALAPPDATA not detected in Windows environment")
-                    fname = os.path.join(
-                        appdata, "Globus Connect\\client-id.txt")
+                            "LOCALAPPDATA not detected in Windows environment"
+                        )
+                    fname = os.path.join(appdata, "Globus Connect\\client-id.txt")
                 else:
-                    fname = os.path.expanduser(
-                        "~/.globusonline/lta/client-id.txt")
+                    fname = os.path.expanduser("~/.globusonline/lta/client-id.txt")
                 with open(fname) as fp:
                     self._endpoint_id = fp.read().strip()
             except IOError as e:

--- a/globus_sdk/response.py
+++ b/globus_sdk/response.py
@@ -109,7 +109,7 @@ class GlobusHTTPResponse(GlobusResponse):
         # if the caller *really* wants the raw body of the response, they can
         # always use text_body
         except ValueError:
-            logger.warn(
+            logger.warning(
                 ("GlobusHTTPResponse.data is null when body is not " "valid JSON")
             )
             return None

--- a/globus_sdk/response.py
+++ b/globus_sdk/response.py
@@ -20,6 +20,7 @@ class GlobusResponse(object):
     return to a caller. Most basic actions on a GlobusResponse are
     just ways of interacting with this data.
     """
+
     def __init__(self, data, client=None):
         # TODO: In v2, consider making client a required argument
         # client is the originating client object, which can be used by
@@ -43,15 +44,15 @@ class GlobusResponse(object):
         try:
             return data[key]
         except TypeError:
-            logger.error("Can't index into responses of type {}"
-                         .format(type(self)))
+            logger.error("Can't index into responses of type {}".format(type(self)))
             # re-raise with an altered message -- the issue is that whatever
             # type of GlobusResponse you're working with doesn't support
             # indexing
             # "type" is ambiguous, but we don't know if it's the fault of the
             # class at large, or just a particular call's `data` property
-            raise TypeError(('This type of GlobusResponse object '
-                             'does not support indexing.'))
+            raise TypeError(
+                ("This type of GlobusResponse object " "does not support indexing.")
+            )
 
     def __contains__(self, item):
         """
@@ -84,6 +85,7 @@ class GlobusHTTPResponse(GlobusResponse):
     :ivar http_status: HTTP status code returned by the server (int)
     :ivar content_type: Content-Type header returned by the server (str)
     """
+
     def __init__(self, http_response, client=None):
         # the API response as some form of HTTP response object will be the
         # underlying data of an API response
@@ -107,8 +109,9 @@ class GlobusHTTPResponse(GlobusResponse):
         # if the caller *really* wants the raw body of the response, they can
         # always use text_body
         except ValueError:
-            logger.warn(('GlobusHTTPResponse.data is null when body is not '
-                         'valid JSON'))
+            logger.warn(
+                ("GlobusHTTPResponse.data is null when body is not " "valid JSON")
+            )
             return None
 
     @property

--- a/globus_sdk/search/__init__.py
+++ b/globus_sdk/search/__init__.py
@@ -2,4 +2,4 @@ from globus_sdk.search.client import SearchClient
 from globus_sdk.search.query import SearchQuery
 
 
-__all__ = ('SearchClient', 'SearchQuery')
+__all__ = ("SearchClient", "SearchQuery")

--- a/globus_sdk/search/__init__.py
+++ b/globus_sdk/search/__init__.py
@@ -1,5 +1,4 @@
 from globus_sdk.search.client import SearchClient
 from globus_sdk.search.query import SearchQuery
 
-
 __all__ = ("SearchClient", "SearchQuery")

--- a/globus_sdk/search/client.py
+++ b/globus_sdk/search/client.py
@@ -1,10 +1,14 @@
 from __future__ import unicode_literals
+
 import logging
 
 from globus_sdk import exc
-from globus_sdk.base import BaseClient, merge_params, safe_stringify
 from globus_sdk.authorizers import (
-    AccessTokenAuthorizer, RefreshTokenAuthorizer, ClientCredentialsAuthorizer)
+    AccessTokenAuthorizer,
+    ClientCredentialsAuthorizer,
+    RefreshTokenAuthorizer,
+)
+from globus_sdk.base import BaseClient, merge_params, safe_stringify
 from globus_sdk.response import GlobusHTTPResponse
 
 logger = logging.getLogger(__name__)
@@ -40,9 +44,11 @@ class SearchClient(BaseClient):
     *  :py:meth:`.get_query_template_list`
     """
     # disallow basic auth
-    allowed_authorizer_types = [AccessTokenAuthorizer,
-                                RefreshTokenAuthorizer,
-                                ClientCredentialsAuthorizer]
+    allowed_authorizer_types = [
+        AccessTokenAuthorizer,
+        RefreshTokenAuthorizer,
+        ClientCredentialsAuthorizer,
+    ]
     error_class = exc.SearchAPIError
     default_response_class = GlobusHTTPResponse
 
@@ -82,8 +88,16 @@ class SearchClient(BaseClient):
     # Search queries
     #
 
-    def search(self, index_id, q, offset=0, limit=10, query_template=None,
-               advanced=False, **params):
+    def search(
+        self,
+        index_id,
+        q,
+        offset=0,
+        limit=10,
+        query_template=None,
+        advanced=False,
+        **params
+    ):
         """
         ``GET /v1/index/<index_id>/search``
 
@@ -102,11 +116,16 @@ class SearchClient(BaseClient):
         in the API documentation for details.
         """
         index_id = safe_stringify(index_id)
-        merge_params(params, q=q, offset=offset, limit=limit,
-                     query_template=query_template, advanced=advanced)
+        merge_params(
+            params,
+            q=q,
+            offset=offset,
+            limit=limit,
+            query_template=query_template,
+            advanced=advanced,
+        )
 
-        self.logger.info("SearchClient.search({}, ...)"
-                         .format(index_id))
+        self.logger.info("SearchClient.search({}, ...)".format(index_id))
         path = self.qjoin_path("v1/index", index_id, "search")
         return self.get(path, params=params)
 
@@ -151,8 +170,7 @@ class SearchClient(BaseClient):
         in the API documentation for details.
         """
         index_id = safe_stringify(index_id)
-        self.logger.info("SearchClient.post_search({}, ...)"
-                         .format(index_id))
+        self.logger.info("SearchClient.post_search({}, ...)".format(index_id))
         path = self.qjoin_path("v1/index", index_id, "search")
         return self.post(path, data)
 
@@ -252,8 +270,7 @@ class SearchClient(BaseClient):
         in the API documentation for details.
         """
         index_id = safe_stringify(index_id)
-        self.logger.info("SearchClient.delete_by_query({}, ...)"
-                         .format(index_id))
+        self.logger.info("SearchClient.delete_by_query({}, ...)".format(index_id))
         path = self.qjoin_path("v1/index", index_id, "delete_by_query")
         return self.post(path, data)
 
@@ -283,8 +300,9 @@ class SearchClient(BaseClient):
         index_id = safe_stringify(index_id)
         merge_params(params, subject=subject)
 
-        self.logger.info("SearchClient.get_subject({}, {}, ...)"
-                         .format(index_id, subject))
+        self.logger.info(
+            "SearchClient.get_subject({}, {}, ...)".format(index_id, subject)
+        )
         path = self.qjoin_path("v1/index", index_id, "subject")
         return self.get(path, params=params)
 
@@ -310,8 +328,9 @@ class SearchClient(BaseClient):
         index_id = safe_stringify(index_id)
         merge_params(params, subject=subject)
 
-        self.logger.info("SearchClient.delete_subject({}, {}, ...)"
-                         .format(index_id, subject))
+        self.logger.info(
+            "SearchClient.delete_subject({}, {}, ...)".format(index_id, subject)
+        )
         path = self.qjoin_path("v1/index", index_id, "subject")
         return self.delete(path, params=params)
 
@@ -348,8 +367,11 @@ class SearchClient(BaseClient):
         index_id = safe_stringify(index_id)
         merge_params(params, subject=subject, entry_id=entry_id)
 
-        self.logger.info("SearchClient.get_entry({}, {}, {}, ...)"
-                         .format(index_id, subject, entry_id))
+        self.logger.info(
+            "SearchClient.get_entry({}, {}, {}, ...)".format(
+                index_id, subject, entry_id
+            )
+        )
         path = self.qjoin_path("v1/index", index_id, "entry")
         return self.get(path, params=params)
 
@@ -454,8 +476,11 @@ class SearchClient(BaseClient):
         """
         index_id = safe_stringify(index_id)
         merge_params(params, subject=subject, entry_id=entry_id)
-        self.logger.info("SearchClient.delete_entry({}, {}, {}, ...)"
-                         .format(index_id, subject, entry_id))
+        self.logger.info(
+            "SearchClient.delete_entry({}, {}, {}, ...)".format(
+                index_id, subject, entry_id
+            )
+        )
         path = self.qjoin_path("v1/index", index_id, "entry")
         return self.delete(path, params=params)
 
@@ -475,10 +500,10 @@ class SearchClient(BaseClient):
         in the API documentation for details.
         """
         index_id = safe_stringify(index_id)
-        self.logger.info("SearchClient.get_query_template({}, {})"
-                         .format(index_id, template_name))
-        path = self.qjoin_path("v1/index", index_id, "query_template",
-                               template_name)
+        self.logger.info(
+            "SearchClient.get_query_template({}, {})".format(index_id, template_name)
+        )
+        path = self.qjoin_path("v1/index", index_id, "query_template", template_name)
         return self.get(path)
 
     def get_query_template_list(self, index_id):
@@ -493,7 +518,6 @@ class SearchClient(BaseClient):
         in the API documentation for details.
         """
         index_id = safe_stringify(index_id)
-        self.logger.info("SearchClient.get_query_template_list({})"
-                         .format(index_id))
+        self.logger.info("SearchClient.get_query_template_list({})".format(index_id))
         path = self.qjoin_path("v1/index", index_id, "query_template")
         return self.get(path)

--- a/globus_sdk/search/query.py
+++ b/globus_sdk/search/query.py
@@ -13,69 +13,65 @@ class SearchQuery(dict):
     >>>          .add_filter('path.to.field1', ['foo', 'bar']))
     >>> result = sc.post_search(index_id, query)
     """
+
     def set_query(self, query):
-        self['q'] = query
+        self["q"] = query
         return self
 
     def set_limit(self, limit):
-        self['limit'] = limit
+        self["limit"] = limit
         return self
 
     def set_offset(self, offset):
-        self['offset'] = offset
+        self["offset"] = offset
         return self
 
     def set_advanced(self, advanced):
-        self['advanced'] = advanced
+        self["advanced"] = advanced
         return self
 
-    def add_facet(self, name, field_name, type='terms', size=None,
-                  date_interval=None, histogram_range=None, **kwargs):
-        self['facets'] = self.get('facets', [])
-        facet = {
-            'name': name,
-            'field_name': field_name,
-            'type': type,
-        }
+    def add_facet(
+        self,
+        name,
+        field_name,
+        type="terms",
+        size=None,
+        date_interval=None,
+        histogram_range=None,
+        **kwargs
+    ):
+        self["facets"] = self.get("facets", [])
+        facet = {"name": name, "field_name": field_name, "type": type}
         facet.update(kwargs)
         if size is not None:
-            facet['size'] = size
+            facet["size"] = size
         if date_interval is not None:
-            facet['date_interval'] = date_interval
+            facet["date_interval"] = date_interval
         if histogram_range is not None:
             low, high = histogram_range
-            facet['histogram_range'] = {'low': low, 'high': high}
-        self['facets'].append(facet)
+            facet["histogram_range"] = {"low": low, "high": high}
+        self["facets"].append(facet)
         return self
 
-    def add_filter(self, field_name, values, type='match_all', **kwargs):
-        self['filters'] = self.get('filters', [])
-        new_filter = {
-            'field_name': field_name,
-            'values': values,
-            'type': type
-        }
+    def add_filter(self, field_name, values, type="match_all", **kwargs):
+        self["filters"] = self.get("filters", [])
+        new_filter = {"field_name": field_name, "values": values, "type": type}
         new_filter.update(kwargs)
-        self['filters'].append(new_filter)
+        self["filters"].append(new_filter)
         return self
 
     def add_boost(self, field_name, factor, **kwargs):
-        self['boosts'] = self.get('boosts', [])
-        boost = {
-            'field_name': field_name,
-            'factor': factor
-        }
+        self["boosts"] = self.get("boosts", [])
+        boost = {"field_name": field_name, "factor": factor}
         boost.update(kwargs)
-        self['boosts'].append(boost)
+        self["boosts"].append(boost)
         return self
 
     def add_sort(self, field_name, order=None, **kwargs):
-        self['sort'] = self.get('sort', [])
-        sort = {
-            'field_name': field_name,
-        }
+        self["sort"] = self.get("sort", [])
+        sort = {"field_name": field_name}
         sort.update(kwargs)
         if order is not None:
-            sort['order'] = order
-        self['sort'].append(sort)
+            sort["order"] = order
+        self["sort"].append(sort)
         return self

--- a/globus_sdk/transfer/__init__.py
+++ b/globus_sdk/transfer/__init__.py
@@ -1,4 +1,3 @@
 from globus_sdk.transfer.client import TransferClient
 
-
 __all__ = ["TransferClient"]

--- a/globus_sdk/transfer/__init__.py
+++ b/globus_sdk/transfer/__init__.py
@@ -1,4 +1,4 @@
 from globus_sdk.transfer.client import TransferClient
 
 
-__all__ = ['TransferClient']
+__all__ = ["TransferClient"]

--- a/globus_sdk/transfer/client.py
+++ b/globus_sdk/transfer/client.py
@@ -1,14 +1,21 @@
 from __future__ import unicode_literals
+
 import logging
 import time
 
 from globus_sdk import exc
-from globus_sdk.base import BaseClient, merge_params, safe_stringify
 from globus_sdk.authorizers import (
-    AccessTokenAuthorizer, RefreshTokenAuthorizer, ClientCredentialsAuthorizer)
-from globus_sdk.transfer.response import (
-    TransferResponse, IterableTransferResponse, ActivationRequirementsResponse)
+    AccessTokenAuthorizer,
+    ClientCredentialsAuthorizer,
+    RefreshTokenAuthorizer,
+)
+from globus_sdk.base import BaseClient, merge_params, safe_stringify
 from globus_sdk.transfer.paging import PaginatedResource
+from globus_sdk.transfer.response import (
+    ActivationRequirementsResponse,
+    IterableTransferResponse,
+    TransferResponse,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -114,15 +121,18 @@ class TransferClient(BaseClient):
 
     """
     # disallow basic auth
-    allowed_authorizer_types = [AccessTokenAuthorizer,
-                                RefreshTokenAuthorizer,
-                                ClientCredentialsAuthorizer]
+    allowed_authorizer_types = [
+        AccessTokenAuthorizer,
+        RefreshTokenAuthorizer,
+        ClientCredentialsAuthorizer,
+    ]
     error_class = exc.TransferAPIError
     default_response_class = TransferResponse
 
     def __init__(self, authorizer=None, **kwargs):
-        BaseClient.__init__(self, "transfer", base_path="/v0.10/",
-                            authorizer=authorizer, **kwargs)
+        BaseClient.__init__(
+            self, "transfer", base_path="/v0.10/", authorizer=authorizer, **kwargs
+        )
 
     # Convenience methods, providing more pythonic access to common REST
     # resources
@@ -178,20 +188,20 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/endpoint/#update_endpoint_by_id>`_
         in the REST documentation for details.
         """
-        if data.get('myproxy_server'):
-            if data.get('oauth_server'):
+        if data.get("myproxy_server"):
+            if data.get("oauth_server"):
                 raise exc.GlobusSDKUsageError(
                     "an endpoint cannot be reconfigured to use multiple "
                     "identity providers for activation; specify either "
-                    "MyProxy or OAuth, not both")
+                    "MyProxy or OAuth, not both"
+                )
             else:
-                data['oauth_server'] = None
-        elif data.get('oauth_server'):
-            data['myproxy_server'] = None
+                data["oauth_server"] = None
+        elif data.get("oauth_server"):
+            data["myproxy_server"] = None
 
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info("TransferClient.update_endpoint({}, ...)"
-                         .format(endpoint_id))
+        self.logger.info("TransferClient.update_endpoint({}, ...)".format(endpoint_id))
         path = self.qjoin_path("endpoint", endpoint_id)
         return self.put(path, data, params=params)
 
@@ -225,11 +235,12 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/endpoint/#create_endpoint>`_
         in the REST documentation for details.
         """
-        if data.get('myproxy_server') and data.get('oauth_server'):
+        if data.get("myproxy_server") and data.get("oauth_server"):
             raise exc.GlobusSDKUsageError(
                 "an endpoint cannot be created using multiple identity "
                 "providers for activation; specify either MyProxy or OAuth, "
-                "not both")
+                "not both"
+            )
 
         self.logger.info("TransferClient.create_endpoint(...)")
         return self.post("endpoint", data)
@@ -254,13 +265,13 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info("TransferClient.delete_endpoint({})"
-                         .format(endpoint_id))
+        self.logger.info("TransferClient.delete_endpoint({})".format(endpoint_id))
         path = self.qjoin_path("endpoint", endpoint_id)
         return self.delete(path)
 
-    def endpoint_search(self, filter_fulltext=None, filter_scope=None,
-                        num_results=25, **params):
+    def endpoint_search(
+        self, filter_fulltext=None, filter_scope=None, num_results=25, **params
+    ):
         r"""
         .. parsed-literal::
 
@@ -329,15 +340,18 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/endpoint_search>`_.
         in the REST documentation for details.
         """
-        merge_params(params, filter_scope=filter_scope,
-                     filter_fulltext=filter_fulltext)
+        merge_params(params, filter_scope=filter_scope, filter_fulltext=filter_fulltext)
         self.logger.info(
-            "TransferClient.endpoint_manager_monitored_endpoints({})"
-            .format(params))
+            "TransferClient.endpoint_manager_monitored_endpoints({})".format(params)
+        )
         return PaginatedResource(
-            self.get, "endpoint_search", {'params': params},
-            num_results=num_results, max_results_per_call=100,
-            max_total_results=1000)
+            self.get,
+            "endpoint_search",
+            {"params": params},
+            num_results=num_results,
+            max_results_per_call=100,
+            max_total_results=1000,
+        )
 
     def endpoint_autoactivate(self, endpoint_id, **params):
         r"""
@@ -401,8 +415,7 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info("TransferClient.endpoint_autoactivate({})"
-                         .format(endpoint_id))
+        self.logger.info("TransferClient.endpoint_autoactivate({})".format(endpoint_id))
         path = self.qjoin_path("endpoint", endpoint_id, "autoactivate")
         return self.post(path, params=params)
 
@@ -421,8 +434,7 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info("TransferClient.endpoint_deactivate({})"
-                         .format(endpoint_id))
+        self.logger.info("TransferClient.endpoint_deactivate({})".format(endpoint_id))
         path = self.qjoin_path("endpoint", endpoint_id, "deactivate")
         return self.post(path, params=params)
 
@@ -445,8 +457,7 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info("TransferClient.endpoint_activate({})"
-                         .format(endpoint_id))
+        self.logger.info("TransferClient.endpoint_activate({})".format(endpoint_id))
         path = self.qjoin_path("endpoint", endpoint_id, "activate")
         return self.post(path, json_body=requirements_data, params=params)
 
@@ -465,10 +476,10 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
-        path = self.qjoin_path("endpoint", endpoint_id,
-                               "activation_requirements")
-        return self.get(path, params=params,
-                        response_class=ActivationRequirementsResponse)
+        path = self.qjoin_path("endpoint", endpoint_id, "activation_requirements")
+        return self.get(
+            path, params=params, response_class=ActivationRequirementsResponse
+        )
 
     def my_effective_pause_rule_list(self, endpoint_id, **params):
         """
@@ -485,12 +496,11 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info("TransferClient.my_effective_pause_rule_list({}, ...)"
-                         .format(endpoint_id))
-        path = self.qjoin_path('endpoint', endpoint_id,
-                               'my_effective_pause_rule_list')
-        return self.get(path, params=params,
-                        response_class=IterableTransferResponse)
+        self.logger.info(
+            "TransferClient.my_effective_pause_rule_list({}, ...)".format(endpoint_id)
+        )
+        path = self.qjoin_path("endpoint", endpoint_id, "my_effective_pause_rule_list")
+        return self.get(path, params=params, response_class=IterableTransferResponse)
 
     # Shared Endpoints
 
@@ -509,12 +519,11 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info("TransferClient.my_shared_endpoint_list({}, ...)"
-                         .format(endpoint_id))
-        path = self.qjoin_path('endpoint', endpoint_id,
-                               'my_shared_endpoint_list')
-        return self.get(path, params=params,
-                        response_class=IterableTransferResponse)
+        self.logger.info(
+            "TransferClient.my_shared_endpoint_list({}, ...)".format(endpoint_id)
+        )
+        path = self.qjoin_path("endpoint", endpoint_id, "my_shared_endpoint_list")
+        return self.get(path, params=params, response_class=IterableTransferResponse)
 
     def create_shared_endpoint(self, data):
         """
@@ -550,7 +559,7 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         self.logger.info("TransferClient.create_shared_endpoint(...)")
-        return self.post('shared_endpoint', json_body=data)
+        return self.post("shared_endpoint", json_body=data)
 
     # Endpoint servers
 
@@ -569,11 +578,11 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info("TransferClient.endpoint_server_list({}, ...)"
-                         .format(endpoint_id))
-        path = self.qjoin_path('endpoint', endpoint_id, 'server_list')
-        return self.get(path, params=params,
-                        response_class=IterableTransferResponse)
+        self.logger.info(
+            "TransferClient.endpoint_server_list({}, ...)".format(endpoint_id)
+        )
+        path = self.qjoin_path("endpoint", endpoint_id, "server_list")
+        return self.get(path, params=params, response_class=IterableTransferResponse)
 
     def get_endpoint_server(self, endpoint_id, server_id, **params):
         """
@@ -590,10 +599,12 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info("TransferClient.get_endpoint_server({}, {}, ...)"
-                         .format(endpoint_id, server_id))
-        path = self.qjoin_path("endpoint", endpoint_id,
-                               "server", str(server_id))
+        self.logger.info(
+            "TransferClient.get_endpoint_server({}, {}, ...)".format(
+                endpoint_id, server_id
+            )
+        )
+        path = self.qjoin_path("endpoint", endpoint_id, "server", str(server_id))
         return self.get(path, params=params)
 
     def add_endpoint_server(self, endpoint_id, server_data):
@@ -611,8 +622,9 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info("TransferClient.add_endpoint_server({}, ...)"
-                         .format(endpoint_id))
+        self.logger.info(
+            "TransferClient.add_endpoint_server({}, ...)".format(endpoint_id)
+        )
         path = self.qjoin_path("endpoint", endpoint_id, "server")
         return self.post(path, server_data)
 
@@ -631,10 +643,12 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info("TransferClient.update_endpoint_server({}, {}, ...)"
-                         .format(endpoint_id, server_id))
-        path = self.qjoin_path("endpoint", endpoint_id,
-                               "server", str(server_id))
+        self.logger.info(
+            "TransferClient.update_endpoint_server({}, {}, ...)".format(
+                endpoint_id, server_id
+            )
+        )
+        path = self.qjoin_path("endpoint", endpoint_id, "server", str(server_id))
         return self.put(path, server_data)
 
     def delete_endpoint_server(self, endpoint_id, server_id):
@@ -652,10 +666,12 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info("TransferClient.delete_endpoint_server({}, {})"
-                         .format(endpoint_id, server_id))
-        path = self.qjoin_path("endpoint", endpoint_id,
-                               "server", str(server_id))
+        self.logger.info(
+            "TransferClient.delete_endpoint_server({}, {})".format(
+                endpoint_id, server_id
+            )
+        )
+        path = self.qjoin_path("endpoint", endpoint_id, "server", str(server_id))
         return self.delete(path)
 
     #
@@ -677,11 +693,11 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info("TransferClient.endpoint_role_list({}, ...)"
-                         .format(endpoint_id))
-        path = self.qjoin_path('endpoint', endpoint_id, 'role_list')
-        return self.get(path, params=params,
-                        response_class=IterableTransferResponse)
+        self.logger.info(
+            "TransferClient.endpoint_role_list({}, ...)".format(endpoint_id)
+        )
+        path = self.qjoin_path("endpoint", endpoint_id, "role_list")
+        return self.get(path, params=params, response_class=IterableTransferResponse)
 
     def add_endpoint_role(self, endpoint_id, role_data):
         """
@@ -698,9 +714,10 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info("TransferClient.add_endpoint_role({}, ...)"
-                         .format(endpoint_id))
-        path = self.qjoin_path('endpoint', endpoint_id, 'role')
+        self.logger.info(
+            "TransferClient.add_endpoint_role({}, ...)".format(endpoint_id)
+        )
+        path = self.qjoin_path("endpoint", endpoint_id, "role")
         return self.post(path, role_data)
 
     def get_endpoint_role(self, endpoint_id, role_id, **params):
@@ -718,9 +735,10 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info("TransferClient.get_endpoint_role({}, {}, ...)"
-                         .format(endpoint_id, role_id))
-        path = self.qjoin_path('endpoint', endpoint_id, 'role', role_id)
+        self.logger.info(
+            "TransferClient.get_endpoint_role({}, {}, ...)".format(endpoint_id, role_id)
+        )
+        path = self.qjoin_path("endpoint", endpoint_id, "role", role_id)
         return self.get(path, params=params)
 
     def delete_endpoint_role(self, endpoint_id, role_id):
@@ -738,9 +756,10 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info("TransferClient.delete_endpoint_role({}, {})"
-                         .format(endpoint_id, role_id))
-        path = self.qjoin_path('endpoint', endpoint_id, 'role', role_id)
+        self.logger.info(
+            "TransferClient.delete_endpoint_role({}, {})".format(endpoint_id, role_id)
+        )
+        path = self.qjoin_path("endpoint", endpoint_id, "role", role_id)
         return self.delete(path)
 
     #
@@ -762,11 +781,11 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info("TransferClient.endpoint_acl_list({}, ...)"
-                         .format(endpoint_id))
-        path = self.qjoin_path('endpoint', endpoint_id, 'access_list')
-        return self.get(path, params=params,
-                        response_class=IterableTransferResponse)
+        self.logger.info(
+            "TransferClient.endpoint_acl_list({}, ...)".format(endpoint_id)
+        )
+        path = self.qjoin_path("endpoint", endpoint_id, "access_list")
+        return self.get(path, params=params, response_class=IterableTransferResponse)
 
     def get_endpoint_acl_rule(self, endpoint_id, rule_id, **params):
         """
@@ -783,9 +802,12 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info("TransferClient.get_endpoint_acl_rule({}, {}, ...)"
-                         .format(endpoint_id, rule_id))
-        path = self.qjoin_path('endpoint', endpoint_id, 'access', rule_id)
+        self.logger.info(
+            "TransferClient.get_endpoint_acl_rule({}, {}, ...)".format(
+                endpoint_id, rule_id
+            )
+        )
+        path = self.qjoin_path("endpoint", endpoint_id, "access", rule_id)
         return self.get(path, params=params)
 
     def add_endpoint_acl_rule(self, endpoint_id, rule_data):
@@ -827,9 +849,10 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info("TransferClient.add_endpoint_acl_rule({}, ...)"
-                         .format(endpoint_id))
-        path = self.qjoin_path('endpoint', endpoint_id, 'access')
+        self.logger.info(
+            "TransferClient.add_endpoint_acl_rule({}, ...)".format(endpoint_id)
+        )
+        path = self.qjoin_path("endpoint", endpoint_id, "access")
         return self.post(path, rule_data)
 
     def update_endpoint_acl_rule(self, endpoint_id, rule_id, rule_data):
@@ -847,9 +870,12 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info("TransferClient.update_endpoint_acl_rule({}, {}, ...)"
-                         .format(endpoint_id, rule_id))
-        path = self.qjoin_path('endpoint', endpoint_id, 'access', rule_id)
+        self.logger.info(
+            "TransferClient.update_endpoint_acl_rule({}, {}, ...)".format(
+                endpoint_id, rule_id
+            )
+        )
+        path = self.qjoin_path("endpoint", endpoint_id, "access", rule_id)
         return self.put(path, rule_data)
 
     def delete_endpoint_acl_rule(self, endpoint_id, rule_id):
@@ -867,9 +893,12 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info("TransferClient.delete_endpoint_acl_rule({}, {})"
-                         .format(endpoint_id, rule_id))
-        path = self.qjoin_path('endpoint', endpoint_id, 'access', rule_id)
+        self.logger.info(
+            "TransferClient.delete_endpoint_acl_rule({}, {})".format(
+                endpoint_id, rule_id
+            )
+        )
+        path = self.qjoin_path("endpoint", endpoint_id, "access", rule_id)
         return self.delete(path)
 
     #
@@ -891,8 +920,9 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         self.logger.info("TransferClient.bookmark_list({})".format(params))
-        return self.get('bookmark_list', params=params,
-                        response_class=IterableTransferResponse)
+        return self.get(
+            "bookmark_list", params=params, response_class=IterableTransferResponse
+        )
 
     def create_bookmark(self, bookmark_data):
         """
@@ -908,9 +938,8 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/endpoint_bookmarks/#create_bookmark>`_
         in the REST documentation for details.
         """
-        self.logger.info("TransferClient.create_bookmark({})"
-                         .format(bookmark_data))
-        return self.post('bookmark', bookmark_data)
+        self.logger.info("TransferClient.create_bookmark({})".format(bookmark_data))
+        return self.post("bookmark", bookmark_data)
 
     def get_bookmark(self, bookmark_id, **params):
         """
@@ -928,7 +957,7 @@ class TransferClient(BaseClient):
         """
         bookmark_id = safe_stringify(bookmark_id)
         self.logger.info("TransferClient.get_bookmark({})".format(bookmark_id))
-        path = self.qjoin_path('bookmark', bookmark_id)
+        path = self.qjoin_path("bookmark", bookmark_id)
         return self.get(path, params=params)
 
     def update_bookmark(self, bookmark_id, bookmark_data):
@@ -945,9 +974,8 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/endpoint_bookmarks/#update_bookmark>`_
         in the REST documentation for details.
         """
-        self.logger.info("TransferClient.update_bookmark({})"
-                         .format(bookmark_id))
-        path = self.qjoin_path('bookmark', bookmark_id)
+        self.logger.info("TransferClient.update_bookmark({})".format(bookmark_id))
+        path = self.qjoin_path("bookmark", bookmark_id)
         return self.put(path, bookmark_data)
 
     def delete_bookmark(self, bookmark_id):
@@ -964,9 +992,8 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/endpoint_bookmarks/#delete_bookmark_by_id>`_
         in the REST documentation for details.
         """
-        self.logger.info("TransferClient.delete_bookmark({})"
-                         .format(bookmark_id))
-        path = self.qjoin_path('bookmark', bookmark_id)
+        self.logger.info("TransferClient.delete_bookmark({})".format(bookmark_id))
+        path = self.qjoin_path("bookmark", bookmark_id)
         return self.delete(path)
 
     #
@@ -994,11 +1021,11 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info("TransferClient.operation_ls({}, {})"
-                         .format(endpoint_id, params))
+        self.logger.info(
+            "TransferClient.operation_ls({}, {})".format(endpoint_id, params)
+        )
         path = self.qjoin_path("operation/endpoint", endpoint_id, "ls")
-        return self.get(path, params=params,
-                        response_class=IterableTransferResponse)
+        return self.get(path, params=params, response_class=IterableTransferResponse)
 
     def operation_mkdir(self, endpoint_id, path, **params):
         """
@@ -1021,14 +1048,13 @@ class TransferClient(BaseClient):
         """
         endpoint_id = safe_stringify(endpoint_id)
         path = safe_stringify(path)
-        self.logger.info("TransferClient.operation_mkdir({}, {}, {})"
-                         .format(endpoint_id, path, params))
-        resource_path = self.qjoin_path("operation/endpoint", endpoint_id,
-                                        "mkdir")
-        json_body = {
-            'DATA_TYPE': 'mkdir',
-            'path': path
-        }
+        self.logger.info(
+            "TransferClient.operation_mkdir({}, {}, {})".format(
+                endpoint_id, path, params
+            )
+        )
+        resource_path = self.qjoin_path("operation/endpoint", endpoint_id, "mkdir")
+        json_body = {"DATA_TYPE": "mkdir", "path": path}
         return self.post(resource_path, json_body=json_body, params=params)
 
     def operation_rename(self, endpoint_id, oldpath, newpath, **params):
@@ -1054,15 +1080,13 @@ class TransferClient(BaseClient):
         endpoint_id = safe_stringify(endpoint_id)
         oldpath = safe_stringify(oldpath)
         newpath = safe_stringify(newpath)
-        self.logger.info("TransferClient.operation_rename({}, {}, {}, {})"
-                         .format(endpoint_id, oldpath, newpath, params))
-        resource_path = self.qjoin_path("operation/endpoint", endpoint_id,
-                                        "rename")
-        json_body = {
-            'DATA_TYPE': 'rename',
-            'old_path': oldpath,
-            'new_path': newpath
-        }
+        self.logger.info(
+            "TransferClient.operation_rename({}, {}, {}, {})".format(
+                endpoint_id, oldpath, newpath, params
+            )
+        )
+        resource_path = self.qjoin_path("operation/endpoint", endpoint_id, "rename")
+        json_body = {"DATA_TYPE": "rename", "old_path": oldpath, "new_path": newpath}
         return self.post(resource_path, json_body=json_body, params=params)
 
     def operation_symlink(self, endpoint_id, symlink_target, path, **params):
@@ -1091,14 +1115,16 @@ class TransferClient(BaseClient):
         endpoint_id = safe_stringify(endpoint_id)
         symlink_target = safe_stringify(symlink_target)
         path = safe_stringify(path)
-        self.logger.info("TransferClient.operation_symlink({}, {}, {}, {})"
-                         .format(endpoint_id, symlink_target, path, params))
-        resource_path = self.qjoin_path("operation/endpoint", endpoint_id,
-                                        "symlink")
+        self.logger.info(
+            "TransferClient.operation_symlink({}, {}, {}, {})".format(
+                endpoint_id, symlink_target, path, params
+            )
+        )
+        resource_path = self.qjoin_path("operation/endpoint", endpoint_id, "symlink")
         json_body = {
             "DATA_TYPE": "symlink",
             "symlink_target": symlink_target,
-            "path": path
+            "path": path,
         }
         return self.post(resource_path, json_body=json_body, params=params)
 
@@ -1164,7 +1190,7 @@ class TransferClient(BaseClient):
         in the REST documentation for more details.
         """
         self.logger.info("TransferClient.submit_transfer(...)")
-        return self.post('/transfer', data)
+        return self.post("/transfer", data)
 
     def submit_delete(self, data):
         """
@@ -1193,7 +1219,7 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         self.logger.info("TransferClient.submit_delete(...)")
-        return self.post('/delete', data)
+        return self.post("/delete", data)
 
     #
     # Task inspection and management
@@ -1239,9 +1265,13 @@ class TransferClient(BaseClient):
         """
         self.logger.info("TransferClient.task_list(...)")
         return PaginatedResource(
-            self.get, 'task_list', {'params': params},
-            num_results=num_results, max_results_per_call=1000,
-            paging_style=PaginatedResource.PAGING_STYLE_TOTAL)
+            self.get,
+            "task_list",
+            {"params": params},
+            num_results=num_results,
+            max_results_per_call=1000,
+            paging_style=PaginatedResource.PAGING_STYLE_TOTAL,
+        )
 
     def task_event_list(self, task_id, num_results=10, **params):
         r"""
@@ -1284,13 +1314,16 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/task/#get_event_list>`_
         in the REST documentation for details.
         """
-        self.logger.info("TransferClient.task_event_list({}, ...)"
-                         .format(task_id))
-        path = self.qjoin_path('task', task_id, 'event_list')
+        self.logger.info("TransferClient.task_event_list({}, ...)".format(task_id))
+        path = self.qjoin_path("task", task_id, "event_list")
         return PaginatedResource(
-            self.get, path, {'params': params},
-            num_results=num_results, max_results_per_call=1000,
-            paging_style=PaginatedResource.PAGING_STYLE_TOTAL)
+            self.get,
+            path,
+            {"params": params},
+            num_results=num_results,
+            max_results_per_call=1000,
+            paging_style=PaginatedResource.PAGING_STYLE_TOTAL,
+        )
 
     def get_task(self, task_id, **params):
         """
@@ -1393,22 +1426,29 @@ class TransferClient(BaseClient):
         >>>     print(".", end="")
         >>> print("\n{0} completed!".format(task_id))
         """
-        self.logger.info("TransferClient.task_wait({}, {}, {})"
-                         .format(task_id, timeout, polling_interval))
+        self.logger.info(
+            "TransferClient.task_wait({}, {}, {})".format(
+                task_id, timeout, polling_interval
+            )
+        )
 
         # check valid args
         if timeout < 1:
             self.logger.error(
-                "task_wait() timeout={} is less than minimum of 1s"
-                .format(timeout))
+                "task_wait() timeout={} is less than minimum of 1s".format(timeout)
+            )
             raise exc.GlobusSDKUsageError(
-                "TransferClient.task_wait timeout has a minimum of 1")
+                "TransferClient.task_wait timeout has a minimum of 1"
+            )
         if polling_interval < 1:
             self.logger.error(
-                "task_wait() polling_interval={} is less than minimum of 1s"
-                .format(polling_interval))
+                "task_wait() polling_interval={} is less than minimum of 1s".format(
+                    polling_interval
+                )
+            )
             raise exc.GlobusSDKUsageError(
-                "TransferClient.task_wait polling_interval has a minimum of 1")
+                "TransferClient.task_wait polling_interval has a minimum of 1"
+            )
 
         # ensure that we always wait at least one interval, even if the timeout
         # is shorter than the polling interval, by reducing the interval to the
@@ -1425,24 +1465,25 @@ class TransferClient(BaseClient):
         while True:
             # get task, check if status != ACTIVE
             task = self.get_task(task_id)
-            status = task['status']
-            if status != 'ACTIVE':
+            status = task["status"]
+            if status != "ACTIVE":
                 self.logger.debug(
-                    "task_wait(task_id={}) terminated with status={}"
-                    .format(task_id, status))
+                    "task_wait(task_id={}) terminated with status={}".format(
+                        task_id, status
+                    )
+                )
                 return True
 
             # make sure to check if we timed out before sleeping again, so we
             # don't sleep an extra polling_interval
             waited_time += polling_interval
             if timed_out(waited_time):
-                self.logger.debug(
-                    "task_wait(task_id={}) timed out".format(task_id))
+                self.logger.debug("task_wait(task_id={}) timed out".format(task_id))
                 return False
 
             self.logger.debug(
-                "task_wait(task_id={}) waiting {}s"
-                .format(task_id, polling_interval))
+                "task_wait(task_id={}) waiting {}s".format(task_id, polling_interval)
+            )
             time.sleep(polling_interval)
         # unreachable -- end of task_wait
 
@@ -1460,8 +1501,7 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/task/#get_task_pause_info>`_
         in the REST documentation for details.
         """
-        self.logger.info("TransferClient.task_pause_info({}, ...)"
-                         .format(task_id))
+        self.logger.info("TransferClient.task_pause_info({}, ...)".format(task_id))
         resource_path = self.qjoin_path("task", task_id, "pause_info")
         return self.get(resource_path, params=params)
 
@@ -1507,15 +1547,19 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/task/#get_task_successful_transfers>`_
         in the REST documentation for details.
         """
-        self.logger.info("TransferClient.task_successful_transfers({}, ...)"
-                         .format(task_id))
+        self.logger.info(
+            "TransferClient.task_successful_transfers({}, ...)".format(task_id)
+        )
 
-        resource_path = self.qjoin_path("task", task_id,
-                                        "successful_transfers")
+        resource_path = self.qjoin_path("task", task_id, "successful_transfers")
         return PaginatedResource(
-            self.get, resource_path, {'params': params},
-            num_results=num_results, max_results_per_call=1000,
-            paging_style=PaginatedResource.PAGING_STYLE_MARKER)
+            self.get,
+            resource_path,
+            {"params": params},
+            num_results=num_results,
+            max_results_per_call=1000,
+            paging_style=PaginatedResource.PAGING_STYLE_MARKER,
+        )
 
     #
     # advanced endpoint management (requires endpoint manager role)
@@ -1536,11 +1580,10 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         self.logger.info(
-            "TransferClient.endpoint_manager_monitored_endpoints({})"
-            .format(params))
-        path = self.qjoin_path('endpoint_manager', 'monitored_endpoints')
-        return self.get(path, params=params,
-                        response_class=IterableTransferResponse)
+            "TransferClient.endpoint_manager_monitored_endpoints({})".format(params)
+        )
+        path = self.qjoin_path("endpoint_manager", "monitored_endpoints")
+        return self.get(path, params=params, response_class=IterableTransferResponse)
 
     def endpoint_manager_hosted_endpoint_list(self, endpoint_id, **params):
         """
@@ -1557,12 +1600,16 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info(("TransferClient.endpoint_manager_"
-                          "hosted_endpoint_list({})".format(endpoint_id)))
-        path = self.qjoin_path("endpoint_manager", "endpoint",
-                               endpoint_id, "hosted_endpoint_list")
-        return self.get(path, params=params,
-                        response_class=IterableTransferResponse)
+        self.logger.info(
+            (
+                "TransferClient.endpoint_manager_"
+                "hosted_endpoint_list({})".format(endpoint_id)
+            )
+        )
+        path = self.qjoin_path(
+            "endpoint_manager", "endpoint", endpoint_id, "hosted_endpoint_list"
+        )
+        return self.get(path, params=params, response_class=IterableTransferResponse)
 
     def endpoint_manager_get_endpoint(self, endpoint_id, **params):
         """
@@ -1581,8 +1628,9 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info(("TransferClient.endpoint_manager_"
-                          "get_endpoint({})".format(endpoint_id)))
+        self.logger.info(
+            ("TransferClient.endpoint_manager_" "get_endpoint({})".format(endpoint_id))
+        )
         path = self.qjoin_path("endpoint_manager", "endpoint", endpoint_id)
         return self.get(path, params=params)
 
@@ -1603,12 +1651,16 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info(("TransferClient.endpoint_manager_"
-                          "endpoint_acl_list({}, ...)".format(endpoint_id)))
-        path = self.qjoin_path("endpoint_manager", "endpoint",
-                               endpoint_id, "access_list")
-        return self.get(path, params=params,
-                        response_class=IterableTransferResponse)
+        self.logger.info(
+            (
+                "TransferClient.endpoint_manager_"
+                "endpoint_acl_list({}, ...)".format(endpoint_id)
+            )
+        )
+        path = self.qjoin_path(
+            "endpoint_manager", "endpoint", endpoint_id, "access_list"
+        )
+        return self.get(path, params=params, response_class=IterableTransferResponse)
 
     #
     # endpoint manager task methods
@@ -1663,11 +1715,15 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         self.logger.info("TransferClient.endpoint_manager_task_list(...)")
-        path = self.qjoin_path('endpoint_manager', 'task_list')
+        path = self.qjoin_path("endpoint_manager", "task_list")
         return PaginatedResource(
-            self.get, path, {'params': params},
-            num_results=num_results, max_results_per_call=1000,
-            paging_style=PaginatedResource.PAGING_STYLE_LAST_KEY)
+            self.get,
+            path,
+            {"params": params},
+            num_results=num_results,
+            max_results_per_call=1000,
+            paging_style=PaginatedResource.PAGING_STYLE_LAST_KEY,
+        )
 
     def endpoint_manager_get_task(self, task_id, **params):
         """
@@ -1687,13 +1743,13 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         task_id = safe_stringify(task_id)
-        self.logger.info(("TransferClient.endpoint_manager_"
-                          "get_task({}, ...)".format(task_id)))
+        self.logger.info(
+            ("TransferClient.endpoint_manager_" "get_task({}, ...)".format(task_id))
+        )
         path = self.qjoin_path("endpoint_manager", "task", task_id)
         return self.get(path, params=params)
 
-    def endpoint_manager_task_event_list(self, task_id,
-                                         num_results=10, **params):
+    def endpoint_manager_task_event_list(self, task_id, num_results=10, **params):
         """
         List events (for example, faults and errors) for a given task as an
         admin. Requires activity monitor effective role on the destination
@@ -1727,14 +1783,21 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         task_id = safe_stringify(task_id)
-        self.logger.info(("TransferClient.endpoint_manager_"
-                          "task_event_list({}, ...)".format(task_id)))
-        path = self.qjoin_path("endpoint_manager", "task",
-                               task_id, "event_list")
+        self.logger.info(
+            (
+                "TransferClient.endpoint_manager_"
+                "task_event_list({}, ...)".format(task_id)
+            )
+        )
+        path = self.qjoin_path("endpoint_manager", "task", task_id, "event_list")
         return PaginatedResource(
-            self.get, path, {"params": params},
-            num_results=num_results, max_results_per_call=1000,
-            paging_style=PaginatedResource.PAGING_STYLE_TOTAL)
+            self.get,
+            path,
+            {"params": params},
+            num_results=num_results,
+            max_results_per_call=1000,
+            paging_style=PaginatedResource.PAGING_STYLE_TOTAL,
+        )
 
     def endpoint_manager_task_pause_info(self, task_id, **params):
         """
@@ -1754,14 +1817,18 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         task_id = safe_stringify(task_id)
-        self.logger.info(("TransferClient.endpoint_manager_"
-                         "task_pause_info({}, ...)".format(task_id)))
-        path = self.qjoin_path("endpoint_manager", "task",
-                               task_id, "pause_info")
+        self.logger.info(
+            (
+                "TransferClient.endpoint_manager_"
+                "task_pause_info({}, ...)".format(task_id)
+            )
+        )
+        path = self.qjoin_path("endpoint_manager", "task", task_id, "pause_info")
         return self.get(path, params=params)
 
-    def endpoint_manager_task_successful_transfers(self, task_id,
-                                                   num_results=100, **params):
+    def endpoint_manager_task_successful_transfers(
+        self, task_id, num_results=100, **params
+    ):
         """
         Get the successful file transfers for a completed Task as an admin.
 
@@ -1794,15 +1861,24 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         task_id = safe_stringify(task_id)
-        self.logger.info(("TransferClient.endpoint_manager_task_"
-                          "successful_transfers({}, ...)".format(task_id)))
+        self.logger.info(
+            (
+                "TransferClient.endpoint_manager_task_"
+                "successful_transfers({}, ...)".format(task_id)
+            )
+        )
 
-        resource_path = self.qjoin_path("endpoint_manager", "task", task_id,
-                                        "successful_transfers")
+        resource_path = self.qjoin_path(
+            "endpoint_manager", "task", task_id, "successful_transfers"
+        )
         return PaginatedResource(
-            self.get, resource_path, {'params': params},
-            num_results=num_results, max_results_per_call=1000,
-            paging_style=PaginatedResource.PAGING_STYLE_MARKER)
+            self.get,
+            resource_path,
+            {"params": params},
+            num_results=num_results,
+            max_results_per_call=1000,
+            paging_style=PaginatedResource.PAGING_STYLE_MARKER,
+        )
 
     def endpoint_manager_cancel_tasks(self, task_ids, message, **params):
         """
@@ -1834,12 +1910,13 @@ class TransferClient(BaseClient):
         """
         task_ids = [safe_stringify(i) for i in task_ids]
         message = safe_stringify(message)
-        self.logger.info(("TransferClient.endpoint_manager_"
-                          "cancel_tasks({},{})".format(task_ids, message)))
-        json_body = {
-            "message": safe_stringify(message),
-            "task_id_list": task_ids
-        }
+        self.logger.info(
+            (
+                "TransferClient.endpoint_manager_"
+                "cancel_tasks({},{})".format(task_ids, message)
+            )
+        )
+        json_body = {"message": safe_stringify(message), "task_id_list": task_ids}
         path = self.qjoin_path("endpoint_manager", "admin_cancel")
         return self.post(path, json_body=json_body, params=params)
 
@@ -1868,10 +1945,13 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/advanced_endpoint_management/#get_cancel_status_by_id>`_
         in the REST documentation for details.
         """
-        self.logger.info(("TransferClient.endpoint_manager_"
-                          "cancel_status({})".format(admin_cancel_id)))
-        path = self.qjoin_path("endpoint_manager", "admin_cancel",
-                               admin_cancel_id)
+        self.logger.info(
+            (
+                "TransferClient.endpoint_manager_"
+                "cancel_status({})".format(admin_cancel_id)
+            )
+        )
+        path = self.qjoin_path("endpoint_manager", "admin_cancel", admin_cancel_id)
         return self.get(path, params=params)
 
     def endpoint_manager_pause_tasks(self, task_ids, message, **params):
@@ -1904,12 +1984,13 @@ class TransferClient(BaseClient):
         """
         task_ids = [safe_stringify(i) for i in task_ids]
         message = safe_stringify(message)
-        self.logger.info(("TransferClient.endpoint_manager_"
-                          "pause_tasks({},{})".format(task_ids, message)))
-        json_body = {
-            "message": safe_stringify(message),
-            "task_id_list": task_ids
-        }
+        self.logger.info(
+            (
+                "TransferClient.endpoint_manager_"
+                "pause_tasks({},{})".format(task_ids, message)
+            )
+        )
+        json_body = {"message": safe_stringify(message), "task_id_list": task_ids}
         path = self.qjoin_path("endpoint_manager", "admin_pause")
         return self.post(path, json_body=json_body, params=params)
 
@@ -1939,11 +2020,10 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         task_ids = [safe_stringify(i) for i in task_ids]
-        self.logger.info(("TransferClient.endpoint_manager_"
-                          "resume_tasks({})".format(task_ids)))
-        json_body = {
-            "task_id_list": task_ids
-        }
+        self.logger.info(
+            ("TransferClient.endpoint_manager_" "resume_tasks({})".format(task_ids))
+        )
+        json_body = {"task_id_list": task_ids}
         path = self.qjoin_path("endpoint_manager", "admin_resume")
         return self.post(path, json_body=json_body, params=params)
 
@@ -1981,12 +2061,10 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/advanced_endpoint_management/#get_pause_rules>`_
         in the REST documentation for details.
         """
-        self.logger.info(("TransferClient.endpoint_manager_"
-                          "pause_rule_list(...)"))
+        self.logger.info(("TransferClient.endpoint_manager_" "pause_rule_list(...)"))
         path = self.qjoin_path("endpoint_manager", "pause_rule_list")
         merge_params(params, filter_endpoint=filter_endpoint)
-        return self.get(path, params=params,
-                        response_class=IterableTransferResponse)
+        return self.get(path, params=params, response_class=IterableTransferResponse)
 
     def endpoint_manager_create_pause_rule(self, data):
         """
@@ -2018,8 +2096,7 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/advanced_endpoint_management/#create_pause_rule>`_
         in the REST documentation for details.
         """
-        self.logger.info(("TransferClient.endpoint_manager_"
-                          "create_pause_rule(...)"))
+        self.logger.info(("TransferClient.endpoint_manager_" "create_pause_rule(...)"))
         path = self.qjoin_path("endpoint_manager", "pause_rule")
         return self.post(path, data)
 
@@ -2049,8 +2126,12 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         pause_rule_id = safe_stringify(pause_rule_id)
-        self.logger.info(("TransferClient.endpoint_manager_"
-                          "get_pause_rule({})".format(pause_rule_id)))
+        self.logger.info(
+            (
+                "TransferClient.endpoint_manager_"
+                "get_pause_rule({})".format(pause_rule_id)
+            )
+        )
         path = self.qjoin_path("endpoint_manager", "pause_rule", pause_rule_id)
         return self.get(path, params=params)
 
@@ -2083,8 +2164,12 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         pause_rule_id = safe_stringify(pause_rule_id)
-        self.logger.info(("TransferClient.endpoint_manager_"
-                          "update_pause_rule({})".format(pause_rule_id)))
+        self.logger.info(
+            (
+                "TransferClient.endpoint_manager_"
+                "update_pause_rule({})".format(pause_rule_id)
+            )
+        )
         path = self.qjoin_path("endpoint_manager", "pause_rule", pause_rule_id)
         return self.put(path, data)
 
@@ -2115,7 +2200,11 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         pause_rule_id = safe_stringify(pause_rule_id)
-        self.logger.info(("TransferClient.endpoint_manager_"
-                          "delete_pause_rule({})".format(pause_rule_id)))
+        self.logger.info(
+            (
+                "TransferClient.endpoint_manager_"
+                "delete_pause_rule({})".format(pause_rule_id)
+            )
+        )
         path = self.qjoin_path("endpoint_manager", "pause_rule", pause_rule_id)
         return self.delete(path, params=params)

--- a/globus_sdk/transfer/data.py
+++ b/globus_sdk/transfer/data.py
@@ -5,6 +5,7 @@ extend ``dict``, so they can be passed seamlessly to
 conversion.
 """
 from __future__ import unicode_literals
+
 import logging
 
 from globus_sdk.base import safe_stringify
@@ -92,37 +93,44 @@ class TransferData(dict):
     :meth:`submit_transfer <globus_sdk.TransferClient.submit_transfer>`
     documentation for example usage.
     """
-    def __init__(self, transfer_client, source_endpoint, destination_endpoint,
-                 label=None, submission_id=None, sync_level=None,
-                 verify_checksum=False, preserve_timestamp=False,
-                 encrypt_data=False, deadline=None,
-                 recursive_symlinks="ignore", **kwargs):
+
+    def __init__(
+        self,
+        transfer_client,
+        source_endpoint,
+        destination_endpoint,
+        label=None,
+        submission_id=None,
+        sync_level=None,
+        verify_checksum=False,
+        preserve_timestamp=False,
+        encrypt_data=False,
+        deadline=None,
+        recursive_symlinks="ignore",
+        **kwargs
+    ):
         source_endpoint = safe_stringify(source_endpoint)
         destination_endpoint = safe_stringify(destination_endpoint)
         logger.info("Creating a new TransferData object")
         self["DATA_TYPE"] = "transfer"
-        self["submission_id"] = submission_id or \
-            transfer_client.get_submission_id()["value"]
-        logger.info("TransferData.submission_id = {}"
-                    .format(self["submission_id"]))
+        self["submission_id"] = (
+            submission_id or transfer_client.get_submission_id()["value"]
+        )
+        logger.info("TransferData.submission_id = {}".format(self["submission_id"]))
         self["source_endpoint"] = source_endpoint
-        logger.info("TransferData.source_endpoint = {}"
-                    .format(source_endpoint))
+        logger.info("TransferData.source_endpoint = {}".format(source_endpoint))
         self["destination_endpoint"] = destination_endpoint
-        logger.info("TransferData.destination_endpoint = {}"
-                    .format(destination_endpoint))
+        logger.info(
+            "TransferData.destination_endpoint = {}".format(destination_endpoint)
+        )
         self["verify_checksum"] = verify_checksum
-        logger.info("TransferData.verify_checksum = {}"
-                    .format(verify_checksum))
+        logger.info("TransferData.verify_checksum = {}".format(verify_checksum))
         self["preserve_timestamp"] = preserve_timestamp
-        logger.info("TransferData.preserve_timestamp = {}"
-                    .format(preserve_timestamp))
+        logger.info("TransferData.preserve_timestamp = {}".format(preserve_timestamp))
         self["encrypt_data"] = encrypt_data
-        logger.info("TransferData.encrypt_data = {}"
-                    .format(encrypt_data))
+        logger.info("TransferData.encrypt_data = {}".format(encrypt_data))
         self["recursive_symlinks"] = recursive_symlinks
-        logger.info("TransferData.recursive_symlinks = {}"
-                    .format(recursive_symlinks))
+        logger.info("TransferData.recursive_symlinks = {}".format(recursive_symlinks))
 
         if label is not None:
             self["label"] = label
@@ -140,16 +148,22 @@ class TransferData(dict):
         # garbage overnight
         if sync_level is not None:
             sync_dict = {"exists": 0, "size": 1, "mtime": 2, "checksum": 3}
-            self['sync_level'] = sync_dict.get(sync_level, sync_level)
-            logger.info("TransferData.sync_level = {} ({})"
-                        .format(self['sync_level'], sync_level))
+            self["sync_level"] = sync_dict.get(sync_level, sync_level)
+            logger.info(
+                "TransferData.sync_level = {} ({})".format(
+                    self["sync_level"], sync_level
+                )
+            )
 
         self["DATA"] = []
 
         self.update(kwargs)
         for option, value in kwargs.items():
-            logger.info("TransferData.{} = {} (option passed in via kwargs)"
-                        .format(option, value))
+            logger.info(
+                "TransferData.{} = {} (option passed in via kwargs)".format(
+                    option, value
+                )
+            )
 
     def add_item(self, source_path, destination_path, recursive=False):
         """
@@ -168,10 +182,14 @@ class TransferData(dict):
             "destination_path": destination_path,
             "recursive": recursive,
         }
-        logger.debug('TransferData[{}, {}].add_item: "{}"->"{}"'
-                     .format(self["source_endpoint"],
-                             self["destination_endpoint"],
-                             source_path, destination_path))
+        logger.debug(
+            'TransferData[{}, {}].add_item: "{}"->"{}"'.format(
+                self["source_endpoint"],
+                self["destination_endpoint"],
+                source_path,
+                destination_path,
+            )
+        )
         self["DATA"].append(item_data)
 
     def add_symlink_item(self, source_path, destination_path):
@@ -189,10 +207,14 @@ class TransferData(dict):
             "source_path": source_path,
             "destination_path": destination_path,
         }
-        logger.debug('TransferData[{}, {}].add_symlink_item: "{}"->"{}"'
-                     .format(self["source_endpoint"],
-                             self["destination_endpoint"],
-                             source_path, destination_path))
+        logger.debug(
+            'TransferData[{}, {}].add_symlink_item: "{}"->"{}"'.format(
+                self["source_endpoint"],
+                self["destination_endpoint"],
+                source_path,
+                destination_path,
+            )
+        )
         self["DATA"].append(item_data)
 
 
@@ -247,21 +269,28 @@ class DeleteData(dict):
     See the :meth:`submit_delete <globus_sdk.TransferClient.submit_delete>`
     documentation for example usage.
     """
-    def __init__(self, transfer_client, endpoint, label=None,
-                 submission_id=None, recursive=False, deadline=None, **kwargs):
+
+    def __init__(
+        self,
+        transfer_client,
+        endpoint,
+        label=None,
+        submission_id=None,
+        recursive=False,
+        deadline=None,
+        **kwargs
+    ):
         endpoint = safe_stringify(endpoint)
         logger.info("Creating a new DeleteData object")
         self["DATA_TYPE"] = "delete"
-        self["submission_id"] = submission_id or \
-            transfer_client.get_submission_id()["value"]
-        logger.info("DeleteData.submission_id = {}"
-                    .format(self["submission_id"]))
+        self["submission_id"] = (
+            submission_id or transfer_client.get_submission_id()["value"]
+        )
+        logger.info("DeleteData.submission_id = {}".format(self["submission_id"]))
         self["endpoint"] = endpoint
-        logger.info("DeleteData.endpoint = {}"
-                    .format(endpoint))
+        logger.info("DeleteData.endpoint = {}".format(endpoint))
         self["recursive"] = recursive
-        logger.info("DeleteData.recursive = {}"
-                    .format(recursive))
+        logger.info("DeleteData.recursive = {}".format(recursive))
 
         if label is not None:
             self["label"] = label
@@ -275,8 +304,9 @@ class DeleteData(dict):
 
         self.update(kwargs)
         for option, value in kwargs.items():
-            logger.info("DeleteData.{} = {} (option passed in via kwargs)"
-                        .format(option, value))
+            logger.info(
+                "DeleteData.{} = {} (option passed in via kwargs)".format(option, value)
+            )
 
     def add_item(self, path):
         """
@@ -288,10 +318,6 @@ class DeleteData(dict):
         document.
         """
         path = safe_stringify(path)
-        item_data = {
-            "DATA_TYPE": "delete_item",
-            "path": path,
-        }
-        logger.debug('DeleteData[{}].add_item: "{}"'
-                     .format(self["endpoint"], path))
+        item_data = {"DATA_TYPE": "delete_item", "path": path}
+        logger.debug('DeleteData[{}].add_item: "{}"'.format(self["endpoint"], path))
         self["DATA"].append(item_data)

--- a/globus_sdk/transfer/response/__init__.py
+++ b/globus_sdk/transfer/response/__init__.py
@@ -1,7 +1,6 @@
+from globus_sdk.transfer.response.activation import ActivationRequirementsResponse
 from globus_sdk.transfer.response.base import TransferResponse
 from globus_sdk.transfer.response.iterable import IterableTransferResponse
-from globus_sdk.transfer.response.activation import ActivationRequirementsResponse
-
 
 __all__ = [
     "TransferResponse",

--- a/globus_sdk/transfer/response/__init__.py
+++ b/globus_sdk/transfer/response/__init__.py
@@ -1,11 +1,10 @@
 from globus_sdk.transfer.response.base import TransferResponse
 from globus_sdk.transfer.response.iterable import IterableTransferResponse
-from globus_sdk.transfer.response.activation import (
-    ActivationRequirementsResponse)
+from globus_sdk.transfer.response.activation import ActivationRequirementsResponse
 
 
 __all__ = [
-    'TransferResponse',
-    'IterableTransferResponse',
-    'ActivationRequirementsResponse'
+    "TransferResponse",
+    "IterableTransferResponse",
+    "ActivationRequirementsResponse",
 ]

--- a/globus_sdk/transfer/response/activation.py
+++ b/globus_sdk/transfer/response/activation.py
@@ -18,6 +18,7 @@ class ActivationRequirementsResponse(TransferResponse):
     <https://docs.globus.org/api/transfer/endpoint_activation/#activation_requirements_document>`_
     in the API documentation for details.
     """
+
     def __init__(self, *args, **kwargs):
         TransferResponse.__init__(self, *args, **kwargs)
 
@@ -82,10 +83,13 @@ class ActivationRequirementsResponse(TransferResponse):
 
         :rtype: ``bool``
         """
-        return (self.supports_auto_activation or
-                self["oauth_server"] is not None or
-                any(x for x in self["DATA"]
-                    if x['type'] in ('myproxy', 'delegate_myproxy')))
+        return (
+            self.supports_auto_activation
+            or self["oauth_server"] is not None
+            or any(
+                x for x in self["DATA"] if x["type"] in ("myproxy", "delegate_myproxy")
+            )
+        )
 
     def active_until(self, time_seconds, relative_time=True):
         """

--- a/globus_sdk/transfer/response/base.py
+++ b/globus_sdk/transfer/response/base.py
@@ -8,6 +8,7 @@ class TransferResponse(GlobusHTTPResponse):
     Base class for :class:`TransferClient <globus_sdk.TransferClient>`
     responses.
     """
+
     def __str__(self):
         # Make printing responses more convenient. Relies on the
         # fact that Transfer API responses are always JSON.

--- a/globus_sdk/transfer/response/iterable.py
+++ b/globus_sdk/transfer/response/iterable.py
@@ -13,5 +13,6 @@ class IterableTransferResponse(TransferResponse):
     >>> for item in r:
     >>>     print(item["name"], item["type"])
     """
+
     def __iter__(self):
         return iter(self["DATA"])

--- a/globus_sdk/utils/__init__.py
+++ b/globus_sdk/utils/__init__.py
@@ -1,5 +1,4 @@
 from globus_sdk.utils.string_handling import safe_b64encode
 from globus_sdk.utils.string_hashing import sha256_string
 
-
 __all__ = ("safe_b64encode", "sha256_string")

--- a/globus_sdk/utils/__init__.py
+++ b/globus_sdk/utils/__init__.py
@@ -2,4 +2,4 @@ from globus_sdk.utils.string_handling import safe_b64encode
 from globus_sdk.utils.string_hashing import sha256_string
 
 
-__all__ = ('safe_b64encode', 'sha256_string')
+__all__ = ("safe_b64encode", "sha256_string")

--- a/globus_sdk/utils/string_handling.py
+++ b/globus_sdk/utils/string_handling.py
@@ -3,8 +3,8 @@ from base64 import b64encode
 
 def safe_b64encode(s):
     try:
-        encoded = b64encode(s.encode('utf-8'))
+        encoded = b64encode(s.encode("utf-8"))
     except UnicodeDecodeError:
         encoded = b64encode(s)
 
-    return encoded.decode('utf-8')
+    return encoded.decode("utf-8")

--- a/globus_sdk/utils/string_hashing.py
+++ b/globus_sdk/utils/string_hashing.py
@@ -2,4 +2,4 @@ import hashlib
 
 
 def sha256_string(s):
-    return hashlib.sha256(s.encode('utf-8')).hexdigest()
+    return hashlib.sha256(s.encode("utf-8")).hexdigest()

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,8 @@ include_trailing_comma = true
 force_grid_wrap = 0
 combine_as_imports = true
 line_length = 88
+# TODO: remove this config line when it becomes the default behavior of isort
+not_skip = __init__.py
 
 
 [flake8]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,19 @@
 [bdist_wheel]
 universal = 1
+
+[isort]
+multi_line_output = 3
+include_trailing_comma = true
+force_grid_wrap = 0
+combine_as_imports = true
+line_length = 88
+
+
+[flake8]
+exclude = .git,__pycache__,.eggs,dist,venv,.venv*,venv27,virtualenv,docs,docs-source,build
+
+# we enforce 80 char width with `black` "loosely", so flake8 should be set to
+# not fail on up to 88 chars of width
+max-line-length = 88
+
+ignore = W503,W504

--- a/setup.py
+++ b/setup.py
@@ -1,21 +1,24 @@
-import warnings
 import os.path
 import sys
-from setuptools import setup, find_packages
+import warnings
 
+from setuptools import find_packages, setup
 
 if sys.version_info < (2, 7):
-    raise NotImplementedError("""\n
+    raise NotImplementedError(
+        """\n
 ##############################################################
 # globus-sdk does not support python versions older than 2.7 #
-##############################################################""")
+##############################################################"""
+    )
 
 # warn on older/untested python3s
 # it's not disallowed, but it could be an issue for some people
 if sys.version_info > (3,) and sys.version_info < (3, 4):
     warnings.warn(
-        'Installing globus-sdk on Python 3 versions older than 3.4 '
-        'may result in degraded functionality or even errors.')
+        "Installing globus-sdk on Python 3 versions older than 3.4 "
+        "may result in degraded functionality or even errors."
+    )
 
 
 # single source of truth for package version
@@ -23,66 +26,67 @@ version_ns = {}
 with open(os.path.join("globus_sdk", "version.py")) as f:
     exec(f.read(), version_ns)
 
-setup(name="globus-sdk",
-      version=version_ns["__version__"],
-      description="Globus SDK for Python",
-      long_description=open("README.rst").read(),
-      author="Globus Team",
-      author_email="support@globus.org",
-      url="https://github.com/globus/globus-sdk-python",
-      packages=find_packages(exclude=['tests', 'tests.*']),
-      install_requires=[
-          'requests>=2.0.0,<3.0.0',
-          'six>=1.10.0,<2.0.0',
-          'pyjwt[crypto]>=1.5.3,<2.0.0'
-      ],
-
-      extras_require={
-          # empty extra included to support older installs
-          'jwt': [],
-
-          # the _development extra is for SDK developers only
-          'development': [
-              # testing reqs
-              'flake8>=3.0,<4.0',
-              'pytest>=3.7.4,<4.0',
-              'pytest-cov>=2.5.1,<3.0',
-              'pytest-xdist>=1.22.5,<2.0',
-              # mock on py2, py3.4 and py3.5
-              # not just py2: py3 versions of mock don't all have the same
-              # interface!
-              'mock==2.0.0;python_version<"3.6"',
-              # mocking HTTP responses
-              'httpretty==0.9.5',
-
-              # builds + uploads to pypi
-              'twine==1.11.0',
-              'wheel==0.31.1',
-
-              # docs
-              'sphinx==1.4.1',
-              'guzzle_sphinx_theme==0.7.11',
-          ]
-      },
-
-      include_package_data=True,
-
-      keywords=["globus", "file transfer"],
-      classifiers=[
-          "Development Status :: 5 - Production/Stable",
-          "Intended Audience :: Developers",
-          "License :: OSI Approved :: Apache Software License",
-          "Operating System :: MacOS :: MacOS X",
-          "Operating System :: Microsoft :: Windows",
-          "Operating System :: POSIX",
-          "Programming Language :: Python",
-          "Programming Language :: Python :: 2.7",
-          "Programming Language :: Python :: 3.4",
-          "Programming Language :: Python :: 3.5",
-          "Programming Language :: Python :: 3.6",
-          "Programming Language :: Python :: 3.7",
-          "Topic :: Communications :: File Sharing",
-          "Topic :: Internet :: WWW/HTTP",
-          "Topic :: Software Development :: Libraries :: Python Modules",
-      ],
-      )
+setup(
+    name="globus-sdk",
+    version=version_ns["__version__"],
+    description="Globus SDK for Python",
+    long_description=open("README.rst").read(),
+    author="Globus Team",
+    author_email="support@globus.org",
+    url="https://github.com/globus/globus-sdk-python",
+    packages=find_packages(exclude=["tests", "tests.*"]),
+    install_requires=[
+        "requests>=2.0.0,<3.0.0",
+        "six>=1.10.0,<2.0.0",
+        "pyjwt[crypto]>=1.5.3,<2.0.0",
+    ],
+    extras_require={
+        # empty extra included to support older installs
+        "jwt": [],
+        # the _development extra is for SDK developers only
+        "development": [
+            # linting
+            "flake8>=3.0,<4.0",
+            "isort>=4.3,<5.0",
+            # black requires py3.6+
+            'black==18.9b0;python_version>="3.6"',
+            # flake-bugbear requires py3.5+
+            'flake8-bugbear==18.8.0;python_version>="3.5"',
+            # testing
+            "pytest>=3.7.4,<4.0",
+            "pytest-cov>=2.5.1,<3.0",
+            "pytest-xdist>=1.22.5,<2.0",
+            # mock on py2, py3.4 and py3.5
+            # not just py2: py3 versions of mock don't all have the same
+            # interface!
+            'mock==2.0.0;python_version<"3.6"',
+            # mocking HTTP responses
+            "httpretty==0.9.5",
+            # builds + uploads to pypi
+            "twine==1.11.0",
+            "wheel==0.31.1",
+            # docs
+            "sphinx==1.4.1",
+            "guzzle_sphinx_theme==0.7.11",
+        ],
+    },
+    include_package_data=True,
+    keywords=["globus", "file transfer"],
+    classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: MacOS :: MacOS X",
+        "Operating System :: Microsoft :: Windows",
+        "Operating System :: POSIX",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Topic :: Communications :: File Sharing",
+        "Topic :: Internet :: WWW/HTTP",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+    ],
+)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,5 @@
-import pytest
 import httpretty
-
+import pytest
 
 # disable the use of real sockets when HTTPretty socket mocking is in place --
 # if you make a real API call, it will immediately error

--- a/tests/functional/auth/test_auth_client_flow.py
+++ b/tests/functional/auth/test_auth_client_flow.py
@@ -4,11 +4,9 @@ from six.moves.urllib.parse import quote_plus
 import globus_sdk
 from globus_sdk.auth.oauth2_constants import DEFAULT_REQUESTED_SCOPES
 from globus_sdk.auth.oauth2_native_app import make_native_app_challenge
-
 from tests.common import register_api_route
 
-
-CLIENT_ID = 'd0f1d9b0-bd81-4108-be74-ea981664453a'
+CLIENT_ID = "d0f1d9b0-bd81-4108-be74-ea981664453a"
 INVALID_GRANT_RESPONSE_BODY = '{"error":"invalid_grant"}'
 
 
@@ -25,39 +23,45 @@ def test_oauth2_get_authorize_url_native():
 
     # get url_and validate results
     url_res = ac.oauth2_get_authorize_url()
-    expected_vals = [ac.base_url + "v2/oauth2/authorize?",
-                     "client_id=" + ac.client_id,
-                     "redirect_uri=" +
-                     quote_plus(ac.base_url + "v2/web/auth-code"),
-                     "scope=" + quote_plus(
-                         " ".join(DEFAULT_REQUESTED_SCOPES)),
-                     "state=" + "_default",
-                     "response_type=" + "code",
-                     "code_challenge=" +
-                     quote_plus(flow_manager.challenge),
-                     "code_challenge_method=" + "S256",
-                     "access_type=" + "online"]
+    expected_vals = [
+        ac.base_url + "v2/oauth2/authorize?",
+        "client_id=" + ac.client_id,
+        "redirect_uri=" + quote_plus(ac.base_url + "v2/web/auth-code"),
+        "scope=" + quote_plus(" ".join(DEFAULT_REQUESTED_SCOPES)),
+        "state=" + "_default",
+        "response_type=" + "code",
+        "code_challenge=" + quote_plus(flow_manager.challenge),
+        "code_challenge_method=" + "S256",
+        "access_type=" + "online",
+    ]
     for val in expected_vals:
         assert val in url_res
 
     # starting flow with specified paramaters
     flow_manager = globus_sdk.auth.GlobusNativeAppFlowManager(
-        ac, requested_scopes="scopes", redirect_uri="uri",
-        state="state", verifier=("a" * 43), refresh_tokens=True)
+        ac,
+        requested_scopes="scopes",
+        redirect_uri="uri",
+        state="state",
+        verifier=("a" * 43),
+        refresh_tokens=True,
+    )
     ac.current_oauth2_flow_manager = flow_manager
 
     # get url_and validate results
     url_res = ac.oauth2_get_authorize_url()
     verifier, remade_challenge = make_native_app_challenge("a" * 43)
-    expected_vals = [ac.base_url + "v2/oauth2/authorize?",
-                     "client_id=" + ac.client_id,
-                     "redirect_uri=" + "uri",
-                     "scope=" + "scopes",
-                     "state=" + "state",
-                     "response_type=" + "code",
-                     "code_challenge=" + quote_plus(remade_challenge),
-                     "code_challenge_method=" + "S256",
-                     "access_type=" + "offline"]
+    expected_vals = [
+        ac.base_url + "v2/oauth2/authorize?",
+        "client_id=" + ac.client_id,
+        "redirect_uri=" + "uri",
+        "scope=" + "scopes",
+        "state=" + "state",
+        "response_type=" + "code",
+        "code_challenge=" + quote_plus(remade_challenge),
+        "code_challenge_method=" + "S256",
+        "access_type=" + "offline",
+    ]
     for val in expected_vals:
         assert val in url_res
 
@@ -71,39 +75,45 @@ def test_oauth2_get_authorize_url_confidential():
     ac = globus_sdk.AuthClient(client_id=CLIENT_ID)
 
     # default parameters for starting auth flow
-    flow_manager = globus_sdk.auth.GlobusAuthorizationCodeFlowManager(
-        ac, "uri")
+    flow_manager = globus_sdk.auth.GlobusAuthorizationCodeFlowManager(ac, "uri")
     ac.current_oauth2_flow_manager = flow_manager
 
     # get url_and validate results
     url_res = ac.oauth2_get_authorize_url()
-    expected_vals = [ac.base_url + "v2/oauth2/authorize?",
-                     "client_id=" + ac.client_id,
-                     "redirect_uri=" + "uri",
-                     "scope=" + quote_plus(
-                         " ".join(DEFAULT_REQUESTED_SCOPES)),
-                     "state=" + "_default",
-                     "response_type=" + "code",
-                     "access_type=" + "online"]
+    expected_vals = [
+        ac.base_url + "v2/oauth2/authorize?",
+        "client_id=" + ac.client_id,
+        "redirect_uri=" + "uri",
+        "scope=" + quote_plus(" ".join(DEFAULT_REQUESTED_SCOPES)),
+        "state=" + "_default",
+        "response_type=" + "code",
+        "access_type=" + "online",
+    ]
 
     for val in expected_vals:
         assert val in url_res
 
     # starting flow with specified paramaters
     flow_manager = globus_sdk.auth.GlobusAuthorizationCodeFlowManager(
-        ac, requested_scopes="scopes", redirect_uri="uri",
-        state="state", refresh_tokens=True)
+        ac,
+        requested_scopes="scopes",
+        redirect_uri="uri",
+        state="state",
+        refresh_tokens=True,
+    )
     ac.current_oauth2_flow_manager = flow_manager
 
     # get url_and validate results
     url_res = ac.oauth2_get_authorize_url()
-    expected_vals = [ac.base_url + "v2/oauth2/authorize?",
-                     "client_id=" + ac.client_id,
-                     "redirect_uri=" + "uri",
-                     "scope=" + "scopes",
-                     "state=" + "state",
-                     "response_type=" + "code",
-                     "access_type=" + "offline"]
+    expected_vals = [
+        ac.base_url + "v2/oauth2/authorize?",
+        "client_id=" + ac.client_id,
+        "redirect_uri=" + "uri",
+        "scope=" + "scopes",
+        "state=" + "state",
+        "response_type=" + "code",
+        "access_type=" + "offline",
+    ]
     for val in expected_vals:
         assert val in url_res
 
@@ -113,8 +123,13 @@ def test_oauth2_exchange_code_for_tokens_native():
     Starts a NativeAppFlowManager, Confirms invalid code raises 401
     Further testing cannot be done without user login credentials
     """
-    register_api_route('auth', '/v2/oauth2/token', method='POST',
-                       body=INVALID_GRANT_RESPONSE_BODY, status=401)
+    register_api_route(
+        "auth",
+        "/v2/oauth2/token",
+        method="POST",
+        body=INVALID_GRANT_RESPONSE_BODY,
+        status=401,
+    )
 
     ac = globus_sdk.AuthClient(client_id=CLIENT_ID)
     flow_manager = globus_sdk.auth.GlobusNativeAppFlowManager(ac)
@@ -131,12 +146,16 @@ def test_oauth2_exchange_code_for_tokens_confidential():
     Starts an AuthorizationCodeFlowManager, Confirms bad code raises 401
     Further testing cannot be done without user login credentials
     """
-    register_api_route('auth', '/v2/oauth2/token', method='POST',
-                       body=INVALID_GRANT_RESPONSE_BODY, status=401)
+    register_api_route(
+        "auth",
+        "/v2/oauth2/token",
+        method="POST",
+        body=INVALID_GRANT_RESPONSE_BODY,
+        status=401,
+    )
 
     ac = globus_sdk.AuthClient(client_id=CLIENT_ID)
-    flow_manager = globus_sdk.auth.GlobusAuthorizationCodeFlowManager(
-        ac, "uri")
+    flow_manager = globus_sdk.auth.GlobusAuthorizationCodeFlowManager(ac, "uri")
     ac.current_oauth2_flow_manager = flow_manager
 
     with pytest.raises(globus_sdk.AuthAPIError) as excinfo:

--- a/tests/functional/auth/test_simple_auth_usage.py
+++ b/tests/functional/auth/test_simple_auth_usage.py
@@ -1,15 +1,16 @@
 import json
 import uuid
-import pytest
+
 import httpretty
+import pytest
 
 import globus_sdk
-
 from tests.common import register_api_route
 
 
 class StringWrapper(object):
     """Simple test object to be a non-string obj wrapping a string"""
+
     def __init__(self, s):
         self.s = s
 
@@ -21,9 +22,10 @@ UNAUTHORIZED_RESPONSE_BODY = (
     '{"errors": [{"status": "401", '
     '"id": "cb6a50f8-ac67-11e8-b5fd-0e54e5d1d510", "code": "UNAUTHORIZED", '
     '"detail": "Call must be authenticated", "title": "Unauthorized"}], '
-    '"error_description": "Unauthorized", "error": "unauthorized"}')
+    '"error_description": "Unauthorized", "error": "unauthorized"}'
+)
 
-IDENTITIES_SINGLE_RESPONSE = '''\
+IDENTITIES_SINGLE_RESPONSE = """\
 {
   "identities": [
     {
@@ -36,10 +38,10 @@ IDENTITIES_SINGLE_RESPONSE = '''\
       "username": "globus@globus.org"
     }
   ]
-}'''
+}"""
 
 
-IDENTITIES_MULTIPLE_RESPONSE = '''\
+IDENTITIES_MULTIPLE_RESPONSE = """\
 {
   "identities": [
     {
@@ -61,21 +63,25 @@ IDENTITIES_MULTIPLE_RESPONSE = '''\
       "username": "sirosen@globus.org"
     }
   ]
-}'''
+}"""
 
 
 @pytest.fixture
 def identities_single_response():
     register_api_route(
-        'auth', '/v2/api/identities?usernames=foobar@example.com',
-        body=IDENTITIES_SINGLE_RESPONSE)
+        "auth",
+        "/v2/api/identities?usernames=foobar@example.com",
+        body=IDENTITIES_SINGLE_RESPONSE,
+    )
 
 
 @pytest.fixture
 def identities_multiple_response():
     register_api_route(
-        'auth', '/v2/api/identities?usernames=foobar@example.com',
-        body=IDENTITIES_MULTIPLE_RESPONSE)
+        "auth",
+        "/v2/api/identities?usernames=foobar@example.com",
+        body=IDENTITIES_MULTIPLE_RESPONSE,
+    )
 
 
 @pytest.fixture
@@ -85,22 +91,29 @@ def client():
 
 def test_get_identities_unauthorized(client):
     register_api_route(
-        'auth', '/v2/api/identities?usernames=foobar@example.com',
-        body=UNAUTHORIZED_RESPONSE_BODY, status=401)
+        "auth",
+        "/v2/api/identities?usernames=foobar@example.com",
+        body=UNAUTHORIZED_RESPONSE_BODY,
+        status=401,
+    )
 
     with pytest.raises(globus_sdk.AuthAPIError) as excinfo:
-        client.get_identities(usernames='foobar@example.com')
+        client.get_identities(usernames="foobar@example.com")
 
     err = excinfo.value
-    assert err.code == 'UNAUTHORIZED'
+    assert err.code == "UNAUTHORIZED"
     assert err.raw_text == UNAUTHORIZED_RESPONSE_BODY
     assert err.raw_json == json.loads(UNAUTHORIZED_RESPONSE_BODY)
 
 
 @pytest.mark.parametrize(
-    'usernames',
-    ['globus@globus.org', StringWrapper('globus@globus.org'),
-     ['globus@globus.org'], ('globus@globus.org',)]
+    "usernames",
+    [
+        "globus@globus.org",
+        StringWrapper("globus@globus.org"),
+        ["globus@globus.org"],
+        ("globus@globus.org",),
+    ],
 )
 def test_get_identities_success(usernames, client, identities_single_response):
     res = client.get_identities(usernames=usernames)
@@ -108,71 +121,85 @@ def test_get_identities_success(usernames, client, identities_single_response):
     assert res.data == json.loads(IDENTITIES_SINGLE_RESPONSE)
 
     lastreq = httpretty.last_request()
-    assert 'usernames' in lastreq.querystring
-    assert lastreq.querystring['usernames'] == ['globus@globus.org']
+    assert "usernames" in lastreq.querystring
+    assert lastreq.querystring["usernames"] == ["globus@globus.org"]
     # provision defaults to false
-    assert 'provision' in lastreq.querystring
-    assert lastreq.querystring['provision'] == ['false']
+    assert "provision" in lastreq.querystring
+    assert lastreq.querystring["provision"] == ["false"]
 
 
 @pytest.mark.parametrize(
-    'usernames, expect',
+    "usernames, expect",
     [
-        ('globus@globus.org,sirosen@globus.org',
-         'globus@globus.org,sirosen@globus.org'),
-
-        ((StringWrapper('sirosen@globus.org'),
-          StringWrapper('globus@globus.org')),
-         'sirosen@globus.org,globus@globus.org'),
-
-        (['globus@globus.org', 'sirosen@globus.org'],
-         'globus@globus.org,sirosen@globus.org')
-    ]
+        (
+            "globus@globus.org,sirosen@globus.org",
+            "globus@globus.org,sirosen@globus.org",
+        ),
+        (
+            (StringWrapper("sirosen@globus.org"), StringWrapper("globus@globus.org")),
+            "sirosen@globus.org,globus@globus.org",
+        ),
+        (
+            ["globus@globus.org", "sirosen@globus.org"],
+            "globus@globus.org,sirosen@globus.org",
+        ),
+    ],
 )
-def test_get_identities_multiple_success(usernames, expect, client,
-                                         identities_multiple_response):
+def test_get_identities_multiple_success(
+    usernames, expect, client, identities_multiple_response
+):
     res = client.get_identities(usernames=usernames)
 
     assert res.data == json.loads(IDENTITIES_MULTIPLE_RESPONSE)
 
     lastreq = httpretty.last_request()
-    assert 'usernames' in lastreq.querystring
-    assert lastreq.querystring['usernames'] == [expect]
+    assert "usernames" in lastreq.querystring
+    assert lastreq.querystring["usernames"] == [expect]
 
 
 @pytest.mark.parametrize(
-    'inval, outval',
-    [(True, 'true'), (False, 'false'), (1, 'true'), (0, 'true'),
-     ('fALSe', 'false'), ('true', 'true')]
+    "inval, outval",
+    [
+        (True, "true"),
+        (False, "false"),
+        (1, "true"),
+        (0, "true"),
+        ("fALSe", "false"),
+        ("true", "true"),
+    ],
 )
-def test_get_identities_provision(inval, outval, client,
-                                  identities_single_response):
-    client.get_identities(usernames='globus@globus.org', provision=inval)
+def test_get_identities_provision(inval, outval, client, identities_single_response):
+    client.get_identities(usernames="globus@globus.org", provision=inval)
     lastreq = httpretty.last_request()
-    assert 'provision' in lastreq.querystring
-    assert lastreq.querystring['provision'] == [outval]
+    assert "provision" in lastreq.querystring
+    assert lastreq.querystring["provision"] == [outval]
 
 
 @pytest.mark.parametrize(
-    'ids',
+    "ids",
     [
         # two uuids, already comma delimited
-        ','.join(['46bd0f56-e24f-11e5-a510-131bef46955c',
-                  'ae341a98-d274-11e5-b888-dbae3a8ba545']),
-
+        ",".join(
+            [
+                "46bd0f56-e24f-11e5-a510-131bef46955c",
+                "ae341a98-d274-11e5-b888-dbae3a8ba545",
+            ]
+        ),
         # a list of two UUID objects
-        [uuid.UUID('46bd0f56-e24f-11e5-a510-131bef46955c'),
-         uuid.UUID('ae341a98-d274-11e5-b888-dbae3a8ba545')]
-    ]
+        [
+            uuid.UUID("46bd0f56-e24f-11e5-a510-131bef46955c"),
+            uuid.UUID("ae341a98-d274-11e5-b888-dbae3a8ba545"),
+        ],
+    ],
 )
-def test_get_identities_multiple_ids_success(
-        ids, client, identities_multiple_response):
-    expect = ','.join(['46bd0f56-e24f-11e5-a510-131bef46955c',
-                       'ae341a98-d274-11e5-b888-dbae3a8ba545'])
+def test_get_identities_multiple_ids_success(ids, client, identities_multiple_response):
+    expect = ",".join(
+        ["46bd0f56-e24f-11e5-a510-131bef46955c", "ae341a98-d274-11e5-b888-dbae3a8ba545"]
+    )
     res = client.get_identities(ids=ids)
 
     assert res.data == json.loads(IDENTITIES_MULTIPLE_RESPONSE)
 
     lastreq = httpretty.last_request()
-    assert 'ids' in lastreq.querystring
-    assert lastreq.querystring['ids'] == [expect]
+    assert "ids" in lastreq.querystring
+    assert lastreq.querystring["ids"] == [expect]

--- a/tests/functional/transfer/conftest.py
+++ b/tests/functional/transfer/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+
 import globus_sdk
 
 

--- a/tests/functional/transfer/test_iterable.py
+++ b/tests/functional/transfer/test_iterable.py
@@ -2,9 +2,7 @@
 Tests for IterableTransferResponse responses from TransferClient
 """
 import globus_sdk
-
 from tests.common import register_api_route
-
 
 SERVER_LIST_TEXT = """{
   "DATA": [
@@ -30,22 +28,22 @@ SERVER_LIST_TEXT = """{
 
 
 def test_server_list(client):
-    epid = 'epid'
+    epid = "epid"
     register_api_route(
-        'transfer', '/endpoint/{}/server_list'.format(epid),
-        body=SERVER_LIST_TEXT)
+        "transfer", "/endpoint/{}/server_list".format(epid), body=SERVER_LIST_TEXT
+    )
 
     res = client.endpoint_server_list(epid)
     # it should still be a subclass of GlobusResponse
     assert isinstance(res, globus_sdk.GlobusResponse)
 
     # fetch top-level attrs
-    assert res['DATA_TYPE'] == 'endpoint_server_list'
-    assert res['endpoint'] == 'go#ep1'
+    assert res["DATA_TYPE"] == "endpoint_server_list"
+    assert res["endpoint"] == "go#ep1"
 
     # intentionally access twice -- unlike PaginatedResource, this is allowed
     # and works
     assert len(list(res)) == 1
     assert len(list(res)) == 1
 
-    assert list(res)[0]['DATA_TYPE'] == 'server'
+    assert list(res)[0]["DATA_TYPE"] == "server"

--- a/tests/functional/transfer/test_paginated.py
+++ b/tests/functional/transfer/test_paginated.py
@@ -2,11 +2,11 @@
 Tests for PaginatedResource responses from TransferClient
 """
 import json
+
 import httpretty
 import pytest
 
 from tests.common import register_api_route
-
 
 # empty search
 EMPTY_SEARCH_RESULT = """{
@@ -21,83 +21,94 @@ EMPTY_SEARCH_RESULT = """{
 # single page of data
 SINGLE_PAGE_SEARCH_RESULT = {
     "DATA_TYPE": "endpoint_list",
-    "offset": 0, "limit": 100, "has_next_page": False,
+    "offset": 0,
+    "limit": 100,
+    "has_next_page": False,
     "DATA": [
-        {"DATA_TYPE": "endpoint",
-         "display_name": "SDK Test Stub {}".format(x)}
+        {"DATA_TYPE": "endpoint", "display_name": "SDK Test Stub {}".format(x)}
         for x in range(100)
-    ]
+    ],
 }
 
 # multiple pages of results, very stubby
 MULTIPAGE_SEARCH_RESULTS = [
     {
         "DATA_TYPE": "endpoint_list",
-        "offset": 0, "limit": 100, "has_next_page": True,
+        "offset": 0,
+        "limit": 100,
+        "has_next_page": True,
         "DATA": [
-            {"DATA_TYPE": "endpoint",
-             "display_name": "SDK Test Stub {}".format(x)}
+            {"DATA_TYPE": "endpoint", "display_name": "SDK Test Stub {}".format(x)}
             for x in range(100)
-        ]
+        ],
     },
     {
         "DATA_TYPE": "endpoint_list",
-        "offset": 100, "limit": 100, "has_next_page": True,
+        "offset": 100,
+        "limit": 100,
+        "has_next_page": True,
         "DATA": [
-            {"DATA_TYPE": "endpoint",
-             "display_name": "SDK Test Stub {}".format(x + 100)}
+            {
+                "DATA_TYPE": "endpoint",
+                "display_name": "SDK Test Stub {}".format(x + 100),
+            }
             for x in range(100)
-        ]
+        ],
     },
     {
         "DATA_TYPE": "endpoint_list",
-        "offset": 200, "limit": 100, "has_next_page": False,
+        "offset": 200,
+        "limit": 100,
+        "has_next_page": False,
         "DATA": [
-            {"DATA_TYPE": "endpoint",
-             "display_name": "SDK Test Stub {}".format(x + 200)}
+            {
+                "DATA_TYPE": "endpoint",
+                "display_name": "SDK Test Stub {}".format(x + 200),
+            }
             for x in range(100)
-        ]
+        ],
     },
 ]
 
 
 def test_endpoint_search_noresults(client):
-    register_api_route('transfer', '/endpoint_search',
-                       body=EMPTY_SEARCH_RESULT)
+    register_api_route("transfer", "/endpoint_search", body=EMPTY_SEARCH_RESULT)
 
-    res = client.endpoint_search('search query!')
+    res = client.endpoint_search("search query!")
     assert res.data == []
 
 
 def test_endpoint_search_one_page(client):
-    register_api_route('transfer', '/endpoint_search',
-                       body=json.dumps(SINGLE_PAGE_SEARCH_RESULT))
+    register_api_route(
+        "transfer", "/endpoint_search", body=json.dumps(SINGLE_PAGE_SEARCH_RESULT)
+    )
 
     # without cranking up num_results, we'll only get 25
-    res = client.endpoint_search('search query!')
+    res = client.endpoint_search("search query!")
     assert len(list(res)) == 25
 
     # paginated results don't have __getitem__ !
     # attempting to __getitem__ on a response object defaults to a TypeError
     with pytest.raises(TypeError):
-        res['DATA_TYPE']
+        res["DATA_TYPE"]
 
     # second fetch is empty
     assert list(res) == []
 
     # reload
-    res = client.endpoint_search('search query!')
+    res = client.endpoint_search("search query!")
     for res_obj in res:
-        assert res_obj['DATA_TYPE'] == 'endpoint'
+        assert res_obj["DATA_TYPE"] == "endpoint"
 
 
 def test_endpoint_search_reduced(client):
-    register_api_route('transfer', '/endpoint_search',
-                       body=json.dumps(SINGLE_PAGE_SEARCH_RESULT))
+    register_api_route(
+        "transfer", "/endpoint_search", body=json.dumps(SINGLE_PAGE_SEARCH_RESULT)
+    )
 
     # result has 100 items -- num_results caps it even if the API
     # returns more
-    res = client.endpoint_search('search query!', num_results=10)
+    res = client.endpoint_search("search query!", num_results=10)
     assert len(list(res)) == 10
 
 
@@ -105,16 +116,16 @@ def test_endpoint_search_multipage(client):
     pages = [json.dumps(x) for x in MULTIPAGE_SEARCH_RESULTS]
     responses = [httpretty.Response(p) for p in pages]
 
-    register_api_route('transfer', '/endpoint_search', responses=responses)
+    register_api_route("transfer", "/endpoint_search", responses=responses)
 
     # without cranking up num_results, we'll only get 25
-    res = list(client.endpoint_search('search_query'))
+    res = list(client.endpoint_search("search_query"))
     assert len(res) == 25
 
     # reapply (resets responses)
-    register_api_route('transfer', '/endpoint_search', responses=responses)
+    register_api_route("transfer", "/endpoint_search", responses=responses)
 
     # num_results=None -> no limit
-    res = list(client.endpoint_search('search_query', num_results=None))
-    assert res[-1]['display_name'] == "SDK Test Stub 299"
-    assert len(res) == sum(len(x['DATA']) for x in MULTIPAGE_SEARCH_RESULTS)
+    res = list(client.endpoint_search("search_query", num_results=None))
+    assert res[-1]["display_name"] == "SDK Test Stub 299"
+    assert len(res) == sum(len(x["DATA"]) for x in MULTIPAGE_SEARCH_RESULTS)

--- a/tests/functional/transfer/test_simple.py
+++ b/tests/functional/transfer/test_simple.py
@@ -1,14 +1,17 @@
 import json
 import uuid
+
 import httpretty
 import pytest
 import six
 
 import globus_sdk
-
 from tests.common import (
-    GO_EP1_ID, GO_EP2_ID, GO_EP1_SERVER_ID,
-    register_api_route_fixture_file)
+    GO_EP1_ID,
+    GO_EP1_SERVER_ID,
+    GO_EP2_ID,
+    register_api_route_fixture_file,
+)
 
 
 def test_get_endpoint(client):
@@ -17,11 +20,11 @@ def test_get_endpoint(client):
     """
     # register get_endpoint mock data
     register_api_route_fixture_file(
-        'transfer', '/endpoint/{}'.format(GO_EP1_ID),
-        'get_endpoint_goep1.json')
+        "transfer", "/endpoint/{}".format(GO_EP1_ID), "get_endpoint_goep1.json"
+    )
     register_api_route_fixture_file(
-        'transfer', '/endpoint/{}'.format(GO_EP2_ID),
-        'get_endpoint_goep2.json')
+        "transfer", "/endpoint/{}".format(GO_EP2_ID), "get_endpoint_goep2.json"
+    )
 
     # load the tutorial endpoint documents
     ep1_doc = client.get_endpoint(GO_EP1_ID)
@@ -36,19 +39,19 @@ def test_get_endpoint(client):
 
     # double check a couple of fields, consider this done
     assert ep1_doc["canonical_name"] == "go#ep1"
-    assert ep1_doc["DATA"][0]['id'] == GO_EP1_SERVER_ID
+    assert ep1_doc["DATA"][0]["id"] == GO_EP1_SERVER_ID
     assert ep2_doc["canonical_name"] == "go#ep2"
 
 
 def test_update_endpoint(client):
     epid = uuid.uuid1()
-    register_api_route_fixture_file('transfer', '/endpoint/{}'.format(epid),
-                                    'ep_update.json', method='PUT')
+    register_api_route_fixture_file(
+        "transfer", "/endpoint/{}".format(epid), "ep_update.json", method="PUT"
+    )
 
     # NOTE: pass epid as UUID, not str
     # requires that TransferClient correctly translates it
-    update_data = {"display_name": "Updated Name",
-                   "description": "Updated description"}
+    update_data = {"display_name": "Updated Name", "description": "Updated description"}
     update_doc = client.update_endpoint(epid, update_data)
 
     # make sure response is a successful update
@@ -64,39 +67,41 @@ def test_update_endpoint_rewrites_activation_servers(client):
     """
     Update endpoint, validate results
     """
-    epid = 'example-id'
-    register_api_route_fixture_file('transfer', '/endpoint/{}'.format(epid),
-                                    'ep_create.json', method='PUT')
+    epid = "example-id"
+    register_api_route_fixture_file(
+        "transfer", "/endpoint/{}".format(epid), "ep_create.json", method="PUT"
+    )
 
     # sending myproxy_server implicitly adds oauth_server=null
-    update_data = {'myproxy_server': 'foo'}
+    update_data = {"myproxy_server": "foo"}
     client.update_endpoint(epid, update_data.copy())
     req = httpretty.last_request()
     assert req.body != six.b(json.dumps(update_data))
-    update_data['oauth_server'] = None
+    update_data["oauth_server"] = None
     assert req.body == six.b(json.dumps(update_data))
 
     # sending oauth_server implicitly adds myproxy_server=null
-    update_data = {'oauth_server': 'foo'}
+    update_data = {"oauth_server": "foo"}
     client.update_endpoint(epid, update_data.copy())
     req = httpretty.last_request()
     assert req.body != six.b(json.dumps(update_data))
-    update_data['myproxy_server'] = None
+    update_data["myproxy_server"] = None
     assert req.body == six.b(json.dumps(update_data))
 
 
 def test_update_endpoint_invalid_activation_servers(client):
-    epid = 'example-id'
-    update_data = {'oauth_server': 'foo', 'myproxy_server': 'bar'}
+    epid = "example-id"
+    update_data = {"oauth_server": "foo", "myproxy_server": "bar"}
     with pytest.raises(globus_sdk.GlobusSDKUsageError) as excinfo:
         client.update_endpoint(epid, update_data)
 
-    assert 'either MyProxy or OAuth, not both' in str(excinfo.value)
+    assert "either MyProxy or OAuth, not both" in str(excinfo.value)
 
 
 def test_create_endpoint(client):
-    register_api_route_fixture_file('transfer', '/endpoint',
-                                    'ep_create.json', method='POST')
+    register_api_route_fixture_file(
+        "transfer", "/endpoint", "ep_create.json", method="POST"
+    )
 
     create_data = {"display_name": "Name", "description": "desc"}
     create_doc = client.create_endpoint(create_data)
@@ -111,8 +116,8 @@ def test_create_endpoint(client):
 
 
 def test_create_endpoint_invalid_activation_servers(client):
-    create_data = {'oauth_server': 'foo', 'myproxy_server': 'bar'}
+    create_data = {"oauth_server": "foo", "myproxy_server": "bar"}
     with pytest.raises(globus_sdk.GlobusSDKUsageError) as excinfo:
         client.create_endpoint(create_data)
 
-    assert 'either MyProxy or OAuth, not both' in str(excinfo.value)
+    assert "either MyProxy or OAuth, not both" in str(excinfo.value)

--- a/tests/functional/transfer/test_task_submit.py
+++ b/tests/functional/transfer/test_task_submit.py
@@ -1,12 +1,11 @@
 """
 Tests for submitting Transfer and Delete tasks
 """
-import globus_sdk
-import six
 import pytest
+import six
 
-from tests.common import register_api_route, GO_EP1_ID, GO_EP2_ID
-
+import globus_sdk
+from tests.common import GO_EP1_ID, GO_EP2_ID, register_api_route
 
 TRANSFER_SUBMISSION_NODATA_ERROR = """{
   "code": "ClientError.BadRequest.NoTransferItems",
@@ -53,14 +52,14 @@ DELETE_SUBMISSION_SUCCESS = """{
 
 @pytest.fixture
 def mock_submission_id():
-    register_api_route('transfer', '/submission_id',
-                       body='{"value": "foosubmitid"}')
+    register_api_route("transfer", "/submission_id", body='{"value": "foosubmitid"}')
 
 
 @pytest.fixture
 def transfer_data(client, mock_submission_id):
     def _transfer_data(**kwargs):
         return globus_sdk.TransferData(client, GO_EP1_ID, GO_EP2_ID, **kwargs)
+
     return _transfer_data
 
 
@@ -68,52 +67,60 @@ def transfer_data(client, mock_submission_id):
 def delete_data(client, mock_submission_id):
     def _delete_data(**kwargs):
         return globus_sdk.DeleteData(client, GO_EP1_ID, **kwargs)
+
     return _delete_data
 
 
 def test_transfer_submit_failure(client, transfer_data):
-    register_api_route('transfer', '/transfer', method='POST', status=400,
-                       body=TRANSFER_SUBMISSION_NODATA_ERROR)
+    register_api_route(
+        "transfer",
+        "/transfer",
+        method="POST",
+        status=400,
+        body=TRANSFER_SUBMISSION_NODATA_ERROR,
+    )
 
     with pytest.raises(globus_sdk.TransferAPIError) as excinfo:
         client.submit_transfer(transfer_data())
 
     assert excinfo.value.http_status == 400
-    assert excinfo.value.request_id == 'oUAA6Sq2P'
+    assert excinfo.value.request_id == "oUAA6Sq2P"
     assert excinfo.value.code == "ClientError.BadRequest.NoTransferItems"
 
 
 def test_transfer_submit_success(client, transfer_data):
-    register_api_route('transfer', '/transfer', method='POST',
-                       body=TRANSFER_SUBMISSION_SUCCESS)
+    register_api_route(
+        "transfer", "/transfer", method="POST", body=TRANSFER_SUBMISSION_SUCCESS
+    )
 
-    tdata = transfer_data(label='mytask', sync_level='exists',
-                          deadline='2018-06-01', custom_param='foo')
-    assert tdata['custom_param'] == 'foo'
-    assert tdata['sync_level'] == 0
+    tdata = transfer_data(
+        label="mytask", sync_level="exists", deadline="2018-06-01", custom_param="foo"
+    )
+    assert tdata["custom_param"] == "foo"
+    assert tdata["sync_level"] == 0
 
-    tdata.add_item(six.b('/path/to/foo'), six.u('/path/to/bar'))
-    tdata.add_symlink_item('linkfoo', 'linkbar')
+    tdata.add_item(six.b("/path/to/foo"), six.u("/path/to/bar"))
+    tdata.add_symlink_item("linkfoo", "linkbar")
 
     res = client.submit_transfer(tdata)
 
     assert res
-    assert res['submission_id'] == 'foosubmitid'
-    assert res['task_id'] == 'f51bdaea-ad78-11e8-823c-0a3b7ca8ce66'
+    assert res["submission_id"] == "foosubmitid"
+    assert res["task_id"] == "f51bdaea-ad78-11e8-823c-0a3b7ca8ce66"
 
 
 def test_delete_submit_success(client, delete_data):
-    register_api_route('transfer', '/delete', method='POST',
-                       body=DELETE_SUBMISSION_SUCCESS)
+    register_api_route(
+        "transfer", "/delete", method="POST", body=DELETE_SUBMISSION_SUCCESS
+    )
 
-    ddata = delete_data(label='mytask', deadline='2018-06-01',
-                        custom_param='foo')
-    assert ddata['custom_param'] == 'foo'
+    ddata = delete_data(label="mytask", deadline="2018-06-01", custom_param="foo")
+    assert ddata["custom_param"] == "foo"
 
-    ddata.add_item('/path/to/foo')
+    ddata.add_item("/path/to/foo")
 
     res = client.submit_delete(ddata)
 
     assert res
-    assert res['submission_id'] == 'foosubmitid'
-    assert res['task_id'] == 'b5370336-ad79-11e8-823c-0a3b7ca8ce66'
+    assert res["submission_id"] == "foosubmitid"
+    assert res["task_id"] == "b5370336-ad79-11e8-823c-0a3b7ca8ce66"

--- a/tests/unit/authorizers/test_access_token_authorizer.py
+++ b/tests/unit/authorizers/test_access_token_authorizer.py
@@ -2,8 +2,7 @@ import pytest
 
 from globus_sdk.authorizers import AccessTokenAuthorizer
 
-
-TOKEN = 'DUMMY_TOKEN'
+TOKEN = "DUMMY_TOKEN"
 
 
 @pytest.fixture

--- a/tests/unit/authorizers/test_basic_authorizer.py
+++ b/tests/unit/authorizers/test_basic_authorizer.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import base64
+
 import pytest
 import six
 
@@ -21,8 +22,7 @@ def test_set_authorization_header(authorizer):
     header_dict = {}
     authorizer.set_authorization_header(header_dict)
     assert header_dict["Authorization"][:6] == "Basic "
-    decoded = base64.b64decode(
-        six.b(header_dict["Authorization"][6:])).decode('utf-8')
+    decoded = base64.b64decode(six.b(header_dict["Authorization"][6:])).decode("utf-8")
     assert decoded == "{}:{}".format(USERNAME, PASSWORD)
 
 
@@ -30,12 +30,10 @@ def test_set_authorization_header_existing(authorizer):
     """
     Confirms that an existing Authorization field is overwritten
     """
-    header_dict = {"Header": "value",
-                   "Authorization": "previous_value"}
+    header_dict = {"Header": "value", "Authorization": "previous_value"}
     authorizer.set_authorization_header(header_dict)
     assert header_dict["Authorization"][:6] == "Basic "
-    decoded = base64.b64decode(
-        six.b(header_dict["Authorization"][6:])).decode('utf-8')
+    decoded = base64.b64decode(six.b(header_dict["Authorization"][6:])).decode("utf-8")
     assert decoded == "{}:{}".format(USERNAME, PASSWORD)
     assert header_dict["Header"] == "value"
 
@@ -48,8 +46,8 @@ def test_handle_missing_authorization(authorizer):
 
 
 @pytest.mark.parametrize(
-    'username, password',
-    [("user", u"テスト"), (u"дум", 'pass'), (u"テスト", u"дум")])
+    "username, password", [("user", u"テスト"), (u"дум", "pass"), (u"テスト", u"дум")]
+)
 def test_unicode_handling(username, password):
     """
     With a unicode string for the password, set and verify the
@@ -60,6 +58,5 @@ def test_unicode_handling(username, password):
     authorizer.set_authorization_header(header_dict)
 
     assert header_dict["Authorization"][:6] == "Basic "
-    decoded = base64.b64decode(
-        six.b(header_dict["Authorization"][6:])).decode('utf-8')
+    decoded = base64.b64decode(six.b(header_dict["Authorization"][6:])).decode("utf-8")
     assert decoded == u"{}:{}".format(username, password)

--- a/tests/unit/authorizers/test_client_credentials_authorizer.py
+++ b/tests/unit/authorizers/test_client_credentials_authorizer.py
@@ -1,15 +1,16 @@
 import pytest
+
+from globus_sdk.authorizers import ClientCredentialsAuthorizer
+
 try:
     import mock
 except ImportError:
     from unittest import mock
 
-from globus_sdk.authorizers import ClientCredentialsAuthorizer
 
-
-ACCESS_TOKEN = 'access_token_1'
+ACCESS_TOKEN = "access_token_1"
 EXPIRES_AT = -1
-SCOPES = 'scopes'
+SCOPES = "scopes"
 
 
 @pytest.fixture
@@ -31,7 +32,8 @@ def client(response):
 @pytest.fixture
 def authorizer(client):
     return ClientCredentialsAuthorizer(
-        client, SCOPES, access_token=ACCESS_TOKEN, expires_at=EXPIRES_AT)
+        client, SCOPES, access_token=ACCESS_TOKEN, expires_at=EXPIRES_AT
+    )
 
 
 def test_get_token_response(authorizer, response, client):
@@ -42,7 +44,8 @@ def test_get_token_response(authorizer, response, client):
     res = authorizer._get_token_response()
     assert res == response
     client.oauth2_client_credentials_tokens.assert_called_once_with(
-        requested_scopes=SCOPES)
+        requested_scopes=SCOPES
+    )
 
 
 def test_multiple_resource_servers(authorizer, response):
@@ -52,7 +55,8 @@ def test_multiple_resource_servers(authorizer, response):
     called.
     """
     response.by_resource_server["rs2"] = {
-        "expires_at_seconds": -1, "access_token": "access_token_3"
+        "expires_at_seconds": -1,
+        "access_token": "access_token_3",
     }
     with pytest.raises(ValueError) as excinfo:
         authorizer._extract_token_data(response)

--- a/tests/unit/authorizers/test_null_authorizer.py
+++ b/tests/unit/authorizers/test_null_authorizer.py
@@ -17,8 +17,7 @@ def test_set_authorization_header_existing():
     """
     Confirms that an existing Authorization field is removed
     """
-    header_dict = {"Header": "value",
-                   "Authorization": "previous_value"}
+    header_dict = {"Header": "value", "Authorization": "previous_value"}
     authorizer = NullAuthorizer()
     authorizer.set_authorization_header(header_dict)
     assert header_dict == {"Header": "value"}

--- a/tests/unit/authorizers/test_refresh_token_authorizer.py
+++ b/tests/unit/authorizers/test_refresh_token_authorizer.py
@@ -1,10 +1,12 @@
 import pytest
+
+from globus_sdk.authorizers import RefreshTokenAuthorizer
+
 try:
     import mock
 except ImportError:
     from unittest import mock
 
-from globus_sdk.authorizers import RefreshTokenAuthorizer
 
 REFRESH_TOKEN = "refresh_token_1"
 ACCESS_TOKEN = "access_token_1"
@@ -30,8 +32,8 @@ def client(response):
 @pytest.fixture
 def authorizer(client):
     return RefreshTokenAuthorizer(
-        REFRESH_TOKEN, client, access_token=ACCESS_TOKEN,
-        expires_at=EXPIRES_AT)
+        REFRESH_TOKEN, client, access_token=ACCESS_TOKEN, expires_at=EXPIRES_AT
+    )
 
 
 def test_get_token_response(authorizer, client, response):
@@ -53,7 +55,9 @@ def test_multiple_resource_servers(authorizer, response):
     called.
     """
     response.by_resource_server["rs2"] = {
-        "expires_at_seconds": -1, "access_token": "access_token_3"}
+        "expires_at_seconds": -1,
+        "access_token": "access_token_3",
+    }
     with pytest.raises(ValueError) as excinfo:
         authorizer._extract_token_data(response)
     assert "didn't return exactly one token" in str(excinfo.value)

--- a/tests/unit/helpers/test_search.py
+++ b/tests/unit/helpers/test_search.py
@@ -2,6 +2,7 @@
 Unit tests for globus_sdk.SearchQuery
 """
 import pytest
+
 from globus_sdk import SearchQuery
 
 
@@ -18,117 +19,148 @@ def test_init():
         assert param_query[par] == params[par]
 
 
-@pytest.mark.parametrize(
-    'attrname', ['q', 'limit', 'offset', 'advanced'])
+@pytest.mark.parametrize("attrname", ["q", "limit", "offset", "advanced"])
 def test_set_method(attrname):
     query = SearchQuery()
-    method = getattr(
-        query, 'set_{}'.format('query' if attrname == 'q' else attrname))
+    method = getattr(query, "set_{}".format("query" if attrname == "q" else attrname))
     # start absent
     assert attrname not in query
     # returns self
-    assert method('foo') is query
+    assert method("foo") is query
     # sets value
-    assert query[attrname] == 'foo'
+    assert query[attrname] == "foo"
 
 
 def test_add_facet():
     query = SearchQuery()
-    assert 'facets' not in query
+    assert "facets" not in query
 
     # simple terms facet
     # returns self
-    assert query.add_facet('facetname', 'fieldname') is query
-    assert query['facets']
-    assert len(query['facets']) == 1
-    assert query['facets'][0] == {'type': 'terms', 'name': 'facetname',
-                                  'field_name': 'fieldname'}
+    assert query.add_facet("facetname", "fieldname") is query
+    assert query["facets"]
+    assert len(query["facets"]) == 1
+    assert query["facets"][0] == {
+        "type": "terms",
+        "name": "facetname",
+        "field_name": "fieldname",
+    }
 
     # terms with size
-    query.add_facet('n', 'f', size=5)
-    assert len(query['facets']) == 2
-    assert query['facets'][1] == {'type': 'terms', 'name': 'n',
-                                  'field_name': 'f', 'size': 5}
+    query.add_facet("n", "f", size=5)
+    assert len(query["facets"]) == 2
+    assert query["facets"][1] == {
+        "type": "terms",
+        "name": "n",
+        "field_name": "f",
+        "size": 5,
+    }
 
     # date histogram
-    query.add_facet('n', 'f', type='date_histogram', date_interval='year',
-                    histogram_range=(1870, 1880))
-    assert len(query['facets']) == 3
-    assert query['facets'][2] == {
-        'type': 'date_histogram', 'name': 'n', 'field_name': 'f',
-        'date_interval': 'year', 'histogram_range': {'low': 1870, 'high': 1880}
+    query.add_facet(
+        "n",
+        "f",
+        type="date_histogram",
+        date_interval="year",
+        histogram_range=(1870, 1880),
+    )
+    assert len(query["facets"]) == 3
+    assert query["facets"][2] == {
+        "type": "date_histogram",
+        "name": "n",
+        "field_name": "f",
+        "date_interval": "year",
+        "histogram_range": {"low": 1870, "high": 1880},
     }
 
     # unknown param
-    query.add_facet('facetname', 'fieldname', nonexistentparam='value1')
-    assert len(query['facets']) == 4
-    assert query['facets'][3] == {'type': 'terms', 'name': 'facetname',
-                                  'field_name': 'fieldname',
-                                  'nonexistentparam': 'value1'}
+    query.add_facet("facetname", "fieldname", nonexistentparam="value1")
+    assert len(query["facets"]) == 4
+    assert query["facets"][3] == {
+        "type": "terms",
+        "name": "facetname",
+        "field_name": "fieldname",
+        "nonexistentparam": "value1",
+    }
 
 
 def test_add_filter():
     query = SearchQuery()
-    assert 'filters' not in query
+    assert "filters" not in query
 
     # returns self
-    assert query.add_filter('f', [1, 2, 3]) is query
+    assert query.add_filter("f", [1, 2, 3]) is query
 
-    assert query['filters']
-    assert len(query['filters']) == 1
-    assert query['filters'][0] == {'field_name': 'f', 'type': 'match_all',
-                                   'values': [1, 2, 3]}
+    assert query["filters"]
+    assert len(query["filters"]) == 1
+    assert query["filters"][0] == {
+        "field_name": "f",
+        "type": "match_all",
+        "values": [1, 2, 3],
+    }
 
     # match_any + custom param
-    query.add_filter('f', [1, 2, 3], type='match_any', nonexistentparam='val1')
-    assert len(query['filters']) == 2
-    assert query['filters'][1] == {'field_name': 'f', 'type': 'match_any',
-                                   'values': [1, 2, 3],
-                                   'nonexistentparam': 'val1'}
+    query.add_filter("f", [1, 2, 3], type="match_any", nonexistentparam="val1")
+    assert len(query["filters"]) == 2
+    assert query["filters"][1] == {
+        "field_name": "f",
+        "type": "match_any",
+        "values": [1, 2, 3],
+        "nonexistentparam": "val1",
+    }
 
     # range
-    query.add_filter('f', [{'from': 1, 'to': 100}], type='range')
-    assert len(query['filters']) == 3
-    assert query['filters'][2] == {'field_name': 'f', 'type': 'range',
-                                   'values': [{'from': 1, 'to': 100}]}
+    query.add_filter("f", [{"from": 1, "to": 100}], type="range")
+    assert len(query["filters"]) == 3
+    assert query["filters"][2] == {
+        "field_name": "f",
+        "type": "range",
+        "values": [{"from": 1, "to": 100}],
+    }
 
 
 def test_add_boost():
     query = SearchQuery()
-    assert 'boosts' not in query
+    assert "boosts" not in query
 
     # returns self
-    assert query.add_boost('f', 2) == query
+    assert query.add_boost("f", 2) == query
 
-    assert query['boosts']
-    assert len(query['boosts']) == 1
-    assert query['boosts'][0] == {'field_name': 'f', 'factor': 2}
+    assert query["boosts"]
+    assert len(query["boosts"]) == 1
+    assert query["boosts"][0] == {"field_name": "f", "factor": 2}
 
     # custom param
-    query.add_boost('f', 1.1, nonexistentparam='value1')
-    assert len(query['boosts']) == 2
-    assert query['boosts'][1] == {'field_name': 'f', 'factor': 1.1,
-                                  'nonexistentparam': 'value1'}
+    query.add_boost("f", 1.1, nonexistentparam="value1")
+    assert len(query["boosts"]) == 2
+    assert query["boosts"][1] == {
+        "field_name": "f",
+        "factor": 1.1,
+        "nonexistentparam": "value1",
+    }
 
 
 def test_add_sort():
     query = SearchQuery()
-    assert 'sort' not in query
+    assert "sort" not in query
 
     # returns self
-    assert query.add_sort('f') is query
+    assert query.add_sort("f") is query
 
-    assert query['sort']
-    assert len(query['sort']) == 1
-    assert query['sort'][0] == {'field_name': 'f'}
+    assert query["sort"]
+    assert len(query["sort"]) == 1
+    assert query["sort"][0] == {"field_name": "f"}
 
     # with order
-    query.add_sort('f', order='asc')
-    assert len(query['sort']) == 2
-    assert query['sort'][1] == {'field_name': 'f', 'order': 'asc'}
+    query.add_sort("f", order="asc")
+    assert len(query["sort"]) == 2
+    assert query["sort"][1] == {"field_name": "f", "order": "asc"}
 
     # custom param
-    query.add_sort('f', order='asc', nonexistentparam='value1')
-    assert len(query['sort']) == 3
-    assert query['sort'][2] == {'field_name': 'f', 'order': 'asc',
-                                'nonexistentparam': 'value1'}
+    query.add_sort("f", order="asc", nonexistentparam="value1")
+    assert len(query["sort"]) == 3
+    assert query["sort"][2] == {
+        "field_name": "f",
+        "order": "asc",
+        "nonexistentparam": "value1",
+    }

--- a/tests/unit/helpers/test_transfer.py
+++ b/tests/unit/helpers/test_transfer.py
@@ -1,13 +1,13 @@
-import globus_sdk
 import pytest
 
+import globus_sdk
 from tests.common import GO_EP1_ID, GO_EP2_ID
 
 
 @pytest.fixture
 def client():
     def _mock_submission_id(*args, **kwargs):
-        return {'value': 'fooid'}
+        return {"value": "fooid"}
 
     tc = globus_sdk.TransferClient()
     tc.get_submission_id = _mock_submission_id
@@ -19,6 +19,7 @@ def client():
 def transfer_data(client):
     def _transfer_data(**kwargs):
         return globus_sdk.TransferData(client, GO_EP1_ID, GO_EP2_ID, **kwargs)
+
     return _transfer_data
 
 
@@ -26,6 +27,7 @@ def transfer_data(client):
 def delete_data(client):
     def _delete_data(**kwargs):
         return globus_sdk.DeleteData(client, GO_EP1_ID, **kwargs)
+
     return _delete_data
 
 

--- a/tests/unit/responses/conftest.py
+++ b/tests/unit/responses/conftest.py
@@ -9,6 +9,7 @@ def make_oauth_token_response():
     """
     response with conveniently formatted names to help with iteration in tests
     """
+
     def f(client=None):
         return make_response(
             response_class=globus_sdk.auth.token_response.OAuthTokenResponse,
@@ -28,7 +29,7 @@ def make_oauth_token_response():
                         "refresh_token": "refresh_token_2",
                         "resource_server": "resource_server_2",
                         "scope": "scope2 scope2:0 scope2:1",
-                        "token_type": "bearer"
+                        "token_type": "bearer",
                     },
                     {
                         "access_token": "access_token_3",
@@ -36,11 +37,13 @@ def make_oauth_token_response():
                         "refresh_token": "refresh_token_3",
                         "resource_server": "resource_server_3",
                         "scope": "scope3:0 scope3:1",
-                        "token_type": "bearer"
-                    }
-                ]
+                        "token_type": "bearer",
+                    },
+                ],
             },
-            client=client)
+            client=client,
+        )
+
     return f
 
 

--- a/tests/unit/responses/test_activation_response.py
+++ b/tests/unit/responses/test_activation_response.py
@@ -1,21 +1,31 @@
-import requests
 import json
-import six
 import time
+
 import pytest
+import requests
+import six
 
 from globus_sdk.transfer.response import ActivationRequirementsResponse
 
 
-def make_response(activated=True, expires_in=0,
-                  auto_activation_supported=True,
-                  oauth_server=None, DATA=[]):
+def make_response(
+    activated=True,
+    expires_in=0,
+    auto_activation_supported=True,
+    oauth_server=None,
+    DATA=None,
+):
     """
     Helper for making ActivationRequirementsResponses with known fields
     """
-    data = {"activated": activated, "expires_in": expires_in,
-            "oauth_server": oauth_server, "DATA": DATA,
-            "auto_activation_supported": auto_activation_supported}
+    DATA = DATA or []
+    data = {
+        "activated": activated,
+        "expires_in": expires_in,
+        "oauth_server": oauth_server,
+        "DATA": DATA,
+        "auto_activation_supported": auto_activation_supported,
+    }
     response = requests.Response()
     response.headers["Content-Type"] = "application/json"
     response._content = six.b(json.dumps(data))
@@ -37,7 +47,7 @@ def test_expires_at():
     assert response.expires_at is None
 
 
-@pytest.mark.parametrize('value', (True, False))
+@pytest.mark.parametrize("value", (True, False))
 def test_supports_auto_activation(value):
     """
     Gets supports_auto_activation from made responses, validates results
@@ -54,15 +64,16 @@ def test_supports_web_activation():
     response = make_response(auto_activation_supported=True)
     assert response.supports_web_activation
     # has an oauth server,
-    response = make_response(auto_activation_supported=False,
-                             oauth_server="server")
+    response = make_response(auto_activation_supported=False, oauth_server="server")
     assert response.supports_web_activation
     # or one of the other documents is myproxy or delegate_myproxy,
-    response = make_response(auto_activation_supported=False,
-                             DATA=[{"type": "myproxy"}])
+    response = make_response(
+        auto_activation_supported=False, DATA=[{"type": "myproxy"}]
+    )
     assert response.supports_web_activation
-    response = make_response(auto_activation_supported=False,
-                             DATA=[{"type": "delegate_myproxy"}])
+    response = make_response(
+        auto_activation_supported=False, DATA=[{"type": "delegate_myproxy"}]
+    )
     assert response.supports_web_activation
 
     # otherwise false

--- a/tests/unit/responses/test_oauth_token_response.py
+++ b/tests/unit/responses/test_oauth_token_response.py
@@ -6,27 +6,29 @@ def test_by_resource_server_lookups(oauth_token_response):
 
     # things which should hold for all
     for n in (1, 2, 3):
-        name = 'resource_server_{}'.format(n)
-        for attr in ('access_token', 'refresh_token', 'resource_server'):
-            assert by_rs[name][attr] == '{}_{}'.format(attr, n)
+        name = "resource_server_{}".format(n)
+        for attr in ("access_token", "refresh_token", "resource_server"):
+            assert by_rs[name][attr] == "{}_{}".format(attr, n)
 
-        assert 'expires_in' not in by_rs[name]
-        assert 'expires_at_seconds' in by_rs[name]
+        assert "expires_in" not in by_rs[name]
+        assert "expires_at_seconds" in by_rs[name]
 
-        assert by_rs[name]['token_type'] == 'bearer'
+        assert by_rs[name]["token_type"] == "bearer"
 
-    assert by_rs['resource_server_1']['scope'] == 'scope1'
-    assert by_rs['resource_server_2']['scope'] == 'scope2 scope2:0 scope2:1'
-    assert by_rs['resource_server_3']['scope'] == 'scope3:0 scope3:1'
+    assert by_rs["resource_server_1"]["scope"] == "scope1"
+    assert by_rs["resource_server_2"]["scope"] == "scope2 scope2:0 scope2:1"
+    assert by_rs["resource_server_3"]["scope"] == "scope3:0 scope3:1"
 
 
 @pytest.mark.parametrize(
-    'scopestr, resource_server',
-    [('scope1', 'resource_server_1'),
-     ('scope2 scope2:0 scope2:1', 'resource_server_2'),
-     ('scope3:0 scope3:1', 'resource_server_3')])
-def test_by_scopes_lookups_simple(
-        scopestr, resource_server, oauth_token_response):
+    "scopestr, resource_server",
+    [
+        ("scope1", "resource_server_1"),
+        ("scope2 scope2:0 scope2:1", "resource_server_2"),
+        ("scope3:0 scope3:1", "resource_server_3"),
+    ],
+)
+def test_by_scopes_lookups_simple(scopestr, resource_server, oauth_token_response):
     by_scopes = oauth_token_response.by_scopes
 
     # containment
@@ -35,35 +37,35 @@ def test_by_scopes_lookups_simple(
         assert x in by_scopes
 
     # maps correctly
-    assert by_scopes[scopestr]['resource_server'] == resource_server
+    assert by_scopes[scopestr]["resource_server"] == resource_server
 
 
 def test_by_scopes_lookups_failures(oauth_token_response):
     by_scopes = oauth_token_response.by_scopes
 
-    mixed_scopes = 'scope1 scope2'
+    mixed_scopes = "scope1 scope2"
 
     # containment
     assert mixed_scopes not in by_scopes
-    assert 'badscope' not in by_scopes
+    assert "badscope" not in by_scopes
 
     # try to actually do it, ensure KeyErrors have good messages
     with pytest.raises(KeyError) as excinfo:
         by_scopes[mixed_scopes]
-    assert 'did not match exactly one token' in str(excinfo.value)
+    assert "did not match exactly one token" in str(excinfo.value)
 
     with pytest.raises(KeyError) as excinfo:
-        by_scopes['badscope']
-    assert 'was not found' in str(excinfo.value)
+        by_scopes["badscope"]
+    assert "was not found" in str(excinfo.value)
 
 
 def test_by_scopes_lookups_fancy(oauth_token_response):
     by_scopes = oauth_token_response.by_scopes
 
     # repeated scope
-    assert (by_scopes['scope3:0 scope3:0']['resource_server'] ==
-            'resource_server_3')
+    assert by_scopes["scope3:0 scope3:0"]["resource_server"] == "resource_server_3"
 
     # not matching order from original document
-    assert (by_scopes['scope2:1 scope2 scope2:0']['resource_server'] ==
-            'resource_server_2')
+    assert (
+        by_scopes["scope2:1 scope2 scope2:0"]["resource_server"] == "resource_server_2"
+    )

--- a/tests/unit/responses/test_response.py
+++ b/tests/unit/responses/test_response.py
@@ -1,13 +1,13 @@
-from collections import namedtuple
-import requests
 import json
-import six
+from collections import namedtuple
+
 import pytest
+import requests
+import six
 
-from globus_sdk.response import GlobusResponse, GlobusHTTPResponse
+from globus_sdk.response import GlobusHTTPResponse, GlobusResponse
 
-
-_TestResponse = namedtuple('_TestResponse', ('data', 'r'))
+_TestResponse = namedtuple("_TestResponse", ("data", "r"))
 
 
 @pytest.fixture
@@ -36,7 +36,7 @@ def malformed_http_response():
     malformed_response = requests.Response()
     malformed_response._content = six.b("{")
     malformed_response.headers["Content-Type"] = "application/json"
-    return _TestResponse('{', GlobusHTTPResponse(malformed_response))
+    return _TestResponse("{", GlobusHTTPResponse(malformed_response))
 
 
 @pytest.fixture
@@ -48,8 +48,13 @@ def text_http_response():
     return _TestResponse(text_data, GlobusHTTPResponse(text_response))
 
 
-def test_data(dict_response, list_response, json_http_response,
-              malformed_http_response, text_http_response):
+def test_data(
+    dict_response,
+    list_response,
+    json_http_response,
+    malformed_http_response,
+    text_http_response,
+):
     """
     Gets the data from the GlobusResponses, confirms results
     Gets the data from each HTTPResponse, confirms expected data from json
@@ -116,5 +121,5 @@ def test_text(json_http_response, malformed_http_response, text_http_response):
     Gets the text from each HTTPResponse, confirms expected results
     """
     assert json_http_response.r.text == json.dumps(json_http_response.data)
-    assert malformed_http_response.r.text == '{'
+    assert malformed_http_response.r.text == "{"
     assert text_http_response.r.text == text_http_response.data

--- a/tests/unit/responses/test_token_response_pickleability.py
+++ b/tests/unit/responses/test_token_response_pickleability.py
@@ -2,6 +2,7 @@ import logging
 import os
 import pickle
 import tempfile
+
 import pytest
 
 import globus_sdk
@@ -32,9 +33,10 @@ def test_pickle_and_unpickle_no_usage(token_response):
     Test pickle and unpickle, with no usage of the result,
     for all pickle protocol versions supported by the current interpreter.
     """
-    pickled_versions = [pickle.dumps(token_response, protocol=n)
-                        for n in range(pickle.HIGHEST_PROTOCOL + 1)]
+    pickled_versions = [
+        pickle.dumps(token_response, protocol=n)
+        for n in range(pickle.HIGHEST_PROTOCOL + 1)
+    ]
     unpickled_versions = [pickle.loads(x) for x in pickled_versions]
     for x in unpickled_versions:
-        assert (x.by_resource_server ==
-                token_response.by_resource_server)
+        assert x.by_resource_server == token_response.by_resource_server

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -30,7 +30,15 @@ def custom_config(configdata):
         configdata = six.StringIO(configdata)
 
     def loadconf(cfgparser):
-        cfgparser._parser.readfp(configdata)
+        # try to use the new version of this method, added in py3.2
+        try:
+            readfp_func = cfgparser._parser.read_file
+        # but failover to the pre-3.2 version
+        except AttributeError:
+            readfp_func = cfgparser._parser.readfp
+        # and fail-open if there's some other issue
+
+        readfp_func(configdata)
 
     with mock.patch("globus_sdk.config.GlobusConfigParser._load_config", loadconf):
         globus_sdk.config._get_parser()

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,15 +1,16 @@
-from contextlib import contextmanager
-try:
-    import mock
-except ImportError:
-    from unittest import mock
-
 import os
+from contextlib import contextmanager
+
 import pytest
 import six
 from six.moves.configparser import ConfigParser
 
 import globus_sdk.config
+
+try:
+    import mock
+except ImportError:
+    from unittest import mock
 
 
 @contextmanager
@@ -25,14 +26,13 @@ def custom_config(configdata):
     globus_sdk.config._parser = None
 
     # not file-like, wrap it
-    if not hasattr(configdata, 'read'):
+    if not hasattr(configdata, "read"):
         configdata = six.StringIO(configdata)
 
     def loadconf(cfgparser):
         cfgparser._parser.readfp(configdata)
 
-    with mock.patch(
-            'globus_sdk.config.GlobusConfigParser._load_config', loadconf):
+    with mock.patch("globus_sdk.config.GlobusConfigParser._load_config", loadconf):
         globus_sdk.config._get_parser()
         yield
 
@@ -51,8 +51,7 @@ def only_lib_config():
     def loadconf(cfgparser):
         cfgparser._parser.read([globus_sdk.config._get_lib_config_path()])
 
-    with mock.patch(
-            'globus_sdk.config.GlobusConfigParser._load_config', loadconf):
+    with mock.patch("globus_sdk.config.GlobusConfigParser._load_config", loadconf):
         yield
 
     # clear that temporary parser
@@ -72,29 +71,32 @@ def test_get_lib_config():
     parser.read(path)
 
     # and check that 'default' and 'preview' are populated
-    for env in ('default', 'preview'):
-        section = 'environment {}'.format(env)
-        for key in ('auth_service', 'nexus_service', 'transfer_service',
-                    'search_service'):
+    for env in ("default", "preview"):
+        section = "environment {}".format(env)
+        for key in (
+            "auth_service",
+            "nexus_service",
+            "transfer_service",
+            "search_service",
+        ):
             opt = parser.get(section, key)
             assert opt
 
 
 def test_verify_ssl_true():
     with custom_config("[environment default]\nssl_verify = true\n"):
-        assert globus_sdk.config.get_ssl_verify('default')
+        assert globus_sdk.config.get_ssl_verify("default")
 
 
 def test_verify_ssl_false():
     with custom_config("[environment default]\nssl_verify = false\n"):
-        assert not globus_sdk.config.get_ssl_verify('default')
+        assert not globus_sdk.config.get_ssl_verify("default")
 
 
 def test_verify_ssl_invalid():
     with pytest.raises(ValueError):
-        with custom_config(
-                "[environment default]\nssl_verify = invalidvalue\n"):
-            assert not globus_sdk.config.get_ssl_verify('default')
+        with custom_config("[environment default]\nssl_verify = invalidvalue\n"):
+            assert not globus_sdk.config.get_ssl_verify("default")
 
 
 def test_init_loads():
@@ -111,7 +113,8 @@ def test_conf_get():
     Confirms that get reads expected results
     Tests section, environment, failover_to_general, and check_env params
     """
-    confio = six.StringIO("""\
+    confio = six.StringIO(
+        """\
 [general]
 option = general_value
 
@@ -122,31 +125,36 @@ option = section_value
 option = environment_value
 
 [nonexistent]
-""")
+"""
+    )
     with custom_config(confio):
         conf = globus_sdk.config._get_parser()
         with mock.patch.dict(os.environ):
-            os.environ['GLOBUS_SDK_OPTION'] = 'os_environ_value'
-            assert conf.get('option') == 'general_value'
-            assert conf.get('option', section='section') == 'section_value'
-            assert (conf.get('option', environment='section') ==
-                    'environment_value')
-            assert conf.get('option', section='nonexistent') is None
-            assert conf.get('option', section='nonexistent',
-                            failover_to_general=True) == 'general_value'
-            assert conf.get('option', check_env=True) == 'os_environ_value'
+            os.environ["GLOBUS_SDK_OPTION"] = "os_environ_value"
+            assert conf.get("option") == "general_value"
+            assert conf.get("option", section="section") == "section_value"
+            assert conf.get("option", environment="section") == "environment_value"
+            assert conf.get("option", section="nonexistent") is None
+            assert (
+                conf.get("option", section="nonexistent", failover_to_general=True)
+                == "general_value"
+            )
+            assert conf.get("option", check_env=True) == "os_environ_value"
             # environment > section
-            assert conf.get('option', section='section',
-                            environment='section') == 'environment_value'
+            assert (
+                conf.get("option", section="section", environment="section")
+                == "environment_value"
+            )
             # check_env > environment
-            assert conf.get('option', environment='section',
-                            check_env=True) == 'os_environ_value'
+            assert (
+                conf.get("option", environment="section", check_env=True)
+                == "os_environ_value"
+            )
 
 
 def test_parser_is_singleton():
     # do two fetches, assert 'is'
-    assert (globus_sdk.config._get_parser() is
-            globus_sdk.config._get_parser())
+    assert globus_sdk.config._get_parser() is globus_sdk.config._get_parser()
 
 
 def test_get_service_url():
@@ -154,7 +162,8 @@ def test_get_service_url():
     Confirms get_service_url returns expected results
     Tests environments, services, and missing values
     """
-    confio = six.StringIO("""\
+    confio = six.StringIO(
+        """\
 [general]
 
 [environment default]
@@ -166,16 +175,25 @@ auth_service = https://auth.preview.globus.org/
 transfer_service = https://transfer.api.preview.globus.org/
 
 [environment nonexistent]
-""")
+"""
+    )
     with custom_config(confio):
-        assert (globus_sdk.config.get_service_url("default", "auth") ==
-                "https://auth.globus.org/")
-        assert (globus_sdk.config.get_service_url("default", "transfer") ==
-                "https://transfer.api.globus.org/")
-        assert (globus_sdk.config.get_service_url("preview", "auth") ==
-                "https://auth.preview.globus.org/")
-        assert (globus_sdk.config.get_service_url("preview", "transfer") ==
-                "https://transfer.api.preview.globus.org/")
+        assert (
+            globus_sdk.config.get_service_url("default", "auth")
+            == "https://auth.globus.org/"
+        )
+        assert (
+            globus_sdk.config.get_service_url("default", "transfer")
+            == "https://transfer.api.globus.org/"
+        )
+        assert (
+            globus_sdk.config.get_service_url("preview", "auth")
+            == "https://auth.preview.globus.org/"
+        )
+        assert (
+            globus_sdk.config.get_service_url("preview", "transfer")
+            == "https://transfer.api.preview.globus.org/"
+        )
 
         with pytest.raises(ValueError):
             globus_sdk.config.get_service_url("nonexistent", "auth")
@@ -186,7 +204,8 @@ def test_get_ssl_verify():
     Confirms get_ssl_verify returns expected results
     Tests true/false, and invalid values
     """
-    confio = six.StringIO("""\
+    confio = six.StringIO(
+        """\
 [general]
 
 [environment trueenv]
@@ -199,22 +218,24 @@ ssl_verify = false
 ssl_verify = invalid
 
 [environment nonexistent]
-""")
+"""
+    )
     with custom_config(confio):
-        assert globus_sdk.config.get_ssl_verify('trueenv')
-        assert not globus_sdk.config.get_ssl_verify('falseenv')
+        assert globus_sdk.config.get_ssl_verify("trueenv")
+        assert not globus_sdk.config.get_ssl_verify("falseenv")
         # default = True
-        assert globus_sdk.config.get_ssl_verify('nonexistent')
+        assert globus_sdk.config.get_ssl_verify("nonexistent")
 
         with pytest.raises(ValueError):
-            globus_sdk.config.get_ssl_verify('invalid')
+            globus_sdk.config.get_ssl_verify("invalid")
 
 
 @pytest.mark.parametrize(
     "value, expected_result",
-    [(x, True) for x in [str(True), "1", "YES", "true", "True", "ON"]] +
-    [(x, False) for x in [str(False), "0", "NO", "false", "False", "OFF"]] +
-    [(x, ValueError) for x in ['invalid', "1.0", "0.0", "t", "f"]])
+    [(x, True) for x in [str(True), "1", "YES", "true", "True", "ON"]]
+    + [(x, False) for x in [str(False), "0", "NO", "false", "False", "OFF"]]
+    + [(x, ValueError) for x in ["invalid", "1.0", "0.0", "t", "f"]],
+)
 def test_bool_cast(value, expected_result):
     """
     Confirms bool cast returns correct bools from sets of string values

--- a/tests/unit/test_exc.py
+++ b/tests/unit/test_exc.py
@@ -1,15 +1,21 @@
-from collections import namedtuple
 import json
-import requests
+from collections import namedtuple
+
 import pytest
+import requests
 import six
 
-from globus_sdk.exc import (GlobusAPIError, TransferAPIError, AuthAPIError,
-                            NetworkError, GlobusTimeoutError,
-                            GlobusConnectionError, convert_request_exception)
+from globus_sdk.exc import (
+    AuthAPIError,
+    GlobusAPIError,
+    GlobusConnectionError,
+    GlobusTimeoutError,
+    NetworkError,
+    TransferAPIError,
+    convert_request_exception,
+)
 
-
-_TestResponse = namedtuple('_TestResponse', ('data', 'r'))
+_TestResponse = namedtuple("_TestResponse", ("data", "r"))
 
 
 def _mk_response(data, status, headers=None, data_transform=None):
@@ -28,32 +34,38 @@ def _mk_response(data, status, headers=None, data_transform=None):
 
 
 def _mk_json_response(data, status):
-    return _mk_response(data, status, data_transform=json.dumps,
-                        headers={'Content-Type': 'application/json'})
+    return _mk_response(
+        data,
+        status,
+        data_transform=json.dumps,
+        headers={"Content-Type": "application/json"},
+    )
 
 
 @pytest.fixture
 def json_response():
-    json_data = {"errors": [{"message": "json error message",
-                             "code": "Json Error"}]}
+    json_data = {"errors": [{"message": "json error message", "code": "Json Error"}]}
     return _mk_json_response(json_data, 400)
 
 
 @pytest.fixture
 def text_response():
-    text_data = 'error message'
+    text_data = "error message"
     return _mk_response(text_data, 401)
 
 
 @pytest.fixture
 def malformed_response():
-    return _mk_response('{', 403)
+    return _mk_response("{", 403)
 
 
 @pytest.fixture
 def transfer_response():
-    transfer_data = {"message": "transfer error message",
-                     "code": "Transfer Error", "request_id": 123}
+    transfer_data = {
+        "message": "transfer error message",
+        "code": "Transfer Error",
+        "request_id": 123,
+    }
     return _mk_json_response(transfer_data, 404)
 
 
@@ -65,8 +77,9 @@ def simple_auth_response():
 
 @pytest.fixture
 def nested_auth_response():
-    auth_data = {"errors": [{"detail": "nested auth error message",
-                             "code": "Auth Error"}]}
+    auth_data = {
+        "errors": [{"detail": "nested auth error message", "code": "Auth Error"}]
+    }
     return _mk_json_response(auth_data, 404)
 
 
@@ -92,68 +105,74 @@ def test_raw_text_works(json_response, text_response):
 
 def test_get_args(json_response, text_response, malformed_response):
     err = GlobusAPIError(json_response.r)
-    assert err._get_args() == ('400', 'Json Error', 'json error message')
+    assert err._get_args() == ("400", "Json Error", "json error message")
     err = GlobusAPIError(text_response.r)
-    assert err._get_args() == ('401', 'Error', 'error message')
+    assert err._get_args() == ("401", "Error", "error message")
     err = GlobusAPIError(malformed_response.r)
-    assert err._get_args() == ('403', 'Error', '{')
+    assert err._get_args() == ("403", "Error", "{")
 
 
-def test_get_args_transfer(json_response, text_response, malformed_response,
-                           transfer_response):
+def test_get_args_transfer(
+    json_response, text_response, malformed_response, transfer_response
+):
     err = TransferAPIError(transfer_response.r)
-    assert err._get_args() == ('404', 'Transfer Error',
-                               'transfer error message', 123)
+    assert err._get_args() == ("404", "Transfer Error", "transfer error message", 123)
 
     # wrong format
     err = TransferAPIError(json_response.r)
-    assert err._get_args() == ('400', 'Error',
-                               json.dumps(json_response.data), None)
+    assert err._get_args() == ("400", "Error", json.dumps(json_response.data), None)
     # defaults for non-json
     err = TransferAPIError(text_response.r)
-    assert err._get_args() == ('401', 'Error', 'error message', None)
+    assert err._get_args() == ("401", "Error", "error message", None)
     err = TransferAPIError(malformed_response.r)
-    assert err._get_args() == ('403', 'Error', '{', None)
+    assert err._get_args() == ("403", "Error", "{", None)
 
 
-def test_get_args_auth(json_response, text_response, malformed_response,
-                       simple_auth_response, nested_auth_response):
+def test_get_args_auth(
+    json_response,
+    text_response,
+    malformed_response,
+    simple_auth_response,
+    nested_auth_response,
+):
     err = AuthAPIError(simple_auth_response.r)
-    assert err._get_args() == ('404', 'Error',
-                               'simple auth error message')
+    assert err._get_args() == ("404", "Error", "simple auth error message")
     err = AuthAPIError(nested_auth_response.r)
-    assert err._get_args() == ('404', 'Auth Error',
-                               'nested auth error message')
+    assert err._get_args() == ("404", "Auth Error", "nested auth error message")
 
     # wrong format, but similar/close
     err = AuthAPIError(json_response.r)
-    assert err._get_args() == ('400', 'Json Error', 'json error message')
+    assert err._get_args() == ("400", "Json Error", "json error message")
 
     # non-json
     err = AuthAPIError(text_response.r)
-    assert err._get_args() == ('401', 'Error', 'error message')
+    assert err._get_args() == ("401", "Error", "error message")
     err = AuthAPIError(malformed_response.r)
-    assert err._get_args() == ('403', 'Error', '{')
+    assert err._get_args() == ("403", "Error", "{")
 
 
 @pytest.mark.parametrize(
-    'exc, wrap_class',
-    [(requests.RequestException("exc_message"), NetworkError),
-     (requests.Timeout("timeout_message"), GlobusTimeoutError),
-     (requests.ConnectionError("connection_message"), GlobusConnectionError)]
+    "exc, wrap_class",
+    [
+        (requests.RequestException("exc_message"), NetworkError),
+        (requests.Timeout("timeout_message"), GlobusTimeoutError),
+        (requests.ConnectionError("connection_message"), GlobusConnectionError),
+    ],
 )
 def test_requests_err_wrappers(exc, wrap_class):
-    msg = 'dummy message'
+    msg = "dummy message"
     err = wrap_class(msg, exc)
     assert err.underlying_exception == exc
     assert str(err) == msg
 
 
 @pytest.mark.parametrize(
-    'exc, conv_class',
-    [(requests.RequestException("exc_message"), NetworkError),
-     (requests.Timeout("timeout_message"), GlobusTimeoutError),
-     (requests.ConnectionError("connection_message"), GlobusConnectionError)]
+    "exc, conv_class",
+    [
+        (requests.RequestException("exc_message"), NetworkError),
+        (requests.Timeout("timeout_message"), GlobusTimeoutError),
+        (requests.ConnectionError("connection_message"), GlobusConnectionError),
+    ],
 )
 def test_convert_requests_exception(exc, conv_class):
     conv = convert_request_exception(exc)

--- a/tests/unit/test_imports.py
+++ b/tests/unit/test_imports.py
@@ -7,22 +7,28 @@ interpreter's state, invoke these via subprocess check_call() calls.
 These should all be using `shell=True` (the subprocess invoked interpreter
 doesn't behave correctly without it).
 """
-import subprocess
 import os
+import subprocess
 import sys
+
 import pytest
 
-
-PYTHON_BINARY = os.environ.get('GLOBUS_TEST_PY', sys.executable)
+PYTHON_BINARY = os.environ.get("GLOBUS_TEST_PY", sys.executable)
 
 
 @pytest.mark.parametrize(
-    'importstring',
-    ["from globus_sdk import *",
-     "from globus_sdk import TransferClient, AuthClient, SearchClient"])
+    "importstring",
+    [
+        "from globus_sdk import *",
+        "from globus_sdk import TransferClient, AuthClient, SearchClient",
+    ],
+)
 def test_import_str(importstring):
-    proc = subprocess.Popen('{} -c "{}"'.format(PYTHON_BINARY, importstring),
-                            shell=True, stdout=subprocess.PIPE,
-                            stderr=subprocess.PIPE)
+    proc = subprocess.Popen(
+        '{} -c "{}"'.format(PYTHON_BINARY, importstring),
+        shell=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
     status = proc.wait()
     assert status is 0, str(proc.communicate())

--- a/tests/unit/test_transfer_paging.py
+++ b/tests/unit/test_transfer_paging.py
@@ -1,7 +1,8 @@
-import requests
 import json
-import six
+
 import pytest
+import requests
+import six
 
 from globus_sdk.transfer.paging import PaginatedResource
 from globus_sdk.transfer.response import IterableTransferResponse
@@ -10,12 +11,12 @@ N = 25
 
 
 class PagingSimulator(object):
-
     def __init__(self, n):
         self.n = n  # the number of simulated items
 
-    def simulate_get(self, path, params=None,
-                     headers=None, response_class=None, retry_401=True):
+    def simulate_get(
+        self, path, params=None, headers=None, response_class=None, retry_401=True
+    ):
         """
         Simulates a paginated response from a Globus API get supporting limit,
         offset, and has next page
@@ -53,8 +54,12 @@ def test_data(paging_simulator):
     # num_results < n
     less_results = N - 7
     pr_less = PaginatedResource(
-        paging_simulator.simulate_get, "path", {"params": {}},
-        max_results_per_call=10, num_results=less_results)
+        paging_simulator.simulate_get,
+        "path",
+        {"params": {}},
+        max_results_per_call=10,
+        num_results=less_results,
+    )
     # confirm results
     for item, expected in zip(pr_less.data, range(less_results)):
         assert item["value"] == expected
@@ -64,8 +69,12 @@ def test_data(paging_simulator):
     # num_results > n
     more_results = N + 7
     pr_more = PaginatedResource(
-        paging_simulator.simulate_get, "path", {"params": {}},
-        max_results_per_call=10, num_results=more_results)
+        paging_simulator.simulate_get,
+        "path",
+        {"params": {}},
+        max_results_per_call=10,
+        num_results=more_results,
+    )
     # confirm results
     for item, expected in zip(pr_more.data, range(N)):
         assert item["value"] == expected
@@ -73,8 +82,12 @@ def test_data(paging_simulator):
 
     # num_results = None (fetch all)
     pr_none = PaginatedResource(
-        paging_simulator.simulate_get, "path", {"params": {}},
-        max_results_per_call=10, num_results=None)
+        paging_simulator.simulate_get,
+        "path",
+        {"params": {}},
+        max_results_per_call=10,
+        num_results=None,
+    )
     # confirm results
     for item, expected in zip(pr_none.data, range(N)):
         assert item["value"] == expected
@@ -87,8 +100,12 @@ def test_iterable_func(paging_simulator):
     sanity checks usage
     """
     pr = PaginatedResource(
-        paging_simulator.simulate_get, "path", {"params": {}},
-        max_results_per_call=10, num_results=None)
+        paging_simulator.simulate_get,
+        "path",
+        {"params": {}},
+        max_results_per_call=10,
+        num_results=None,
+    )
 
     generator = pr.iterable_func()
     for i in range(N):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -3,22 +3,21 @@ from globus_sdk import utils
 
 
 def test_safe_b64encode_non_ascii():
-    test_string = 'ⓤⓢⓔⓡⓝⓐⓜⓔ'
-    expected_b64 = '4pOk4pOi4pOU4pOh4pOd4pOQ4pOc4pOU'
+    test_string = "ⓤⓢⓔⓡⓝⓐⓜⓔ"
+    expected_b64 = "4pOk4pOi4pOU4pOh4pOd4pOQ4pOc4pOU"
 
     assert utils.safe_b64encode(test_string) == expected_b64
 
 
 def test_safe_b64encode_ascii():
-    test_string = 'username'
-    expected_b64 = 'dXNlcm5hbWU='
+    test_string = "username"
+    expected_b64 = "dXNlcm5hbWU="
 
     assert utils.safe_b64encode(test_string) == expected_b64
 
 
 def test_sha256string():
-    test_string = 'foo'
-    expected_sha = ('2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f'
-                    '98a5e886266e7ae')
+    test_string = "foo"
+    expected_sha = "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f" "98a5e886266e7ae"
 
     assert utils.sha256_string(test_string) == expected_sha


### PR DESCRIPTION
Take time to chew on this. I'm not going to force it if others don't like the result or have qualms about the tools themselves.

- switch from simple `flake8` usage to full-on `black` autoformatter
- start using `isort`
- add `flake8-bugbear` plugin
- use setuptools platform specific dependencies to only install and lint with `black` and `flake8-bugbear` on python versions which support them
- move `flake8` config into `setup.cfg`, to live alongside `isort` config
- add `make autoformat` and `make lint` to do the sensible things with these new tools
- change `make travis` to invoke `make lint`; no change to appveyor
- cut down the contrib guide to a reasonable size
- fix warnings in test runs from py3.7 deprecations (closes #324)

I'm considering `tox` as a tooling option much more strongly now that tests can run fast and safely in a local environment with multiple configured pythons -- previously, I'd have advised anyone outside of SDK maintainers to wait for the Travis and AppVeyor builds to see if their changes passed. However, one massive refactor at a time.

As Jason promised, I've already had cases where I "disagree" with `black` about something, and then have the wonderful experience of realizing that I've just removed an aesthetic opinion of mine -- about how something should look -- from our shared codebase.