### PR TITLE
Add globus_sdk.IdentityMap for Auth ID lookups

### DIFF
--- a/docs/clients/auth.rst
+++ b/docs/clients/auth.rst
@@ -1,7 +1,7 @@
 .. module:: globus_sdk.auth
 
 Auth Client
------------
+===========
 
 .. autoclass:: globus_sdk.AuthClient
    :members:
@@ -20,3 +20,16 @@ Auth Client
    :member-order: bysource
    :show-inheritance:
    :exclude-members: error_class, default_response_class
+
+Helper Objects
+--------------
+
+..
+    We set special-members so that __getitem__ and __delitem__ are included.
+    But then we need to exclude specific members because we don't want people
+    reading about __weakref__ in our docs.
+.. autoclass:: globus_sdk.IdentityMap
+   :members:
+   :special-members:
+   :exclude-members: __dict__,__weakref__
+   :show-inheritance:

--- a/globus_sdk/__init__.py
+++ b/globus_sdk/__init__.py
@@ -1,6 +1,11 @@
 import logging
 
-from globus_sdk.auth import AuthClient, ConfidentialAppAuthClient, NativeAppAuthClient
+from globus_sdk.auth import (
+    AuthClient,
+    ConfidentialAppAuthClient,
+    IdentityMap,
+    NativeAppAuthClient,
+)
 from globus_sdk.authorizers import (
     AccessTokenAuthorizer,
     BasicAuthorizer,
@@ -49,6 +54,7 @@ __all__ = (
     "AuthClient",
     "NativeAppAuthClient",
     "ConfidentialAppAuthClient",
+    "IdentityMap",
     "TransferClient",
     "TransferData",
     "DeleteData",

--- a/globus_sdk/auth/__init__.py
+++ b/globus_sdk/auth/__init__.py
@@ -3,6 +3,7 @@ from globus_sdk.auth.client_types import (
     ConfidentialAppAuthClient,
     NativeAppAuthClient,
 )
+from globus_sdk.auth.identity_map import IdentityMap
 from globus_sdk.auth.oauth2_authorization_code import GlobusAuthorizationCodeFlowManager
 from globus_sdk.auth.oauth2_native_app import GlobusNativeAppFlowManager
 
@@ -10,6 +11,7 @@ __all__ = [
     "AuthClient",
     "NativeAppAuthClient",
     "ConfidentialAppAuthClient",
+    "IdentityMap",
     "GlobusNativeAppFlowManager",
     "GlobusAuthorizationCodeFlowManager",
 ]

--- a/globus_sdk/auth/identity_map.py
+++ b/globus_sdk/auth/identity_map.py
@@ -1,11 +1,16 @@
-import re
-
-# what qualifies as a valid Identity Username?
-_USERNAME_PATTERN = re.compile(r"^[a-zA-Z0-9]+.*@[a-zA-z0-9-]+\..*[a-zA-Z]+$")
+import uuid
 
 
 def is_username(val):
-    return _USERNAME_PATTERN.match(val) is not None
+    """
+    If the value parses as a UUID, then it's an ID, not a username.
+    If it does not parse as such, then it must be a username.
+    """
+    try:
+        uuid.UUID(val)
+        return False
+    except ValueError:
+        return True
 
 
 def split_ids_and_usernames(identity_ids):
@@ -49,7 +54,7 @@ class IdentityMap(object):
     - seed the ``IdentityMap`` with IDs and Usernames via :py:meth:`~IdentityMap.add` (you
       can also do this during initialization)
 
-    - retreive identity IDs or Usernames from the map
+    - retrieve identity IDs or Usernames from the map
 
     Because the map can be populated with a collection of identity IDs and Usernames
     prior to lookups being performed, it can improve the efficiency of these operations
@@ -71,7 +76,7 @@ class IdentityMap(object):
     Correct usage looks something like so::
 
         ac = globus_sdk.AuthClient(...)
-        idmap = globus_sdk.ext.IdentityMap(
+        idmap = globus_sdk.IdentityMap(
             ac, ["foo@globusid.org", "bar@uchicago.edu"]
         )
         idmap.add("baz@xsede.org")

--- a/globus_sdk/auth/identity_map.py
+++ b/globus_sdk/auth/identity_map.py
@@ -1,0 +1,222 @@
+import re
+
+# what qualifies as a valid Identity Username?
+_USERNAME_PATTERN = re.compile(r"^[a-zA-Z0-9]+.*@[a-zA-z0-9-]+\..*[a-zA-Z]+$")
+
+
+def is_username(val):
+    return _USERNAME_PATTERN.match(val) is not None
+
+
+def split_ids_and_usernames(identity_ids):
+    ids = set()
+    usernames = set()
+
+    for val in identity_ids:
+        if is_username(val):
+            usernames.add(val)
+        else:
+            ids.add(val)
+
+    return ids, usernames
+
+
+class IdentityMap(object):
+    r"""
+    There's a common pattern of having a large batch of Globus Auth Identities which you
+    want to inspect. For example, you may have a list of identity IDs fetched from
+    Access Control Lists on Globus Endpoints. In order to display these identities to an
+    end user, you may want to resolve them to usernames.
+
+    However, naively looking up the identities one-by-one is very inefficient. It's best
+    to do batched lookups with multiple identities at once. In these cases, an
+    ``IdentityMap`` can be used to do those batched lookups for you.
+
+    An ``IdentityMap`` is a mapping-like type which converts Identity IDs and Identity
+    Names to Identity records (dictionaries) using the Globus Auth API.
+
+    .. note::
+
+        ``IdentityMap`` objects are not full Mappings in the same sense as python dicts
+        and similar objects. By design, they only implement a small part of the Mapping
+        protocol.
+
+    The basic usage pattern is
+
+    - create an ``IdentityMap`` with an AuthClient which will be used to call out to
+      Globus Auth
+
+    - seed the ``IdentityMap`` with IDs and Usernames via :py:meth:`~IdentityMap.add` (you
+      can also do this during initialization)
+
+    - retreive identity IDs or Usernames from the map
+
+    Because the map can be populated with a collection of identity IDs and Usernames
+    prior to lookups being performed, it can improve the efficiency of these operations
+    up to 100x over individual lookups.
+
+    If you attempt to retrieve an identity which has not been previously added to the
+    map, it will be immediately added. But adding many identities beforehand will
+    improve performance.
+
+    The ``IdentityMap`` will cache its results so that repeated lookups of the same Identity
+    will not repeat work. It will also map identities both by ID and by Username,
+    regardless of how they're initially looked up.
+
+    .. warning::
+
+        If an Identity is not found in Globus Auth, it will trigger a KeyError when
+        looked up. Your code must be ready to handle KeyErrors when doing a lookup.
+
+    Correct usage looks something like so::
+
+        ac = globus_sdk.AuthClient(...)
+        idmap = globus_sdk.ext.IdentityMap(
+            ac, ["foo@globusid.org", "bar@uchicago.edu"]
+        )
+        idmap.add("baz@xsede.org")
+        # adding by ID is also valid
+        idmap.add("c699d42e-d274-11e5-bf75-1fc5bf53bb24")
+        # map ID to username
+        assert (
+            idmap["c699d42e-d274-11e5-bf75-1fc5bf53bb24"]["username"]
+            == "go@globusid.org"
+        )
+        # map username to ID
+        assert (
+            idmap["go@globusid.org"]["id"]
+            == "c699d42e-d274-11e5-bf75-1fc5bf53bb24"
+        )
+
+    And simple handling of errors::
+
+        try:
+            record = idmap["no-such-valid-id@example.org"]
+        except KeyError:
+            username = "NO_SUCH_IDENTITY"
+        else:
+            username = record["username"]
+
+    or you may achieve this by using the :py:meth:`~.IdentityMap.get` method::
+
+        # internally handles the KeyError and returns the default value
+        record = idmap.get("no-such-valid-id@example.org", None)
+        username = record["username"] if record is not None else "NO_SUCH_IDENTITY"
+
+    **Parameters**
+
+    ``auth_client`` (*globus_sdk.AuthClient*)
+      The ``AuthClient`` object which will be used for lookups against Globus Auth
+
+    ``identity_ids`` (*iterable of strings*)
+      A list or other iterable of usernames or identity IDs (potentially mixed together)
+      which will be used to seed the ``IdentityMap`` 's tracking of unresolved Identities.
+
+    ``id_batch_size`` (*int*)
+      A non-default batch size to use when communicating with Globus Auth. Leaving this
+      set to the default is strongly recommended.
+
+    **Methods**
+
+    *  :py:meth:`~.IdentityMap.add`
+    *  :py:meth:`~.IdentityMap.get`
+    *  :py:meth:`~.IdentityMap.__getitem__`
+    *  :py:meth:`~.IdentityMap.__delitem__`
+    """  # noqa
+
+    _default_id_batch_size = 100
+
+    def __init__(self, auth_client, identity_ids=None, id_batch_size=None):
+        self.auth_client = auth_client
+        self.id_batch_size = id_batch_size or self._default_id_batch_size
+
+        # uniquify, copy, and split into IDs vs usernames
+        self.unresolved_ids, self.unresolved_usernames = split_ids_and_usernames(
+            [] if identity_ids is None else identity_ids
+        )
+
+        # the cache is a dict mapping IDs and Usernames
+        self._cache = {}
+
+    def _fetch_batch_including(self, key):
+        """
+        Batch resolve identifiers (usernames or IDs), being sure to include the desired,
+        named key. The key also determines which kind of batch will be built --
+        usernames or IDs.
+
+        Store the results in the internal cache.
+        """
+        # for whichever set of unresolved names is appropriate, build the batch to
+        # lookup up to *at most* the batch size
+        # also, remove the unresolved names from tracking so that they will not be
+        # looked up again
+        batch = []
+        set_to_use = (
+            self.unresolved_usernames if is_username(key) else self.unresolved_ids
+        )
+        for _ in range(0, min(self.id_batch_size - 1, len(set_to_use))):
+            batch.append(set_to_use.pop())
+        # avoid double-adding the provided key, but add it if it's missing
+        if key not in batch:
+            batch.append(key)
+        else:
+            try:
+                batch.append(set_to_use.pop())
+            except KeyError:  # empty set, ignore
+                pass
+
+        response = self.auth_client.get_identities(
+            **(dict(usernames=batch) if is_username(key) else dict(ids=batch))
+        )
+        for x in response["identities"]:
+            self._cache[x["id"]] = x
+            self._cache[x["username"]] = x
+
+    def add(self, identity_id):
+        """
+        Add a username or ID to the ``IdentityMap`` for batch lookups later.
+
+        Returns True if the ID was added for lookup.
+        Returns False if it was rejected as a duplicate of an already known name.
+
+        **Parameters**
+
+        ``identity_id`` (*string*)
+          A string Identity ID or Identity Name (a.k.a. "username") to add
+        """
+        if identity_id in self._cache:
+            return False
+        if is_username(identity_id):
+            if identity_id in self.unresolved_usernames:
+                return False
+            else:
+                self.unresolved_usernames.add(identity_id)
+                return True
+        if identity_id in self.unresolved_ids:
+            return False
+        self.unresolved_ids.add(identity_id)
+        return True
+
+    def get(self, key, default=None):
+        """
+        A dict-like get() method which accepts a default value.
+        """
+        try:
+            return self[key]
+        except KeyError:
+            return default
+
+    def __getitem__(self, key):
+        """
+        ``IdentityMap`` supports dict-like lookups with ``map[key]``
+        """
+        if key not in self._cache:
+            self._fetch_batch_including(key)
+        return self._cache[key]
+
+    def __delitem__(self, key):
+        """
+        ``IdentityMap`` supports ``del map[key]``. Note that this only removes lookup
+        values from the cache and will not impact the set of unresolved/pending IDs.
+        """
+        del self._cache[key]

--- a/tests/functional/auth/test_identity_map.py
+++ b/tests/functional/auth/test_identity_map.py
@@ -1,0 +1,197 @@
+import httpretty
+import pytest
+
+import globus_sdk
+from tests.common import register_api_route
+
+IDENTITIES_MULTIPLE_RESPONSE = """\
+{
+  "identities": [
+    {
+      "email": null,
+      "id": "46bd0f56-e24f-11e5-a510-131bef46955c",
+      "identity_provider": "927d7238-f917-4eb2-9ace-c523fa9ba34e",
+      "name": null,
+      "organization": null,
+      "status": "unused",
+      "username": "globus@globus.org"
+    },
+    {
+      "email": "sirosen@globus.org",
+      "id": "ae341a98-d274-11e5-b888-dbae3a8ba545",
+      "identity_provider": "927d7238-f917-4eb2-9ace-c523fa9ba34e",
+      "name": "Stephen Rosen",
+      "organization": "Globus Team",
+      "status": "used",
+      "username": "sirosen@globus.org"
+    }
+  ]
+}"""
+
+IDENTITIES_SINGLE_RESPONSE = """\
+{
+  "identities": [
+    {
+      "email": "sirosen@globus.org",
+      "id": "ae341a98-d274-11e5-b888-dbae3a8ba545",
+      "identity_provider": "927d7238-f917-4eb2-9ace-c523fa9ba34e",
+      "name": "Stephen Rosen",
+      "organization": "Globus Team",
+      "status": "used",
+      "username": "sirosen@globus.org"
+    }
+  ]
+}"""
+
+
+@pytest.fixture
+def client():
+    return globus_sdk.AuthClient()
+
+
+def test_identity_map(client):
+    register_api_route(
+        "auth",
+        "/v2/api/identities?usernames=sirosen@globus.org&provision=false",
+        body=IDENTITIES_SINGLE_RESPONSE,
+    )
+    idmap = globus_sdk.IdentityMap(client, ["sirosen@globus.org"])
+    assert idmap["sirosen@globus.org"]["organization"] == "Globus Team"
+
+    # lookup by ID also works
+    assert (
+        idmap["ae341a98-d274-11e5-b888-dbae3a8ba545"]["organization"] == "Globus Team"
+    )
+
+    # the last (only) API call was the one by username
+    last_req = httpretty.last_request()
+    assert "ids" not in last_req.querystring
+    assert last_req.querystring["usernames"] == ["sirosen@globus.org"]
+    assert last_req.querystring["provision"] == ["false"]
+
+
+def test_identity_map_initialization_no_values(client):
+    idmap = globus_sdk.IdentityMap(client)
+    assert idmap.unresolved_ids == set()
+    assert idmap.unresolved_usernames == set()
+
+
+def test_identity_map_initialization_mixed_and_duplicate_values(client):
+    # splits things up and deduplicates values into sets
+    idmap = globus_sdk.IdentityMap(
+        client,
+        [
+            "sirosen@globus.org",
+            "ae341a98-d274-11e5-b888-dbae3a8ba545",
+            "globus@globus.org",
+            "sirosen@globus.org",
+            "globus@globus.org",
+            "ae341a98-d274-11e5-b888-dbae3a8ba545",
+            "sirosen@globus.org",
+            "ae341a98-d274-11e5-b888-dbae3a8ba545",
+        ],
+    )
+    assert idmap.unresolved_ids == set(["ae341a98-d274-11e5-b888-dbae3a8ba545"])
+    assert idmap.unresolved_usernames == set(
+        ["sirosen@globus.org", "globus@globus.org"]
+    )
+
+
+def test_identity_map_initialization_batch_size(client):
+    idmap = globus_sdk.IdentityMap(client, id_batch_size=10)
+    assert idmap.unresolved_ids == set()
+    assert idmap.unresolved_usernames == set()
+    assert idmap.id_batch_size == 10
+
+
+def test_identity_map_add(client):
+    idmap = globus_sdk.IdentityMap(client)
+    assert idmap.add("sirosen@globus.org") is True
+    assert idmap.add("sirosen@globus.org") is False
+    assert idmap.add("46bd0f56-e24f-11e5-a510-131bef46955c") is True
+    assert idmap.add("46bd0f56-e24f-11e5-a510-131bef46955c") is False
+
+
+def test_identity_map_add_after_lookup(client):
+    register_api_route(
+        "auth",
+        "/v2/api/identities?usernames=sirosen@globus.org&provision=false",
+        body=IDENTITIES_SINGLE_RESPONSE,
+    )
+    idmap = globus_sdk.IdentityMap(client)
+    x = idmap["sirosen@globus.org"]["id"]
+    # this is the key: adding it will indicate that we've already seen this ID, perhaps
+    # "unintuitively", and that's part of the value of `add()` returning a boolean value
+    assert idmap.add(x) is False
+    assert idmap[x] == idmap["sirosen@globus.org"]
+
+
+def test_identity_map_multiple(client):
+    register_api_route(
+        "auth",
+        (
+            "/v2/api/identities?"
+            "usernames=sirosen@globus.org,globus@globus.org&provision=false"
+        ),
+        body=IDENTITIES_MULTIPLE_RESPONSE,
+    )
+    idmap = globus_sdk.IdentityMap(client, ["sirosen@globus.org", "globus@globus.org"])
+    assert idmap["sirosen@globus.org"]["organization"] == "Globus Team"
+    assert idmap["globus@globus.org"]["organization"] is None
+
+    last_req = httpretty.last_request()
+    # order doesn't matter, but it should be just these two
+    # if IdentityMap doesn't deduplicate correctly, it could send
+    # `sirosen@globus.org,globus@globus.org,sirosen@globus.org` on the first lookup
+    assert last_req.querystring["usernames"] in [
+        ["sirosen@globus.org,globus@globus.org"],
+        ["globus@globus.org,sirosen@globus.org"],
+    ]
+    assert last_req.querystring["provision"] == ["false"]
+
+
+def test_identity_map_keyerror(client):
+    register_api_route(
+        "auth",
+        "/v2/api/identities?usernames=sirosen2@globus.org&provision=false",
+        body=IDENTITIES_SINGLE_RESPONSE,
+    )
+    idmap = globus_sdk.IdentityMap(client)
+    # a name which doesn't come back, indicating that it was not found, will KeyError
+    with pytest.raises(KeyError):
+        idmap["sirosen2@globus.org"]
+
+    last_req = httpretty.last_request()
+    assert last_req.querystring["usernames"] == ["sirosen2@globus.org"]
+    assert last_req.querystring["provision"] == ["false"]
+
+
+def test_identity_map_get_with_default(client):
+    register_api_route(
+        "auth",
+        "/v2/api/identities?usernames=sirosen2@globus.org&provision=false",
+        body=IDENTITIES_SINGLE_RESPONSE,
+    )
+    magic = object()  # sentinel value
+    idmap = globus_sdk.IdentityMap(client)
+    # a name which doesn't come back, if looked up with `get()` should return the
+    # default
+    assert idmap.get("sirosen2@globus.org", magic) is magic
+
+
+def test_identity_map_del(client):
+    register_api_route(
+        "auth",
+        "/v2/api/identities?usernames=sirosen@globus.org&provision=false",
+        body=IDENTITIES_SINGLE_RESPONSE,
+    )
+    idmap = globus_sdk.IdentityMap(client)
+    identity_id = idmap["sirosen@globus.org"]["id"]
+    del idmap[identity_id]
+    assert idmap.get("sirosen@globus.org")["id"] == identity_id
+    # we've only made one request so far
+    assert len(httpretty.httpretty.latest_requests) == 1
+    # but a lookup by ID after a del is going to trigger another request because we've
+    # invalidated the cached ID data and are asking the IDMap to look it up again
+    assert idmap.get(identity_id)["username"] == "sirosen@globus.org"
+    assert len(httpretty.httpretty.latest_requests) == 2

--- a/tests/functional/auth/test_identity_map.py
+++ b/tests/functional/auth/test_identity_map.py
@@ -50,11 +50,7 @@ def client():
 
 
 def test_identity_map(client):
-    register_api_route(
-        "auth",
-        "/v2/api/identities?usernames=sirosen@globus.org&provision=false",
-        body=IDENTITIES_SINGLE_RESPONSE,
-    )
+    register_api_route("auth", "/v2/api/identities", body=IDENTITIES_SINGLE_RESPONSE)
     idmap = globus_sdk.IdentityMap(client, ["sirosen@globus.org"])
     assert idmap["sirosen@globus.org"]["organization"] == "Globus Team"
 
@@ -113,11 +109,7 @@ def test_identity_map_add(client):
 
 
 def test_identity_map_add_after_lookup(client):
-    register_api_route(
-        "auth",
-        "/v2/api/identities?usernames=sirosen@globus.org&provision=false",
-        body=IDENTITIES_SINGLE_RESPONSE,
-    )
+    register_api_route("auth", "/v2/api/identities", body=IDENTITIES_SINGLE_RESPONSE)
     idmap = globus_sdk.IdentityMap(client)
     x = idmap["sirosen@globus.org"]["id"]
     # this is the key: adding it will indicate that we've already seen this ID, perhaps
@@ -128,12 +120,7 @@ def test_identity_map_add_after_lookup(client):
 
 def test_identity_map_multiple(client):
     register_api_route(
-        "auth",
-        (
-            "/v2/api/identities?"
-            "usernames=sirosen@globus.org,globus@globus.org&provision=false"
-        ),
-        body=IDENTITIES_MULTIPLE_RESPONSE,
+        "auth", ("/v2/api/identities"), body=IDENTITIES_MULTIPLE_RESPONSE
     )
     idmap = globus_sdk.IdentityMap(client, ["sirosen@globus.org", "globus@globus.org"])
     assert idmap["sirosen@globus.org"]["organization"] == "Globus Team"
@@ -151,11 +138,7 @@ def test_identity_map_multiple(client):
 
 
 def test_identity_map_keyerror(client):
-    register_api_route(
-        "auth",
-        "/v2/api/identities?usernames=sirosen2@globus.org&provision=false",
-        body=IDENTITIES_SINGLE_RESPONSE,
-    )
+    register_api_route("auth", "/v2/api/identities", body=IDENTITIES_SINGLE_RESPONSE)
     idmap = globus_sdk.IdentityMap(client)
     # a name which doesn't come back, indicating that it was not found, will KeyError
     with pytest.raises(KeyError):
@@ -167,11 +150,7 @@ def test_identity_map_keyerror(client):
 
 
 def test_identity_map_get_with_default(client):
-    register_api_route(
-        "auth",
-        "/v2/api/identities?usernames=sirosen2@globus.org&provision=false",
-        body=IDENTITIES_SINGLE_RESPONSE,
-    )
+    register_api_route("auth", "/v2/api/identities", body=IDENTITIES_SINGLE_RESPONSE)
     magic = object()  # sentinel value
     idmap = globus_sdk.IdentityMap(client)
     # a name which doesn't come back, if looked up with `get()` should return the
@@ -180,11 +159,7 @@ def test_identity_map_get_with_default(client):
 
 
 def test_identity_map_del(client):
-    register_api_route(
-        "auth",
-        "/v2/api/identities?usernames=sirosen@globus.org&provision=false",
-        body=IDENTITIES_SINGLE_RESPONSE,
-    )
+    register_api_route("auth", "/v2/api/identities", body=IDENTITIES_SINGLE_RESPONSE)
     idmap = globus_sdk.IdentityMap(client)
     identity_id = idmap["sirosen@globus.org"]["id"]
     del idmap[identity_id]


### PR DESCRIPTION
The IdentityMap is mostly a port of the LazyIdentityMap found within the Globus CLI. It has several notable differences, however:

- it accepts usernames or identity IDs and internally differentiates them
- it is lazier than the LazyIdentityMap because it only looks up one batch at a time (maybe the CLI implementation should have been called EagerIdentityMap)
- it has an external interface more clearly defined for consumers to interact with it (because that's the point of doing this work, basically)
- it will "prioritize" a given key by forcing it into a record batch for lookup
- it returns full record dicts, not just usernames

In addition to the IdentityMap itself, this includes tests which exercise almost all of the IdentityMap behaviors.
The IdentityMap is primarily a wrapper over an internal `_cache` dictionary which maps both usernames and IDs, undifferentiated, to records. You can `del` items from the cache to force fresh lookups if you believe data has gone stale, and `IdentityMap.get` has the same signature as `dict.get`.

It's important to note that IdentityMap does not implement the full `Mapping` protocol (defined in modern pythons by the collections.abc module). The issue for us in this case is that certain operations like `__contains__` are very unclear. For example, if the map has a key added to it but it hasn't looked it up yet, does it "contain" that key? If you were checking to see if a key had already been added the
answer is "yes". But if you wanted to know if `idmap[key]` will KeyError, the answer is "maybe/unknown". The only way to answer "contains" if you want to know that is to actually do a lookup, and having `in` checks side-effecting in python seems bad.

Therefore, `in` is intentionally left undefined. We can add new methods, similar to `has_key(key, resolved/unresolved=True/False)` in the future if users come to us with a desire for this information and can clarify their use-cases.
For the most part, `idmap.get(key) is not None` should suffice if anyone ever cares to check.

I worked through tests mostly with the goal of complete line coverage, but there are some untested behaviors I can target if it seems important. 

Absent a more obvious place to put this in docs, I've included it on the Auth clients page (similar to the `TransferData` and `DeleteData` objects).

Resolves #366 