### PR TITLE
Convert testsuite to tox; net simplification

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,21 @@
-sudo: required
+sudo: false
+dist: xenial
 language: python
 matrix:
   include:
     - python: "2.7"
-      dist: xenial
     - python: "3.4"
-      dist: trusty
     - python: "3.5"
-      dist: xenial
     - python: "3.6"
-      dist: xenial
+    # hack py37, py38 to use a different Travis worker type
+    # sudo:required gets us the VM builds where these pythons work
     - python: "3.7"
-      dist: xenial
+      sudo: required
     - python: "3.8-dev"
-      dist: xenial
+      sudo: required
     - python: "pypy"
-      dist: trusty
     - python: "pypy3"
-      dist: trusty
+    - python: "nightly"
     - os: windows
       language: sh
       python: "2.7"
@@ -36,6 +34,9 @@ matrix:
     - python: "3.8-dev"
     - python: "pypy"
     - python: "pypy3"
+    - python: "nightly"
 cache: pip
+install:
+  - pip install -e '.[development]'
 script:
-  - make travis
+  - tox -e py  # invoke with calling python

--- a/Makefile
+++ b/Makefile
@@ -1,35 +1,20 @@
-# allow specification of python version and venv loc for devs, so you can
-#    make test PYTHON_VERSION=python3.6 VIRTUALENV=.venv36
-#    make test PYTHON_VERSION=python2.7 VIRTUALENV=.venv27
-# and be happy
-# we don't need tox just to do this (though it might make life easier in the
-# future, especially now that tests are fast)
+# allow specification of python version for devs. Examples:
+#    make autoformat PYTHON_VERSION=python3.6
 PYTHON_VERSION?=python3
-VIRTUALENV?=.venv
-AUTOFORMAT_TARGETS=tests/ globus_sdk/ setup.py
+VIRTUALENV=.venv
 
 .PHONY: docs build upload test lint autoformat clean help
 
-
 help:
-	@echo "These are our make targets and what they do."
-	@echo "All unlisted targets are internal."
+	@echo "Globus SDK 'make' targets"
 	@echo ""
 	@echo "  help:         Show this helptext"
-	@echo "  localdev:     Setup local development env with a 'setup.py develop'"
 	@echo "  build:        Create the distributions which we like to upload to pypi"
-	@echo "  lint:         All linting steps (may be limited by what your python version supports)"
+	@echo "  upload:       [build] + upload to pypi using twine"
+	@echo "  test:         Run the full suite of tests + linting"
 	@echo "  autoformat:   Run code autoformatters"
-	@echo "  test:         Run the full suite of tests"
 	@echo "  docs:         Clean old HTML docs and rebuild them with sphinx"
-	@echo "  upload:       [build], but also upload to pypi using twine"
 	@echo "  clean:        Remove typically unwanted files, mostly from [build]"
-	@echo "  all:          Wrapper for [localdev] + [docs] + [test]"
-
-
-all: localdev docs test
-localdev: $(VIRTUALENV)
-
 
 $(VIRTUALENV): setup.py
 	# don't recreate it if it already exists -- just run the setup steps
@@ -39,42 +24,19 @@ $(VIRTUALENV): setup.py
 	# explicit touch to ensure good update time relative to setup.py
 	touch $(VIRTUALENV)
 
+# run outside of tox because specifying a tox environment for py3.6+ is awkward
+autoformat: $(VIRTUALENV)
+	$(VIRTUALENV)/bin/isort --recursive tests/ globus_sdk/ setup.py
+	if [ -f "$(VIRTUALENV)/bin/black" ]; then $(VIRTUALENV)/bin/black  tests/ globus_sdk/ setup.py; fi
 
+test: $(VIRTUALENV)
+	$(VIRTUALENV)/bin/tox
+docs: $(VIRTUALENV)
+	$(VIRTUALENV)/bin/tox -e docs
 build: $(VIRTUALENV)
 	$(VIRTUALENV)/bin/python setup.py sdist bdist_wheel
