### PR TITLE
Shared endpoint list

### DIFF
--- a/globus_sdk/base.py
+++ b/globus_sdk/base.py
@@ -198,7 +198,15 @@ class BaseClient(object):
     def qjoin_path(self, *parts):
         return "/" + "/".join(quote(part) for part in parts)
 
-    def get(self, path, params=None, headers=None, response_class=None, retry_401=True):
+    def get(
+        self,
+        path,
+        params=None,
+        headers=None,
+        response_class=None,
+        response_kwargs=None,
+        retry_401=True,
+    ):
         """
         Make a GET request to the specified path.
 
@@ -217,6 +225,10 @@ class BaseClient(object):
               Class for response object, overrides the client's
               ``default_response_class``
 
+            ``response_kwargs`` (*dict*)
+              Kwargs that will be passed to the response_class's __init__
+              method
+
             ``retry_401`` (*bool*)
               Retry on 401 responses with fresh Authorization if
               ``self.authorizer`` supports it
@@ -231,6 +243,7 @@ class BaseClient(object):
             params=params,
             headers=headers,
             response_class=response_class,
+            response_kwargs=response_kwargs,
             retry_401=retry_401,
         )
 
@@ -242,6 +255,7 @@ class BaseClient(object):
         headers=None,
         text_body=None,
         response_class=None,
+        response_kwargs=None,
         retry_401=True,
     ):
         """
@@ -269,6 +283,10 @@ class BaseClient(object):
               Class for response object, overrides the client's
               ``default_response_class``
 
+            ``response_kwargs`` (*dict*)
+              Kwargs that will be passed to the response_class's __init__
+              method
+
             ``retry_401`` (*bool*)
               Retry on 401 responses with fresh Authorization if
               ``self.authorizer`` supports it
@@ -285,11 +303,18 @@ class BaseClient(object):
             headers=headers,
             text_body=text_body,
             response_class=response_class,
+            response_kwargs=response_kwargs,
             retry_401=retry_401,
         )
 
     def delete(
-        self, path, params=None, headers=None, response_class=None, retry_401=True
+        self,
+        path,
+        params=None,
+        headers=None,
+        response_class=None,
+        response_kwargs=None,
+        retry_401=True,
     ):
         """
         Make a DELETE request to the specified path.
@@ -309,6 +334,10 @@ class BaseClient(object):
               Class for response object, overrides the client's
               ``default_response_class``
 
+            ``response_kwargs`` (*dict*)
+              Kwargs that will be passed to the response_class's __init__
+              method
+
             ``retry_401`` (*bool*)
               Retry on 401 responses with fresh Authorization if
               ``self.authorizer`` supports it
@@ -323,6 +352,7 @@ class BaseClient(object):
             params=params,
             headers=headers,
             response_class=response_class,
+            response_kwargs=response_kwargs,
             retry_401=retry_401,
         )
 
@@ -334,6 +364,7 @@ class BaseClient(object):
         headers=None,
         text_body=None,
         response_class=None,
+        response_kwargs=None,
         retry_401=True,
     ):
         """
@@ -361,6 +392,10 @@ class BaseClient(object):
               Class for response object, overrides the client's
               ``default_response_class``
 
+            ``response_kwargs`` (*dict*)
+              Kwargs that will be passed to the response_class's __init__
+              method
+
             ``retry_401`` (*bool*)
               Retry on 401 responses with fresh Authorization if
               ``self.authorizer`` supports it
@@ -377,6 +412,7 @@ class BaseClient(object):
             headers=headers,
             text_body=text_body,
             response_class=response_class,
+            response_kwargs=response_kwargs,
             retry_401=retry_401,
         )
 
@@ -388,6 +424,7 @@ class BaseClient(object):
         headers=None,
         text_body=None,
         response_class=None,
+        response_kwargs=None,
         retry_401=True,
     ):
         """
@@ -415,6 +452,10 @@ class BaseClient(object):
               Class for response object, overrides the client's
               ``default_response_class``
 
+            ``response_kwargs`` (*dict*)
+              Kwargs that will be passed to the response_class's __init__
+              method
+
             ``retry_401`` (*bool*)
               Retry on 401 responses with fresh Authorization if
               ``self.authorizer`` supports it
@@ -431,6 +472,7 @@ class BaseClient(object):
             headers=headers,
             text_body=text_body,
             response_class=response_class,
+            response_kwargs=response_kwargs,
             retry_401=retry_401,
         )
 
@@ -443,6 +485,7 @@ class BaseClient(object):
         json_body=None,
         text_body=None,
         response_class=None,
+        response_kwargs=None,
         retry_401=True,
     ):
         """
