### PR TITLE
Cleanup Makefile with several improvements

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -23,8 +23,7 @@ Linting & Testing
     editor.
 - All code must pass `make test`, which runs linting and tests.
 
-NOTE: `black` requires python3.6+, so you may find it necessary to
-`make clean autoformat PYTHON_VERSION=python3.6` or equivalent.
+NOTE: `black` requires python3.6+
 
 Expectations for Pull Requests
 ------------------------------

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,7 @@
 PYTHON_VERSION?=python3
 VIRTUALENV=.venv
 
-.PHONY: docs build upload localdev test lint autoformat clean help
-
+.PHONY: help
 help:
 	@echo "Globus SDK 'make' targets"
 	@echo ""
@@ -16,6 +15,7 @@ help:
 	@echo "  docs:         Clean old HTML docs and rebuild them with sphinx"
 	@echo "  clean:        Remove typically unwanted files, mostly from [build]"
 
+.PHONY: localdev
 localdev: $(VIRTUALENV)
 $(VIRTUALENV): setup.py
 	# don't recreate it if it already exists -- just run the setup steps
@@ -26,18 +26,24 @@ $(VIRTUALENV): setup.py
 	touch $(VIRTUALENV)
 
 # run outside of tox because specifying a tox environment for py3.6+ is awkward
+.PHONY: autoformat
 autoformat: $(VIRTUALENV)
 	$(VIRTUALENV)/bin/isort --recursive tests/ globus_sdk/ setup.py
 	if [ -f "$(VIRTUALENV)/bin/black" ]; then $(VIRTUALENV)/bin/black  tests/ globus_sdk/ setup.py; fi
 
+.PHONY: test
 test: $(VIRTUALENV)
 	$(VIRTUALENV)/bin/tox
+.PHONY: docs
 docs: $(VIRTUALENV)
 	$(VIRTUALENV)/bin/tox -e docs
+.PHONY: build
 build: $(VIRTUALENV)
 	$(VIRTUALENV)/bin/python setup.py sdist bdist_wheel
+.PHONY: upload
 upload: build
 	$(VIRTUALENV)/bin/twine upload dist/*
 
+.PHONY: clean
 clean:
 	rm -rf $(VIRTUALENV) dist build *.egg-info .tox

--- a/Makefile
+++ b/Makefile
@@ -2,17 +2,17 @@
 #    make autoformat PYTHON_VERSION=python3.6
 PYTHON_VERSION?=python3
 VIRTUALENV=.venv
+SDK_VERSION=$(shell grep '^__version__' globus_sdk/version.py | cut -d '"' -f2)
 
 .PHONY: help
 help:
 	@echo "Globus SDK 'make' targets"
 	@echo ""
 	@echo "  help:         Show this helptext"
-	@echo "  build:        Create the distributions which we like to upload to pypi"
-	@echo "  upload:       [build] + upload to pypi using twine"
 	@echo "  test:         Run the full suite of tests + linting"
 	@echo "  autoformat:   Run code autoformatters"
 	@echo "  docs:         Clean old HTML docs and rebuild them with sphinx"
+	@echo "  release:      create a signed tag, clean old builds, do a fresh build, and upload to pypi"
 	@echo "  clean:        Remove typically unwanted files, mostly from [build]"
 
 .PHONY: localdev
@@ -37,11 +37,15 @@ test: $(VIRTUALENV)
 .PHONY: docs
 docs: $(VIRTUALENV)
 	$(VIRTUALENV)/bin/tox -e docs
-.PHONY: build
-build: $(VIRTUALENV)
+
+.PHONY: showvars
+showvars:
+	@echo "SDK_VERSION=$(SDK_VERSION)"
+.PHONY: release
+release: $(VIRTUALENV)
+	git tag -s "$(SDK_VERSION)" -m "v$(SDK_VERSION)"
+	rm -rf dist
 	$(VIRTUALENV)/bin/python setup.py sdist bdist_wheel
-.PHONY: upload
-upload: build
 	$(VIRTUALENV)/bin/twine upload dist/*
 
 .PHONY: clean


### PR DESCRIPTION
c9f466e: change the usage of `.PHONY`.
I've recently started doing this in Makefiles I maintain, as it avoids having drift between the `.PHONY` list at the top and the actual targets in the file.

13e3d47: add `make release` (#345)

134d63e: simplify makefile layout, strip it down to be a bit more minimalist