### PR TITLE
Add pre-commit config, convert to tox

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,28 @@
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks.git
+  rev: v0.9.1
+  hooks:
+    - id: check-merge-conflict
+    - id: trailing-whitespace
+- repo: https://github.com/python/black
+  rev: 19.3b0
+  hooks:
+    - id: black
+      name: "Autoformat python files"
+      types: [python]
+      language_version: python3
+- repo: https://gitlab.com/pycqa/flake8
+  rev: 3.7.8
+  hooks:
+    - id: flake8
+      name: "Lint python files"
+      types: [python]
+      language_version: python3
+      additional_dependencies: ['flake8-bugbear==19.3.0']
+- repo: https://github.com/timothycrosley/isort
+  rev: 4.3.21
+  hooks:
+    - id: isort
+      name: "Sort python imports"
+      types: [python]
+      language_version: python3

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,31 +4,21 @@ language: python
 matrix:
   include:
     - python: "2.7"
-      env: TOXENV=py,lowestdeps
-    # py2 linting build (flake8 on py2 can flag different stuff)
-    - name: "Python: 2.7 (linting)"
-      python: "2.7"
-      env: TOXENV=lint
-    # test on 3.4, 3.5, 3.6
-    - python: "3.4"
       env: TOXENV=py
+    # test on 3.5...3.8
     - python: "3.5"
       env: TOXENV=py
     - python: "3.6"
-      env: TOXENV=py,lowestdeps
-    # separate py3.6 linting build, which runs 'black --check' (no py2 support)
-    - name: "Python: 3.6 (linting)"
+      env: TOXENV=py
+    # use py3.6 for linting build to support black, isort
+    - name: "lint (python: 3.6)"
       python: "3.6"
-      env: TOXENV=py36-lint
+      env: TOXENV=lint
     - python: "3.7"
       env: TOXENV=py
     - python: "3.8"
       env: TOXENV=py
     - python: "pypy"
-      env: TOXENV=py
-    - python: "pypy3"
-      env: TOXENV=py
-    - python: "nightly"
       env: TOXENV=py
     # non-Linux testing
     #   https://docs.travis-ci.com/user/languages/python/#running-python-tests-on-multiple-operating-systems
@@ -37,14 +27,14 @@ matrix:
     - name: "py2 + windows"
       os: windows
       language: shell
-      env: TOXENV=py,lowestdeps,lint PATH=/c/Python27:/c/Python27/Scripts:$PATH
+      env: TOXENV=py PATH=/c/Python27:/c/Python27/Scripts:$PATH
       before_install:
         - choco install python2
         - python -m pip install --upgrade pip wheel
     - name: "py3.8 + windows"
       os: windows
       language: shell
-      env: TOXENV=py,lowestdeps,py38-lint PATH=/c/Python38:/c/Python38/Scripts:$PATH
+      env: TOXENV=py PATH=/c/Python38:/c/Python38/Scripts:$PATH
       before_install:
         - choco install python3
         - python -m pip install --upgrade pip wheel
@@ -53,17 +43,15 @@ matrix:
       os: osx
       osx_image: xcode10.2  # py3.7 on macOS 10.14, but we will use py2
       language: shell
-      env: TOXENV=py2,py2-lowestdeps,py2-lint
+      env: TOXENV=py2
     - name: "py3 + macOS"
       os: osx
       osx_image: xcode10.2  # py3.7 on macOS 10.14
       language: shell
-      env: TOXENV=py3,py3-lowestdeps,py37-lint
+      env: TOXENV=py3
 
   allow_failures:
     - python: "pypy"
-    - python: "pypy3"
-    - python: "nightly"
 cache: pip
 install:
   - pip install -e '.[development]'

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -17,13 +17,48 @@ Reporting Bugs & Requesting Features
 Linting & Testing
 -----------------
 
-- All code is autoformatted with https://github.com/ambv/black[black] and
-   https://github.com/timothycrosley/isort[isort]. You may run
-    `make autoformat` to do this or configure these tools for use in your
-    editor.
-- All code must pass `make test`, which runs linting and tests.
+Testing the SDK requires https://tox.readthedocs.io/en/latest/[tox].
 
