### PR TITLE
Add changelog doc, tweak contrib doc very mildly

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,229 @@
+CHANGELOG
+=========
+
+Unreleased
+----------
+
+* Add a property to paginated responses to indicate that there are more results available than the user requested (`#346`_)
+* Add CHANGELOG file to the repo; not just GitHub releases
+
+.. _#346: https://github.com/globus/globus-sdk-python/pull/346
+
+v1.7.1
+------
+
+* Allow arbitrary keyword args to `TransferData.add_item()` and `DeleteData.add_item()`, which passthrough to the item bodies (`#339`_)
+* Minor internal improvements (`#342`_, `#343`_)
+
+.. _#343: https://github.com/globus/globus-sdk-python/pull/343
+.. _#342: https://github.com/globus/globus-sdk-python/pull/342
+.. _#339: https://github.com/globus/globus-sdk-python/pull/339
+
+v1.7.0
+------
+
+* Add `get_task` and `get_task_list` to `SearchClient` (`#335`_, `#336`_)
+* Internal maintenance and testing improvements (`#331`_, `#334`_, `#333`_)
+
+.. _#336: https://github.com/globus/globus-sdk-python/pull/336
+.. _#335: https://github.com/globus/globus-sdk-python/pull/335
+.. _#334: https://github.com/globus/globus-sdk-python/pull/334
+.. _#333: https://github.com/globus/globus-sdk-python/pull/333
+.. _#331: https://github.com/globus/globus-sdk-python/pull/331
+
+v1.6.1
+------
+
+* Replace egg distribution format with wheels (`#314`_)
+* Internal maintenance
+
+.. _#314: https://github.com/globus/globus-sdk-python/pull/314
+
+v1.6.0
+------
+
+* Correct handling of environment="production" as an argument to client construction (`#307`_)
+* RenewingAuthorizer and its subclasses now expose the check_expiration_time method (`#309`_)
+* Allow parameters to be passed to customize the request body of ConfidentialAppAuthClient.oauth2_get_dependent_tokens (`#308`_)
+* Use sha256 hashes of tokens (instead of last 5 chars) in debug logging (`#305`_)
+* Add the patch() method to BaseClient and its subclasses, sending an HTTP PATCH request (`#302`_)
+* Officially add support for python 3.7 (`#300`_)
+* Make pickling SDK objects safer (but still not officially supported!) (`#284`_)
+* Malformed SDK usage may now raise GlobusSDKUsageError instead of ValueError. GlobusSDKUsageError inherits from ValueError (`#281`_)
+* Numerous documentation improvements (`#279`_, `#294`_, `#296`_, `#297`_)
+
+.. _#309: https://github.com/globus/globus-sdk-python/pull/309
+.. _#308: https://github.com/globus/globus-sdk-python/pull/308
+.. _#307: https://github.com/globus/globus-sdk-python/pull/307
+.. _#305: https://github.com/globus/globus-sdk-python/pull/305
+.. _#302: https://github.com/globus/globus-sdk-python/pull/302
+.. _#300: https://github.com/globus/globus-sdk-python/pull/300
+.. _#297: https://github.com/globus/globus-sdk-python/pull/297
+.. _#296: https://github.com/globus/globus-sdk-python/pull/296
+.. _#294: https://github.com/globus/globus-sdk-python/pull/294
+.. _#284: https://github.com/globus/globus-sdk-python/pull/284
+.. _#281: https://github.com/globus/globus-sdk-python/pull/281
+.. _#279: https://github.com/globus/globus-sdk-python/pull/279
+
+v1.5.0
+------
+
+* Add support for retrieving a local Globus Connect Personal endpoint's UUID (`#276`_)
+* Fix bug in search client parameter handling (`#274`_)
+
+.. _#276: https://github.com/globus/globus-sdk-python/pull/276
+.. _#274: https://github.com/globus/globus-sdk-python/pull/274
+
+v1.4.1
+------
+
+* Send `Content-Type: application/json` on requests with JSON request bodies (`#266`_)
+* Support connection timeouts. Default timeout of 60 seconds (`#264`_)
+
+.. _#266: https://github.com/globus/globus-sdk-python/pull/266
+.. _#264: https://github.com/globus/globus-sdk-python/pull/264
+
+v1.4.0
+------
+
+* Access token response data by way of scope name (`#261`_)
+* Make `cryptography` a strict requirement, globus-sdk[jwt] is no longer necessary (`#257`_, `#260`_)
+* Simplify OAuthTokenResponse.decode_id_token to not require the client as an argument (`#255`_)
+* Add (beta) SearchClient class (`#259`_)
+
+.. _#261: https://github.com/globus/globus-sdk-python/pull/261
+.. _#260: https://github.com/globus/globus-sdk-python/pull/260
+.. _#259: https://github.com/globus/globus-sdk-python/pull/259
+.. _#257: https://github.com/globus/globus-sdk-python/pull/257
+.. _#255: https://github.com/globus/globus-sdk-python/pull/255
+
+v1.3.0
+------
+
+* Improve error message when installation onto python2.6 is attempted (`#245`_)
+* Raise errors on client instantiation when `GLOBUS_SDK_ENVIRONMENT` appears to be invalid, support `GLOBUS_SDK_ENVIRONMENT=preview` (`#247`_)
+
+.. _#245: https://github.com/globus/globus-sdk-python/pull/245
+.. _#247: https://github.com/globus/globus-sdk-python/pull/247
+
+v1.2.2
+------
+
+* Allow client classes to accept `base_url` as an argument to `__init__()` (`#241`_)
+* Fix packaging to not include testsuite (`#232`_)
+* Improve docs on `TransferClient` helper classes (`#231`_, `#233`_)
+
+.. _#241: https://github.com/globus/globus-sdk-python/pull/241
+.. _#233: https://github.com/globus/globus-sdk-python/pull/233
+.. _#232: https://github.com/globus/globus-sdk-python/pull/232
+.. _#231: https://github.com/globus/globus-sdk-python/pull/231
+
+v1.2.1
+------
+
+* Use PyJWT instead of python-jose for JWT support (`#227`_)
+
+.. _#227: https://github.com/globus/globus-sdk-python/pull/227
+
+v1.2.0
+------
+
+* Add Transfer symlink support (`#218`_)
+* Better handle UTF-8 inputs (`#208`_)
+* Fix endpoint manager resume (`#224`_)
+* Doc Updates & Minor Improvements
+
+.. _#224: https://github.com/globus/globus-sdk-python/pull/224
+.. _#218: https://github.com/globus/globus-sdk-python/pull/218
+.. _#208: https://github.com/globus/globus-sdk-python/pull/208
+
+v1.1.1
+------
+
+* Use correct paging style when making `endpoint_manager_task_list` calls (`#210`_)
+
+.. _#210: https://github.com/globus/globus-sdk-python/pull/210
+
+v1.1.0
+------
+
+* Add endpoint_manager methods to TransferClient (`#191`_, `#199`_, `#200`_, `#201`_, `#203`_)
+* Change "identities_set" to "identity_set" for token introspection (`#163`_)
+* Fix docs references to `oauth2_start_flow_*` (`#190`_)
+* Support iterable requested_scopes everywhere (`#185`_)
+* Add python 3.6 to supported platforms (`#180`_)
+* Remove "Beta" from docs (`#179`_)
+* Update dev status classifier to 5, prod (`#178`_)
+* Numerous improvements to testsuite
+
+.. _#203: https://github.com/globus/globus-sdk-python/pull/203
+.. _#201: https://github.com/globus/globus-sdk-python/pull/201
+.. _#200: https://github.com/globus/globus-sdk-python/pull/200
+.. _#199: https://github.com/globus/globus-sdk-python/pull/199
+.. _#191: https://github.com/globus/globus-sdk-python/pull/191
+.. _#190: https://github.com/globus/globus-sdk-python/pull/190
+.. _#185: https://github.com/globus/globus-sdk-python/pull/185
+.. _#180: https://github.com/globus/globus-sdk-python/pull/180
+.. _#179: https://github.com/globus/globus-sdk-python/pull/179
+.. _#178: https://github.com/globus/globus-sdk-python/pull/178
+.. _#163: https://github.com/globus/globus-sdk-python/pull/163
+
+v1.0.0
+------
+
+* Adds `AuthAPIError` with more flexible error payload handling (`#175`_)
+
+.. _#175: https://github.com/globus/globus-sdk-python/pull/175
+
+v0.7.2
+------
+
+* Add `AuthClient.validate_token` (`#172`_)
+* Bugfix for `on_refresh` users of `RefreshTokenAuthorizer` and `ClientCredentialsAuthorizer` (`#173`_)
+
+.. _#173: https://github.com/globus/globus-sdk-python/pull/173
+.. _#172: https://github.com/globus/globus-sdk-python/pull/172
+
+v0.7.1
+------
+
+* Remove deprecated `oauth2_start_flow_*` methods (`#170`_)
+* Add the `ClientCredentialsAuthorizer` (`#164`_)
+* Add `jwt` extra install target. `pip install "globus_sdk[jwt]"` installs `python-jose` (`#169`_)
+
+.. _#170: https://github.com/globus/globus-sdk-python/pull/170
+.. _#169: https://github.com/globus/globus-sdk-python/pull/169
+.. _#164: https://github.com/globus/globus-sdk-python/pull/164
+
+v0.7.0
+------
+
+* Make `OAuthTokenResponse.decode_id_token()` respect `ssl_verify=no` configuration (`#161`_)
+* Remove all properties of `OAuthTokenResponse` other than `by_resource_server` (`#162`_)
+
+.. _#162: https://github.com/globus/globus-sdk-python/pull/162
+.. _#161: https://github.com/globus/globus-sdk-python/pull/161
+
+v0.6.0
+------
+
+* Opt out of the Globus Auth behavior where a `GET` of an identity username will provision that identity (`#145`_)
+* Fixup OAuth2 PKCE to be spec-compliant (`#154`_)
+* Wrap some `requests` network-related errors in custom exceptions (`#155`_)
+* Add `deadline` support to `TransferData` and `DeleteData` (`#159`_)
+
+.. _#159: https://github.com/globus/globus-sdk-python/pull/159
+.. _#155: https://github.com/globus/globus-sdk-python/pull/155
+.. _#154: https://github.com/globus/globus-sdk-python/pull/154
+.. _#145: https://github.com/globus/globus-sdk-python/pull/145
+
+v0.5.1
+------
+
+* Add support for the `prefill_named_grant` option to the Native App authorization flow (`#143`_)
+* Unicode string improvements (`#129`_)
+* Better handle unexpected error payloads (`#135`_)
+
+.. _#143: https://github.com/globus/globus-sdk-python/pull/143
+.. _#135: https://github.com/globus/globus-sdk-python/pull/135
+.. _#129: https://github.com/globus/globus-sdk-python/pull/129

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,14 +1,6 @@
 CHANGELOG
 =========
 
