### PR TITLE
Property to reveal more results available

### DIFF
--- a/tests/unit/test_transfer_paging.py
+++ b/tests/unit/test_transfer_paging.py
@@ -93,6 +93,34 @@ def test_data(paging_simulator):
         assert item["value"] == expected
     assert pr_none.num_results_fetched == N
 
+    # limit < N should show more results available
+    pr_more_available = PaginatedResource(
+        paging_simulator.simulate_get,
+        "path",
+        {"params": {}},
+        max_results_per_call=10,
+        num_results=5,
+    )
+
+    # confirm results
+    for item, expected in zip(pr_more_available.data, range(N)):
+        assert item["value"] == expected
+    assert pr_more_available.limit_less_than_available_results is True
+
+    # limit > N should show no more results available
+    pr_no_more_available = PaginatedResource(
+        paging_simulator.simulate_get,
+        "path",
+        {"params": {}},
+        max_results_per_call=10,
+        num_results=N,
+    )
+
+    # confirm results
+    for item, expected in zip(pr_more_available.data, range(N)):
+        assert item["value"] == expected
+    assert pr_no_more_available.limit_less_than_available_results is False
+
 
 def test_iterable_func(paging_simulator):
     """


### PR DESCRIPTION
### Context

Discussions have taken place about the Transfer API endpoint search, the number of results returned and how a user might be able to know the total number of results or some other way to know they aren't seeing everything that's available.

### Proposal
This is one proposed solution which adds a property to the PagedResponse class that will become true if the underlying API indicates there are more results available than the user requested (i.e., by way of a limit parameter).

Example:

```
import globus_sdk

tc = globus_sdk.TransferClient(
    authorizer=globus_sdk.AccessTokenAuthorizer(access_token=<token>)
)

res = tc.endpoint_search(filter_fulltext='globus', limit=5)
endpoints = list(res)

assert res.limit_less_than_available_results is True
```

Which then could be leveraged in the CLI to inform the user that they're not seeing all available results.