### PR TITLE
Replace "deprecations" doc with "versioning"

### DIFF
--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -1,15 +1,4 @@
 Deprecations
 ============
 
-The Globus SDK uses python ``DeprecationWarning`` and
-``PendingDeprecationWarning`` classes to indicate deprecated and soon-to-be
-deprecated behaviors.  In order to see these warnings, run python with the
-flags:
-
-::
-
- python -Wonce::DeprecationWarning \
-        -Wonce::PendingDeprecationWarning
-
-Note: The ``-W`` flag must precede any module you are passing to ``python``,
-or it will be fed into ``sys.argv`` inside of the module.
+See the :ref:`versioning` page.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,7 +31,7 @@ Table of Contents
    oauth
    authorization
    config
-   deprecations
+   versioning
    examples
 
 License

--- a/docs/versioning.rst
+++ b/docs/versioning.rst
@@ -1,0 +1,34 @@
+.. _versioning:
+
+Versioning Policy
+=================
+
+The Globus SDK follows `Semantic Versioning <https://semver.org/>`_.
+
+That means that we use version numbers of the form **MAJOR.MINOR.PATCH**.
+
+When the SDK needs to make incompatible API changes, the **MAJOR** version
+number will be incremented. **MINOR** and **PATCH** version increments indicate
+new features or bugfixes.
+
+Public Interfaces
+-----------------
+
+Features documented here are public and all other components of the SDK should
+be considered private. Undocumented components may be subject to backwards
+incompatible changes without increments to the **MAJOR** version.
+
+Recommended Pinning
+-------------------
+
+We recommend that users of the SDK pin only to the major version which they
+require. e.g. specify ``globus-sdk>=1.7,<2.0`` in your package requirements.
+
+Upgrade Caveat
+--------------
+
+It is always possible for new features or bugfixes to cause issues.
+
+If you are installing the SDK into mission-critical production systems, we
+strongly encourage you to establish a method of pinning the exact version used
+and testing upgrades.


### PR DESCRIPTION
Public doc that states we use semver, so it's not just an implicit assumption about how 3-digit version numbers work.

closes #347