### PR TITLE
Replace Travis status badge with GitHub actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,4 @@
-name: Test
+name: build
 on:
   push:
   pull_request:

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
-.. image:: https://travis-ci.org/globus/globus-sdk-python.svg?branch=master
+.. image:: https://github.com/globus/globus-sdk-python/workflows/build/badge.svg?event=push
     :alt: build status
-    :target: https://travis-ci.org/globus/globus-sdk-python
+    :target: https://github.com/globus/globus-sdk-python/actions?query=workflow%3Abuild
 
 .. image:: https://img.shields.io/pypi/v/globus-sdk.svg
     :alt: Latest Released Version


### PR DESCRIPTION
This replaces the build status badge that's currently referencing Travis to instead use the status from the GitHub workflow. The badge gets the name of the workflow in it so I renamed the workflow from "Test" to "build."

Example:

<img width="134" alt="Screen Shot 2020-12-21 at 10 07 02 AM" src="https://user-images.githubusercontent.com/214142/102802978-c1b40580-4374-11eb-8b1c-fcede627e2ac.png">