-
 upload: build
 	$(VIRTUALENV)/bin/twine upload dist/*
 
-
-autoformat: $(VIRTUALENV)
-	$(VIRTUALENV)/bin/isort --recursive $(AUTOFORMAT_TARGETS)
-	if [ -f "$(VIRTUALENV)/bin/black" ]; then $(VIRTUALENV)/bin/black $(AUTOFORMAT_TARGETS); fi
-
-
-lint: $(VIRTUALENV)
-	if [ -f "$(VIRTUALENV)/bin/black" ]; then $(VIRTUALENV)/bin/black --check $(AUTOFORMAT_TARGETS); fi
-	$(VIRTUALENV)/bin/isort --recursive --check-only $(AUTOFORMAT_TARGETS)
-	$(VIRTUALENV)/bin/flake8
-
-
-test: $(VIRTUALENV)
-	$(VIRTUALENV)/bin/pytest -v --cov=globus_sdk
-
-
-travis:
-	pip install -U pip setuptools
-	pip install -e '.[development]'
-	$(MAKE) lint
-	pytest -v tests/
-
-
-docs: $(VIRTUALENV)
-	. $(VIRTUALENV)/bin/activate && $(MAKE) -C docs/ clean html
-
-
 clean:
-	-rm -r $(VIRTUALENV)
-	-rm -r dist
-	-rm -r build
-	-rm -r *.egg-info
+	rm -rf $(VIRTUALENV) dist build *.egg-info .tox

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,7 @@ environment:
     - PYTHON: "C:\\Python34-x64"
     - PYTHON: "C:\\Python35-x64"
     - PYTHON: "C:\\Python36-x64"
+    - PYTHON: "C:\\Python37-x64"
 
 install:
   # invoke python explicitly, and wrap it in build.cmd so that compilation of
@@ -17,7 +18,7 @@ install:
 
 test_script:
   # explicitly invoke under the build environment's python
-  - "%PYTHON%\\python.exe -m pytest -v --cov=globus_sdk"
+  - "%PYTHON%\\python.exe -m tox -e py"
 
 build: off
 deploy: off

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ not_skip = __init__.py
 
 
 [flake8]
-exclude = .git,__pycache__,.eggs,dist,venv,.venv*,venv27,virtualenv,docs,docs-source,build
+exclude = .git,.tox,__pycache__,.eggs,dist,venv,.venv*,venv27,virtualenv,docs,docs-source,build
 
 # we enforce 80 char width with `black` "loosely", so flake8 should be set to
 # not fail on up to 88 chars of width

--- a/setup.py
+++ b/setup.py
@@ -43,8 +43,10 @@ setup(
     extras_require={
         # empty extra included to support older installs
         "jwt": [],
-        # the _development extra is for SDK developers only
+        # the development extra is for SDK developers only
         "development": [
+            # drive testing with tox
+            "tox>=3.5.3,<4.0",
             # linting
             "flake8>=3.0,<4.0",
             "isort>=4.3,<5.0",

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,19 @@
+[tox]
+envlist = py{37,36,35,34,27,py,py3}
+skip_missing_interpreters = true
+
+[testenv]
+usedevelop = true
+extras = development
+commands =
+    flake8
+    isort --recursive --check-only tests/ globus_sdk/ setup.py
+    py36,py37: black --check  tests/ globus_sdk/ setup.py
+    pytest -v --cov=globus_sdk
+
+[testenv:docs]
+whitelist_externals = rm
+changedir = docs/
+# clean the build dir before rebuilding
+commands_pre = rm -rf _build/
+commands = sphinx-build -d _build/doctrees -b dirhtml _build/dirhtml


### PR DESCRIPTION
- Add tox for multipython testing, drives linting and test steps
- Keep autoformatting explicitly driven off of a controllable virtualenv because tox doesn't have great support for environments dependent on a range of python versions
- Cut down on Makefile complexity
- Cut down .travis.yml and appveyor.yml complexity
- Move doc building into tox because the python version it runs with doesn't matter

For the automated testing platforms, this isn't a big deal, but I like being able to run `make test` locally, and have that check both py2 and py3.
I waffled a little on whether `tox` should or should not be in the `[development]` dependencies, and ultimately landed on "in" because we want to control the version of it regardless of where we're building.