### PR TITLE
Handle no content-type header in response

### DIFF
--- a/globus_sdk/response.py
+++ b/globus_sdk/response.py
@@ -96,7 +96,7 @@ class GlobusHTTPResponse(GlobusResponse):
         # clearer, but less consistent with requests (for better and
         # worse).
         self.http_status = http_response.status_code
-        self.content_type = http_response.headers["Content-Type"]
+        self.content_type = http_response.headers.get("Content-Type")
 
     @property
     def data(self):

--- a/tests/unit/responses/test_response.py
+++ b/tests/unit/responses/test_response.py
@@ -32,6 +32,13 @@ def json_http_response():
 
 
 @pytest.fixture
+def http_no_content_type_response():
+    res = requests.Response()
+    assert "Content-Type" not in res.headers
+    return _TestResponse(None, GlobusHTTPResponse(res))
+
+
+@pytest.fixture
 def malformed_http_response():
     malformed_response = requests.Response()
     malformed_response._content = six.b("{")
@@ -123,3 +130,10 @@ def test_text(json_http_response, malformed_http_response, text_http_response):
     assert json_http_response.r.text == json.dumps(json_http_response.data)
     assert malformed_http_response.r.text == "{"
     assert text_http_response.r.text == text_http_response.data
+
+
+def test_no_content_type_header(http_no_content_type_response):
+    """
+    Response without a Content-Type HTTP header should be okay
+    """
+    assert http_no_content_type_response.r.content_type is None


### PR DESCRIPTION
`Content-Type` is never a required header and is often (correctly) not sent when the http status is `204` (no content).

This change adapts `GlobusHTTPResponse` to handle http responses that do not include a `Content-Type` header.
