### PR TITLE
Update testing matrix and switch from httpretty to responses

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,7 +7,14 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["2.7", "3.5", "3.6", "3.7", "3.8"]
+        python-version: ["2.7", "3.9"]
+        include:
+          - os: ubuntu-latest
+            python-version: 3.6
+          - os: ubuntu-latest
+            python-version: 3.7
+          - os: ubuntu-latest
+            python-version: 3.8
     name: "Python ${{ matrix.python-version }} on ${{ matrix.os }} "
     runs-on: ${{ matrix.os }}
     steps:
@@ -20,14 +27,12 @@ jobs:
         run: |
           python -m pip install -U tox
       - name: Run Linting
-        # only lint on 3.8 for two reasons
-        #  1. faster overall runs
-        #  2. Linting fails on py3.5 because tools require 3.6+
-        if: ${{ matrix.python-version == '3.8' }}
+        # only lint on 3.9 for faster overall runs
+        if: ${{ matrix.python-version == '3.9' }}
         run: python -m tox -e lint
       - name: Run Tests
         run: python -m tox -e py
       - name: Ensure docs build
-        # docs are only ever built on a linux 3.8 box (readthedocs)
-        if: ${{ matrix.python-version == '3.8' && matrix.os == 'ubuntu-latest' }}
+        # docs are only ever built on a linux 3.9 box (readthedocs)
+        if: ${{ matrix.python-version == '3.9' && matrix.os == 'ubuntu-latest' }}
         run: python -m tox -e docs

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
             # mock on py2
             'mock==2.0.0;python_version<"3.6"',
             # mocking HTTP responses
-            "httpretty==0.9.5",
+            "responses==0.12.1",
             # builds + uploads to pypi
             'twine==3.2.0;python_version>="3.6"',
             'wheel==0.34.2;python_version>="3.6"',

--- a/setup.py
+++ b/setup.py
@@ -14,9 +14,9 @@ if sys.version_info < (2, 7):
 
 # warn on older/untested python3s
 # it's not disallowed, but it could be an issue for some people
-if sys.version_info > (3,) and sys.version_info < (3, 5):
+if sys.version_info > (3,) and sys.version_info < (3, 6):
     warnings.warn(
-        "Installing globus-sdk on Python 3 versions older than 3.5 "
+        "Installing globus-sdk on Python 3 versions older than 3.6 "
         "may result in degraded functionality or even errors."
     )
 
