### PR TITLE
Update pre-commit and dev dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,13 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks.git
-  rev: v3.1.0
+  rev: v3.4.0
   hooks:
     - id: check-merge-conflict
     - id: trailing-whitespace
+- repo: https://github.com/sirosen/check-jsonschema
+  rev: 0.3.0
+  hooks:
+    - id: check-github-workflows
 - repo: https://github.com/python/black
   rev: 20.8b1
   hooks:
@@ -20,7 +24,7 @@ repos:
       language_version: python3
       additional_dependencies: ['flake8-bugbear==20.11.1']
 - repo: https://github.com/timothycrosley/isort
-  rev: 5.6.4
+  rev: 5.7.0
   hooks:
     - id: isort
       name: "Sort python imports"

--- a/setup.py
+++ b/setup.py
@@ -64,11 +64,11 @@ setup(
             # pyinstaller is needed in order to test the pyinstaller hook
             'pyinstaller;python_version>="3.6"',
             # builds + uploads to pypi
-            'twine==3.2.0;python_version>="3.6"',
-            'wheel==0.34.2;python_version>="3.6"',
+            'twine>=3,<4;python_version>="3.6"',
+            'wheel==0.36.2;python_version>="3.6"',
             # docs
-            'sphinx==3.1.2;python_version>="3.6"',
-            'sphinx-material==0.0.30;python_version>="3.6"',
+            'sphinx==3.4.3;python_version>="3.6"',
+            'sphinx-material==0.0.32;python_version>="3.6"',
         ],
     },
     entry_points={

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ extras = development
 commands = pytest -v --cov=globus_sdk
 
 [testenv:lint]
-deps = pre-commit~=2.6.0
+deps = pre-commit~=2.9.3
 skip_install = true
 commands = pre-commit run --all-files
 


### PR DESCRIPTION
These are pretty innocuous changes to some of the dev dependencies.
Primarily, I want to get the workflow checker added to pre-commit.

I've also opened up `twine` to `<4.0` in the dev dependencies. WAY back in time, we had issues in which minor twine versions would break for some of us, so we were pinning the exact version. We can go back to pinning it if it becomes an issue, but I doubt it will be necessary again.