### PR TITLE
Don't append trailing slashes when no path is given

### DIFF
--- a/globus_sdk/base.py
+++ b/globus_sdk/base.py
@@ -117,8 +117,7 @@ class BaseClient(object):
             self.base_url = config.get_service_url(self.environment, service)
         else:
             self.base_url = base_url
-        if base_path is not None:
-            self.base_url = slash_join(self.base_url, base_path)
+        self.base_url = slash_join(self.base_url, base_path)
 
         # setup the basics for wrapping a Requests Session
         # including basics for internal header dict
@@ -558,6 +557,8 @@ def slash_join(a, b):
     Join a and b with a single slash, regardless of whether they already
     contain a trailing/leading slash or neither.
     """
+    if not b:  # "" or None, don't append a slash
+        return a
     if a.endswith("/"):
         if b.startswith("/"):
             return a[:-1] + b

--- a/tests/unit/test_base_client.py
+++ b/tests/unit/test_base_client.py
@@ -144,7 +144,11 @@ def test_http_methods(method, allows_body, base_client):
         assert excinfo.value.message == "foo"
 
 
-@pytest.mark.parametrize("a, b", [(a, b) for a in ["a", "a/"] for b in ["b", "/b"]])
+@pytest.mark.parametrize(
+    "a, b",
+    [(a, b) for a in ["a", "a/"] for b in ["b", "/b"]]
+    + [("a/b", c) for c in ["", None]],
+)
 def test_slash_join(a, b):
     """
     slash_joins a's with and without trailing "/"


### PR DESCRIPTION
BaseClient.get("") should call the base URL without appending a slash if none was present. Makes it possible to call out to servers which care about this sort of thing.

closes #363

EDIT: I changed the PR title but the commit message is slightly wrong. Tell me to fix it if you care, but I think it's fine.