### PR TITLE
Add note to successful transfers docstring

### DIFF
--- a/globus_sdk/transfer/client.py
+++ b/globus_sdk/transfer/client.py
@@ -1507,6 +1507,12 @@ class TransferClient(BaseClient):
         """
         Get the successful file transfers for a completed Task.
 
+        .. note::
+
+            This does not include files that were checked but skipped as part of a sync
+            transfer, only files that were actually transferred, and does not include
+            any directories.
+
         ``GET /task/<task_id>/successful_transfers``
 
         :rtype: :class:`PaginatedResource


### PR DESCRIPTION
This note is pulled from the underlying API docs. Including it in the SDK documentation may help avoid confusion about this API behavior in the future. (I have a case of someone who I believe was tripped up by the fact that files don't appear in the listing after a sync transfer.)

---

I don't want to go too far down a slippery slope of pulling all API docs into the SDK docstrings, since that's why we link out to the external doc on docs.globus.org , but a small compromise like this seems reasonable to me.