### PR TITLE
Push release tag to upstream during release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ showvars:
 	@echo "SDK_VERSION=$(SDK_VERSION)"
 release:
 	git tag -s "$(SDK_VERSION)" -m "v$(SDK_VERSION)"
+	-git push $(shell git rev-parse --abbrev-ref @{push} | cut -d '/' -f1) refs/tags/$SDK_VERSION
 	tox -e publish-release
 
 .PHONY: clean


### PR DESCRIPTION
This adds an attempt to push the release tag to the caller's upstream during `make release`.