### PR TITLE
Update to separate CI linting step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,17 +5,27 @@ matrix:
   include:
     - python: "2.7"
       env: TOXENV=py,lowestdeps
+    # py2 linting build (flake8 on py2 can flag different stuff)
+    - python: "2.7"
+      env: TOXENV=lint
+    # test on 3.4, 3.5, 3.6
     - python: "3.4"
       env: TOXENV=py
     - python: "3.5"
       env: TOXENV=py
     - python: "3.6"
       env: TOXENV=py,lowestdeps
+    # separate py3.6 linting build, which runs 'black --check' (no py2 support)
+    - python: "3.6"
+      env: TOXENV=py36-lint
     # hack py37, py38 to use a different Travis worker type
     # sudo:required gets us the VM builds where these pythons work
     - python: "3.7"
       env: TOXENV=py
       sudo: required
+    # TODO: re-evaluate these
+    # 3.8-dev and nightly don't support flake8
+    # travis pypy builds seem to have been busted
     - python: "3.8-dev"
       env: TOXENV=py
       sudo: required
@@ -25,10 +35,11 @@ matrix:
       env: TOXENV=py
     - python: "nightly"
       env: TOXENV=py
+    # windows testing
     - os: windows
       language: sh
       python: "2.7"
-      env: TOXENV=py,lowestdeps
+      env: TOXENV=py,lowestdeps,lint
       before_install:
         - choco install python2
         - export PATH="/c/Python27:/c/Python27/Scripts:$PATH"
@@ -36,7 +47,7 @@ matrix:
     - os: windows
       language: sh
       python: "3.7"
-      env: TOXENV=py,lowestdeps
+      env: TOXENV=py,lowestdeps,py37-lint
       before_install:
         - choco install python3
         - export PATH="/c/Python37:/c/Python37/Scripts:$PATH"

--- a/globus_sdk/transfer/data.py
+++ b/globus_sdk/transfer/data.py
@@ -165,8 +165,7 @@ class TransferData(dict):
                 )
             )
 
-    def add_item(self, source_path, destination_path,
-                 recursive=False, **params):
+    def add_item(self, source_path, destination_path, recursive=False, **params):
         """
         Add a file or directory to be transfered. If the item is a symlink
         to a file or directory, the file or directory at the target of

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist =
     py{37,36,35,34,27,py,py3}
     py{37,36,35,27}-lowestdeps
+    py{37,36,27}-lint
 skip_missing_interpreters = true
 
 [testenv]
@@ -13,10 +14,10 @@ deps =
     lowestdeps: pyjwt[crypto]==1.5.3
 
 commands =
-    flake8
-    isort --recursive --check-only tests/ globus_sdk/ setup.py
-    py36,py37: black --check  tests/ globus_sdk/ setup.py
-    pytest -v --cov=globus_sdk
+    lint: flake8
+    lint: isort --recursive --check-only tests/ globus_sdk/ setup.py
+    py36-lint,py37-lint: black --check  tests/ globus_sdk/ setup.py
+    !lint: pytest -v --cov=globus_sdk
 
 [testenv:docs]
 whitelist_externals = rm


### PR DESCRIPTION
And fix `black --check` not happening in certain builds.

- tox.ini lists linting separately from testing
- expand the Travis matrix to hit the new cases

Also, tweak one file to pass `black --check`

I'm not 100% confident in the tox config, so please read with a critical eye. But this appears to do what I want. It separates the linting step, limits linting to py2.7 and py3.6 only (saves some time/cycles and cleans up output), still runs linting on windows boxes (just in case), etc etc.