### PR TITLE
Add a pyinstaller hook and simple test

### DIFF
--- a/globus_sdk/_pyinstaller/__init__.py
+++ b/globus_sdk/_pyinstaller/__init__.py
@@ -1,0 +1,5 @@
+import os
+
+
+def get_hook_dirs():
+    return [os.path.dirname(__file__)]

--- a/globus_sdk/_pyinstaller/hook-globus_sdk.py
+++ b/globus_sdk/_pyinstaller/hook-globus_sdk.py
@@ -1,0 +1,18 @@
+#
+# this is the pyinstaller hook which describes how to collect data to freeze the
+# 'globus_sdk' correctly
+#
+# pyinstaller hooks are modules which define a number of known variables, which
+# pyinstaller then loads and uses
+#
+#
+# This module is based on the PyInstaller Hook Sample
+# see:  https://github.com/pyinstaller/hooksample
+#
+
+from PyInstaller.utils.hooks import collect_data_files
+
+# "datas" is a list of files which need to be included as data files
+# collect_data_files will crawl the source tree and grab up *all* non-python files
+# exclude any files in the pyinstaller dir
+datas = collect_data_files("globus_sdk", excludes=["_pyinstaller"])

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,8 @@ setup(
             'mock==2.0.0;python_version<"3.6"',
             # mocking HTTP responses
             "responses==0.12.1",
+            # pyinstaller is needed in order to test the pyinstaller hook
+            'pyinstaller;python_version>="3.6"',
             # builds + uploads to pypi
             'twine==3.2.0;python_version>="3.6"',
             'wheel==0.34.2;python_version>="3.6"',
@@ -68,6 +70,9 @@ setup(
             'sphinx==3.1.2;python_version>="3.6"',
             'sphinx-material==0.0.30;python_version>="3.6"',
         ],
+    },
+    entry_points={
+        "pyinstaller40": ["hook-dirs = globus_sdk._pyinstaller:get_hook_dirs"]
     },
     include_package_data=True,
     keywords=["globus", "file transfer"],

--- a/tests/functional/test_pyinstaller_packaging.py
+++ b/tests/functional/test_pyinstaller_packaging.py
@@ -1,0 +1,68 @@
+#
+# This module is based on the PyInstaller Hook Sample test
+# see:  https://github.com/pyinstaller/hooksample
+#
+# this is a pytest test which
+# - runs pyinstaller on the SDK with a simple app
+# - runs the app
+#
+# the app imports the SDK and constructs a client object to make
+# sure that imports are working correctly
+# because client object creation loads config, it also ensures that config data can be
+# read
+
+import subprocess
+
+import pytest
+
+try:
+    import sysconfig
+except ImportError:
+    sysconfig = None
+
+try:
+    from PyInstaller import __main__ as pyi_main
+except ImportError:
+    pyi_main = None
+
+
+def shared_libraries_are_available():
+    """
+    check if python was built with --enable-shared or if the system python (with
+    dynamically linked libs) is in use
+    default to guessing that the shared libs are not available (be conservative)
+    """
+    # if detection isn't possible because sysconfig isn't available (py2) then fail
+    if not sysconfig:
+        return False
+    enable_shared = sysconfig.get_config_var("Py_ENABLE_SHARED")
+    return enable_shared == 1
+
+
+@pytest.mark.skipif(
+    not shared_libraries_are_available(),
+    reason="requires that python was built with --enable-shared",
+)
+@pytest.mark.skipif(
+    not pyi_main, reason="pyinstaller not available in test environment"
+)
+def test_pyinstaller_hook(tmp_path):
+    appfile = tmp_path / "sample.py"
+    appfile.write_text(
+        """\
+import globus_sdk
+ac = globus_sdk.AuthClient()
+"""
+    )
+    pyi_main.run(
+        [
+            "--workpath",
+            str(tmp_path / "build"),
+            "--distpath",
+            str(tmp_path / "dist"),
+            "--specpath",
+            str(tmp_path),
+            str(appfile),
+        ]
+    )
+    subprocess.run([str(tmp_path / "dist" / "sample" / "sample")], check=True)


### PR DESCRIPTION
closes #384

This adds a pyinstaller hook and a simple test to the testsuite which tries to do a pyinstaller build of a miniscule (two line) app.

The pyinstaller hook is quite simple -- it just ensures that non-python files are included in the SDK package. The hook itself needs a setuptools entry point which identifies the hook location (one of the only bits of setuptools config pyinstaller respects).

In order for the testing to work, a few steps are needed:
- add pyinstaller to 'development' requirements for py3+
- add the test to the testsuite
- skip the test if the environment doesn't support a pyinstaller build

Skipping in the right contexts is the trickiest part. It seems that pyinstaller needs a shared-library python build. That's the default for a lot of system packaging, but it's not guaranteed. Furthermore, pyenv builds won't include shared libraries by default, but will use static linking instead. Precisely because this is so finicky, we want to allow tests without it. That way, developer laptop testing can work even if the python env isn't "just so".

GitHub Actions should build pythons appropriately to run the pyinstaller test, so we have a good guarantee of things working.

We don't test the pyinstaller hook for py2 -- if it doesn't work for that version, that's fine (wontfix).

---

The one thing I wasn't sure about was where to put internal doc on this subject. Basically, I've imitated the sample repo from pyinstaller ( https://github.com/pyinstaller/hooksample ) and tried not to think too hard about this. But if we need more internal doc, maybe I could add `globus_sdk/_pyinstaller/README`? I'm just not certain it's necessary.