### PR TITLE
Minor cleanup and config revision

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,7 +13,7 @@ trim_trailing_whitespace = true
 [*.md]
 trim_trailing_whitespace = false
 
-[*.{json,yml}]
+[*.{json,yml,yaml}]
 indent_size = 2
 
 [Makefile]

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -3,9 +3,6 @@ Contributing to the Globus SDK
 
 First off, thank you so much for taking the time to contribute! :+1:
 
-If you want to do local development, you can setup a development virtualenv in
-`.venv` by running `make localdev`.
-
 Reporting Bugs & Requesting Features
 ------------------------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,15 +2,7 @@
 universal = 1
 
 [isort]
-multi_line_output = 3
-include_trailing_comma = true
-force_grid_wrap = 0
-combine_as_imports = true
-line_length = 88
-# TODO: remove this config line when it becomes the default behavior of isort
-not_skip = __init__.py
-
-default_section = THIRDPARTY
+profile = black
 known_first_party = tests, globus_sdk
 
 


### PR DESCRIPTION
* Adds `.yaml` to the editorconfig.
* Use new "profile" support introduced in isort 5.
* Remove outdated info from the contributing guide.