-NOTE: `black` requires python3.6+
+Once you have `tox` installed, you can run testing or linting on the repo
+with `tox` or `tox -e lint`. These are wrapped for convenience as `make test`
+and `make lint` as well.
+
+All code must pass `make lint test`, which runs linting and tests.
+
+Optional, but recommended linting setup
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For the best development experience, we recommend setting up linting and
+autofixing integrations with your editor and git. These settings are optional,
+but strongly recommended.
+
+Install pre-commit hooks
+++++++++++++++++++++++++
+
+This automatically formats and lints your staged changes when you commit.
+
+You must install https://pre-commit.com/[pre-commit] in order to use these
+hooks. Once you have the tool, just run
+
+    $ pre-commit install
+
+NOTE: If you need to bypass pre-commit hooks, you can commit with `--no-verify`
+
+Integrate Linters & Fixers with your Editor
++++++++++++++++++++++++++++++++++++++++++++
+
+All code is autoformatted with https://github.com/ambv/black[black] and
+https://github.com/timothycrosley/isort[isort], and checked with
+https://flake8.pycqa.org/[flake8].
+
+Many editors, including vim, emacs, Atom, and VS Code have plugins or
+extensions that allow them to automatically run `black` and `isort` whenever a
+file is saved, and show errors flagged by `flake8` in a separate pane, buffer,
+or sidebar.
+
+Configuring such editor integrations will save you time and energy, as your
+work will usually pass linting before you even run `make lint` or commit your
+changes.
 
 Expectations for Pull Requests
 ------------------------------

--- a/Makefile
+++ b/Makefile
@@ -1,48 +1,21 @@
 SDK_VERSION=$(shell grep '^__version__' globus_sdk/version.py | cut -d '"' -f2)
 
-.PHONY: help
-help:
-	@echo "Globus SDK 'make' targets"
-	@echo ""
-	@echo "  help:         Show this helptext"
-	@echo "  test:         Run the full suite of tests + linting"
-	@echo "  autoformat:   Run code autoformatters"
-	@echo "  docs:         Clean old HTML docs and rebuild them with sphinx"
-	@echo "  release:      create a signed tag, clean old builds, do a fresh build, and upload to pypi"
-	@echo "  clean:        Remove typically unwanted files, mostly from [build]"
+# these are just tox invocations wrapped nicely for convenience
+.PHONY: lint test docs
+lint:
+	tox -e lint
+test:
+	tox
+docs:
+	tox -e docs
 
-.PHONY: localdev
-localdev: .venv
-.venv:
-	virtualenv --python=python3 .venv
-	.venv/bin/pip install -U pip setuptools
-	.venv/bin/pip install -e '.[development]'
-	# explicit touch to ensure good update time relative to setup.py
-	touch .venv
-
-# run outside of tox because specifying a tox environment for py3.6+ is awkward
-.PHONY: autoformat
-autoformat: .venv
-	.venv/bin/isort --recursive tests/ globus_sdk/ setup.py
-	.venv/bin/black tests/ globus_sdk/ setup.py
-
-.PHONY: test
-test: .venv
-	.venv/bin/tox
-.PHONY: docs
-docs: .venv
-	.venv/bin/tox -e docs
-
-.PHONY: showvars
+.PHONY: showvars release
 showvars:
 	@echo "SDK_VERSION=$(SDK_VERSION)"
-.PHONY: release
-release: .venv
+release:
 	git tag -s "$(SDK_VERSION)" -m "v$(SDK_VERSION)"