@@ -471,6 +514,10 @@ class BaseClient(object):
             ``response_class`` (*class*)
               Class for response object, overrides the client's
               ``default_response_class``
+
+            ``response_kwargs`` (*dict*)
+              Kwargs that will be passed to the response_class's __init__
+              method
 
             ``retry_401`` (*bool*)
               Retry on 401 responses with fresh Authorization if
@@ -543,9 +590,11 @@ class BaseClient(object):
                 "request completed with response code: {}".format(r.status_code)
             )
             if response_class is None:
-                return self.default_response_class(r, client=self)
+                return self.default_response_class(
+                    r, client=self, **(response_kwargs or {})
+                )
             else:
-                return response_class(r, client=self)
+                return response_class(r, client=self, **(response_kwargs or {}))
 
         self.logger.debug(
             "request completed with (error) response code: {}".format(r.status_code)

--- a/globus_sdk/transfer/client.py
+++ b/globus_sdk/transfer/client.py
@@ -65,6 +65,7 @@ class TransferClient(BaseClient):
     *  :py:meth:`.endpoint_get_activation_requirements`
     *  :py:meth:`.my_effective_pause_rule_list`
     *  :py:meth:`.my_shared_endpoint_list`
+    *  :py:meth:`.shared_endpoint_list`
     *  :py:meth:`.create_shared_endpoint`
     *  :py:meth:`.endpoint_server_list`
     *  :py:meth:`.get_endpoint_server`
@@ -514,7 +515,7 @@ class TransferClient(BaseClient):
         **External Documentation**
 
         See
-        `Get shared endpoint list \
+        `Get my shared endpoint list \
         <https://docs.globus.org/api/transfer/endpoint/#get_shared_endpoint_list>`_
         in the REST documentation for details.
         """
@@ -524,6 +525,35 @@ class TransferClient(BaseClient):
         )
         path = self.qjoin_path("endpoint", endpoint_id, "my_shared_endpoint_list")
         return self.get(path, params=params, response_class=IterableTransferResponse)
+
+    def shared_endpoint_list(self, endpoint_id, **params):
+        """
+        ``GET /endpoint/<endpoint_xid>/shared_endpoint_list``
+
+        :rtype: :class:`PaginatedResource
+                <globus_sdk.transfer.paging.PaginatedResource>`,
+                an iterable of :class:`GlobusResponse
+                <globus_sdk.response.GlobusResponse>`
+
+        **External Documentation**
+
+        See
+        `Get shared endpoint list \
+        <https://docs.globus.org/api/transfer/endpoint/#get_shared_endpoint_list2>`_
+        in the REST documentation for details.
+        """
+        endpoint_id = safe_stringify(endpoint_id)
+        self.logger.info(
+            "TransferClient.shared_endpoint_list({}, ...)".format(endpoint_id)
+        )
+        path = self.qjoin_path("endpoint", endpoint_id, "shared_endpoint_list")
+        return PaginatedResource(
+            self.get,
+            path,
+            {"params": params},
+            iter_key="shared_endpoints",
+            paging_style=PaginatedResource.PAGING_STYLE_TOKEN,
+        )
 
     def create_shared_endpoint(self, data):
         """

--- a/globus_sdk/transfer/response/iterable.py
+++ b/globus_sdk/transfer/response/iterable.py
@@ -6,13 +6,17 @@ class IterableTransferResponse(TransferResponse):
     Response class for non-paged list oriented resources. Allows top level
     fields to be accessed normally via standard item access, and also
     provides a convenient way to iterate over the sub-item list in the
-    ``DATA`` key:
+    specified ``iter_key``:
 
     >>> print("Path:", r["path"])
-    >>> # Equivalent to: for item in r["DATA"]
+    >>> # Equivalent to: for item in r[iter_key]
     >>> for item in r:
     >>>     print(item["name"], item["type"])
     """
 
+    def __init__(self, http_response, iter_key="DATA", client=None):
+        TransferResponse.__init__(self, http_response, client=client)
+        self.iter_key = iter_key
+
     def __iter__(self):
-        return iter(self["DATA"])
+        return iter(self[self.iter_key])

--- a/tests/unit/test_transfer_paging.py
+++ b/tests/unit/test_transfer_paging.py
@@ -15,7 +15,13 @@ class PagingSimulator(object):
         self.n = n  # the number of simulated items
 
     def simulate_get(
-        self, path, params=None, headers=None, response_class=None, retry_401=True
+        self,
+        path,
+        params=None,
+        headers=None,
+        response_class=None,
+        response_kwargs=None,
+        retry_401=True,
     ):
         """
         Simulates a paginated response from a Globus API get supporting limit,
@@ -38,6 +44,45 @@ class PagingSimulator(object):
         response._content = six.b(json.dumps(data))
         response.headers["Content-Type"] = "application/json"
         return IterableTransferResponse(response)
+
+    def simulate_get_shared_endpoint_list(
+        self,
+        path,
+        params=None,
+        headers=None,
+        response_class=None,
+        response_kwargs=None,
+        retry_401=True,
+    ):
+        """
+        Simulates a paginated response from GET shared_endpoint_list
+        which uses a different paging style and a non DATA key
+
+        Uses simplified next_token logic where next_token is the first int
+        to return on the next page
+        """
+        data = {}
+        next_token = params.get("next_token") or 0
+        max_results = 10  # limited for ease of testing
+
+        # if we are capped by n
+        if next_token + max_results >= self.n:
+            shared_endpoints = [{"id": i} for i in range(next_token, self.n)]
+            next_token = None
+
+        # if we are capped by max results
+        else:
+            shared_endpoints = [
+                {"id": i} for i in range(next_token, next_token + max_results)
+            ]
+            next_token = next_token + max_results
+
+        # make the simulated response
+        data = {"shared_endpoints": shared_endpoints, "next_token": next_token}
+        response = requests.Response()
+        response._content = six.b(json.dumps(data))
+        response.headers["Content-Type"] = "application/json"
+        return IterableTransferResponse(response, **(response_kwargs or {}))
 
 
 @pytest.fixture
@@ -113,3 +158,54 @@ def test_iterable_func(paging_simulator):
 
     with pytest.raises(StopIteration):
         six.next(generator)
+
+
+def test_shared_endpoint_iteration(paging_simulator):
+    """
+    Confirms PaginatedResource handles the non standard
+    formatting of the shared_endpoint_list response
+    """
+    # num_results < n
+    less_results = N - 7
+    pr_less = PaginatedResource(
+        paging_simulator.simulate_get_shared_endpoint_list,
+        "path",
+        {"params": {}},
+        paging_style=PaginatedResource.PAGING_STYLE_TOKEN,
+        iter_key="shared_endpoints",
+        num_results=less_results,
+    )
+    # confirm results
+    for item, expected in zip(pr_less.data, range(less_results)):
+        assert item["id"] == expected
+
+    assert pr_less.num_results_fetched == less_results
+
+    # num_results > n
+    more_results = N + 7
+    pr_more = PaginatedResource(
+        paging_simulator.simulate_get_shared_endpoint_list,
+        "path",
+        {"params": {}},
+        paging_style=PaginatedResource.PAGING_STYLE_TOKEN,
+        iter_key="shared_endpoints",
+        num_results=more_results,
+    )
+    # confirm results
+    for item, expected in zip(pr_more.data, range(N)):
+        assert item["id"] == expected
+    assert pr_more.num_results_fetched == N
+
+    # num_results = None (fetch all)
+    pr_none = PaginatedResource(
+        paging_simulator.simulate_get_shared_endpoint_list,
+        "path",
+        {"params": {}},
+        paging_style=PaginatedResource.PAGING_STYLE_TOKEN,
+        iter_key="shared_endpoints",
+        num_results=None,
+    )
+    # confirm results
+    for item, expected in zip(pr_none.data, range(N)):
+        assert item["id"] == expected
+    assert pr_none.num_results_fetched == N


### PR DESCRIPTION
Resolves #318 

Turns out this API endpoint does more than just use a new pagination method, it also doesn't use `DATA` as its key for iterable data.

I decided to handle this by adding a specifiable `iter_key` to the `IterableTransferResponse` class which required passing a lot of kwargs around.

If this is too much of a mess, I would not be opposed to a more straightforward solution.