@@ -61,9 +61,7 @@ setup(
             "pytest<5.0",
             "pytest-cov<3.0",
             "pytest-xdist<2.0",
-            # mock on py2, py3.4 and py3.5
-            # not just py2: py3 versions of mock don't all have the same
-            # interface!
+            # mock on py2
             'mock==2.0.0;python_version<"3.6"',
             # mocking HTTP responses
             "httpretty==0.9.5",
@@ -86,10 +84,10 @@ setup(
         "Operating System :: POSIX",
         "Programming Language :: Python",
         "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Topic :: Communications :: File Sharing",
         "Topic :: Internet :: WWW/HTTP",
         "Topic :: Software Development :: Libraries :: Python Modules",

--- a/tests/common.py
+++ b/tests/common.py
@@ -32,8 +32,18 @@ GO_EP1_SERVER_ID = 207976
 # end constants
 
 
+def get_last_request():
+    return responses.calls[-1].request
+
+
 def register_api_route(
-    service, path, method=responses.GET, adding_headers=None, replace=False, **kwargs
+    service,
+    path,
+    method=responses.GET,
+    adding_headers=None,
+    replace=False,
+    match_querystring=False,
+    **kwargs
 ):
     """
     Handy wrapper for adding URIs to the response mock state.
@@ -53,9 +63,21 @@ def register_api_route(
         adding_headers = {"Content-Type": "application/json"}
 
     if replace:
-        responses.replace(method, full_url, headers=adding_headers, **kwargs)
+        responses.replace(
+            method,
+            full_url,
+            headers=adding_headers,
+            match_querystring=match_querystring,
+            **kwargs
+        )
     else:
-        responses.add(method, full_url, headers=adding_headers, **kwargs)
+        responses.add(
+            method,
+            full_url,
+            headers=adding_headers,
+            match_querystring=match_querystring,
+            **kwargs
+        )
 
 
 def register_api_route_fixture_file(service, path, filename, **kwargs):

--- a/tests/common.py
+++ b/tests/common.py
@@ -7,8 +7,8 @@ import inspect
 import json
 import os
 
-import httpretty
 import requests
+import responses
 import six
 
 import globus_sdk
@@ -33,12 +33,11 @@ GO_EP1_SERVER_ID = 207976
 
 
 def register_api_route(
-    service, path, method=httpretty.GET, adding_headers=None, **kwargs
+    service, path, method=responses.GET, adding_headers=None, replace=False, **kwargs
 ):
     """
-    Handy wrapper for adding URIs to the HTTPretty state.
+    Handy wrapper for adding URIs to the response mock state.
     """
-    assert httpretty.is_enabled()
     base_url_map = {
         "auth": "https://auth.globus.org/",
         "nexus": "https://nexus.api.globusonline.org/",
@@ -53,7 +52,10 @@ def register_api_route(
     if adding_headers is None:
         adding_headers = {"Content-Type": "application/json"}
 
-    httpretty.register_uri(method, full_url, adding_headers=adding_headers, **kwargs)
+    if replace:
+        responses.replace(method, full_url, headers=adding_headers, **kwargs)
+    else:
+        responses.add(method, full_url, headers=adding_headers, **kwargs)
 
 
 def register_api_route_fixture_file(service, path, filename, **kwargs):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,20 +1,16 @@
-import httpretty
 import pytest
-
-# disable the use of real sockets when HTTPretty socket mocking is in place --
-# if you make a real API call, it will immediately error
-httpretty.httpretty.allow_net_connect = False
+import responses
 
 
 @pytest.fixture(autouse=True)
-def enable_httpretty():
+def mocked_responses():
     """
-    All tests enable HTTPretty patching of the python socket module, replacing
-    all network IO.
+    All tests enable `responses` patching of the `requests` package, replacing
+    all HTTP calls.
     """
-    httpretty.enable()
+    responses.start()
 
     yield
 
-    httpretty.disable()
-    httpretty.reset()
+    responses.stop()
+    responses.reset()

--- a/tests/functional/auth/test_simple_auth_usage.py
+++ b/tests/functional/auth/test_simple_auth_usage.py
@@ -1,11 +1,10 @@
 import json
 import uuid
 
-import httpretty
 import pytest
 
 import globus_sdk
-from tests.common import register_api_route
+from tests.common import get_last_request, register_api_route
 
 
 class StringWrapper(object):
@@ -120,12 +119,11 @@ def test_get_identities_success(usernames, client, identities_single_response):
 
     assert res.data == json.loads(IDENTITIES_SINGLE_RESPONSE)
 
-    lastreq = httpretty.last_request()
-    assert "usernames" in lastreq.querystring
-    assert lastreq.querystring["usernames"] == ["globus@globus.org"]
-    # provision defaults to false
-    assert "provision" in lastreq.querystring
-    assert lastreq.querystring["provision"] == ["false"]
+    lastreq = get_last_request()
+    assert lastreq.params == {
+        "usernames": "globus@globus.org",
+        "provision": "false",  # provision defaults to false
+    }
 
 
 @pytest.mark.parametrize(
@@ -152,9 +150,9 @@ def test_get_identities_multiple_success(
 
     assert res.data == json.loads(IDENTITIES_MULTIPLE_RESPONSE)
 
-    lastreq = httpretty.last_request()
-    assert "usernames" in lastreq.querystring
-    assert lastreq.querystring["usernames"] == [expect]
+    lastreq = get_last_request()
+    assert "usernames" in lastreq.params
+    assert lastreq.params["usernames"] == expect
 
 
 @pytest.mark.parametrize(
@@ -170,9 +168,9 @@ def test_get_identities_multiple_success(
 )
 def test_get_identities_provision(inval, outval, client, identities_single_response):
     client.get_identities(usernames="globus@globus.org", provision=inval)
-    lastreq = httpretty.last_request()
-    assert "provision" in lastreq.querystring
-    assert lastreq.querystring["provision"] == [outval]
+    lastreq = get_last_request()
+    assert "provision" in lastreq.params
+    assert lastreq.params["provision"] == outval
 
 
 @pytest.mark.parametrize(
@@ -200,6 +198,6 @@ def test_get_identities_multiple_ids_success(ids, client, identities_multiple_re
 
     assert res.data == json.loads(IDENTITIES_MULTIPLE_RESPONSE)
 
-    lastreq = httpretty.last_request()
-    assert "ids" in lastreq.querystring
-    assert lastreq.querystring["ids"] == [expect]
+    lastreq = get_last_request()
+    assert "ids" in lastreq.params
+    assert lastreq.params["ids"] == expect

--- a/tests/functional/transfer/test_simple.py
+++ b/tests/functional/transfer/test_simple.py
@@ -1,15 +1,14 @@
 import json
 import uuid
 
-import httpretty
 import pytest
-import six
 
 import globus_sdk
 from tests.common import (
     GO_EP1_ID,
     GO_EP1_SERVER_ID,
     GO_EP2_ID,
+    get_last_request,
     register_api_route_fixture_file,
 )
 
@@ -59,8 +58,8 @@ def test_update_endpoint(client):
     assert update_doc["code"] == "Updated"
     assert update_doc["message"] == "Endpoint updated successfully"
 
-    req = httpretty.last_request()
-    assert req.body == six.b(json.dumps(update_data))
+    req = get_last_request()
+    assert json.loads(req.body) == update_data
 
 
 def test_update_endpoint_rewrites_activation_servers(client):
@@ -75,18 +74,18 @@ def test_update_endpoint_rewrites_activation_servers(client):
     # sending myproxy_server implicitly adds oauth_server=null
     update_data = {"myproxy_server": "foo"}
     client.update_endpoint(epid, update_data.copy())
-    req = httpretty.last_request()
-    assert req.body != six.b(json.dumps(update_data))
+    req = get_last_request()
+    assert json.loads(req.body) != update_data
     update_data["oauth_server"] = None
-    assert req.body == six.b(json.dumps(update_data))
+    assert json.loads(req.body) == update_data
 
     # sending oauth_server implicitly adds myproxy_server=null
     update_data = {"oauth_server": "foo"}
     client.update_endpoint(epid, update_data.copy())
-    req = httpretty.last_request()
-    assert req.body != six.b(json.dumps(update_data))
+    req = get_last_request()
+    assert json.loads(req.body) != update_data
     update_data["myproxy_server"] = None
-    assert req.body == six.b(json.dumps(update_data))
+    assert json.loads(req.body) == update_data
 
 
 def test_update_endpoint_invalid_activation_servers(client):
@@ -111,8 +110,8 @@ def test_create_endpoint(client):
     assert create_doc["code"] == "Created"
     assert create_doc["message"] == "Endpoint created successfully"
 
-    req = httpretty.last_request()
-    assert req.body == six.b(json.dumps(create_data))
+    req = get_last_request()
+    assert json.loads(req.body) == create_data
 
 
 def test_create_endpoint_invalid_activation_servers(client):

--- a/tests/unit/test_base_client.py
+++ b/tests/unit/test_base_client.py
@@ -2,8 +2,8 @@ import json
 import logging.handlers
 import uuid
 
-import httpretty
 import pytest
+import responses
 import six
 
 import globus_sdk
@@ -92,7 +92,7 @@ def test_http_methods(method, allows_body, base_client):
     methodname = method.upper()
     resolved_method = getattr(base_client, method)
     register_api_route(
-        "transfer", "/madeuppath/objectname", method=methodname, body='{"x": "y"}'
+        "transfer", "/madeuppath/objectname", method=methodname, json={"x": "y"}
     )
 
     # client should be able to compose the path itself
@@ -100,28 +100,28 @@ def test_http_methods(method, allows_body, base_client):
 
     # request with no body
     res = resolved_method(path)
-    req = httpretty.last_request()
+    req = responses.calls[-1].request
 
     assert req.method == methodname
-    assert req.body == six.b("")
+    assert req.body is None
     assert "x" in res
     assert res["x"] == "y"
 
     if allows_body:
         jsonbody = {"foo": "bar"}
         res = resolved_method(path, json_body=jsonbody)
-        req = httpretty.last_request()
+        req = responses.calls[-1].request
 
         assert req.method == methodname
-        assert req.body == six.b(json.dumps(jsonbody))
+        assert req.body == json.dumps(jsonbody)
         assert "x" in res
         assert res["x"] == "y"
 
         res = resolved_method(path, text_body="abc")
-        req = httpretty.last_request()
+        req = responses.calls[-1].request
 
         assert req.method == methodname
-        assert req.body == six.b("abc")
+        assert req.body == "abc"
         assert "x" in res
         assert res["x"] == "y"
 
@@ -132,7 +132,8 @@ def test_http_methods(method, allows_body, base_client):
             "/madeuppath/objectname",
             method=methodname,
             status=status,
-            body='{"x": "y", "code": "ErrorCode", "message": "foo"}',
+            json={"x": "y", "code": "ErrorCode", "message": "foo"},
+            replace=True,
         )
 
         with pytest.raises(globus_sdk.GlobusAPIError) as excinfo:

--- a/tests/unit/test_base_client.py
+++ b/tests/unit/test_base_client.py
@@ -3,12 +3,11 @@ import logging.handlers
 import uuid
 
 import pytest
-import responses
 import six
 
 import globus_sdk
 from globus_sdk.base import BaseClient, merge_params, safe_stringify, slash_join
-from tests.common import register_api_route
+from tests.common import get_last_request, register_api_route
 
 
 @pytest.fixture
@@ -100,7 +99,7 @@ def test_http_methods(method, allows_body, base_client):
 
     # request with no body
     res = resolved_method(path)
-    req = responses.calls[-1].request
+    req = get_last_request()
 
     assert req.method == methodname
     assert req.body is None
@@ -110,7 +109,7 @@ def test_http_methods(method, allows_body, base_client):
     if allows_body:
         jsonbody = {"foo": "bar"}
         res = resolved_method(path, json_body=jsonbody)
-        req = responses.calls[-1].request
+        req = get_last_request()
 
         assert req.method == methodname
         assert req.body == json.dumps(jsonbody)
@@ -118,7 +117,7 @@ def test_http_methods(method, allows_body, base_client):
         assert res["x"] == "y"
 
         res = resolved_method(path, text_body="abc")
-        req = responses.calls[-1].request
+        req = get_last_request()
 
         assert req.method == methodname
         assert req.body == "abc"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{38,37,36,35,27}
+envlist = py{39,38,37,36,27}
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
`responses` is simpler for us to use than `httpretty`, and because we wrapped our primary usage of `httpretty` (hooray!) in the past, the replacement is basically painless.
Some bits here and there need to be twiddled, of course.

I gave up on tracking down exactly why the tests have started failing again, but httpretty was clearly somehow involved/at-fault.

`responses` isn't at 1.0, but it appears to be stable. I think it's doing the thing that m2crypto used to do, in which 1.0 is never released so that backwards compatibility and semver is never something they have to think about.

In addition to dropping 3.5 and adding 3.9 to testing, this makes the matrix a bit smaller.