### PR TITLE
Drop python2

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["2.7", "3.9"]
+        python-version: ["3.9"]
         include:
           - os: ubuntu-latest
             python-version: 3.6

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,3 +30,8 @@ repos:
       name: "Sort python imports"
       types: [python]
       language_version: python3
+- repo: https://github.com/asottile/pyupgrade
+  rev: v2.7.4
+  hooks:
+    - id: pyupgrade
+      args: ["--py36-plus"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,23 +13,22 @@ repos:
   hooks:
     - id: black
       name: "Autoformat python files"
-      types: [python]
-      language_version: python3
+- repo: https://github.com/asottile/blacken-docs
+  rev: v1.9.2
+  hooks:
+    - id: blacken-docs
+      additional_dependencies: ['black==20.8b1']
 - repo: https://gitlab.com/pycqa/flake8
   rev: 3.8.4
   hooks:
     - id: flake8
       name: "Lint python files"
-      types: [python]
-      language_version: python3
       additional_dependencies: ['flake8-bugbear==20.11.1']
 - repo: https://github.com/timothycrosley/isort
   rev: 5.7.0
   hooks:
     - id: isort
       name: "Sort python imports"
-      types: [python]
-      language_version: python3
 - repo: https://github.com/asottile/pyupgrade
   rev: v2.7.4
   hooks:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,4 +8,4 @@ python:
     - method: pip
       path: .
       extra_requirements:
-        - development
+        - dev

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 import globus_sdk
 

--- a/docs/examples/advanced_transfer.rst
+++ b/docs/examples/advanced_transfer.rst
@@ -24,6 +24,7 @@ Start out by computing the current time as a ``datetime``:
 .. code-block:: python
 
     import datetime
+
     now = datetime.datetime.utcnow()
 
 Then, compute a relative timestamp using ``timedelta``:
@@ -38,6 +39,7 @@ as in
 .. code-block:: python
 
     import globus_sdk
+
     # get various components needed for a Transfer Task
     # beyond the scope of this example
     transfer_client = globus_sdk.TransferClient(...)
@@ -46,8 +48,11 @@ as in
 
     # note how `future_1minute` is used here
     submission_data = globus_sdk.TransferData(
-        transfer_client, source_endpoint_uuid, dest_endpoint_uuid,
-        deadline=str(future_1minute))
+        transfer_client,
+        source_endpoint_uuid,
+        dest_endpoint_uuid,
+        deadline=str(future_1minute),
+    )
 
 
 Retrying Task Submission
@@ -84,17 +89,17 @@ retry logic from the core task submission logic.
     logger = logging.getLogger(__name__)
 
 
-    def retry_globus_function(func, retries=5, func_name='<func>'):
+    def retry_globus_function(func, retries=5, func_name="<func>"):
         """
         Define what it means to retry a "Globus Function", some function or
         method which produces Globus SDK errors on failure.
         """
+
         def actually_retry():
             """
             Helper: run the next retry
             """
-            return retry_globus_function(func, retries=(retries - 1),
-                                         func_name=func_name)
+            return retry_globus_function(func, retries=(retries - 1), func_name=func_name)
 
         def check_for_reraise():
             """
@@ -103,8 +108,7 @@ retry logic from the core task submission logic.
                     must be run inside an exception handler
             """
             if retries < 1:
-                logger.error('Retried {} too many times.'
-                             .format(func_name))
+                logger.error("Retried {} too many times.".format(func_name))
                 raise
 
         try:
@@ -112,13 +116,17 @@ retry logic from the core task submission logic.
         except NetworkError:
             # log with exc_info=True to capture a full stacktrace as a
             # debug-level log
-            logger.debug(('Globus func {} experienced a network error'
-                          .format(func_name)), exc_info=True)
+            logger.debug(
+                ("Globus func {} experienced a network error".format(func_name)),
+                exc_info=True,
+            )
             check_for_reraise()
         except GlobusAPIError:
             # again, log with exc_info=True to capture a full stacktrace
-            logger.warn(('Globus func {} experienced a network error'
-                         .format(func_name)), exc_info=True)
+            logger.warn(
+                ("Globus func {} experienced a network error".format(func_name)),
+                exc_info=True,
+            )
             check_for_reraise()
 
         # if we reach this point without returning or erroring, retry
@@ -141,14 +149,15 @@ constraint:
         # create a function with no arguments, for our retry handler
         def locally_bound_func():
             return transfer_client.submit_transfer(transfer_data)
-        return retry_globus_function(locally_bound_func,
-                                     func_name='submit_transfer')
+
+        return retry_globus_function(locally_bound_func, func_name="submit_transfer")
 
 Now we're finally all-set to create a ``TransferData`` and submit it:
 
 .. code-block:: python
 
     from globus_sdk import TransferClient, TransferData
+
     # get various components needed for a Transfer Task
     # beyond the scope of this example
     transfer_client = TransferClient(...)
@@ -156,10 +165,11 @@ Now we're finally all-set to create a ``TransferData`` and submit it:
     dest_endpoint_uuid = ...
 
     submission_data = TransferData(
-        transfer_client, source_endpoint_uuid, dest_endpoint_uuid)
+        transfer_client, source_endpoint_uuid, dest_endpoint_uuid
+    )
 
     # add any number of items to the submission data
-    submission_data.add_item('/source/path', 'dest/path')
+    submission_data.add_item("/source/path", "dest/path")
     ...
 
     # do it!

--- a/docs/examples/authorization.rst
+++ b/docs/examples/authorization.rst
@@ -22,16 +22,16 @@ With the tokens in hand, it's just a simple matter of wrapping the tokens in
 
     from globus_sdk import AuthClient, TransferClient, AccessTokenAuthorizer
 
-    AUTH_ACCESS_TOKEN = '...'
-    TRANSFER_ACCESS_TOKEN = '...'
+    AUTH_ACCESS_TOKEN = "..."
+    TRANSFER_ACCESS_TOKEN = "..."
 
     # note that we don't provide the client ID in this case
     # if you're using an Access Token you can't do the OAuth2 flows
-    auth_client = AuthClient(
-        authorizer=AccessTokenAuthorizer(AUTH_ACCESS_TOKEN))
+    auth_client = AuthClient(authorizer=AccessTokenAuthorizer(AUTH_ACCESS_TOKEN))
 
     transfer_client = TransferClient(
-        authorizer=AccessTokenAuthorizer(TRANSFER_ACCESS_TOKEN))
+        authorizer=AccessTokenAuthorizer(TRANSFER_ACCESS_TOKEN)
+    )
 
 Refresh Token Authorization on AuthClient and TransferClient
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -50,26 +50,30 @@ for Globus Auth, so creating the authorizer is more complex this time.
 
 .. code-block:: python
 
-    from globus_sdk import (AuthClient, TransferClient, ConfidentialAppAuthClient,
-                            RefreshTokenAuthorizer)
+    from globus_sdk import (
+        AuthClient,
+        TransferClient,
+        ConfidentialAppAuthClient,
+        RefreshTokenAuthorizer,
+    )
 
     # for doing the refresh
-    CLIENT_ID = '...'
-    CLIENT_SECRET = '...'
+    CLIENT_ID = "..."
+    CLIENT_SECRET = "..."
 
     # the actual tokens
-    AUTH_REFRESH_TOKEN = '...'
-    TRANSFER_REFRESH_TOKEN = '...'
+    AUTH_REFRESH_TOKEN = "..."
+    TRANSFER_REFRESH_TOKEN = "..."
 
     # making the authorizer requires that we have an AuthClient which can talk
     # OAuth2 to Globus Auth
     internal_auth_client = ConfidentialAppAuthClient(CLIENT_ID, CLIENT_SECRET)
 
     # now let's bake a couple of authorizers
-    auth_authorizer = RefreshTokenAuthorizer(AUTH_REFRESH_TOKEN,
-                                             internal_auth_client)
-    transfer_authorizer = RefreshTokenAuthorizer(TRANSFER_REFRESH_TOKEN,
-                                                 internal_auth_client)
+    auth_authorizer = RefreshTokenAuthorizer(AUTH_REFRESH_TOKEN, internal_auth_client)
+    transfer_authorizer = RefreshTokenAuthorizer(
+        TRANSFER_REFRESH_TOKEN, internal_auth_client
+    )
 
     # auth_client here is totally different from "internal_auth_client" above
     # the former is being used to request new tokens periodically, while this
@@ -96,8 +100,8 @@ By way of example:
 
     from globus_sdk import ConfidentialAppAuthClient
 
-    CLIENT_ID = '...'
-    CLIENT_SECRET = '...'
+    CLIENT_ID = "..."
+    CLIENT_SECRET = "..."
 
     client = ConfidentialAppAuthClient(CLIENT_ID, CLIENT_SECRET)
 

--- a/docs/examples/client_credentials.rst
+++ b/docs/examples/client_credentials.rst
@@ -44,18 +44,18 @@ The shortest version of the flow looks like this:
     import globus_sdk
 
     # you must have a client ID
-    CLIENT_ID = '...'
+    CLIENT_ID = "..."
     # the secret, loaded from wherever you store it
-    CLIENT_SECRET = '...'
+    CLIENT_SECRET = "..."
 
     client = globus_sdk.ConfidentialAppAuthClient(CLIENT_ID, CLIENT_SECRET)
     token_response = client.oauth2_client_credentials_tokens()
 
     # the useful values that you want at the end of this
-    globus_auth_data = token_response.by_resource_server['auth.globus.org']
-    globus_transfer_data = token_response.by_resource_server['transfer.api.globus.org']
-    globus_auth_token = globus_auth_data['access_token']
-    globus_transfer_token = globus_transfer_data['access_token']
+    globus_auth_data = token_response.by_resource_server["auth.globus.org"]
+    globus_transfer_data = token_response.by_resource_server["transfer.api.globus.org"]
+    globus_auth_token = globus_auth_data["access_token"]
+    globus_transfer_token = globus_transfer_data["access_token"]
 
 
 Use the Resulting Tokens
@@ -71,8 +71,7 @@ For example, after running the code above,
 
     authorizer = globus_sdk.AccessTokenAuthorizer(globus_transfer_token)
     tc = globus_sdk.TransferClient(authorizer=authorizer)
-    print("Endpoints Belonging to {}@clients.auth.globus.org:"
-          .format(CLIENT_ID))
+    print("Endpoints Belonging to {}@clients.auth.globus.org:".format(CLIENT_ID))
     for ep in tc.endpoint_search(filter_scope="my-endpoints"):
         print("[{}] {}".format(ep["id"], ep["display_name"]))
 
@@ -108,20 +107,19 @@ Use it like so:
     import globus_sdk
 
     # you must have a client ID
-    CLIENT_ID = '...'
+    CLIENT_ID = "..."
     # the secret, loaded from wherever you store it
-    CLIENT_SECRET = '...'
+    CLIENT_SECRET = "..."
 
     confidential_client = globus_sdk.ConfidentialAppAuthClient(
-        client_id=CLIENT_ID, client_secret=CLIENT_SECRET)
+        client_id=CLIENT_ID, client_secret=CLIENT_SECRET
+    )
     scopes = "urn:globus:auth:scope:transfer.api.globus.org:all"
-    cc_authorizer = globus_sdk.ClientCredentialsAuthorizer(
-        confidential_client, scopes)
+    cc_authorizer = globus_sdk.ClientCredentialsAuthorizer(confidential_client, scopes)
     # create a new client
     transfer_client = globus_sdk.TransferClient(authorizer=cc_authorizer)
 
     # usage is still the same
-    print("Endpoints Belonging to {}@clients.auth.globus.org:"
-          .format(CLIENT_ID))
+    print("Endpoints Belonging to {}@clients.auth.globus.org:".format(CLIENT_ID))
     for ep in tc.endpoint_search(filter_scope="my-endpoints"):
         print("[{}] {}".format(ep["id"], ep["display_name"]))

--- a/docs/examples/native_app.rst
+++ b/docs/examples/native_app.rst
@@ -42,24 +42,22 @@ The shortest version of the flow looks like this:
     import globus_sdk
 
     # you must have a client ID
-    CLIENT_ID = '...'
+    CLIENT_ID = "..."
 
     client = globus_sdk.NativeAppAuthClient(CLIENT_ID)
     client.oauth2_start_flow()
 
     authorize_url = client.oauth2_get_authorize_url()
-    print('Please go to this URL and login: {0}'.format(authorize_url))
+    print("Please go to this URL and login: {0}".format(authorize_url))
 
-    # or just input() on python3
-    auth_code = raw_input(
-        'Please enter the code you get after login here: ').strip()
+    auth_code = input("Please enter the code you get after login here: ").strip()
     token_response = client.oauth2_exchange_code_for_tokens(auth_code)
 
     # the useful values that you want at the end of this
-    globus_auth_data = token_response.by_resource_server['auth.globus.org']
-    globus_transfer_data = token_response.by_resource_server['transfer.api.globus.org']
-    globus_auth_token = globus_auth_data['access_token']
-    globus_transfer_token = globus_transfer_data['access_token']
+    globus_auth_data = token_response.by_resource_server["auth.globus.org"]
+    globus_transfer_data = token_response.by_resource_server["transfer.api.globus.org"]
+    globus_auth_token = globus_auth_data["access_token"]
+    globus_transfer_token = globus_transfer_data["access_token"]
 
 
 Do It With Refresh Tokens

--- a/docs/examples/three_legged_oauth.rst
+++ b/docs/examples/three_legged_oauth.rst
@@ -44,14 +44,14 @@ Save the resulting secret a file named ``example_app.conf``, along with the clie
 
 .. code-block:: python
 
-    SERVER_NAME = 'localhost:5000'
+    SERVER_NAME = "localhost:5000"
     # this is the session secret, used to protect the Flask session. You should
     # use a longer secret string known only to your application
     # details are beyond the scope of this example
-    SECRET_KEY = 'abc123!'
+    SECRET_KEY = "abc123!"
 
-    APP_CLIENT_ID = '<CLIENT_ID>'
-    APP_CLIENT_SECRET = '<CLIENT_SECRET>'
+    APP_CLIENT_ID = "<CLIENT_ID>"
+    APP_CLIENT_SECRET = "<CLIENT_SECRET>"
 
 Shared Utilities
 ~~~~~~~~~~~~~~~~
@@ -79,17 +79,18 @@ it, along with the defintiion for your Flask app, in ``example_app.py``:
     import globus_sdk
 
     app = Flask(__name__)
-    app.config.from_pyfile('example_app.conf')
+    app.config.from_pyfile("example_app.conf")
 
 
     # actually run the app if this is called as a script
-    if __name__ == '__main__':
+    if __name__ == "__main__":
         app.run()
 
 
     def load_app_client():
         return globus_sdk.ConfidentialAppAuthClient(
-            app.config['APP_CLIENT_ID'], app.config['APP_CLIENT_SECRET'])
+            app.config["APP_CLIENT_ID"], app.config["APP_CLIENT_SECRET"]
+        )
 
 Login
 ~~~~~
@@ -99,18 +100,19 @@ basic index page:
 
 .. code-block:: python
 
-    @app.route('/')
+    @app.route("/")
     def index():
         """
         This could be any page you like, rendered by Flask.
         For this simple example, it will either redirect you to login, or print
         a simple message.
         """
-        if not session.get('is_authenticated'):
-            return redirect(url_for('login'))
+        if not session.get("is_authenticated"):
+            return redirect(url_for("login"))
         return "You are successfully logged in!"
 
-    @app.route('/login')
+
+    @app.route("/login")
     def login():
         """
         Login via Globus Auth.
@@ -122,7 +124,7 @@ basic index page:
              param
         """
         # the redirect URI, as a complete URI (not relative path)