-	rm -rf dist
-	.venv/bin/python setup.py sdist bdist_wheel
-	.venv/bin/twine upload dist/*
+	tox -e publish-release
 
 .PHONY: clean
 clean:
-	rm -rf .venv dist build *.egg-info .tox
+	rm -rf dist build *.egg-info .tox

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,51 +13,48 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
 import os
+import sys
+
+import guzzle_sphinx_theme
+
+import globus_sdk  # noqa: E402
+
+# isort: off
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath("../"))
 
-import globus_sdk
 
-import guzzle_sphinx_theme
+# isort: on
+
+
 html_theme_path = guzzle_sphinx_theme.html_theme_path()
 
 # -- General configuration ------------------------------------------------
 
-# If your documentation needs a minimal Sphinx version, state it here.
-#needs_sphinx = '1.0'
-
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = [
-    'sphinx.ext.autodoc',
-    'sphinx.ext.todo',
-    'sphinx.ext.viewcode',
-]
+extensions = ["sphinx.ext.autodoc", "sphinx.ext.todo", "sphinx.ext.viewcode"]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 # source_suffix = ['.rst', '.md']
-source_suffix = '.rst'
-
-# The encoding of source files.
-#source_encoding = 'utf-8-sig'
+source_suffix = ".rst"
 
 # The master toctree document.
-master_doc = 'index'
+master_doc = "index"
 
 # General information about the project.
-project = 'globus-sdk-python'
-copyright = '2016, Globus'
-author = 'Globus Team'
+project = "globus-sdk-python"
+copyright = "2016, Globus"
+author = "Globus Team"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -73,41 +70,14 @@ release = version
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = 'en'
-
-# There are two options for replacing |today|: either, you set today to some
-# non-false value, then it is used:
-#today = ''
-# Else, today_fmt is used as the format for a strftime call.
-#today_fmt = '%B %d, %Y'
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['_build']
-
-# The reST default role (used for this markup: `text`) to use for all
-# documents.
-#default_role = None
-
-# If true, '()' will be appended to :func: etc. cross-reference text.
-#add_function_parentheses = True
-
-# If true, the current module name will be prepended to all description
-# unit titles (such as .. function::).
-#add_module_names = True
-
-# If true, sectionauthor and moduleauthor directives will be shown in the
-# output. They are ignored by default.
-#show_authors = False
+exclude_patterns = ["_build"]
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
-
-# A list of ignored prefixes for module index sorting.
-#modindex_common_prefix = []
-
-# If true, keep warnings as "system message" paragraphs in the built documents.
-#keep_warnings = False
+pygments_style = "sphinx"
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = True
@@ -117,251 +87,19 @@ todo_include_todos = True
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'guzzle_sphinx_theme'
-
-# Theme options are theme-specific and customize the look and feel of a theme
-# further.  For a list of options available for each theme, see the
-# documentation.
-#html_theme_options = {}
-
-# Add any paths that contain custom themes here, relative to this directory.
-#html_theme_path = []
-
-# The name for this set of Sphinx documents.  If None, it defaults to
-# "<project> v<release> documentation".
-#html_title = None
-
-# A shorter title for the navigation bar.  Default is the same as html_title.
-#html_short_title = None
+html_theme = "guzzle_sphinx_theme"
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
-html_logo = '_static/logo.png'
-
-# The name of an image file (relative to this directory) to use as a favicon of
-# the docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
-# pixels large.
-#html_favicon = None
+html_logo = "_static/logo.png"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
-
-# Add any extra paths that contain custom files (such as robots.txt or
-# .htaccess) here, relative to this directory. These files are copied
-# directly to the root of the documentation.
-#html_extra_path = []
-
-# If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
-# using the given strftime format.
-#html_last_updated_fmt = '%b %d, %Y'
-
-# If true, SmartyPants will be used to convert quotes and dashes to
-# typographically correct entities.
-#html_use_smartypants = True
+html_static_path = ["_static"]
 
 # Custom sidebar templates, maps document names to template names.
-html_sidebars = {
-    '**': ['logo.html',
-           'globaltoc.html',
-           'searchbox.html']
-}
-
-# Additional templates that should be rendered to pages, maps page names to
-# template names.
-#html_additional_pages = {}
-
-# If false, no module index is generated.
-#html_domain_indices = True
-
-# If false, no index is generated.
-#html_use_index = True
-
-# If true, the index is split into individual pages for each letter.
-#html_split_index = False
-
-# If true, links to the reST sources are added to the pages.
-#html_show_sourcelink = True
-
-# If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
-#html_show_sphinx = True
-
-# If true, "(C) Copyright ..." is shown in the HTML footer. Default is True.
-#html_show_copyright = True
-
-# If true, an OpenSearch description file will be output, and all pages will
-# contain a <link> tag referring to it.  The value of this option must be the
-# base URL from which the finished HTML is served.
-#html_use_opensearch = ''
-
-# This is the file name suffix for HTML files (e.g. ".xhtml").
-#html_file_suffix = None
-
-# Language to be used for generating the HTML full-text search index.
-# Sphinx supports the following languages:
-#   'da', 'de', 'en', 'es', 'fi', 'fr', 'h', 'it', 'ja'
-#   'nl', 'no', 'pt', 'ro', 'r', 'sv', 'tr'
-#html_search_language = 'en'
-
-# A dictionary with options for the search language support, empty by default.
-# Now only 'ja' uses this config value
-#html_search_options = {'type': 'default'}
-
-# The name of a javascript file (relative to the configuration directory) that
-# implements a search results scorer. If empty, the default will be used.
-#html_search_scorer = 'scorer.js'
+html_sidebars = {"**": ["logo.html", "globaltoc.html", "searchbox.html"]}
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'globus-sdk-pythondoc'
-
-# -- Options for LaTeX output ---------------------------------------------
-
-latex_elements = {
-# The paper size ('letterpaper' or 'a4paper').
-#'papersize': 'letterpaper',
-
-# The font size ('10pt', '11pt' or '12pt').
-#'pointsize': '10pt',
-
-# Additional stuff for the LaTeX preamble.
-#'preamble': '',
-
-# Latex figure (float) alignment
-#'figure_align': 'htbp',
-}
-
-# Grouping the document tree into LaTeX files. List of tuples
-# (source start file, target name, title,
-#  author, documentclass [howto, manual, or own class]).
-latex_documents = [
-    (master_doc, 'globus-sdk-python.tex', 'globus-sdk-python Documentation',
-     'Author', 'manual'),
-]
-
-# The name of an image file (relative to this directory) to place at the top of
-# the title page.
-#latex_logo = None
-
-# For "manual" documents, if this is true, then toplevel headings are parts,
-# not chapters.
-#latex_use_parts = False
-
-# If true, show page references after internal links.
-#latex_show_pagerefs = False
-
-# If true, show URL addresses after external links.
-#latex_show_urls = False
-
-# Documents to append as an appendix to all manuals.
-#latex_appendices = []
-
-# If false, no module index is generated.
-#latex_domain_indices = True
-
-
-# -- Options for manual page output ---------------------------------------
-
-# One entry per manual page. List of tuples
-# (source start file, name, description, authors, manual section).
-man_pages = [
-    (master_doc, 'globus-sdk-python', 'globus-sdk-python Documentation',
-     [author], 1)
-]
-
-# If true, show URL addresses after external links.
-#man_show_urls = False
-
-
-# -- Options for Texinfo output -------------------------------------------
-
-# Grouping the document tree into Texinfo files. List of tuples
-# (source start file, target name, title, author,
-#  dir menu entry, description, category)
-texinfo_documents = [
-    (master_doc, 'globus-sdk-python', 'globus-sdk-python Documentation',
-     author, 'globus-sdk-python', 'One line description of project.',
-     'Miscellaneous'),
-]
-
-# Documents to append as an appendix to all manuals.
-#texinfo_appendices = []
-
-# If false, no module index is generated.
-#texinfo_domain_indices = True
-
-# How to display URL addresses: 'footnote', 'no', or 'inline'.
-#texinfo_show_urls = 'footnote'
-
-# If true, do not generate a @detailmenu in the "Top" node's menu.
-#texinfo_no_detailmenu = False
-
-
-# -- Options for Epub output ----------------------------------------------
-
-# Bibliographic Dublin Core info.
-epub_title = project
-epub_author = author
-epub_publisher = author
-epub_copyright = copyright
-
-# The basename for the epub file. It defaults to the project name.
-#epub_basename = project
-
-# The HTML theme for the epub output. Since the default themes are not
-# optimized for small screen space, using the same theme for HTML and epub
-# output is usually not wise. This defaults to 'epub', a theme designed to save
-# visual space.
-#epub_theme = 'epub'
-
-# The language of the text. It defaults to the language option
-# or 'en' if the language is not set.
-#epub_language = ''
-
-# The scheme of the identifier. Typical schemes are ISBN or URL.
-#epub_scheme = ''
-
-# The unique identifier of the text. This can be a ISBN number
-# or the project homepage.
-#epub_identifier = ''
-
-# A unique identification for the text.
-#epub_uid = ''
-
-# A tuple containing the cover image and cover page html template filenames.
-#epub_cover = ()
-
-# A sequence of (type, uri, title) tuples for the guide element of content.opf.
-#epub_guide = ()
-
-# HTML files that should be inserted before the pages created by sphinx.
-# The format is a list of tuples containing the path and title.
-#epub_pre_files = []
-
-# HTML files that should be inserted after the pages created by sphinx.
-# The format is a list of tuples containing the path and title.
-#epub_post_files = []
-
-# A list of files that should not be packed into the epub file.
-epub_exclude_files = ['search.html']
-
-# The depth of the table of contents in toc.ncx.
-#epub_tocdepth = 3
-
-# Allow duplicate toc entries.
-#epub_tocdup = True
-
-# Choose between 'default' and 'includehidden'.
-#epub_tocscope = 'default'
-
-# Fix unsupported image types using the Pillow.
-#epub_fix_images = False
-
-# Scale large images.
-#epub_max_image_width = 0
-
-# How to display URL addresses: 'footnote', 'no', or 'inline'.
-#epub_show_urls = 'inline'
-
-# If false, no index is generated.
-#epub_use_index = True
+htmlhelp_basename = "globus-sdk-pythondoc"

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,9 @@ line_length = 88
 # TODO: remove this config line when it becomes the default behavior of isort
 not_skip = __init__.py
 
+default_section = THIRDPARTY
+known_first_party = tests, globus_sdk
+
 
 [flake8]
 exclude = .git,.tox,__pycache__,.eggs,dist,venv,.venv*,venv27,virtualenv,docs,docs-source,build

--- a/tox.ini
+++ b/tox.ini
@@ -1,27 +1,33 @@
 [tox]
-envlist =
-    py{38,37,36,35,34,27,py,py3}
-    py{38,37,36,35,27}-lowestdeps
-    py{38,37,36,27}-lint
+envlist = py{38,37,36,35,27}
 skip_missing_interpreters = true
 
 [testenv]
 usedevelop = true
 extras = development
-deps =
-    lowestdeps: requests==2.9.2
-    lowestdeps: six==1.10.0
-    lowestdeps: pyjwt[crypto]==1.5.3
+commands = pytest -v --cov=globus_sdk
 
-commands =
-    lint: flake8
-    lint: isort --recursive --check-only tests/ globus_sdk/ setup.py
-    py36-lint,py37-lint: black --check  tests/ globus_sdk/ setup.py
-    !lint: pytest -v --cov=globus_sdk
+[testenv:lint]
+deps = pre-commit~=1.20
+skip_install = true
+commands = pre-commit run --all-files
 
 [testenv:docs]
+deps = sphinx
+       guzzle_sphinx_theme==0.7.11
 whitelist_externals = rm
 changedir = docs/
 # clean the build dir before rebuilding
 commands_pre = rm -rf _build/
 commands = sphinx-build . -d _build/doctrees -b dirhtml _build/dirhtml
+
+[testenv:publish-release]
+skip_install = true
+deps = twine
+       wheel
+# clean the build dir before rebuilding
+whitelist_externals = rm
+commands_pre = rm -rf dist/
+commands =
+    python setup.py sdist bdist_wheel
+    twine upload dist/*


### PR DESCRIPTION
Replace makefile logic for managing venvs with tox usage and add pre-commit config.
Also, trim down the sphinx config so that linting can pass reasonably on it.

Update contrib doc to match. Separate linting and testing requirements from the recommendations (editor config, pre-commit). Note that testing requires tox.

Removes some extra targets from tox and Travis (like `lowestdeps` and multi-platform linting).

---

At this point, I've been using pre-commit happily in other projects and repos, and I think it's time to overhaul and modernize this config. It's also nice to use tox a bit more and clear out some of the somewhat-painful stuff in the makefile.