### PR TITLE
Minor tweaks to contrib doc

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -21,11 +21,9 @@ Linting & Testing
    https://github.com/timothycrosley/isort[isort]. You may run
     `make autoformat` to do this or configure these tools for use in your
     editor.
-- Code must pass `make lint`, which checks that autoformatting is clean and
-    that `flake8` passes
-- All code must pass `make test`
+- All code must pass `make test`, which runs linting and tests.
 
-NOTE: `black` requires python3.6, so you may find it necessary to
+NOTE: `black` requires python3.6+, so you may find it necessary to
 `make clean autoformat PYTHON_VERSION=python3.6` or equivalent.
 
 Expectations for Pull Requests


### PR DESCRIPTION
I setup a precommit hook for myself to run `make lint` (because, due to quirks of my vim config to disable linting for certain projects, I've sometimes had issues where linting gets turned off incorrectly). However, it immediately failed because we removed `make lint` and folded it into `make test`.

Update the contrib doc for accuracy on this.

<details><summary>Also, in case anyone wants it, this is what I'm using for pre-commit</summary>

```
$ cat .git/hooks/pre-commit
#!/bin/sh
# go to repo root
cd "$(dirname "$0")/../.." || exit 1
# Redirect output to stderr.
exec 1>&2
# run command
make .venv && .venv/bin/tox -e py36-lint
```
</details>