-        redirect_uri = url_for('login', _external=True)
+        redirect_uri = url_for("login", _external=True)
 
         client = load_app_client()
         client.oauth2_start_flow(redirect_uri)
@@ -130,21 +132,18 @@ basic index page:
         # If there's no "code" query string parameter, we're in this route
         # starting a Globus Auth login flow.
         # Redirect out to Globus Auth
-        if 'code' not in request.args:
+        if "code" not in request.args:
             auth_uri = client.oauth2_get_authorize_url()
             return redirect(auth_uri)
         # If we do have a "code" param, we're coming back from Globus Auth
         # and can start the process of exchanging an auth code for a token.
         else:
-            code = request.args.get('code')
+            code = request.args.get("code")
             tokens = client.oauth2_exchange_code_for_tokens(code)
 
             # store the resulting tokens in the session
-            session.update(
-                tokens=tokens.by_resource_server,
-                is_authenticated=True
-            )
-            return redirect(url_for('index'))
+            session.update(tokens=tokens.by_resource_server, is_authenticated=True)
+            return redirect(url_for("index"))
 
 Logout
 ~~~~~~
@@ -155,7 +154,7 @@ Globus Auth beforehand:
 
 .. code-block:: python
 
-    @app.route('/logout')
+    @app.route("/logout")
     def logout():
         """
         - Revoke the tokens with Globus Auth.
@@ -165,23 +164,25 @@ Globus Auth beforehand:
         client = load_app_client()
 
         # Revoke the tokens with Globus Auth
-        for token in (token_info['access_token']
-                      for token_info in session['tokens'].values()):
+        for token in (
+            token_info["access_token"] for token_info in session["tokens"].values()
+        ):
             client.oauth2_revoke_token(token)
 
         # Destroy the session state
         session.clear()
 
         # the return redirection location to give to Globus AUth
-        redirect_uri = url_for('index', _external=True)
+        redirect_uri = url_for("index", _external=True)
 
         # build the logout URI with query params
         # there is no tool to help build this (yet!)
         globus_logout_url = (
-            'https://auth.globus.org/v2/web/logout' +
-            '?client={}'.format(app.config['PORTAL_CLIENT_ID']) +
-            '&redirect_uri={}'.format(redirect_uri) +
-            '&redirect_name=Globus Example App')
+            "https://auth.globus.org/v2/web/logout"
+            + "?client={}".format(app.config["PORTAL_CLIENT_ID"])
+            + "&redirect_uri={}".format(redirect_uri)
+            + "&redirect_name=Globus Example App"
+        )
 
         # Redirect the user to the Globus Auth logout page
         return redirect(globus_logout_url)
@@ -197,7 +198,8 @@ For example, one might do the following:
 .. code-block:: python
 
     authorizer = globus_sdk.AccessTokenAuthorizer(
-        session['tokens']['transfer.api.globus.org']['access_token'])
+        session["tokens"]["transfer.api.globus.org"]["access_token"]
+    )
     transfer_client = globus_sdk.TransferClient(authorizer=authorizer)
 
     print("Endpoints belonging to the current logged-in user:")

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -93,27 +93,23 @@ Run the following code sample to get your Access Tokens:
 
     import globus_sdk
 
-    CLIENT_ID = '<YOUR_ID_HERE>'
+    CLIENT_ID = "<YOUR_ID_HERE>"
 
     client = globus_sdk.NativeAppAuthClient(CLIENT_ID)
     client.oauth2_start_flow()
 
     authorize_url = client.oauth2_get_authorize_url()
-    print('Please go to this URL and login: {0}'.format(authorize_url))
+    print("Please go to this URL and login: {0}".format(authorize_url))
 
-    # this is to work on Python2 and Python3 -- you can just use raw_input() or
-    # input() for your specific version
-    get_input = getattr(__builtins__, 'raw_input', input)
-    auth_code = get_input(
-        'Please enter the code you get after login here: ').strip()
+    auth_code = input("Please enter the code you get after login here: ").strip()
     token_response = client.oauth2_exchange_code_for_tokens(auth_code)
 
-    globus_auth_data = token_response.by_resource_server['auth.globus.org']
-    globus_transfer_data = token_response.by_resource_server['transfer.api.globus.org']
+    globus_auth_data = token_response.by_resource_server["auth.globus.org"]
+    globus_transfer_data = token_response.by_resource_server["transfer.api.globus.org"]
 
     # most specifically, you want these tokens as strings
-    AUTH_TOKEN = globus_auth_data['access_token']
-    TRANSFER_TOKEN = globus_transfer_data['access_token']
+    AUTH_TOKEN = globus_auth_data["access_token"]
+    TRANSFER_TOKEN = globus_transfer_data["access_token"]
 
 
 Managing credentials is one of the more advanced features of the SDK.
@@ -175,11 +171,9 @@ Remember:
     client = globus_sdk.NativeAppAuthClient(CLIENT_ID)
     client.oauth2_start_flow()
 
-    print('Please go to this URL and login: {0}'
-          .format(client.oauth2_get_authorize_url()))
+    print("Please go to this URL and login: {0}".format(client.oauth2_get_authorize_url()))
 
-    get_input = getattr(__builtins__, 'raw_input', input)
-    auth_code = get_input('Please enter the code here: ').strip()
+    auth_code = input("Please enter the code here: ").strip()
     token_response = client.oauth2_exchange_code_for_tokens(auth_code)
 
 Though it has a few attributes and methods, by far the most important thing
@@ -188,7 +182,7 @@ about ``token_response`` to understand is
 
 Let's take a look at ``str(token_response.by_resource_server)``:
 
-.. code-block:: python
+.. code-block:: python-console
 
     >>> str(token_response.by_resource_server)
     {
@@ -246,11 +240,9 @@ tweak your login flow with one argument:
     client = globus_sdk.NativeAppAuthClient(CLIENT_ID)
     client.oauth2_start_flow(refresh_tokens=True)
 
-    print('Please go to this URL and login: {0}'
-          .format(client.oauth2_get_authorize_url()))
+    print("Please go to this URL and login: {0}".format(client.oauth2_get_authorize_url()))
 
-    get_input = getattr(__builtins__, 'raw_input', input)
-    auth_code = get_input('Please enter the code here: ').strip()
+    auth_code = input("Please enter the code here: ").strip()
     token_response = client.oauth2_exchange_code_for_tokens(auth_code)
 
 If you peek at the ``token_response`` now, you'll see that the
@@ -267,17 +259,18 @@ Let's assume you want to do this with the ``globus_sdk.TransferClient``.
 .. code-block:: python
 
     # let's get stuff for the Globus Transfer service
-    globus_transfer_data = token_response.by_resource_server['transfer.api.globus.org']
+    globus_transfer_data = token_response.by_resource_server["transfer.api.globus.org"]
     # the refresh token and access token, often abbr. as RT and AT
-    transfer_rt = globus_transfer_data['refresh_token']
-    transfer_at = globus_transfer_data['access_token']
-    expires_at_s = globus_transfer_data['expires_at_seconds']
+    transfer_rt = globus_transfer_data["refresh_token"]
+    transfer_at = globus_transfer_data["access_token"]
+    expires_at_s = globus_transfer_data["expires_at_seconds"]
 
     # Now we've got the data we need, but what do we do?
     # That "GlobusAuthorizer" from before is about to come to the rescue
 
     authorizer = globus_sdk.RefreshTokenAuthorizer(
-        transfer_rt, client, access_token=transfer_at, expires_at=expires_at_s)
+        transfer_rt, client, access_token=transfer_at, expires_at=expires_at_s
+    )
 
     # and try using `tc` to make TransferClient calls. Everything should just
     # work -- for days and days, months and months, even years

--- a/globus_sdk/_sphinxext.py
+++ b/globus_sdk/_sphinxext.py
@@ -59,7 +59,7 @@ class AutoMethodList(Directive):
         yield "**Methods**"
         yield ""
         for methodname in _classname2methods(classname, include_methods):
-            yield "* :py:meth:`~{}.{}`".format(classname, methodname)
+            yield f"* :py:meth:`~{classname}.{methodname}`"
 
         yield ""
 

--- a/globus_sdk/auth/client_types/base.py
+++ b/globus_sdk/auth/client_types/base.py
@@ -1,9 +1,5 @@
-from __future__ import print_function, unicode_literals
-
 import collections
 import logging
-
-import six
 
 from globus_sdk import exc
 from globus_sdk.auth.token_response import OAuthTokenResponse
@@ -120,9 +116,7 @@ class AuthClient(BaseClient):
         """
 
         def _convert_listarg(val):
-            if isinstance(val, collections.Iterable) and not isinstance(
-                val, six.string_types
-            ):
+            if isinstance(val, collections.Iterable) and not isinstance(val, str):
                 return ",".join(safe_stringify(x) for x in val)
             else:
                 return safe_stringify(val)
@@ -141,14 +135,12 @@ class AuthClient(BaseClient):
         if ids:
             params["ids"] = _convert_listarg(ids)
 
-        self.logger.debug("params={}".format(params))
+        self.logger.debug(f"params={params}")
 
         if "usernames" in params and "ids" in params:
             self.logger.warning(
-                (
-                    "get_identities call with both usernames and "
-                    "identities set! Expected to result in errors"
-                )
+                "get_identities call with both usernames and "
+                "identities set! Expected to result in errors"
             )
 
         return self.get("/v2/api/identities", params=params)
@@ -166,19 +158,17 @@ class AuthClient(BaseClient):
         """
         if not self.current_oauth2_flow_manager:
             self.logger.error(
-                ("OutOfOrderOperations(" "get_authorize_url before start_flow)")
+                "OutOfOrderOperations(get_authorize_url before start_flow)"
             )
             raise exc.GlobusSDKUsageError(
-                (
-                    "Cannot get authorize URL until starting an OAuth2 flow. "
-                    "Call the oauth2_start_flow() method on this "
-                    "AuthClient to resolve"
-                )
+                "Cannot get authorize URL until starting an OAuth2 flow. "
+                "Call the oauth2_start_flow() method on this "
+                "AuthClient to resolve"
             )
         auth_url = self.current_oauth2_flow_manager.get_authorize_url(
             additional_params=additional_params
         )
-        self.logger.info("Got authorization URL: {}".format(auth_url))
+        self.logger.info(f"Got authorization URL: {auth_url}")
         return auth_url
 
     def oauth2_exchange_code_for_tokens(self, auth_code):
@@ -195,21 +185,15 @@ class AuthClient(BaseClient):
         :type auth_code: str
         """
         self.logger.info(
-            (
-                "Final Step of 3-legged OAuth2 Flows: "
-                "Exchanging authorization code for token(s)"
-            )
+            "Final Step of 3-legged OAuth2 Flows: "
+            "Exchanging authorization code for token(s)"
         )
         if not self.current_oauth2_flow_manager:
-            self.logger.error(
-                ("OutOfOrderOperations(" "exchange_code before start_flow)")
-            )
+            self.logger.error("OutOfOrderOperations(exchange_code before start_flow)")
             raise exc.GlobusSDKUsageError(
-                (
-                    "Cannot exchange auth code until starting an OAuth2 flow. "
-                    "Call the oauth2_start_flow() method on this "
-                    "AuthClient to resolve"
-                )
+                "Cannot exchange auth code until starting an OAuth2 flow. "
+                "Call the oauth2_start_flow() method on this "
+                "AuthClient to resolve"
             )
 
         return self.current_oauth2_flow_manager.exchange_code_for_tokens(auth_code)
@@ -236,7 +220,7 @@ class AuthClient(BaseClient):
         :type additional_params: dict, optional
         """
         self.logger.info(
-            ("Executing token refresh; " "typically requires client credentials")
+            "Executing token refresh; typically requires client credentials"
         )
         form_data = {"refresh_token": refresh_token, "grant_type": "refresh_token"}
 

--- a/globus_sdk/auth/client_types/confidential_client.py
+++ b/globus_sdk/auth/client_types/confidential_client.py
@@ -1,7 +1,5 @@
 import logging
 
-import six
-
 from globus_sdk.auth.client_types.base import AuthClient
 from globus_sdk.auth.oauth2_authorization_code import GlobusAuthorizationCodeFlowManager
 from globus_sdk.auth.oauth2_constants import DEFAULT_REQUESTED_SCOPES
@@ -49,9 +47,9 @@ class ConfidentialAppAuthClient(AuthClient):
             self,
             client_id=client_id,
             authorizer=BasicAuthorizer(client_id, client_secret),
-            **kwargs
+            **kwargs,
         )
-        self.logger.info("Finished initializing client, client_id={}".format(client_id))
+        self.logger.info(f"Finished initializing client, client_id={client_id}")
 
     def oauth2_client_credentials_tokens(self, requested_scopes=None):
         r"""
@@ -79,7 +77,7 @@ class ConfidentialAppAuthClient(AuthClient):
         self.logger.info("Fetching token(s) using client credentials")
         requested_scopes = requested_scopes or DEFAULT_REQUESTED_SCOPES
         # convert scopes iterable to string immediately on load
