### PR TITLE
Test use of lowest supported dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,21 +4,31 @@ language: python
 matrix:
   include:
     - python: "2.7"
+      env: TOXENV=py,lowestdeps
     - python: "3.4"
+      env: TOXENV=py
     - python: "3.5"
+      env: TOXENV=py
     - python: "3.6"
+      env: TOXENV=py,lowestdeps
     # hack py37, py38 to use a different Travis worker type
     # sudo:required gets us the VM builds where these pythons work
     - python: "3.7"
+      env: TOXENV=py
       sudo: required
     - python: "3.8-dev"
+      env: TOXENV=py
       sudo: required
     - python: "pypy"
+      env: TOXENV=py
     - python: "pypy3"
+      env: TOXENV=py
     - python: "nightly"
+      env: TOXENV=py
     - os: windows
       language: sh
       python: "2.7"
+      env: TOXENV=py,lowestdeps
       before_install:
         - choco install python2
         - export PATH="/c/Python27:/c/Python27/Scripts:$PATH"
@@ -26,6 +36,7 @@ matrix:
     - os: windows
       language: sh
       python: "3.7"
+      env: TOXENV=py,lowestdeps
       before_install:
         - choco install python3
         - export PATH="/c/Python37:/c/Python37/Scripts:$PATH"
@@ -39,4 +50,4 @@ cache: pip
 install:
   - pip install -e '.[development]'
 script:
-  - tox -e py  # invoke with calling python
+  - tox

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     url="https://github.com/globus/globus-sdk-python",
     packages=find_packages(exclude=["tests", "tests.*"]),
     install_requires=[
-        "requests>=2.0.0,<3.0.0",
+        "requests>=2.9.2,<3.0.0",
         "six>=1.10.0,<2.0.0",
         "pyjwt[crypto]>=1.5.3,<2.0.0",
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,17 @@
 [tox]
-envlist = py{37,36,35,34,27,py,py3}
+envlist =
+    py{37,36,35,34,27,py,py3}
+    py{37,36,35,27}-lowestdeps
 skip_missing_interpreters = true
 
 [testenv]
 usedevelop = true
 extras = development
+deps =
+    lowestdeps: requests==2.9.2
+    lowestdeps: six==1.10.0
+    lowestdeps: pyjwt[crypto]==1.5.3
+
 commands =
     flake8
     isort --recursive --check-only tests/ globus_sdk/ setup.py
@@ -16,4 +23,4 @@ whitelist_externals = rm
 changedir = docs/
 # clean the build dir before rebuilding
 commands_pre = rm -rf _build/
-commands = sphinx-build -d _build/doctrees -b dirhtml _build/dirhtml
+commands = sphinx-build . -d _build/doctrees -b dirhtml _build/dirhtml


### PR DESCRIPTION
Also, revealed that we *actually* require `requests>=2.9.2` because that version fixed a missing export of an error. This was *not* in the `requests` changelog, so I'm not super happy about it.

However, this testing ensures that stuff like this can't happen again: if you start using something which `requests`, `six`, or `pyjwt` adds, the tests will smack you back down for having the audacity to declare false compatibility.

@jaswilli, I want `tox -e lowestdeps` to be a separate Travis Check, if we can figure out that functionality. Does this seem like a good PR to toy with for setting that up?