### PR TITLE
Update doc for TransferData.add_item

### DIFF
--- a/globus_sdk/transfer/data.py
+++ b/globus_sdk/transfer/data.py
@@ -210,6 +210,14 @@ class TransferData(dict):
         Appends a transfer_item document to the DATA key of the transfer
         document.
 
+        .. note::
+
+            The full path to the destination file must be provided for file items.
+            Parent directories of files are not allowed. See
+            `task submission documentation
+            <https://docs.globus.org/api/transfer/task_submit/#submit_transfer_task>`_
+            for more details.
+
         :param source_path: Path to the source directory or file to be transfered
         :type source_path: str
         :param destination_path: Path to the source directory or file will be


### PR DESCRIPTION
To clarify that dest path for a file item can't be the parent directory.

closes #379

Here's how it renders:
![image](https://user-images.githubusercontent.com/1300022/100930768-89c54b00-34b7-11eb-8e25-1e12aa3e77c1.png)