### PR TITLE
Minor doc fixup

### DIFF
--- a/globus_sdk/search/client.py
+++ b/globus_sdk/search/client.py
@@ -42,7 +42,8 @@ class SearchClient(BaseClient):
     *  :py:meth:`.delete_entry`
     *  :py:meth:`.get_query_template`
     *  :py:meth:`.get_query_template_list`
-    *  :py:meth:`.get_task`
+    *  :py:meth:`~.SearchClient.get_task`
+    *  :py:meth:`~.SearchClient.get_task_list`
     """
     # disallow basic auth
     allowed_authorizer_types = [

--- a/globus_sdk/transfer/client.py
+++ b/globus_sdk/transfer/client.py
@@ -94,7 +94,7 @@ class TransferClient(BaseClient):
     *  :py:meth:`.submit_delete`
     *  :py:meth:`.task_list`
     *  :py:meth:`.task_event_list`
-    *  :py:meth:`.get_task`
+    *  :py:meth:`~.TransferClient.get_task`
     *  :py:meth:`.update_task`
     *  :py:meth:`.cancel_task`
     *  :py:meth:`.task_wait`


### PR DESCRIPTION
`SearchClient.get_task` link was ambiguous and actually linked to `TransferClient.get_task` with a warning on doc build. To resolve, make both of them unambiguous.

Also, add missing `SearchClient.get_task_list` link.