### PR TITLE
add external_checksum and checksum_algorithm

### DIFF
--- a/globus_sdk/transfer/data.py
+++ b/globus_sdk/transfer/data.py
@@ -213,24 +213,24 @@ class TransferData(dict):
 
         **Parameters**
 
-        ``source_path`` (*string*)
-        Path to the source directory or file to be transfered
+          ``source_path`` (*string*)
+            Path to the source directory or file to be transfered
 
-        ``destination_path`` (*string*)
-        Path to the source directory or file will be transfered to
+          ``destination_path`` (*string*)
+            Path to the source directory or file will be transfered to
 
-        ``recursive`` (*bool*)
-        Set to True if the target at source path is a directory
+          ``recursive`` (*bool*)
+            Set to True if the target at source path is a directory
 
-        ``external_checksum`` (*string*)
-        A checksum to verify source file integrity before the transfer
-        and destination file integrity after the transfer. Cannot be used
-        with directories. Assumed to be an MD5 checksum unless
-        checksum_algorithm is also given.
+          ``external_checksum`` (*string*)
+            A checksum to verify source file integrity before the transfer
+            and destination file integrity after the transfer. Cannot be used
+            with directories. Assumed to be an MD5 checksum unless
+            checksum_algorithm is also given.
 
-        ``checksum_algorithm`` (*string*)
-        Specifies the checksum algorithm to be used when verify_checksum is
-        True, sync_level is "checksum" or 3, or an external_checksum is given.
+          ``checksum_algorithm`` (*string*)
+            Specifies the checksum algorithm to be used when verify_checksum is
+            True, sync_level is "checksum" or 3, or an external_checksum is given.
         """
         source_path = safe_stringify(source_path)
         destination_path = safe_stringify(destination_path)
@@ -264,11 +264,11 @@ class TransferData(dict):
 
         **Parameters**
 
-        ``source_path`` (*string*)
-        Path to the source symlink
+          ``source_path`` (*string*)
+            Path to the source symlink
 
-        ``destination_path`` (*string*)
-        Path to the source symlink will be transfered to
+          ``destination_path`` (*string*)
+            Path to the source symlink will be transfered to
         """
         source_path = safe_stringify(source_path)
         destination_path = safe_stringify(destination_path)

--- a/globus_sdk/transfer/data.py
+++ b/globus_sdk/transfer/data.py
@@ -194,7 +194,15 @@ class TransferData(dict):
                 )
             )
 
-    def add_item(self, source_path, destination_path, recursive=False, **params):
+    def add_item(
+        self,
+        source_path,
+        destination_path,
+        recursive=False,
+        external_checksum=None,
+        checksum_algorithm=None,
+        **params
+    ):
         """
         Add a file or directory to be transfered. If the item is a symlink
         to a file or directory, the file or directory at the target of
@@ -202,6 +210,27 @@ class TransferData(dict):
 
         Appends a transfer_item document to the DATA key of the transfer
         document.
+
+        **Parameters**
+
+        ``source_path`` (*string*)
+        Path to the source directory or file to be transfered
+
+        ``destination_path`` (*string*)
+        Path to the source directory or file will be transfered to
+
+        ``recursive`` (*bool*)
+        Set to True if the target at source path is a directory
+
+        ``external_checksum`` (*string*)
+        A checksum to verify source file integrity before the transfer
+        and destination file integrity after the transfer. Cannot be used
+        with directories. Assumed to be an MD5 checksum unless
+        checksum_algorithm is also given.
+
+        ``checksum_algorithm`` (*string*)
+        Specifies the checksum algorithm to be used when verify_checksum is
+        True, sync_level is "checksum" or 3, or an external_checksum is given.
         """
         source_path = safe_stringify(source_path)
         destination_path = safe_stringify(destination_path)
@@ -210,6 +239,8 @@ class TransferData(dict):
             "source_path": source_path,
             "destination_path": destination_path,
             "recursive": recursive,
+            "external_checksum": external_checksum,
+            "checksum_algorithm": checksum_algorithm,
         }
         item_data.update(params)
 
@@ -230,6 +261,14 @@ class TransferData(dict):
 
         Appends a transfer_symlink_item document to the DATA key of the
         transfer document.
+
+        **Parameters**
+
+        ``source_path`` (*string*)
+        Path to the source symlink
+
+        ``destination_path`` (*string*)
+        Path to the source symlink will be transfered to
         """
         source_path = safe_stringify(source_path)
         destination_path = safe_stringify(destination_path)

--- a/tests/unit/helpers/test_transfer.py
+++ b/tests/unit/helpers/test_transfer.py
@@ -58,7 +58,7 @@ def test_tranfer_init(transfer_data):
 
 def test_transfer_add_item(transfer_data):
     """
-    Adds two items to TransferData, verifies results
+    Adds three items to TransferData, verifies results
     """
     tdata = transfer_data()
     # add item
@@ -72,6 +72,8 @@ def test_transfer_add_item(transfer_data):
     assert data["source_path"] == source_path
     assert data["destination_path"] == dest_path
     assert not data["recursive"]
+    assert data["external_checksum"] is None
+    assert data["checksum_algorithm"] is None
 
     # add recursive item
     tdata.add_item(source_path, dest_path, recursive=True)
@@ -82,6 +84,22 @@ def test_transfer_add_item(transfer_data):
     assert r_data["source_path"] == source_path
     assert r_data["destination_path"] == dest_path
     assert r_data["recursive"]
+    assert r_data["external_checksum"] is None
+    assert r_data["checksum_algorithm"] is None
+
+    checksum = "d577273ff885c3f84dadb8578bb41399"
+    algorithm = "MD5"
+    tdata.add_item(
+        source_path, dest_path, external_checksum=checksum, checksum_algorithm=algorithm
+    )
+    assert len(tdata["DATA"]) == 3
+    c_data = tdata["DATA"][2]
+    assert c_data["DATA_TYPE"] == "transfer_item"
+    assert c_data["source_path"] == source_path
+    assert c_data["destination_path"] == dest_path
+    assert not c_data["recursive"]
+    assert c_data["external_checksum"] == checksum
+    assert c_data["checksum_algorithm"] == algorithm
 
 
 def test_transfer_add_symlink_item(transfer_data):


### PR DESCRIPTION
Adding these as explicit named arguments along with doc for how they are used by Transfer.

First PR since the linting and pytest changes, but I think `make test` did the right thing?