-        if not isinstance(requested_scopes, six.string_types):
+        if not isinstance(requested_scopes, str):
             requested_scopes = " ".join(requested_scopes)
 
         return self.oauth2_token(
@@ -168,7 +166,7 @@ class ConfidentialAppAuthClient(AuthClient):
                 <globus_sdk.auth.token_response.OAuthTokenResponse>`
         """
         self.logger.info("Getting dependent tokens from access token")
-        self.logger.debug("additional_params={}".format(additional_params))
+        self.logger.debug(f"additional_params={additional_params}")
         form_data = {
             "grant_type": "urn:globus:auth:grant_type:dependent_token",
             "token": token,

--- a/globus_sdk/auth/client_types/native_client.py
+++ b/globus_sdk/auth/client_types/native_client.py
@@ -37,7 +37,7 @@ class NativeAppAuthClient(AuthClient):
         AuthClient.__init__(
             self, client_id=client_id, authorizer=NullAuthorizer(), **kwargs
         )
-        self.logger.info("Finished initializing client, client_id={}".format(client_id))
+        self.logger.info(f"Finished initializing client, client_id={client_id}")
 
     def oauth2_start_flow(
         self,

--- a/globus_sdk/auth/identity_map.py
+++ b/globus_sdk/auth/identity_map.py
@@ -26,7 +26,7 @@ def split_ids_and_usernames(identity_ids):
     return ids, usernames
 
 
-class IdentityMap(object):
+class IdentityMap:
     r"""
     There's a common pattern of having a large batch of Globus Auth Identities which you
     want to inspect. For example, you may have a list of identity IDs fetched from

--- a/globus_sdk/auth/oauth2_authorization_code.py
+++ b/globus_sdk/auth/oauth2_authorization_code.py
@@ -1,7 +1,5 @@
 import logging
-
-import six
-from six.moves.urllib.parse import urlencode
+import urllib.parse
 
 from globus_sdk.auth.oauth2_constants import DEFAULT_REQUESTED_SCOPES
 from globus_sdk.auth.oauth2_flow_manager import GlobusOAuthFlowManager
@@ -57,7 +55,7 @@ class GlobusAuthorizationCodeFlowManager(GlobusOAuthFlowManager):
         # default to the default requested scopes
         self.requested_scopes = requested_scopes or DEFAULT_REQUESTED_SCOPES
         # convert scopes iterable to string immediately on load
-        if not isinstance(self.requested_scopes, six.string_types):
+        if not isinstance(self.requested_scopes, str):
             self.requested_scopes = " ".join(self.requested_scopes)
 
         # store the remaining parameters directly, with no transformation
@@ -68,11 +66,11 @@ class GlobusAuthorizationCodeFlowManager(GlobusOAuthFlowManager):
         self.state = state
 
         logger.debug("Starting Authorization Code Flow with params:")
-        logger.debug("auth_client.client_id={}".format(auth_client.client_id))
-        logger.debug("redirect_uri={}".format(redirect_uri))
-        logger.debug("refresh_tokens={}".format(refresh_tokens))
-        logger.debug("state={}".format(state))
-        logger.debug("requested_scopes={}".format(self.requested_scopes))
+        logger.debug(f"auth_client.client_id={auth_client.client_id}")
+        logger.debug(f"redirect_uri={redirect_uri}")
+        logger.debug(f"refresh_tokens={refresh_tokens}")
+        logger.debug(f"state={state}")
+        logger.debug(f"requested_scopes={self.requested_scopes}")
 
     def get_authorize_url(self, additional_params=None):
         """
@@ -92,10 +90,8 @@ class GlobusAuthorizationCodeFlowManager(GlobusOAuthFlowManager):
         authorize_base_url = slash_join(
             self.auth_client.base_url, "/v2/oauth2/authorize"
         )
-        logger.debug(
-            "Building authorization URI. Base URL: {}".format(authorize_base_url)
-        )
-        logger.debug("additional_params={}".format(additional_params))
+        logger.debug(f"Building authorization URI. Base URL: {authorize_base_url}")
+        logger.debug(f"additional_params={additional_params}")
 
         params = {
             "client_id": self.client_id,
@@ -108,8 +104,8 @@ class GlobusAuthorizationCodeFlowManager(GlobusOAuthFlowManager):
         if additional_params:
             params.update(additional_params)
 
-        params = urlencode(params)
-        return "{0}?{1}".format(authorize_base_url, params)
+        params = urllib.parse.urlencode(params)
+        return f"{authorize_base_url}?{params}"
 
     def exchange_code_for_tokens(self, auth_code):
         """
@@ -120,10 +116,8 @@ class GlobusAuthorizationCodeFlowManager(GlobusOAuthFlowManager):
         <globus_sdk.auth.token_response.OAuthTokenResponse>`
         """
         logger.debug(
-            (
-                "Performing Authorization Code auth_code exchange. "
-                "Sending client_id and client_secret"
-            )
+            "Performing Authorization Code auth_code exchange. "
+            "Sending client_id and client_secret"
         )
         return self.auth_client.oauth2_token(
             {

--- a/globus_sdk/auth/oauth2_flow_manager.py
+++ b/globus_sdk/auth/oauth2_flow_manager.py
@@ -1,4 +1,4 @@
-class GlobusOAuthFlowManager(object):
+class GlobusOAuthFlowManager:
     """
     An abstract class definition that defines the interface for the Flow
     Managers for Globus Auth.
@@ -30,7 +30,7 @@ class GlobusOAuthFlowManager(object):
         :rtype: ``string``
         """
         raise NotImplementedError(
-            "{0} does not implement get_authorize_url()".format(type(self))
+            "{} does not implement get_authorize_url()".format(type(self))
         )
 
     def exchange_code_for_tokens(self, auth_code):
@@ -50,5 +50,5 @@ class GlobusOAuthFlowManager(object):
         :rtype: :class:`OAuthTokenResponse <globus_sdk.OAuthTokenResponse>`
         """
         raise NotImplementedError(
-            "{0} does not implement exchange_code_for_tokens()".format(type(self))
+            "{} does not implement exchange_code_for_tokens()".format(type(self))
         )

--- a/globus_sdk/auth/oauth2_native_app.py
+++ b/globus_sdk/auth/oauth2_native_app.py
@@ -3,9 +3,7 @@ import hashlib
 import logging
 import os
 import re
-
-import six
-from six.moves.urllib.parse import urlencode
+import urllib.parse
 
 from globus_sdk.auth.oauth2_constants import DEFAULT_REQUESTED_SCOPES
 from globus_sdk.auth.oauth2_flow_manager import GlobusOAuthFlowManager
@@ -42,10 +40,8 @@ def make_native_app_challenge(verifier=None):
             raise GlobusSDKUsageError("verifier contained invalid characters")
     else:
         logger.info(
-            (
-                "Autogenerating verifier secret. On low-entropy systems "
-                "this may be insecure"
-            )
+            "Autogenerating verifier secret. On low-entropy systems "
+            "this may be insecure"
         )
 
     code_verifier = verifier or base64.urlsafe_b64encode(os.urandom(32)).decode(
@@ -121,13 +117,13 @@ class GlobusNativeAppFlowManager(GlobusOAuthFlowManager):
                 )
             )
             raise GlobusSDKUsageError(
-                'Invalid value for client_id. Got "{0}"'.format(self.client_id)
+                f'Invalid value for client_id. Got "{self.client_id}"'
             )
 
         # default to the default requested scopes
         self.requested_scopes = requested_scopes or DEFAULT_REQUESTED_SCOPES
         # convert scopes iterable to string immediately on load
-        if not isinstance(self.requested_scopes, six.string_types):
+        if not isinstance(self.requested_scopes, str):
             self.requested_scopes = " ".join(self.requested_scopes)
 
         # default to `/v2/web/auth-code` on whatever environment we're looking
@@ -147,15 +143,15 @@ class GlobusNativeAppFlowManager(GlobusOAuthFlowManager):
         self.prefill_named_grant = prefill_named_grant
 
         logger.debug("Starting Native App Flow with params:")
-        logger.debug("auth_client.client_id={}".format(auth_client.client_id))
-        logger.debug("redirect_uri={}".format(self.redirect_uri))
-        logger.debug("refresh_tokens={}".format(refresh_tokens))
-        logger.debug("state={}".format(state))
-        logger.debug("requested_scopes={}".format(self.requested_scopes))
-        logger.debug("verifier=<REDACTED>,challenge={}".format(self.challenge))
+        logger.debug(f"auth_client.client_id={auth_client.client_id}")
+        logger.debug(f"redirect_uri={self.redirect_uri}")
+        logger.debug(f"refresh_tokens={refresh_tokens}")
+        logger.debug(f"state={state}")
+        logger.debug(f"requested_scopes={self.requested_scopes}")
+        logger.debug(f"verifier=<REDACTED>,challenge={self.challenge}")
 
         if prefill_named_grant is not None:
-            logger.debug("prefill_named_grant={}".format(self.prefill_named_grant))
+            logger.debug(f"prefill_named_grant={self.prefill_named_grant}")
 
     def get_authorize_url(self, additional_params=None):
         """
@@ -175,10 +171,8 @@ class GlobusNativeAppFlowManager(GlobusOAuthFlowManager):
         authorize_base_url = slash_join(
             self.auth_client.base_url, "/v2/oauth2/authorize"
         )
-        logger.debug(
-            "Building authorization URI. Base URL: {}".format(authorize_base_url)
-        )
-        logger.debug("additional_params={}".format(additional_params))
+        logger.debug(f"Building authorization URI. Base URL: {authorize_base_url}")
+        logger.debug(f"additional_params={additional_params}")
 
         params = {
             "client_id": self.client_id,
@@ -195,8 +189,8 @@ class GlobusNativeAppFlowManager(GlobusOAuthFlowManager):
         if additional_params:
             params.update(additional_params)
 
-        params = urlencode(params)
-        return "{0}?{1}".format(authorize_base_url, params)
+        params = urllib.parse.urlencode(params)
+        return f"{authorize_base_url}?{params}"
 
     def exchange_code_for_tokens(self, auth_code):
         """
