### PR TITLE
Fix broken readthedocs integration

### DIFF
--- a/.readthedocs-requirements.txt
+++ b/.readthedocs-requirements.txt
@@ -1,0 +1,3 @@
+# tricky! Specify an editable install with the development extra as a
+# "requirement" and be happy
+-e ".[development]"


### PR DESCRIPTION
It looks like my refactor of requirements into `setup.py` broke the readthedocs integration. Hopefully, this is a clean path forward.

I've put this requirements file into place, and reconfigured the readthedocs project to look for this "requirements" file.

I originally wanted to use the readthedocs.yml config to handle this, but I think it might only be available to paying subscribers. When I try to use it, it doesn't seem to change the build's behavior (but oddly, it is still verified and invalid config will fail the build).