### PR TITLE
[ch2305] Fixing transfer hostname for integration

### DIFF
--- a/globus_sdk/globus.cfg
+++ b/globus_sdk/globus.cfg
@@ -28,7 +28,7 @@ transfer_service = https://transfer.test.api.globusonline.org/
 auth_service = https://auth.integration.globuscs.info/
 nexus_service = https://nexus.api.integration.globuscs.info/
 search_service = https://search.api.integration.globuscs.info/
-transfer_service = https://transfer.integration.api.globuscs.info/
+transfer_service = https://transfer.api.integration.globuscs.info/
 
 [environment staging]
 auth_service = https://auth.staging.globuscs.info/


### PR DESCRIPTION
This is fixing [ch2305](https://app.clubhouse.io/globus/story/2305/sdk-config-cannot-connect-to-the-integration-transfer-instance) by correcting the transfer hostname for the integration environment.