@@ -207,10 +201,8 @@ class GlobusNativeAppFlowManager(GlobusOAuthFlowManager):
         <globus_sdk.auth.token_response.OAuthTokenResponse>`
         """
         logger.debug(
-            (
-                "Performing Native App auth_code exchange. "
-                "Sending verifier and client_id"
-            )
+            "Performing Native App auth_code exchange. "
+            "Sending verifier and client_id"
         )
         return self.auth_client.oauth2_token(
             {

--- a/globus_sdk/authorizers/access_token.py
+++ b/globus_sdk/authorizers/access_token.py
@@ -18,16 +18,14 @@ class AccessTokenAuthorizer(GlobusAuthorizer):
 
     def __init__(self, access_token):
         logger.info(
-            (
-                "Setting up an AccessTokenAuthorizer. It will use an "
-                "auth type of Bearer and cannot handle 401s."
-            )
+            "Setting up an AccessTokenAuthorizer. It will use an "
+            "auth type of Bearer and cannot handle 401s."
         )
         self.access_token = access_token
         self.header_val = "Bearer %s" % access_token
 
         self.access_token_hash = sha256_string(self.access_token)
-        logger.debug('Bearer token has hash "{}"'.format(self.access_token_hash))
+        logger.debug(f'Bearer token has hash "{self.access_token_hash}"')
 
     def set_authorization_header(self, header_dict):
         """

--- a/globus_sdk/authorizers/base.py
+++ b/globus_sdk/authorizers/base.py
@@ -1,10 +1,7 @@
 import abc
 
-import six
 
-
-@six.add_metaclass(abc.ABCMeta)
-class GlobusAuthorizer(object):
+class GlobusAuthorizer(metaclass=abc.ABCMeta):
     """
     A ``GlobusAuthorizer`` is a very simple object which generates valid
     Authorization headers.

--- a/globus_sdk/authorizers/basic.py
+++ b/globus_sdk/authorizers/basic.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import logging
 
 from globus_sdk.authorizers.base import GlobusAuthorizer
@@ -22,16 +20,14 @@ class BasicAuthorizer(GlobusAuthorizer):
 
     def __init__(self, username, password):
         logger.info(
-            (
-                "Setting up a BasicAuthorizer. It will use an "
-                "auth type of Basic and cannot handle 401s."
-            )
+            "Setting up a BasicAuthorizer. It will use an "
+            "auth type of Basic and cannot handle 401s."
         )
-        logger.info("BasicAuthorizer.username = {}".format(username))
+        logger.info(f"BasicAuthorizer.username = {username}")
         self.username = username
         self.password = password
 
-        to_b64 = "{0}:{1}".format(username, password)
+        to_b64 = f"{username}:{password}"
         self.header_val = "Basic %s" % safe_b64encode(to_b64)
 
     def set_authorization_header(self, header_dict):

--- a/globus_sdk/authorizers/client_credentials.py
+++ b/globus_sdk/authorizers/client_credentials.py
@@ -61,20 +61,16 @@ class ClientCredentialsAuthorizer(RenewingAuthorizer):
         on_refresh=None,
     ):
         logger.info(
-            (
-                "Setting up ClientCredentialsAuthorizer with confidential_client ="
-                " instance:{} and scopes = "
-                "{}".format(id(confidential_client), scopes)
-            )
+            "Setting up ClientCredentialsAuthorizer with confidential_client ="
+            " instance:{} and scopes = "
+            "{}".format(id(confidential_client), scopes)
         )
 
         # values for _get_token_data
         self.confidential_client = confidential_client
         self.scopes = scopes
 
-        super(ClientCredentialsAuthorizer, self).__init__(
-            access_token, expires_at, on_refresh
-        )
+        super().__init__(access_token, expires_at, on_refresh)
 
     def _get_token_response(self):
         """

--- a/globus_sdk/authorizers/refresh_token.py
+++ b/globus_sdk/authorizers/refresh_token.py
@@ -56,19 +56,15 @@ class RefreshTokenAuthorizer(RenewingAuthorizer):
         on_refresh=None,
     ):
         logger.info(
-            (
-                "Setting up RefreshTokenAuthorizer with auth_client = "
-                "instance: {}".format(id(auth_client))
-            )
+            "Setting up RefreshTokenAuthorizer with auth_client = "
+            "instance: {}".format(id(auth_client))
         )
 
         # required for _get_token_data
         self.refresh_token = refresh_token
         self.auth_client = auth_client
 
-        super(RefreshTokenAuthorizer, self).__init__(
-            access_token, expires_at, on_refresh
-        )
+        super().__init__(access_token, expires_at, on_refresh)
 
     def _get_token_response(self):
         """

--- a/globus_sdk/authorizers/renewing.py
+++ b/globus_sdk/authorizers/renewing.py
@@ -2,8 +2,6 @@ import abc
 import logging
 import time
 
-import six
-
 from globus_sdk.authorizers.base import GlobusAuthorizer
 from globus_sdk.utils.string_hashing import sha256_string
 
@@ -13,8 +11,7 @@ logger = logging.getLogger(__name__)
 EXPIRES_ADJUST_SECONDS = 60
 
 
-@six.add_metaclass(abc.ABCMeta)
-class RenewingAuthorizer(GlobusAuthorizer):
+class RenewingAuthorizer(GlobusAuthorizer, metaclass=abc.ABCMeta):
     """
     A ``RenewingAuthorizer`` is an abstract superclass to any authorizer
     that needs to get new Access Tokens in order to form Authorization headers.
@@ -48,19 +45,15 @@ class RenewingAuthorizer(GlobusAuthorizer):
 
     def __init__(self, access_token=None, expires_at=None, on_refresh=None):
         logger.info(
-            (
-                "Setting up a RenewingAuthorizer. It will use an "
-                "auth type of Bearer and can handle 401s."
-            )
+            "Setting up a RenewingAuthorizer. It will use an "
+            "auth type of Bearer and can handle 401s."
         )
         if access_token is not None and expires_at is None:
             logger.warning(
-                (
-                    "Initializing a RenewingAuthorizer with an "
-                    "access_token and no expires_at time means that this "
-                    "access_token will be discarded. You should either pass "
-                    "expires_at or not pass an access_token at all"
-                )
+                "Initializing a RenewingAuthorizer with an "
+                "access_token and no expires_at time means that this "
+                "access_token will be discarded. You should either pass "
+                "expires_at or not pass an access_token at all"
             )
             # coerce to None for simplicity / consistency
             access_token = None
@@ -133,9 +126,9 @@ class RenewingAuthorizer(GlobusAuthorizer):
         self.access_token_hash = sha256_string(self.access_token)
 
         logger.info(
-            (
-                "RenewingAuthorizer.access_token updated to token " "with hash" '"{}"'
-            ).format(self.access_token_hash)
+            ('RenewingAuthorizer.access_token updated to token with hash "{}"').format(
+                self.access_token_hash
+            )
         )
 
         if callable(self.on_refresh):
@@ -156,14 +149,12 @@ class RenewingAuthorizer(GlobusAuthorizer):
             self.expires_at is None or time.time() > self.expires_at
         ):
             logger.debug(
-                (
-                    "RenewingAuthorizer determined time has "
-                    "expired. Fetching new Access Token"
-                )
+                "RenewingAuthorizer determined time has "
+                "expired. Fetching new Access Token"
             )
             self._get_new_access_token()
         else:
-            logger.debug(("RenewingAuthorizer determined time has " "not yet expired"))
+            logger.debug("RenewingAuthorizer determined time has not yet expired")
 
     def set_authorization_header(self, header_dict):
         """
@@ -188,10 +179,8 @@ class RenewingAuthorizer(GlobusAuthorizer):
         being fetched.
         """
         logger.debug(
-            (
-                "RenewingAuthorizer seeing 401. Invalidating "
-                "token and preparing for refresh."
-            )
+            "RenewingAuthorizer seeing 401. Invalidating "
+            "token and preparing for refresh."
         )
         # None for expires_at invalidates any current token
         self.expires_at = None

--- a/globus_sdk/base.py
+++ b/globus_sdk/base.py
@@ -1,9 +1,8 @@
 import json
 import logging
+import urllib.parse
 
 import requests
-import six
-from six.moves.urllib.parse import quote
 
 from globus_sdk import config, exc
 from globus_sdk.response import GlobusHTTPResponse
@@ -186,7 +185,7 @@ class BaseClient:
         self._headers["User-Agent"] = f"{self.BASE_USER_AGENT}/{app_name}"
 
     def qjoin_path(self, *parts):
-        return "/" + "/".join(quote(part) for part in parts)
+        return "/" + "/".join(urllib.parse.quote(part) for part in parts)
 
     def get(self, path, params=None, headers=None, response_class=None, retry_401=True):
         """
@@ -559,12 +558,11 @@ def merge_params(base_params, **more_params):
 def safe_stringify(value):
     """
     Converts incoming value to a unicode string. Convert bytes by decoding,
-    anything else has __str__ called, then is converted to bytes and then to
-    unicode to deal with python 2 and 3 differing in definitions of string
+    anything else has __str__ called.
+    Strings are checked to avoid duplications
     """
     if isinstance(value, str):
         return value
     if isinstance(value, bytes):
         return value.decode("utf-8")
-    else:
-        return six.b(str(value)).decode("utf-8")
+    return str(value)

--- a/globus_sdk/base.py
+++ b/globus_sdk/base.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import json
 import logging
 
@@ -35,7 +33,7 @@ class ClientLogAdapter(logging.LoggerAdapter):
         return self.warning(*args, **kwargs)
 
 
-class BaseClient(object):
+class BaseClient:
     r"""
     Simple client with error handling for Globus REST APIs. Implemented
     as a wrapper around a ``requests.Session`` object, with a simplified
@@ -64,7 +62,7 @@ class BaseClient(object):
     # a collection of authorizer types, or None to indicate "any"
     allowed_authorizer_types = None
 
-    BASE_USER_AGENT = "globus-sdk-py-{0}".format(__version__)
+    BASE_USER_AGENT = f"globus-sdk-py-{__version__}"
 
     def __init__(
         self,
@@ -76,7 +74,7 @@ class BaseClient(object):
         app_name=None,
         http_timeout=None,
         *args,
-        **kwargs
+        **kwargs,
     ):
         self._init_logger_adapter()
         self.logger.info(
@@ -94,8 +92,7 @@ class BaseClient(object):
             )
             raise exc.GlobusSDKUsageError(
                 (
-                    "{0} can only take authorizers from {1}, "
-                    "but you have provided {2}"
+                    "{} can only take authorizers from {}, but you have provided {}"
                 ).format(type(self), self.allowed_authorizer_types, type(authorizer))
             )
 
@@ -186,7 +183,7 @@ class BaseClient(object):
         interacting with Globus Support.
         """
         self.app_name = app_name
-        self._headers["User-Agent"] = "{0}/{1}".format(self.BASE_USER_AGENT, app_name)
+        self._headers["User-Agent"] = f"{self.BASE_USER_AGENT}/{app_name}"
 
     def qjoin_path(self, *parts):
         return "/" + "/".join(quote(part) for part in parts)
@@ -211,7 +208,7 @@ class BaseClient(object):
         :return: :class:`GlobusHTTPResponse \
         <globus_sdk.response.GlobusHTTPResponse>` object
         """
-        self.logger.debug("GET to {} with params {}".format(path, params))
+        self.logger.debug(f"GET to {path} with params {params}")
         return self._request(
             "GET",
             path,
@@ -255,7 +252,7 @@ class BaseClient(object):
         :return: :class:`GlobusHTTPResponse \
         <globus_sdk.response.GlobusHTTPResponse>` object
         """
-        self.logger.debug("POST to {} with params {}".format(path, params))
+        self.logger.debug(f"POST to {path} with params {params}")
         return self._request(
             "POST",
             path,
@@ -289,7 +286,7 @@ class BaseClient(object):
         :return: :class:`GlobusHTTPResponse \
         <globus_sdk.response.GlobusHTTPResponse>` object
         """
-        self.logger.debug("DELETE to {} with params {}".format(path, params))
+        self.logger.debug(f"DELETE to {path} with params {params}")
         return self._request(
             "DELETE",
             path,
@@ -333,7 +330,7 @@ class BaseClient(object):
         :return: :class:`GlobusHTTPResponse \
         <globus_sdk.response.GlobusHTTPResponse>` object
         """
-        self.logger.debug("PUT to {} with params {}".format(path, params))
+        self.logger.debug(f"PUT to {path} with params {params}")
         return self._request(
             "PUT",
             path,
@@ -379,7 +376,7 @@ class BaseClient(object):
         :return: :class:`GlobusHTTPResponse \
         <globus_sdk.response.GlobusHTTPResponse>` object
         """
-        self.logger.debug("PATCH to {} with params {}".format(path, params))
+        self.logger.debug(f"PATCH to {path} with params {params}")
         return self._request(
             "PATCH",
             path,
@@ -451,7 +448,7 @@ class BaseClient(object):
             self.authorizer.set_authorization_header(rheaders)
 
         url = slash_join(self.base_url, path)
-        self.logger.debug("request will hit URL:{}".format(url))
+        self.logger.debug(f"request will hit URL:{url}")
 
         # because a 401 can trigger retry, we need to wrap the retry-able thing
         # in a method
@@ -473,7 +470,7 @@ class BaseClient(object):
         # initial request
         r = send_request()
 
-        self.logger.debug("Request made to URL: {}".format(r.url))
+        self.logger.debug(f"Request made to URL: {r.url}")
 
         # potential 401 retry handling
         if r.status_code == 401 and retry_401 and self.authorizer is not None:
@@ -488,16 +485,14 @@ class BaseClient(object):
                 r = send_request()
 
         if 200 <= r.status_code < 400:
-            self.logger.debug(
-                "request completed with response code: {}".format(r.status_code)
-            )
+            self.logger.debug(f"request completed with response code: {r.status_code}")
             if response_class is None:
                 return self.default_response_class(r, client=self)
             else:
                 return response_class(r, client=self)
 
         self.logger.debug(
-            "request completed with (error) response code: {}".format(r.status_code)
+            f"request completed with (error) response code: {r.status_code}"
         )
         raise self.error_class(r)
 
@@ -567,7 +562,7 @@ def safe_stringify(value):
     anything else has __str__ called, then is converted to bytes and then to
     unicode to deal with python 2 and 3 differing in definitions of string
     """
-    if isinstance(value, six.text_type):
+    if isinstance(value, str):
         return value
     if isinstance(value, bytes):
         return value.decode("utf-8")

--- a/globus_sdk/config.py
+++ b/globus_sdk/config.py
@@ -31,14 +31,14 @@ def _get_lib_config_path():
         logger.debug("pkg_resources load of lib config success")
     except ImportError:
         logger.debug(
-            ("pkg_resources load of lib config failed, failing over " "to path joining")
+            "pkg_resources load of lib config failed, failing over to path joining"
         )
         pkg_path = os.path.dirname(__file__)
         path = os.path.join(pkg_path, fname)
     return path
 
 
-class GlobusConfigParser(object):
+class GlobusConfigParser:
     """
     Wraps a ConfigParser to do modified get()s and config file loading.
     """
@@ -63,11 +63,9 @@ class GlobusConfigParser(object):
             )
         except MissingSectionHeaderError:
             logger.error(
-                (
-                    "MissingSectionHeader means invalid config "
-                    "somewhere, and is often an indicator of a stale "
-                    "early form of the Globus SDK config"
-                )
+                "MissingSectionHeader means invalid config "
+                "somewhere, and is often an indicator of a stale "
+                "early form of the Globus SDK config"
             )
             raise GlobusError(
                 "Failed to parse your ~/.globus.cfg Your config file may be "
@@ -109,7 +107,7 @@ class GlobusConfigParser(object):
         # *first* for a value -- env values have higher precedence than config
         # files so that you can locally override the behavior of a command in a
         # given shell or subshell
-        env_option_name = "GLOBUS_SDK_{}".format(option.upper())
+        env_option_name = f"GLOBUS_SDK_{option.upper()}"
         value = None
         if check_env and env_option_name in os.environ:
             logger.debug(
@@ -151,9 +149,7 @@ _parser = None
 
 
 def get_service_url(environment, service):
-    logger.debug(
-        'Service URL Lookup for "{}" under env "{}"'.format(service, environment)
-    )
+    logger.debug(f'Service URL Lookup for "{service}" under env "{environment}"')
     p = _get_parser()
     option = service + "_service"
     # TODO: validate with urlparse?
@@ -166,7 +162,7 @@ def get_service_url(environment, service):
                 "correctly, or not set at all"
             ).format(service, environment)
         )
-    logger.debug('Service URL Lookup Result: "{}" is at "{}"'.format(service, url))
+    logger.debug(f'Service URL Lookup Result: "{service}" is at "{url}"')
     return url
 
 
@@ -181,7 +177,7 @@ def get_http_timeout(environment):
     )
     if value is None:
         value = 60
-    logger.debug("default http_timeout set to {}".format(value))
+    logger.debug(f"default http_timeout set to {value}")
     return value
 
 
@@ -196,7 +192,7 @@ def get_ssl_verify(environment):
     )
     if value is None:
         return True
-    logger.debug("ssl_verify set to {}".format(value))
+    logger.debug(f"ssl_verify set to {value}")
     return value
 
 
@@ -206,7 +202,7 @@ def _bool_cast(value):
         return True
     elif value in ("0", "no", "false", "off"):
         return False
-    logger.error('Value "{}" can\'t cast to bool'.format(value))
+    logger.error(f'Value "{value}" can\'t cast to bool')
     raise ValueError("Invalid config bool")
 
 
@@ -229,7 +225,5 @@ def get_globus_environ(inputenv=None):
     if env == "production":
         env = "default"
     if env != "default":
-        logger.info(
-            ("On lookup, non-default environment: " "globus_environment={}".format(env))
-        )
+        logger.info(f"On lookup, non-default environment: globus_environment={env}")
     return env

--- a/globus_sdk/exc.py
+++ b/globus_sdk/exc.py
@@ -1,7 +1,6 @@
 import logging
 
 import requests
-import six
 
 logger = logging.getLogger(__name__)
 
@@ -42,28 +41,22 @@ class GlobusAPIError(GlobusError):
             "application/json" in r.headers["Content-Type"]
         ):
             logger.debug(
-                (
-                    "Content-Type on error is application/json. "
-                    "Doing error load from JSON"
-                )
+                "Content-Type on error is application/json. "
+                "Doing error load from JSON"
             )
             try:
                 self._load_from_json(r.json())
             except (KeyError, ValueError):
                 logger.error(
-                    (
-                        "Error body could not be JSON decoded! "
-                        "This means the Content-Type is wrong, or the "
-                        "body is malformed!"
-                    )
+                    "Error body could not be JSON decoded! "
+                    "This means the Content-Type is wrong, or the "
+                    "body is malformed!"
                 )
                 self._load_from_text(r.text)
         else:
             logger.debug(
-                (
-                    "Content-Type on error is unknown. "
-                    "Failing over to error load as text (default)"
-                )
+                "Content-Type on error is unknown. "
+                "Failing over to error load as text (default)"
             )
             # fallback to using the entire body as the message for all
             # other types
@@ -87,11 +80,9 @@ class GlobusAPIError(GlobusError):
                 return r.json()
             except ValueError:
                 logger.error(
-                    (
-                        "Error body could not be JSON decoded! "
-                        "This means the Content-Type is wrong, or the "
-                        "body is malformed!"
-                    )
+                    "Error body could not be JSON decoded! "
+                    "This means the Content-Type is wrong, or the "
+                    "body is malformed!"
                 )
                 return None
         else:
@@ -130,11 +121,9 @@ class GlobusAPIError(GlobusError):
         self.code = data["code"]
         if "message" in data:
             logger.debug(
-                (
-                    "Doing JSON load of error response with 'message' "
-                    "field. There may also be a useful 'detail' field "
-                    "to inspect"
-                )
+                "Doing JSON load of error response with 'message' "
+                "field. There may also be a useful 'detail' field "
+                "to inspect"
             )
             self.message = data["message"]
         else:
@@ -229,7 +218,7 @@ class AuthAPIError(GlobusAPIError):
             self.message = data["message"]
         elif "detail" in data:
             self.message = data["detail"]
-        elif "error" in data and isinstance(data["error"], six.string_types):
+        elif "error" in data and isinstance(data["error"], str):
             self.message = data["error"]
         else:
             self.message = "no_extractable_message"
@@ -254,7 +243,7 @@ class NetworkError(GlobusError):
     """
 
     def __init__(self, msg, exc, *args, **kw):
-        super(NetworkError, self).__init__(msg)
+        super().__init__(msg)
         self.underlying_exception = exc
 
 

--- a/globus_sdk/local_endpoint/personal.py
+++ b/globus_sdk/local_endpoint/personal.py
@@ -11,7 +11,7 @@ def _on_windows():
     return os.name == "nt"
 
 
-class LocalGlobusConnectPersonal(object):
+class LocalGlobusConnectPersonal:
     r"""
     A LocalGlobusConnectPersonal object represents the available SDK methods
     for inspecting and controlling a running Globus Connect Personal
@@ -60,7 +60,7 @@ class LocalGlobusConnectPersonal(object):
                     fname = os.path.expanduser("~/.globusonline/lta/client-id.txt")
                 with open(fname) as fp:
                     self._endpoint_id = fp.read().strip()
-            except IOError as e:
+            except OSError as e:
                 # no such file or directory
                 if e.errno == 2:
                     pass

--- a/globus_sdk/response.py
+++ b/globus_sdk/response.py
@@ -3,7 +3,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-class GlobusResponse(object):
+class GlobusResponse:
     """
     Generic response object, with a single ``data`` member.
 
@@ -34,7 +34,7 @@ class GlobusResponse(object):
         return repr(self)
 
     def __repr__(self):
-        return "{0}({1!r})".format(self.__class__.__name__, self.data)
+        return f"{self.__class__.__name__}({self.data!r})"
 
     def __getitem__(self, key):
         # force evaluation of the data property outside of the upcoming
@@ -51,7 +51,7 @@ class GlobusResponse(object):
             # "type" is ambiguous, but we don't know if it's the fault of the
             # class at large, or just a particular call's `data` property
             raise TypeError(
-                ("This type of GlobusResponse object " "does not support indexing.")
+                "This type of GlobusResponse object does not support indexing."
             )
 
     def __contains__(self, item):
@@ -110,7 +110,7 @@ class GlobusHTTPResponse(GlobusResponse):
         # always use text_body
         except ValueError:
             logger.warning(
-                ("GlobusHTTPResponse.data is null when body is not " "valid JSON")
+                "GlobusHTTPResponse.data is null when body is not valid JSON"
             )
             return None
 

--- a/globus_sdk/search/client.py
+++ b/globus_sdk/search/client.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import logging
 
 from globus_sdk import exc
@@ -68,7 +66,7 @@ class SearchClient(BaseClient):
         in the API documentation for details.
         """
         index_id = safe_stringify(index_id)
-        self.logger.info("SearchClient.get_index({})".format(index_id))
+        self.logger.info(f"SearchClient.get_index({index_id})")
         path = self.qjoin_path("v1/index", index_id)
         return self.get(path, params=params)
 
@@ -84,7 +82,7 @@ class SearchClient(BaseClient):
         limit=10,
         query_template=None,
         advanced=False,
-        **params
+        **params,
     ):
         """
         ``GET /v1/index/<index_id>/search``
@@ -113,7 +111,7 @@ class SearchClient(BaseClient):
             advanced=advanced,
         )
 
-        self.logger.info("SearchClient.search({}, ...)".format(index_id))
+        self.logger.info(f"SearchClient.search({index_id}, ...)")
         path = self.qjoin_path("v1/index", index_id, "search")
         return self.get(path, params=params)
 
@@ -158,7 +156,7 @@ class SearchClient(BaseClient):
         in the API documentation for details.
         """
         index_id = safe_stringify(index_id)
-        self.logger.info("SearchClient.post_search({}, ...)".format(index_id))
+        self.logger.info(f"SearchClient.post_search({index_id}, ...)")
         path = self.qjoin_path("v1/index", index_id, "search")
         return self.post(path, data)
 
@@ -220,7 +218,7 @@ class SearchClient(BaseClient):
         in the API documentation for details.
         """
         index_id = safe_stringify(index_id)
-        self.logger.info("SearchClient.ingest({}, ...)".format(index_id))
+        self.logger.info(f"SearchClient.ingest({index_id}, ...)")
         path = self.qjoin_path("v1/index", index_id, "ingest")
         return self.post(path, data)
 
@@ -258,7 +256,7 @@ class SearchClient(BaseClient):
         in the API documentation for details.
         """
         index_id = safe_stringify(index_id)
-        self.logger.info("SearchClient.delete_by_query({}, ...)".format(index_id))
+        self.logger.info(f"SearchClient.delete_by_query({index_id}, ...)")
         path = self.qjoin_path("v1/index", index_id, "delete_by_query")
         return self.post(path, data)
 
@@ -288,9 +286,7 @@ class SearchClient(BaseClient):
         index_id = safe_stringify(index_id)
         merge_params(params, subject=subject)
 
-        self.logger.info(
-            "SearchClient.get_subject({}, {}, ...)".format(index_id, subject)
-        )
+        self.logger.info(f"SearchClient.get_subject({index_id}, {subject}, ...)")
         path = self.qjoin_path("v1/index", index_id, "subject")
         return self.get(path, params=params)
 
@@ -316,9 +312,7 @@ class SearchClient(BaseClient):
         index_id = safe_stringify(index_id)
         merge_params(params, subject=subject)
 
-        self.logger.info(
-            "SearchClient.delete_subject({}, {}, ...)".format(index_id, subject)
-        )
+        self.logger.info(f"SearchClient.delete_subject({index_id}, {subject}, ...)")
         path = self.qjoin_path("v1/index", index_id, "subject")
         return self.delete(path, params=params)
 
@@ -402,7 +396,7 @@ class SearchClient(BaseClient):
         in the API documentation for details.
         """
         index_id = safe_stringify(index_id)
-        self.logger.info("SearchClient.create_entry({}, ...)".format(index_id))
+        self.logger.info(f"SearchClient.create_entry({index_id}, ...)")
         path = self.qjoin_path("v1/index", index_id, "entry")
         return self.post(path, data)
 
@@ -432,7 +426,7 @@ class SearchClient(BaseClient):
         in the API documentation for details.
         """
         index_id = safe_stringify(index_id)
-        self.logger.info("SearchClient.update_entry({}, ...)".format(index_id))
+        self.logger.info(f"SearchClient.update_entry({index_id}, ...)")
         path = self.qjoin_path("v1/index", index_id, "entry")
         return self.put(path, data)
 
@@ -489,7 +483,7 @@ class SearchClient(BaseClient):
         """
         index_id = safe_stringify(index_id)
         self.logger.info(
-            "SearchClient.get_query_template({}, {})".format(index_id, template_name)
+            f"SearchClient.get_query_template({index_id}, {template_name})"
         )
         path = self.qjoin_path("v1/index", index_id, "query_template", template_name)
         return self.get(path)
@@ -506,7 +500,7 @@ class SearchClient(BaseClient):
         in the API documentation for details.
         """
         index_id = safe_stringify(index_id)
-        self.logger.info("SearchClient.get_query_template_list({})".format(index_id))
+        self.logger.info(f"SearchClient.get_query_template_list({index_id})")
         path = self.qjoin_path("v1/index", index_id, "query_template")
         return self.get(path)
 
@@ -526,7 +520,7 @@ class SearchClient(BaseClient):
         >>> print(task["task_id"] + " | " + task['state'])
         """
         task_id = safe_stringify(task_id)
-        self.logger.info("SearchClient.get_task({})".format(task_id))
+        self.logger.info(f"SearchClient.get_task({task_id})")
         path = self.qjoin_path("v1/task", task_id)
         return self.get(path, params=params)
 
@@ -542,6 +536,6 @@ class SearchClient(BaseClient):
         >>>     print(task["task_id"] + " | " + task['state'])
         """
         index_id = safe_stringify(index_id)
-        self.logger.info("SearchClient.get_task_list({})".format(index_id))
+        self.logger.info(f"SearchClient.get_task_list({index_id})")
         path = self.qjoin_path("v1/task_list", index_id)
         return self.get(path, params=params)

--- a/globus_sdk/transfer/client.py
+++ b/globus_sdk/transfer/client.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import logging
 import time
 
@@ -97,7 +95,7 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info("TransferClient.get_endpoint({})".format(endpoint_id))
+        self.logger.info(f"TransferClient.get_endpoint({endpoint_id})")
         path = self.qjoin_path("endpoint", endpoint_id)
         return self.get(path, params=params)
 
@@ -135,7 +133,7 @@ class TransferClient(BaseClient):
             data["myproxy_server"] = None
 
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info("TransferClient.update_endpoint({}, ...)".format(endpoint_id))
+        self.logger.info(f"TransferClient.update_endpoint({endpoint_id}, ...)")
         path = self.qjoin_path("endpoint", endpoint_id)
         return self.put(path, data, params=params)
 
@@ -199,7 +197,7 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info("TransferClient.delete_endpoint({})".format(endpoint_id))
+        self.logger.info(f"TransferClient.delete_endpoint({endpoint_id})")
         path = self.qjoin_path("endpoint", endpoint_id)
         return self.delete(path)
 
@@ -270,7 +268,7 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         merge_params(params, filter_scope=filter_scope, filter_fulltext=filter_fulltext)
-        self.logger.info("TransferClient.endpoint_search({})".format(params))
+        self.logger.info(f"TransferClient.endpoint_search({params})")
         return PaginatedResource(
             self.get,
             "endpoint_search",
@@ -342,7 +340,7 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info("TransferClient.endpoint_autoactivate({})".format(endpoint_id))
+        self.logger.info(f"TransferClient.endpoint_autoactivate({endpoint_id})")
         path = self.qjoin_path("endpoint", endpoint_id, "autoactivate")
         return self.post(path, params=params)
 
@@ -361,7 +359,7 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info("TransferClient.endpoint_deactivate({})".format(endpoint_id))
+        self.logger.info(f"TransferClient.endpoint_deactivate({endpoint_id})")
         path = self.qjoin_path("endpoint", endpoint_id, "deactivate")
         return self.post(path, params=params)
 
@@ -384,7 +382,7 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info("TransferClient.endpoint_activate({})".format(endpoint_id))
+        self.logger.info(f"TransferClient.endpoint_activate({endpoint_id})")
         path = self.qjoin_path("endpoint", endpoint_id, "activate")
         return self.post(path, json_body=requirements_data, params=params)
 
@@ -424,7 +422,7 @@ class TransferClient(BaseClient):
         """
         endpoint_id = safe_stringify(endpoint_id)
         self.logger.info(
-            "TransferClient.my_effective_pause_rule_list({}, ...)".format(endpoint_id)
+            f"TransferClient.my_effective_pause_rule_list({endpoint_id}, ...)"
         )
         path = self.qjoin_path("endpoint", endpoint_id, "my_effective_pause_rule_list")
         return self.get(path, params=params, response_class=IterableTransferResponse)
@@ -446,9 +444,7 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info(
-            "TransferClient.my_shared_endpoint_list({}, ...)".format(endpoint_id)
-        )
+        self.logger.info(f"TransferClient.my_shared_endpoint_list({endpoint_id}, ...)")
         path = self.qjoin_path("endpoint", endpoint_id, "my_shared_endpoint_list")
         return self.get(path, params=params, response_class=IterableTransferResponse)
 
@@ -502,9 +498,7 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info(
-            "TransferClient.endpoint_server_list({}, ...)".format(endpoint_id)
-        )
+        self.logger.info(f"TransferClient.endpoint_server_list({endpoint_id}, ...)")
         path = self.qjoin_path("endpoint", endpoint_id, "server_list")
         return self.get(path, params=params, response_class=IterableTransferResponse)
 
@@ -546,9 +540,7 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info(
-            "TransferClient.add_endpoint_server({}, ...)".format(endpoint_id)
-        )
+        self.logger.info(f"TransferClient.add_endpoint_server({endpoint_id}, ...)")
         path = self.qjoin_path("endpoint", endpoint_id, "server")
         return self.post(path, server_data)
 
@@ -617,9 +609,7 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info(
-            "TransferClient.endpoint_role_list({}, ...)".format(endpoint_id)
-        )
+        self.logger.info(f"TransferClient.endpoint_role_list({endpoint_id}, ...)")
         path = self.qjoin_path("endpoint", endpoint_id, "role_list")
         return self.get(path, params=params, response_class=IterableTransferResponse)
 
@@ -638,9 +628,7 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info(
-            "TransferClient.add_endpoint_role({}, ...)".format(endpoint_id)
-        )
+        self.logger.info(f"TransferClient.add_endpoint_role({endpoint_id}, ...)")
         path = self.qjoin_path("endpoint", endpoint_id, "role")
         return self.post(path, role_data)
 
@@ -660,7 +648,7 @@ class TransferClient(BaseClient):
         """
         endpoint_id = safe_stringify(endpoint_id)
         self.logger.info(
-            "TransferClient.get_endpoint_role({}, {}, ...)".format(endpoint_id, role_id)
+            f"TransferClient.get_endpoint_role({endpoint_id}, {role_id}, ...)"
         )
         path = self.qjoin_path("endpoint", endpoint_id, "role", role_id)
         return self.get(path, params=params)
@@ -681,7 +669,7 @@ class TransferClient(BaseClient):
         """
         endpoint_id = safe_stringify(endpoint_id)
         self.logger.info(
-            "TransferClient.delete_endpoint_role({}, {})".format(endpoint_id, role_id)
+            f"TransferClient.delete_endpoint_role({endpoint_id}, {role_id})"
         )
         path = self.qjoin_path("endpoint", endpoint_id, "role", role_id)
         return self.delete(path)
@@ -705,9 +693,7 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info(
-            "TransferClient.endpoint_acl_list({}, ...)".format(endpoint_id)
-        )
+        self.logger.info(f"TransferClient.endpoint_acl_list({endpoint_id}, ...)")
         path = self.qjoin_path("endpoint", endpoint_id, "access_list")
         return self.get(path, params=params, response_class=IterableTransferResponse)
 
@@ -769,9 +755,7 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info(
-            "TransferClient.add_endpoint_acl_rule({}, ...)".format(endpoint_id)
-        )
+        self.logger.info(f"TransferClient.add_endpoint_acl_rule({endpoint_id}, ...)")
         path = self.qjoin_path("endpoint", endpoint_id, "access")
         return self.post(path, rule_data)
 
@@ -839,7 +823,7 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/endpoint_bookmarks/#get_list_of_bookmarks>`_
         in the REST documentation for details.
         """
-        self.logger.info("TransferClient.bookmark_list({})".format(params))
+        self.logger.info(f"TransferClient.bookmark_list({params})")
         return self.get(
             "bookmark_list", params=params, response_class=IterableTransferResponse
         )
@@ -858,7 +842,7 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/endpoint_bookmarks/#create_bookmark>`_
         in the REST documentation for details.
         """
