### PR TITLE
Fix TransferClient.endpoint_search max results

### DIFF
--- a/globus_sdk/transfer/client.py
+++ b/globus_sdk/transfer/client.py
@@ -341,16 +341,14 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         merge_params(params, filter_scope=filter_scope, filter_fulltext=filter_fulltext)
-        self.logger.info(
-            "TransferClient.endpoint_manager_monitored_endpoints({})".format(params)
-        )
+        self.logger.info("TransferClient.endpoint_search({})".format(params))
         return PaginatedResource(
             self.get,
             "endpoint_search",
             {"params": params},
             num_results=num_results,
             max_results_per_call=100,
-            max_total_results=1000,
+            max_total_results=100000,
         )
 
     def endpoint_autoactivate(self, endpoint_id, **params):


### PR DESCRIPTION
max_total_results=1000 is incorrect! Found this while working on the `globus endpoint search --limit N` feature.
Also, fix a log statement which was just "obviously wrong copypasta".

The maximum number of *pages* of output is 1000 (offset of 0 to 999) and the max page size is 100.

max_total_results is measured against the individual results found via pagination, not the pages. So the correct max_total_results is 1000 * 100 or 100000.

Implementation-wise, `max_total_results` caps the `num_results` parameter, whereas `max_results_per_call` caps the `limit` parameter sent to the API.

I'd like to refactor this to be based on `max_offset` or something else defined in a way more compatible with the API docs, so we don't have this multiplication buried here. However, I don't think it's reasonable
to go about gutting this when it could have interplay and impact with other paginated APIs using different paging styles.