-Unreleased
-----------
-
-* Add a property to paginated responses to indicate that there are more results available than the user requested (`#346`_)
-* Add CHANGELOG file to the repo; not just GitHub releases
-
-.. _#346: https://github.com/globus/globus-sdk-python/pull/346
-
 v1.7.1
 ------
 

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -36,6 +36,7 @@ Expectations for Pull Requests
   - *List any issues closed by the pull request*
   - *Squash intermediate and fixup commits*. We recommend running
     `git rebase --interactive` prior to submitting a pull request.
+  - Add new work to the "Unreleased" section of the changelog
 
 These are our guidelines for good commit messages:
 


### PR DESCRIPTION
Not a big deal, but I sometimes notice the absence of a singular changelog doc. Most prominently, there's no trivially easy view of "what hasn't been released yet". Adding a changelog and having a typical "Unreleased" section makes this nicer.

Add a changelog generated from GitHub release data. (Use md format so that we can just `#NUM` for issue links in GitHub).

Also mention the Unreleased section of the changelog in the contrib doc.

I used this script to generate it:
```
$ cat assemble_changelog.py
#!/usr/bin/env python

import requests

releases = requests.get(
    "https://api.github.com/repos/globus/globus-sdk-python/releases",
    headers={"Accept": "application/vnd.github.v3+json"},
).json()

print("CHANGELOG")
print("=========")
print("")
print("Unreleased")
print("----------")
for release in releases:
    print("")
    print(release["name"])
    print("-" * len(release["name"]))
    print("")
    print(release["body"].replace("\r\n", "\n"))
```
and then did some very mild reformatting to be a little more stylistically consistent.