-        self.logger.info("TransferClient.create_bookmark({})".format(bookmark_data))
+        self.logger.info(f"TransferClient.create_bookmark({bookmark_data})")
         return self.post("bookmark", bookmark_data)
 
     def get_bookmark(self, bookmark_id, **params):
@@ -876,7 +860,7 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         bookmark_id = safe_stringify(bookmark_id)
-        self.logger.info("TransferClient.get_bookmark({})".format(bookmark_id))
+        self.logger.info(f"TransferClient.get_bookmark({bookmark_id})")
         path = self.qjoin_path("bookmark", bookmark_id)
         return self.get(path, params=params)
 
@@ -894,7 +878,7 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/endpoint_bookmarks/#update_bookmark>`_
         in the REST documentation for details.
         """
-        self.logger.info("TransferClient.update_bookmark({})".format(bookmark_id))
+        self.logger.info(f"TransferClient.update_bookmark({bookmark_id})")
         path = self.qjoin_path("bookmark", bookmark_id)
         return self.put(path, bookmark_data)
 
@@ -912,7 +896,7 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/endpoint_bookmarks/#delete_bookmark_by_id>`_
         in the REST documentation for details.
         """
-        self.logger.info("TransferClient.delete_bookmark({})".format(bookmark_id))
+        self.logger.info(f"TransferClient.delete_bookmark({bookmark_id})")
         path = self.qjoin_path("bookmark", bookmark_id)
         return self.delete(path)
 
@@ -941,9 +925,7 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info(
-            "TransferClient.operation_ls({}, {})".format(endpoint_id, params)
-        )
+        self.logger.info(f"TransferClient.operation_ls({endpoint_id}, {params})")
         path = self.qjoin_path("operation/endpoint", endpoint_id, "ls")
         return self.get(path, params=params, response_class=IterableTransferResponse)
 
@@ -1075,7 +1057,7 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/task_submit/#get_submission_id>`_
         in the REST documentation for more details.
         """
-        self.logger.info("TransferClient.get_submission_id({})".format(params))
+        self.logger.info(f"TransferClient.get_submission_id({params})")
         return self.get("submission_id", params=params)
 
     def submit_transfer(self, data):
@@ -1225,7 +1207,7 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/task/#get_event_list>`_
         in the REST documentation for details.
         """
