### PR TITLE
Expand build matrix, fix dev dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ matrix:
     - python: "2.7"
       env: TOXENV=py,lowestdeps
     # py2 linting build (flake8 on py2 can flag different stuff)
-    - python: "2.7"
+    - name: "Python: 2.7 (linting)"
+      python: "2.7"
       env: TOXENV=lint
     # test on 3.4, 3.5, 3.6
     - python: "3.4"
@@ -16,14 +17,13 @@ matrix:
     - python: "3.6"
       env: TOXENV=py,lowestdeps
     # separate py3.6 linting build, which runs 'black --check' (no py2 support)
-    - python: "3.6"
+    - name: "Python: 3.6 (linting)"
+      python: "3.6"
       env: TOXENV=py36-lint
     - python: "3.7"
       env: TOXENV=py
-    - python: "3.8-dev"
+    - python: "3.8"
       env: TOXENV=py
-      # sudo:required gets us the VM builds where this python works
-      sudo: required
     - python: "pypy"
       env: TOXENV=py
     - python: "pypy3"
@@ -41,10 +41,10 @@ matrix:
       before_install:
         - choco install python2
         - python -m pip install --upgrade pip wheel
-    - name: "py3.7 + windows"
+    - name: "py3.8 + windows"
       os: windows
       language: shell
-      env: TOXENV=py,lowestdeps,py37-lint PATH=/c/Python37:/c/Python37/Scripts:$PATH
+      env: TOXENV=py,lowestdeps,py38-lint PATH=/c/Python38:/c/Python38/Scripts:$PATH
       before_install:
         - choco install python3
         - python -m pip install --upgrade pip wheel
@@ -61,7 +61,6 @@ matrix:
       env: TOXENV=py3,py3-lowestdeps,py37-lint
 
   allow_failures:
-    - python: "3.8-dev"
     - python: "pypy"
     - python: "pypy3"
     - python: "nightly"

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,16 +18,11 @@ matrix:
     # separate py3.6 linting build, which runs 'black --check' (no py2 support)
     - python: "3.6"
       env: TOXENV=py36-lint
-    # hack py37, py38 to use a different Travis worker type
-    # sudo:required gets us the VM builds where these pythons work
     - python: "3.7"
       env: TOXENV=py
-      sudo: required
-    # TODO: re-evaluate these
-    # 3.8-dev and nightly don't support flake8
-    # travis pypy builds seem to have been busted
     - python: "3.8-dev"
       env: TOXENV=py
+      # sudo:required gets us the VM builds where this python works
       sudo: required
     - python: "pypy"
       env: TOXENV=py
@@ -35,23 +30,36 @@ matrix:
       env: TOXENV=py
     - python: "nightly"
       env: TOXENV=py
-    # windows testing
-    - os: windows
-      language: sh
-      python: "2.7"
-      env: TOXENV=py,lowestdeps,lint
+    # non-Linux testing
+    #   https://docs.travis-ci.com/user/languages/python/#running-python-tests-on-multiple-operating-systems
+    #
+    # Windows
+    - name: "py2 + windows"
+      os: windows
+      language: shell
+      env: TOXENV=py,lowestdeps,lint PATH=/c/Python27:/c/Python27/Scripts:$PATH
       before_install:
         - choco install python2
-        - export PATH="/c/Python27:/c/Python27/Scripts:$PATH"
         - python -m pip install --upgrade pip wheel
-    - os: windows
-      language: sh
-      python: "3.7"
-      env: TOXENV=py,lowestdeps,py37-lint
+    - name: "py3.7 + windows"
+      os: windows
+      language: shell
+      env: TOXENV=py,lowestdeps,py37-lint PATH=/c/Python37:/c/Python37/Scripts:$PATH
       before_install:
         - choco install python3
-        - export PATH="/c/Python37:/c/Python37/Scripts:$PATH"
         - python -m pip install --upgrade pip wheel
+    # macOS
+    - name: "py2 + macOS"
+      os: osx
+      osx_image: xcode10.2  # py3.7 on macOS 10.14, but we will use py2
+      language: shell
+      env: TOXENV=py2,py2-lowestdeps,py2-lint
+    - name: "py3 + macOS"
+      os: osx
+      osx_image: xcode10.2  # py3.7 on macOS 10.14
+      language: shell
+      env: TOXENV=py3,py3-lowestdeps,py37-lint
+
   allow_failures:
     - python: "3.8-dev"
     - python: "pypy"

--- a/setup.py
+++ b/setup.py
@@ -55,9 +55,9 @@ setup(
             # flake-bugbear requires py3.5+
             'flake8-bugbear==18.8.0;python_version>="3.5"',
             # testing
-            "pytest>=3.7.4,<4.0",
-            "pytest-cov>=2.5.1,<3.0",
-            "pytest-xdist>=1.22.5,<2.0",
+            "pytest<5.0",
+            "pytest-cov<3.0",
+            "pytest-xdist<2.0",
             # mock on py2, py3.4 and py3.5
             # not just py2: py3 versions of mock don't all have the same
             # interface!

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    py{37,36,35,34,27,py,py3}
-    py{37,36,35,27}-lowestdeps
-    py{37,36,27}-lint
+    py{38,37,36,35,34,27,py,py3}
+    py{38,37,36,35,27}-lowestdeps
+    py{38,37,36,27}-lint
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
- update versions of pytest packages to fix pytest-xdist requiring pytest>4,<5

- add OSX to the testing matrix, testing both py2 and py3

- mild changes to the Windows builds

- remove comment about maybe dropping 3.8 and nightly, now that flake8 is working on them again

(I started on this because I thought we had a build issue I had to fix, but it was actually an infinite recursion bug in virtualenv on Windows with py3.7.4+)