### PR TITLE
Add Windows builds to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,20 @@ matrix:
       dist: trusty
     - python: "pypy3"
       dist: trusty
+    - os: windows
+      language: sh
+      python: "2.7"
+      before_install:
+        - choco install python2
+        - export PATH="/c/Python27:/c/Python27/Scripts:$PATH"
+        - python -m pip install --upgrade pip wheel
+    - os: windows
+      language: sh
+      python: "3.7"
+      before_install:
+        - choco install python3
+        - export PATH="/c/Python37:/c/Python37/Scripts:$PATH"
+        - python -m pip install --upgrade pip wheel
   allow_failures:
     - python: "3.8-dev"
     - python: "pypy"


### PR DESCRIPTION
Adds Windows builds for python 2.7 and python 3.7.

Note: leaving AppVeyor in place for now while we see how building with Windows on Travis goes.