-        self.logger.info("TransferClient.task_event_list({}, ...)".format(task_id))
+        self.logger.info(f"TransferClient.task_event_list({task_id}, ...)")
         path = self.qjoin_path("task", task_id, "event_list")
         return PaginatedResource(
             self.get,
@@ -1250,7 +1232,7 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/task/#get_task_by_id>`_
         in the REST documentation for details.
         """
-        self.logger.info("TransferClient.get_task({}, ...)".format(task_id))
+        self.logger.info(f"TransferClient.get_task({task_id}, ...)")
         resource_path = self.qjoin_path("task", task_id)
         return self.get(resource_path, params=params)
 
@@ -1268,7 +1250,7 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/task/#update_task_by_id>`_
         in the REST documentation for details.
         """
-        self.logger.info("TransferClient.update_task({}, ...)".format(task_id))
+        self.logger.info(f"TransferClient.update_task({task_id}, ...)")
         resource_path = self.qjoin_path("task", task_id)
         return self.put(resource_path, data, params=params)
 
@@ -1286,7 +1268,7 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/task/#cancel_task_by_id>`_
         in the REST documentation for details.
         """
-        self.logger.info("TransferClient.cancel_task({})".format(task_id))
+        self.logger.info(f"TransferClient.cancel_task({task_id})")
         resource_path = self.qjoin_path("task", task_id, "cancel")
         return self.post(resource_path)
 
@@ -1342,7 +1324,7 @@ class TransferClient(BaseClient):
         # check valid args
         if timeout < 1:
             self.logger.error(
-                "task_wait() timeout={} is less than minimum of 1s".format(timeout)
+                f"task_wait() timeout={timeout} is less than minimum of 1s"
             )
             raise exc.GlobusSDKUsageError(
                 "TransferClient.task_wait timeout has a minimum of 1"
@@ -1385,11 +1367,11 @@ class TransferClient(BaseClient):
             # don't sleep an extra polling_interval
             waited_time += polling_interval
             if timed_out(waited_time):
-                self.logger.debug("task_wait(task_id={}) timed out".format(task_id))
+                self.logger.debug(f"task_wait(task_id={task_id}) timed out")
                 return False
 
             self.logger.debug(
-                "task_wait(task_id={}) waiting {}s".format(task_id, polling_interval)
+                f"task_wait(task_id={task_id}) waiting {polling_interval}s"
             )
             time.sleep(polling_interval)
         # unreachable -- end of task_wait
@@ -1408,7 +1390,7 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/task/#get_task_pause_info>`_
         in the REST documentation for details.
         """
-        self.logger.info("TransferClient.task_pause_info({}, ...)".format(task_id))
+        self.logger.info(f"TransferClient.task_pause_info({task_id}, ...)")
         resource_path = self.qjoin_path("task", task_id, "pause_info")
         return self.get(resource_path, params=params)
 
@@ -1455,9 +1437,7 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/task/#get_task_successful_transfers>`_
         in the REST documentation for details.
         """
-        self.logger.info(
-            "TransferClient.task_successful_transfers({}, ...)".format(task_id)
-        )
+        self.logger.info(f"TransferClient.task_successful_transfers({task_id}, ...)")
 
         resource_path = self.qjoin_path("task", task_id, "successful_transfers")
         return PaginatedResource(
@@ -1540,7 +1520,7 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         self.logger.info(
-            "TransferClient.endpoint_manager_monitored_endpoints({})".format(params)
+            f"TransferClient.endpoint_manager_monitored_endpoints({params})"
         )
         path = self.qjoin_path("endpoint_manager", "monitored_endpoints")
         return self.get(path, params=params, response_class=IterableTransferResponse)
@@ -1561,10 +1541,8 @@ class TransferClient(BaseClient):
         """
         endpoint_id = safe_stringify(endpoint_id)
         self.logger.info(
-            (
-                "TransferClient.endpoint_manager_"
-                "hosted_endpoint_list({})".format(endpoint_id)
-            )
+            "TransferClient.endpoint_manager_"
+            "hosted_endpoint_list({})".format(endpoint_id)
         )
         path = self.qjoin_path(
             "endpoint_manager", "endpoint", endpoint_id, "hosted_endpoint_list"
@@ -1588,9 +1566,7 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         endpoint_id = safe_stringify(endpoint_id)
-        self.logger.info(
-            ("TransferClient.endpoint_manager_" "get_endpoint({})".format(endpoint_id))
-        )
+        self.logger.info(f"TransferClient.endpoint_manager_get_endpoint({endpoint_id})")
         path = self.qjoin_path("endpoint_manager", "endpoint", endpoint_id)
         return self.get(path, params=params)
 
@@ -1612,10 +1588,8 @@ class TransferClient(BaseClient):
         """
         endpoint_id = safe_stringify(endpoint_id)
         self.logger.info(
-            (
-                "TransferClient.endpoint_manager_"
-                "endpoint_acl_list({}, ...)".format(endpoint_id)
-            )
+            "TransferClient.endpoint_manager_"
+            "endpoint_acl_list({}, ...)".format(endpoint_id)
         )
         path = self.qjoin_path(
             "endpoint_manager", "endpoint", endpoint_id, "access_list"
@@ -1699,9 +1673,7 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         task_id = safe_stringify(task_id)
-        self.logger.info(
-            ("TransferClient.endpoint_manager_" "get_task({}, ...)".format(task_id))
-        )
+        self.logger.info(f"TransferClient.endpoint_manager_get_task({task_id}, ...)")
         path = self.qjoin_path("endpoint_manager", "task", task_id)
         return self.get(path, params=params)
 
@@ -1735,10 +1707,8 @@ class TransferClient(BaseClient):
         """
         task_id = safe_stringify(task_id)
         self.logger.info(
-            (
-                "TransferClient.endpoint_manager_"
-                "task_event_list({}, ...)".format(task_id)
-            )
+            "TransferClient.endpoint_manager_"
+            "task_event_list({}, ...)".format(task_id)
         )
         path = self.qjoin_path("endpoint_manager", "task", task_id, "event_list")
         return PaginatedResource(
@@ -1769,10 +1739,8 @@ class TransferClient(BaseClient):
         """
         task_id = safe_stringify(task_id)
         self.logger.info(
-            (
-                "TransferClient.endpoint_manager_"
-                "task_pause_info({}, ...)".format(task_id)
-            )
+            "TransferClient.endpoint_manager_"
+            "task_pause_info({}, ...)".format(task_id)
         )
         path = self.qjoin_path("endpoint_manager", "task", task_id, "pause_info")
         return self.get(path, params=params)
@@ -1807,10 +1775,8 @@ class TransferClient(BaseClient):
         """
         task_id = safe_stringify(task_id)
         self.logger.info(
-            (
-                "TransferClient.endpoint_manager_task_"
-                "successful_transfers({}, ...)".format(task_id)
-            )
+            "TransferClient.endpoint_manager_task_"
+            "successful_transfers({}, ...)".format(task_id)
         )
 
         resource_path = self.qjoin_path(
@@ -1853,10 +1819,8 @@ class TransferClient(BaseClient):
         """
         task_id = safe_stringify(task_id)
         self.logger.info(
-            (
-                "TransferClient.endpoint_manager_task_"
-                "skipped_errors({}, ...)".format(task_id)
-            )
+            "TransferClient.endpoint_manager_task_"
+            "skipped_errors({}, ...)".format(task_id)
         )
 
         resource_path = self.qjoin_path(
@@ -1897,10 +1861,8 @@ class TransferClient(BaseClient):
         task_ids = [safe_stringify(i) for i in task_ids]
         message = safe_stringify(message)
         self.logger.info(
-            (
-                "TransferClient.endpoint_manager_"
-                "cancel_tasks({},{})".format(task_ids, message)
-            )
+            "TransferClient.endpoint_manager_"
+            "cancel_tasks({},{})".format(task_ids, message)
         )
         json_body = {"message": safe_stringify(message), "task_id_list": task_ids}
         path = self.qjoin_path("endpoint_manager", "admin_cancel")
@@ -1928,10 +1890,8 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         self.logger.info(
-            (
-                "TransferClient.endpoint_manager_"
-                "cancel_status({})".format(admin_cancel_id)
-            )
+            "TransferClient.endpoint_manager_"
+            "cancel_status({})".format(admin_cancel_id)
         )
         path = self.qjoin_path("endpoint_manager", "admin_cancel", admin_cancel_id)
         return self.get(path, params=params)
@@ -1962,10 +1922,8 @@ class TransferClient(BaseClient):
         task_ids = [safe_stringify(i) for i in task_ids]
         message = safe_stringify(message)
         self.logger.info(
-            (
-                "TransferClient.endpoint_manager_"
-                "pause_tasks({},{})".format(task_ids, message)
-            )
+            "TransferClient.endpoint_manager_"
+            "pause_tasks({},{})".format(task_ids, message)
         )
         json_body = {"message": safe_stringify(message), "task_id_list": task_ids}
         path = self.qjoin_path("endpoint_manager", "admin_pause")
@@ -1993,9 +1951,7 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         task_ids = [safe_stringify(i) for i in task_ids]
-        self.logger.info(
-            ("TransferClient.endpoint_manager_" "resume_tasks({})".format(task_ids))
-        )
+        self.logger.info(f"TransferClient.endpoint_manager_resume_tasks({task_ids})")
         json_body = {"task_id_list": task_ids}
         path = self.qjoin_path("endpoint_manager", "admin_resume")
         return self.post(path, json_body=json_body, params=params)
@@ -2027,7 +1983,7 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/advanced_endpoint_management/#get_pause_rules>`_
         in the REST documentation for details.
         """
-        self.logger.info(("TransferClient.endpoint_manager_" "pause_rule_list(...)"))
+        self.logger.info("TransferClient.endpoint_manager_pause_rule_list(...)")
         path = self.qjoin_path("endpoint_manager", "pause_rule_list")
         merge_params(params, filter_endpoint=filter_endpoint)
         return self.get(path, params=params, response_class=IterableTransferResponse)
@@ -2062,7 +2018,7 @@ class TransferClient(BaseClient):
         <https://docs.globus.org/api/transfer/advanced_endpoint_management/#create_pause_rule>`_
         in the REST documentation for details.
         """
-        self.logger.info(("TransferClient.endpoint_manager_" "create_pause_rule(...)"))
+        self.logger.info("TransferClient.endpoint_manager_create_pause_rule(...)")
         path = self.qjoin_path("endpoint_manager", "pause_rule")
         return self.post(path, data)
 
@@ -2089,10 +2045,8 @@ class TransferClient(BaseClient):
         """
         pause_rule_id = safe_stringify(pause_rule_id)
         self.logger.info(
-            (
-                "TransferClient.endpoint_manager_"
-                "get_pause_rule({})".format(pause_rule_id)
-            )
+            "TransferClient.endpoint_manager_"
+            "get_pause_rule({})".format(pause_rule_id)
         )
         path = self.qjoin_path("endpoint_manager", "pause_rule", pause_rule_id)
         return self.get(path, params=params)
@@ -2127,10 +2081,8 @@ class TransferClient(BaseClient):
         """
         pause_rule_id = safe_stringify(pause_rule_id)
         self.logger.info(
-            (
-                "TransferClient.endpoint_manager_"
-                "update_pause_rule({})".format(pause_rule_id)
-            )
+            "TransferClient.endpoint_manager_"
+            "update_pause_rule({})".format(pause_rule_id)
         )
         path = self.qjoin_path("endpoint_manager", "pause_rule", pause_rule_id)
         return self.put(path, data)
@@ -2159,10 +2111,8 @@ class TransferClient(BaseClient):
         """
         pause_rule_id = safe_stringify(pause_rule_id)
         self.logger.info(
-            (
-                "TransferClient.endpoint_manager_"
-                "delete_pause_rule({})".format(pause_rule_id)
-            )
+            "TransferClient.endpoint_manager_"
+            "delete_pause_rule({})".format(pause_rule_id)
         )
         path = self.qjoin_path("endpoint_manager", "pause_rule", pause_rule_id)
         return self.delete(path, params=params)

--- a/globus_sdk/transfer/client.py
+++ b/globus_sdk/transfer/client.py
@@ -302,7 +302,6 @@ class TransferClient(BaseClient):
         >>>           "endpoint:")
         >>>     print("https://app.globus.org/file-manager?origin_id=%s"
         >>>           % ep_id)
-        >>>     # For python 2.X, use raw_input() instead
         >>>     input("Press ENTER after activating the endpoint:")
         >>>     r = tc.endpoint_autoactivate(ep_id, if_expires_in=3600)
 

--- a/globus_sdk/transfer/data.py
+++ b/globus_sdk/transfer/data.py
@@ -4,7 +4,6 @@ extend ``dict``, so they can be passed seamlessly to
 :class:`TransferClient <globus_sdk.TransferClient>` methods without
 conversion.
 """
-from __future__ import unicode_literals
 
 import logging
 
@@ -146,7 +145,7 @@ class TransferData(dict):
         skip_source_errors=False,
         fail_on_quota_errors=False,
         recursive_symlinks="ignore",
-        **kwargs
+        **kwargs,
     ):
         source_endpoint = safe_stringify(source_endpoint)
         destination_endpoint = safe_stringify(destination_endpoint)
@@ -157,33 +156,29 @@ class TransferData(dict):
         )
         logger.info("TransferData.submission_id = {}".format(self["submission_id"]))
         self["source_endpoint"] = source_endpoint
-        logger.info("TransferData.source_endpoint = {}".format(source_endpoint))
+        logger.info(f"TransferData.source_endpoint = {source_endpoint}")
         self["destination_endpoint"] = destination_endpoint
-        logger.info(
-            "TransferData.destination_endpoint = {}".format(destination_endpoint)
-        )
+        logger.info(f"TransferData.destination_endpoint = {destination_endpoint}")
         self["verify_checksum"] = verify_checksum
-        logger.info("TransferData.verify_checksum = {}".format(verify_checksum))
+        logger.info(f"TransferData.verify_checksum = {verify_checksum}")
         self["preserve_timestamp"] = preserve_timestamp
-        logger.info("TransferData.preserve_timestamp = {}".format(preserve_timestamp))
+        logger.info(f"TransferData.preserve_timestamp = {preserve_timestamp}")
         self["encrypt_data"] = encrypt_data
-        logger.info("TransferData.encrypt_data = {}".format(encrypt_data))
+        logger.info(f"TransferData.encrypt_data = {encrypt_data}")
         self["recursive_symlinks"] = recursive_symlinks
-        logger.info("TransferData.recursive_symlinks = {}".format(recursive_symlinks))
+        logger.info(f"TransferData.recursive_symlinks = {recursive_symlinks}")
         self["skip_source_errors"] = skip_source_errors
-        logger.info("TransferData.skip_source_errors = {}".format(skip_source_errors))
+        logger.info(f"TransferData.skip_source_errors = {skip_source_errors}")
         self["fail_on_quota_errors"] = fail_on_quota_errors
-        logger.info(
-            "TransferData.fail_on_quota_errors = {}".format(fail_on_quota_errors)
-        )
+        logger.info(f"TransferData.fail_on_quota_errors = {fail_on_quota_errors}")
 
         if label is not None:
             self["label"] = label
-            logger.debug("TransferData.label = {}".format(label))
+            logger.debug(f"TransferData.label = {label}")
 
         if deadline is not None:
             self["deadline"] = str(deadline)
-            logger.debug("TransferData.deadline = {}".format(deadline))
+            logger.debug(f"TransferData.deadline = {deadline}")
 
         # map the sync_level (if it's a nice string) to one of the known int
         # values
@@ -217,7 +212,7 @@ class TransferData(dict):
         recursive=False,
         external_checksum=None,
         checksum_algorithm=None,
-        **params
+        **params,
     ):
         """
         Add a file or directory to be transfered. If the item is a symlink
@@ -368,7 +363,7 @@ class DeleteData(dict):
         submission_id=None,
         recursive=False,
         deadline=None,
-        **kwargs
+        **kwargs,
     ):
         endpoint = safe_stringify(endpoint)
         logger.info("Creating a new DeleteData object")
@@ -378,25 +373,23 @@ class DeleteData(dict):
         )
         logger.info("DeleteData.submission_id = {}".format(self["submission_id"]))
         self["endpoint"] = endpoint
-        logger.info("DeleteData.endpoint = {}".format(endpoint))
+        logger.info(f"DeleteData.endpoint = {endpoint}")
         self["recursive"] = recursive
-        logger.info("DeleteData.recursive = {}".format(recursive))
+        logger.info(f"DeleteData.recursive = {recursive}")
 
         if label is not None:
             self["label"] = label
-            logger.debug("DeleteData.label = {}".format(label))
+            logger.debug(f"DeleteData.label = {label}")
 
         if deadline is not None:
             self["deadline"] = str(deadline)
-            logger.debug("DeleteData.deadline = {}".format(deadline))
+            logger.debug(f"DeleteData.deadline = {deadline}")
 
         self["DATA"] = []
 
         self.update(kwargs)
         for option, value in kwargs.items():
-            logger.info(
-                "DeleteData.{} = {} (option passed in via kwargs)".format(option, value)
-            )
+            logger.info(f"DeleteData.{option} = {value} (option passed in via kwargs)")
 
     def add_item(self, path, **params):
         """

--- a/globus_sdk/transfer/paging.py
+++ b/globus_sdk/transfer/paging.py
@@ -1,7 +1,5 @@
 import logging
 
-import six
-
 from globus_sdk.exc import GlobusSDKUsageError
 from globus_sdk.response import GlobusResponse
 from globus_sdk.transfer.response import IterableTransferResponse
@@ -9,7 +7,7 @@ from globus_sdk.transfer.response import IterableTransferResponse
 logger = logging.getLogger(__name__)
 
 
-class PaginatedResource(GlobusResponse, six.Iterator):
+class PaginatedResource:
     """
     A ``PaginatedResource`` is an iterable response which implements the Python
     iterator interface. As such, **you can only iterate over
@@ -149,10 +147,7 @@ class PaginatedResource(GlobusResponse, six.Iterator):
 
         # what function call does this class instance wrap up?
         self.client_method = client_method
-        if six.PY2:
-            self.client_object = client_method.im_self
-        else:
-            self.client_object = client_method.__self__
+        self.client_object = client_method.__self__
 
         self.client_path = path
         self.client_kwargs = client_kwargs
@@ -216,10 +211,8 @@ class PaginatedResource(GlobusResponse, six.Iterator):
         # here and now
         if self.generator is None:
             logger.debug(
-                (
-                    "PaginatedResource never got results, "
-                    "iteration empty (not an error!)"
-                )
+                "PaginatedResource never got results, "
+                "iteration empty (not an error!)"
             )
             raise StopIteration()
 
@@ -312,14 +305,14 @@ class PaginatedResource(GlobusResponse, six.Iterator):
                 return self.offset < res["total"]
 
             logger.error(
-                "PaginatedResource.paging_style={} is invalid".format(self.paging_style)
+                f"PaginatedResource.paging_style={self.paging_style} is invalid"
             )
             raise GlobusSDKUsageError("Invalid Paging Style Given to PaginatedResource")
 
         has_next_page = True
         while has_next_page:
             logger.debug(
-                ("PaginatedResource should have more results, " "requesting them now")
+                "PaginatedResource should have more results, requesting them now"
             )
             _set_params_for_next_call()
 

--- a/setup.py
+++ b/setup.py
@@ -1,25 +1,6 @@
 import os.path
-import sys
-import warnings
 
 from setuptools import find_packages, setup
-
-if sys.version_info < (2, 7):
-    raise NotImplementedError(
-        """\n
-##############################################################
-# globus-sdk does not support python versions older than 2.7 #
-##############################################################"""
-    )
-
-# warn on older/untested python3s
-# it's not disallowed, but it could be an issue for some people
-if sys.version_info > (3,) and sys.version_info < (3, 6):
-    warnings.warn(
-        "Installing globus-sdk on Python 3 versions older than 3.6 "
-        "may result in degraded functionality or even errors."
-    )
-
 
 # single source of truth for package version
 version_ns = {}
@@ -35,6 +16,7 @@ setup(
     author_email="support@globus.org",
     url="https://github.com/globus/globus-sdk-python",
     packages=find_packages(exclude=["tests", "tests.*"]),
+    python_requires=">=3.6",
     install_requires=[
         "requests>=2.9.2,<3.0.0",
         "six>=1.10.0,<2.0.0",
@@ -49,26 +31,24 @@ setup(
             "tox>=3.5.3,<4.0",
             # linting
             "flake8>=3.0,<4.0",
-            'isort>=5.6.4,<6.0;python_version>="3.6"',
-            'black==20.8b1;python_version>="3.6"',
+            "isort>=5.6.4,<6.0",
+            "black==20.8b1",
             # flake-bugbear requires py3.6+
-            'flake8-bugbear==20.11.1;python_version>="3.6"',
+            "flake8-bugbear==20.11.1",
             # testing
             "pytest<5.0",
             "pytest-cov<3.0",
             "pytest-xdist<2.0",
-            # mock on py2
-            'mock==2.0.0;python_version<"3.6"',
             # mocking HTTP responses
             "responses==0.12.1",
             # pyinstaller is needed in order to test the pyinstaller hook
-            'pyinstaller;python_version>="3.6"',
+            "pyinstaller",
             # builds + uploads to pypi
-            'twine>=3,<4;python_version>="3.6"',
-            'wheel==0.36.2;python_version>="3.6"',
+            "twine>=3,<4",
+            "wheel==0.36.2",
             # docs
-            'sphinx==3.4.3;python_version>="3.6"',
-            'sphinx-material==0.0.32;python_version>="3.6"',
+            "sphinx==3.4.3",
+            "sphinx-material==0.0.32",
         ],
     },
     entry_points={
@@ -84,7 +64,6 @@ setup(
         "Operating System :: Microsoft :: Windows",
         "Operating System :: POSIX",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@ setup(
     python_requires=">=3.6",
     install_requires=[
         "requests>=2.9.2,<3.0.0",
-        "six>=1.10.0,<2.0.0",
         "pyjwt[crypto]>=1.5.3,<2.0.0",
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -17,15 +17,10 @@ setup(
     url="https://github.com/globus/globus-sdk-python",
     packages=find_packages(exclude=["tests", "tests.*"]),
     python_requires=">=3.6",
-    install_requires=[
-        "requests>=2.9.2,<3.0.0",
-        "pyjwt[crypto]>=1.5.3,<2.0.0",
-    ],
+    install_requires=["requests>=2.9.2,<3.0.0", "pyjwt[crypto]>=1.5.3,<2.0.0"],
     extras_require={
-        # empty extra included to support older installs
-        "jwt": [],
-        # the development extra is for SDK developers only
-        "development": [
+        # the dev extra is for SDK developers only
+        "dev": [
             # drive testing with tox
             "tox>=3.5.3,<4.0",
             # linting
@@ -48,7 +43,7 @@ setup(
             # docs
             "sphinx==3.4.3",
             "sphinx-material==0.0.32",
-        ],
+        ]
     },
     entry_points={
         "pyinstaller40": ["hook-dirs = globus_sdk._pyinstaller:get_hook_dirs"]
@@ -59,16 +54,10 @@ setup(
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: Apache Software License",
-        "Operating System :: MacOS :: MacOS X",
-        "Operating System :: Microsoft :: Windows",
-        "Operating System :: POSIX",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
-        "Topic :: Communications :: File Sharing",
-        "Topic :: Internet :: WWW/HTTP",
-        "Topic :: Software Development :: Libraries :: Python Modules",
     ],
 )

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,4 +1,3 @@
-# -*- coding: utf8 -*-
 """
 Common use helpers and utilities for all tests to leverage.
 Not so disorganized as a "utils" module and not so refined as a public package.
@@ -10,7 +9,6 @@ from unittest import mock
 
 import requests
 import responses
-import six
 
 import globus_sdk
 from globus_sdk.base import slash_join
@@ -101,8 +99,8 @@ def register_api_route_fixture_file(service, path, filename, **kwargs):
     modpath = os.path.abspath(frm[1])
 
     abspath = os.path.join(os.path.dirname(modpath), "fixture_data", filename)
-    with open(abspath) as f:
-        body = six.b(f.read())
+    with open(abspath, "rb") as f:
+        body = f.read()
 
     register_api_route(service, path, body=body, **kwargs)
 
@@ -139,7 +137,7 @@ class PickleableMockResponse(mock.NonCallableMock):
         self, status_code, json_body=None, text=None, headers=None, *args, **kwargs
     ):
         kwargs["spec"] = requests.Response
-        super(PickleableMockResponse, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.__class__ = PickleableMockResponse
 
         # after mock initialization, setup various explicit attributes
@@ -160,7 +158,7 @@ class PickleableMockResponse(mock.NonCallableMock):
     def __getstate__(self):
         """Custom getstate discards most of the magical mock stuff"""
         keys = ["headers", "text", "_json_body", "status_code"]
-        return dict((k, self.__dict__[k]) for k in keys)
+        return {k: self.__dict__[k] for k in keys}
 
     def __setstate__(self, state):
         self.__dict__.update(state)

--- a/tests/common.py
+++ b/tests/common.py
@@ -6,6 +6,7 @@ Not so disorganized as a "utils" module and not so refined as a public package.
 import inspect
 import json
 import os
+from unittest import mock
 
 import requests
 import responses
@@ -13,12 +14,6 @@ import six
 
 import globus_sdk
 from globus_sdk.base import slash_join
-
-try:
-    import mock
-except ImportError:
-    from unittest import mock
-
 
 # constants
 

--- a/tests/functional/auth/test_auth_client_flow.py
+++ b/tests/functional/auth/test_auth_client_flow.py
@@ -1,5 +1,6 @@
+import urllib.parse
+
 import pytest
-from six.moves.urllib.parse import quote_plus
 
 import globus_sdk
 from globus_sdk.auth.oauth2_constants import DEFAULT_REQUESTED_SCOPES
@@ -26,11 +27,11 @@ def test_oauth2_get_authorize_url_native():
     expected_vals = [
         ac.base_url + "v2/oauth2/authorize?",
         "client_id=" + ac.client_id,
-        "redirect_uri=" + quote_plus(ac.base_url + "v2/web/auth-code"),
-        "scope=" + quote_plus(" ".join(DEFAULT_REQUESTED_SCOPES)),
+        "redirect_uri=" + urllib.parse.quote_plus(ac.base_url + "v2/web/auth-code"),
+        "scope=" + urllib.parse.quote_plus(" ".join(DEFAULT_REQUESTED_SCOPES)),
         "state=" + "_default",
         "response_type=" + "code",
-        "code_challenge=" + quote_plus(flow_manager.challenge),
+        "code_challenge=" + urllib.parse.quote_plus(flow_manager.challenge),
         "code_challenge_method=" + "S256",
         "access_type=" + "online",
     ]
@@ -58,7 +59,7 @@ def test_oauth2_get_authorize_url_native():
         "scope=" + "scopes",
         "state=" + "state",
         "response_type=" + "code",
-        "code_challenge=" + quote_plus(remade_challenge),
+        "code_challenge=" + urllib.parse.quote_plus(remade_challenge),
         "code_challenge_method=" + "S256",
         "access_type=" + "offline",
     ]
@@ -84,7 +85,7 @@ def test_oauth2_get_authorize_url_confidential():
         ac.base_url + "v2/oauth2/authorize?",
         "client_id=" + ac.client_id,
         "redirect_uri=" + "uri",
-        "scope=" + quote_plus(" ".join(DEFAULT_REQUESTED_SCOPES)),
+        "scope=" + urllib.parse.quote_plus(" ".join(DEFAULT_REQUESTED_SCOPES)),
         "state=" + "_default",
         "response_type=" + "code",
         "access_type=" + "online",

--- a/tests/functional/auth/test_identity_map.py
+++ b/tests/functional/auth/test_identity_map.py
@@ -86,10 +86,8 @@ def test_identity_map_initialization_mixed_and_duplicate_values(client):
             "ae341a98-d274-11e5-b888-dbae3a8ba545",
         ],
     )
-    assert idmap.unresolved_ids == set(["ae341a98-d274-11e5-b888-dbae3a8ba545"])
-    assert idmap.unresolved_usernames == set(
-        ["sirosen@globus.org", "globus@globus.org"]
-    )
+    assert idmap.unresolved_ids == {"ae341a98-d274-11e5-b888-dbae3a8ba545"}
+    assert idmap.unresolved_usernames == {"sirosen@globus.org", "globus@globus.org"}
 
 
 def test_identity_map_initialization_batch_size(client):

--- a/tests/functional/auth/test_simple_auth_usage.py
+++ b/tests/functional/auth/test_simple_auth_usage.py
@@ -7,7 +7,7 @@ import globus_sdk
 from tests.common import get_last_request, register_api_route
 
 
-class StringWrapper(object):
+class StringWrapper:
     """Simple test object to be a non-string obj wrapping a string"""
 
     def __init__(self, s):

--- a/tests/functional/local_endpoint/test_personal.py
+++ b/tests/functional/local_endpoint/test_personal.py
@@ -1,16 +1,11 @@
 import os
 import shutil
 import tempfile
+from unittest import mock
 
 import pytest
 
 import globus_sdk
-
-try:
-    import mock
-except ImportError:
-    from unittest import mock
-
 
 _IS_WINDOWS = os.name == "nt"
 

--- a/tests/functional/transfer/test_iterable.py
+++ b/tests/functional/transfer/test_iterable.py
@@ -30,7 +30,7 @@ SERVER_LIST_TEXT = """{
 def test_server_list(client):
     epid = "epid"
     register_api_route(
-        "transfer", "/endpoint/{}/server_list".format(epid), body=SERVER_LIST_TEXT
+        "transfer", f"/endpoint/{epid}/server_list", body=SERVER_LIST_TEXT
     )
 
     res = client.endpoint_server_list(epid)

--- a/tests/functional/transfer/test_paginated.py
+++ b/tests/functional/transfer/test_paginated.py
@@ -25,7 +25,7 @@ SINGLE_PAGE_SEARCH_RESULT = {
     "limit": 100,
     "has_next_page": False,
     "DATA": [
-        {"DATA_TYPE": "endpoint", "display_name": "SDK Test Stub {}".format(x)}
+        {"DATA_TYPE": "endpoint", "display_name": f"SDK Test Stub {x}"}
         for x in range(100)
     ],
 }
@@ -38,7 +38,7 @@ MULTIPAGE_SEARCH_RESULTS = [
         "limit": 100,
         "has_next_page": True,
         "DATA": [
-            {"DATA_TYPE": "endpoint", "display_name": "SDK Test Stub {}".format(x)}
+            {"DATA_TYPE": "endpoint", "display_name": f"SDK Test Stub {x}"}
             for x in range(100)
         ],
     },

--- a/tests/functional/transfer/test_simple.py
+++ b/tests/functional/transfer/test_simple.py
@@ -19,10 +19,10 @@ def test_get_endpoint(client):
     """
     # register get_endpoint mock data
     register_api_route_fixture_file(
-        "transfer", "/endpoint/{}".format(GO_EP1_ID), "get_endpoint_goep1.json"
+        "transfer", f"/endpoint/{GO_EP1_ID}", "get_endpoint_goep1.json"
     )
     register_api_route_fixture_file(
-        "transfer", "/endpoint/{}".format(GO_EP2_ID), "get_endpoint_goep2.json"
+        "transfer", f"/endpoint/{GO_EP2_ID}", "get_endpoint_goep2.json"
     )
 
     # load the tutorial endpoint documents
@@ -45,7 +45,7 @@ def test_get_endpoint(client):
 def test_update_endpoint(client):
     epid = uuid.uuid1()
     register_api_route_fixture_file(
-        "transfer", "/endpoint/{}".format(epid), "ep_update.json", method="PUT"
+        "transfer", f"/endpoint/{epid}", "ep_update.json", method="PUT"
     )
 
     # NOTE: pass epid as UUID, not str
@@ -68,7 +68,7 @@ def test_update_endpoint_rewrites_activation_servers(client):
     """
     epid = "example-id"
     register_api_route_fixture_file(
-        "transfer", "/endpoint/{}".format(epid), "ep_create.json", method="PUT"
+        "transfer", f"/endpoint/{epid}", "ep_create.json", method="PUT"
     )
 
     # sending myproxy_server implicitly adds oauth_server=null

--- a/tests/functional/transfer/test_task_submit.py
+++ b/tests/functional/transfer/test_task_submit.py
@@ -2,7 +2,6 @@
 Tests for submitting Transfer and Delete tasks
 """
 import pytest
-import six
 
 import globus_sdk
 from tests.common import GO_EP1_ID, GO_EP2_ID, register_api_route
@@ -99,7 +98,7 @@ def test_transfer_submit_success(client, transfer_data):
     assert tdata["custom_param"] == "foo"
     assert tdata["sync_level"] == 0
 
-    tdata.add_item(six.b("/path/to/foo"), six.u("/path/to/bar"))
+    tdata.add_item(b"/path/to/foo", "/path/to/bar")
     tdata.add_symlink_item("linkfoo", "linkbar")
 
     res = client.submit_transfer(tdata)

--- a/tests/unit/authorizers/test_basic_authorizer.py
+++ b/tests/unit/authorizers/test_basic_authorizer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import base64
 
 import pytest
@@ -23,7 +22,7 @@ def test_set_authorization_header(authorizer):
     authorizer.set_authorization_header(header_dict)
     assert header_dict["Authorization"][:6] == "Basic "
     decoded = base64.b64decode(six.b(header_dict["Authorization"][6:])).decode("utf-8")
-    assert decoded == "{}:{}".format(USERNAME, PASSWORD)
+    assert decoded == f"{USERNAME}:{PASSWORD}"
 
 
 def test_set_authorization_header_existing(authorizer):
@@ -34,7 +33,7 @@ def test_set_authorization_header_existing(authorizer):
     authorizer.set_authorization_header(header_dict)
     assert header_dict["Authorization"][:6] == "Basic "
     decoded = base64.b64decode(six.b(header_dict["Authorization"][6:])).decode("utf-8")
-    assert decoded == "{}:{}".format(USERNAME, PASSWORD)
+    assert decoded == f"{USERNAME}:{PASSWORD}"
     assert header_dict["Header"] == "value"
 
 
@@ -46,7 +45,7 @@ def test_handle_missing_authorization(authorizer):
 
 
 @pytest.mark.parametrize(
-    "username, password", [("user", u"テスト"), (u"дум", "pass"), (u"テスト", u"дум")]
+    "username, password", [("user", "テスト"), ("дум", "pass"), ("テスト", "дум")]
 )
 def test_unicode_handling(username, password):
     """
@@ -59,4 +58,4 @@ def test_unicode_handling(username, password):
 
     assert header_dict["Authorization"][:6] == "Basic "
     decoded = base64.b64decode(six.b(header_dict["Authorization"][6:])).decode("utf-8")
-    assert decoded == u"{}:{}".format(username, password)
+    assert decoded == f"{username}:{password}"

--- a/tests/unit/authorizers/test_basic_authorizer.py
+++ b/tests/unit/authorizers/test_basic_authorizer.py
@@ -1,7 +1,6 @@
 import base64
 
 import pytest
-import six
 
 from globus_sdk.authorizers import BasicAuthorizer
 
@@ -21,7 +20,9 @@ def test_set_authorization_header(authorizer):
     header_dict = {}
     authorizer.set_authorization_header(header_dict)
     assert header_dict["Authorization"][:6] == "Basic "
-    decoded = base64.b64decode(six.b(header_dict["Authorization"][6:])).decode("utf-8")
+    decoded = base64.b64decode(header_dict["Authorization"][6:].encode("utf-8")).decode(
+        "utf-8"
+    )
     assert decoded == f"{USERNAME}:{PASSWORD}"
 
 
@@ -32,7 +33,9 @@ def test_set_authorization_header_existing(authorizer):
     header_dict = {"Header": "value", "Authorization": "previous_value"}
     authorizer.set_authorization_header(header_dict)
     assert header_dict["Authorization"][:6] == "Basic "
-    decoded = base64.b64decode(six.b(header_dict["Authorization"][6:])).decode("utf-8")
+    decoded = base64.b64decode(header_dict["Authorization"][6:].encode("utf-8")).decode(
+        "utf-8"
+    )
     assert decoded == f"{USERNAME}:{PASSWORD}"
     assert header_dict["Header"] == "value"
 
@@ -57,5 +60,7 @@ def test_unicode_handling(username, password):
     authorizer.set_authorization_header(header_dict)
 
     assert header_dict["Authorization"][:6] == "Basic "
-    decoded = base64.b64decode(six.b(header_dict["Authorization"][6:])).decode("utf-8")
+    decoded = base64.b64decode(header_dict["Authorization"][6:].encode("utf-8")).decode(
+        "utf-8"
+    )
     assert decoded == f"{username}:{password}"

--- a/tests/unit/authorizers/test_client_credentials_authorizer.py
+++ b/tests/unit/authorizers/test_client_credentials_authorizer.py
@@ -1,12 +1,8 @@
+from unittest import mock
+
 import pytest
 
 from globus_sdk.authorizers import ClientCredentialsAuthorizer
-
-try:
-    import mock
-except ImportError:
-    from unittest import mock
-
 
 ACCESS_TOKEN = "access_token_1"
 EXPIRES_AT = -1

--- a/tests/unit/authorizers/test_refresh_token_authorizer.py
+++ b/tests/unit/authorizers/test_refresh_token_authorizer.py
@@ -1,12 +1,8 @@
+from unittest import mock
+
 import pytest
 
 from globus_sdk.authorizers import RefreshTokenAuthorizer
-
-try:
-    import mock
-except ImportError:
-    from unittest import mock
-
 
 REFRESH_TOKEN = "refresh_token_1"
 ACCESS_TOKEN = "access_token_1"

--- a/tests/unit/authorizers/test_renewing_authorizer.py
+++ b/tests/unit/authorizers/test_renewing_authorizer.py
@@ -15,7 +15,7 @@ class MockRenewer(RenewingAuthorizer):
     def __init__(self, token_data, **kwargs):
         self.token_data = token_data
         self.token_response = mock.Mock()
-        super(MockRenewer, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
     def _get_token_response(self):
         return self.token_response

--- a/tests/unit/authorizers/test_renewing_authorizer.py
+++ b/tests/unit/authorizers/test_renewing_authorizer.py
@@ -1,13 +1,9 @@
 import time
+from unittest import mock
 
 import pytest
 
 from globus_sdk.authorizers.renewing import EXPIRES_ADJUST_SECONDS, RenewingAuthorizer
-
-try:
-    import mock
-except ImportError:
-    from unittest import mock
 
 
 class MockRenewer(RenewingAuthorizer):

--- a/tests/unit/responses/test_activation_response.py
+++ b/tests/unit/responses/test_activation_response.py
@@ -3,7 +3,6 @@ import time
 
 import pytest
 import requests
-import six
 
 from globus_sdk.transfer.response import ActivationRequirementsResponse
 
@@ -28,7 +27,7 @@ def make_response(
     }
     response = requests.Response()
     response.headers["Content-Type"] = "application/json"
-    response._content = six.b(json.dumps(data))
+    response._content = json.dumps(data).encode("utf-8")
     return ActivationRequirementsResponse(response)
 
 

--- a/tests/unit/responses/test_oauth_token_response.py
+++ b/tests/unit/responses/test_oauth_token_response.py
@@ -6,9 +6,9 @@ def test_by_resource_server_lookups(oauth_token_response):
 
     # things which should hold for all
     for n in (1, 2, 3):
-        name = "resource_server_{}".format(n)
+        name = f"resource_server_{n}"
         for attr in ("access_token", "refresh_token", "resource_server"):
-            assert by_rs[name][attr] == "{}_{}".format(attr, n)
+            assert by_rs[name][attr] == f"{attr}_{n}"
 
         assert "expires_in" not in by_rs[name]
         assert "expires_at_seconds" in by_rs[name]

--- a/tests/unit/responses/test_response.py
+++ b/tests/unit/responses/test_response.py
@@ -41,7 +41,7 @@ def http_no_content_type_response():
 @pytest.fixture
 def malformed_http_response():
     malformed_response = requests.Response()
-    malformed_response._content = six.b("{")
+    malformed_response._content = b"{"
     malformed_response.headers["Content-Type"] = "application/json"
     return _TestResponse("{", GlobusHTTPResponse(malformed_response))
 

--- a/tests/unit/responses/test_response.py
+++ b/tests/unit/responses/test_response.py
@@ -3,7 +3,6 @@ from collections import namedtuple
 
 import pytest
 import requests
-import six
 
 from globus_sdk.response import GlobusHTTPResponse, GlobusResponse
 
@@ -26,7 +25,7 @@ def list_response():
 def json_http_response():
     json_data = {"label1": "value1", "label2": "value2"}
     json_response = requests.Response()
-    json_response._content = six.b(json.dumps(json_data))
+    json_response._content = json.dumps(json_data).encode("utf-8")
     json_response.headers["Content-Type"] = "application/json"
     return _TestResponse(json_data, GlobusHTTPResponse(json_response))
 
@@ -50,7 +49,7 @@ def malformed_http_response():
 def text_http_response():
     text_data = "text data"
     text_response = requests.Response()
-    text_response._content = six.b(text_data)
+    text_response._content = text_data.encode("utf-8")
     text_response.headers["Content-Type"] = "text/plain"
     return _TestResponse(text_data, GlobusHTTPResponse(text_response))
 

--- a/tests/unit/test_base_client.py
+++ b/tests/unit/test_base_client.py
@@ -3,7 +3,6 @@ import logging.handlers
 import uuid
 
 import pytest
-import six
 
 import globus_sdk
 from globus_sdk.base import BaseClient, merge_params, safe_stringify, slash_join
@@ -25,7 +24,7 @@ def base_client():
 ERROR_STATUS_CODES = (400, 404, 405, 409, 500, 503)
 
 
-class testObject(object):
+class testObject:
     """test obj for safe_stringify testing"""
 
     def __str__(self):
@@ -61,7 +60,7 @@ def test_set_app_name(base_client):
     base_client.set_app_name(app_name)
     # confirm results
     assert base_client.app_name == app_name
-    assert base_client._headers["User-Agent"] == "{0}/{1}".format(
+    assert base_client._headers["User-Agent"] == "{}/{}".format(
         base_client.BASE_USER_AGENT, app_name
     )
 
@@ -192,12 +191,12 @@ def test_merge_params():
     assert params == expected
 
 
-@pytest.mark.parametrize("value", ["1", str(1), b"1", u"1", 1, testObject()])
+@pytest.mark.parametrize("value", ["1", str(1), b"1", "1", 1, testObject()])
 def test_safe_stringify(value):
     """
     safe_stringifies strings, bytes, explicit unicode, an int, an object
     and confirms safe_stringify returns utf-8 encoding for all inputs
     """
     safe_value = safe_stringify(value)
-    assert safe_value == u"1"
-    assert type(safe_value) == six.text_type
+    assert safe_value == "1"
+    assert type(safe_value) == str

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,10 +1,10 @@
+import io
 import os
+from configparser import ConfigParser
 from contextlib import contextmanager
 from unittest import mock
 
 import pytest
-import six
-from six.moves.configparser import ConfigParser
 
 import globus_sdk.config
 
@@ -23,7 +23,7 @@ def custom_config(configdata):
 
     # not file-like, wrap it
     if not hasattr(configdata, "read"):
-        configdata = six.StringIO(configdata)
+        configdata = io.StringIO(configdata)
 
     def loadconf(cfgparser):
         # try to use the new version of this method, added in py3.2
@@ -117,7 +117,7 @@ def test_conf_get():
     Confirms that get reads expected results
     Tests section, environment, failover_to_general, and check_env params
     """
-    confio = six.StringIO(
+    confio = io.StringIO(
         """\
 [general]
 option = general_value
@@ -166,7 +166,7 @@ def test_get_service_url():
     Confirms get_service_url returns expected results
     Tests environments, services, and missing values
     """
-    confio = six.StringIO(
+    confio = io.StringIO(
         """\
 [general]
 
@@ -208,7 +208,7 @@ def test_get_ssl_verify():
     Confirms get_ssl_verify returns expected results
     Tests true/false, and invalid values
     """
-    confio = six.StringIO(
+    confio = io.StringIO(
         """\
 [general]
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -76,7 +76,7 @@ def test_get_lib_config():
 
     # and check that 'default' and 'preview' are populated
     for env in ("default", "preview"):
-        section = "environment {}".format(env)
+        section = f"environment {env}"
         for key in (
             "auth_service",
             "nexus_service",

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,16 +1,12 @@
 import os
 from contextlib import contextmanager
+from unittest import mock
 
 import pytest
 import six
 from six.moves.configparser import ConfigParser
 
 import globus_sdk.config
-
-try:
-    import mock
-except ImportError:
-    from unittest import mock
 
 
 @contextmanager

--- a/tests/unit/test_exc.py
+++ b/tests/unit/test_exc.py
@@ -3,7 +3,6 @@ from collections import namedtuple
 
 import pytest
 import requests
-import six
 
 from globus_sdk.exc import (
     AuthAPIError,
@@ -22,9 +21,9 @@ def _mk_response(data, status, headers=None, data_transform=None):
     resp = requests.Response()
 
     if data_transform:
-        resp._content = six.b(data_transform(data))
+        resp._content = data_transform(data).encode("utf-8")
     else:
-        resp._content = six.b(data)
+        resp._content = data.encode("utf-8")
 
     if headers:
         resp.headers.update(headers)

--- a/tests/unit/test_imports.py
+++ b/tests/unit/test_imports.py
@@ -25,7 +25,7 @@ PYTHON_BINARY = os.environ.get("GLOBUS_TEST_PY", sys.executable)
 )
 def test_import_str(importstring):
     proc = subprocess.Popen(
-        '{} -c "{}"'.format(PYTHON_BINARY, importstring),
+        f'{PYTHON_BINARY} -c "{importstring}"',
         shell=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,

--- a/tests/unit/test_transfer_paging.py
+++ b/tests/unit/test_transfer_paging.py
@@ -10,7 +10,7 @@ from globus_sdk.transfer.response import IterableTransferResponse
 N = 25
 
 
-class PagingSimulator(object):
+class PagingSimulator:
     def __init__(self, n):
         self.n = n  # the number of simulated items
 
@@ -137,7 +137,7 @@ def test_iterable_func(paging_simulator):
 
     generator = pr.iterable_func()
     for i in range(N):
-        assert six.next(generator)["value"] == i
+        assert next(generator)["value"] == i
 
     with pytest.raises(StopIteration):
-        six.next(generator)
+        next(generator)

--- a/tests/unit/test_transfer_paging.py
+++ b/tests/unit/test_transfer_paging.py
@@ -2,7 +2,6 @@ import json
 
 import pytest
 import requests
-import six
 
 from globus_sdk.transfer.paging import PaginatedResource
 from globus_sdk.transfer.response import IterableTransferResponse
@@ -35,7 +34,7 @@ class PagingSimulator:
 
         # make the simulated response
         response = requests.Response()
-        response._content = six.b(json.dumps(data))
+        response._content = json.dumps(data).encode("utf-8")
         response.headers["Content-Type"] = "application/json"
         return IterableTransferResponse(response)
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,4 +1,3 @@
-# coding=utf-8
 from globus_sdk import utils
 
 
@@ -18,6 +17,6 @@ def test_safe_b64encode_ascii():
 
 def test_sha256string():
     test_string = "foo"
-    expected_sha = "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f" "98a5e886266e7ae"
+    expected_sha = "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae"
 
     assert utils.sha256_string(test_string) == expected_sha

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{39,38,37,36,27}
+envlist = py{39,38,37,36}
 skip_missing_interpreters = true
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ skip_missing_interpreters = true
 
 [testenv]
 usedevelop = true
-extras = development
+extras = dev
 commands = pytest -v --cov=globus_sdk
 
 [testenv:lint]
@@ -13,7 +13,7 @@ skip_install = true
 commands = pre-commit run --all-files
 
 [testenv:docs]
-extras = development
+extras = dev
 whitelist_externals = rm
 changedir = docs/
 # clean the build dir before rebuilding


### PR DESCRIPTION
- Remove it from package data and the build matrix
- Apply `pyupgrade` and invoke that in cycles until it, `black`, and a handful of manual edits for `flake8` converge
- Remove `six`
- blacken-docs and look for py2-compatible bits of doc (turned out just to be a hunt for `raw_input`)

There are so many files changed by pyupgrade, it's a bit dizzying. I'm going to use GitHub to self-review and try to double-check everything, but obviously this deserves a careful read.

We have the `1.x-line` branch if we ever need to go back. This is for `main`.