### PR TITLE
Add a warning to the tutorial about the Native App setting

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -55,6 +55,10 @@ Enter the following pieces of information:
 
 and click "Create App".
 
+.. warning::
+
+    The **Native App** setting cannot be changed after a client is created.
+
 .. _tutorial_step2:
 
 Step 2: Get and Save Client ID


### PR DESCRIPTION
Call it out as not being changeable after creation.
This should help ensure that nobody misses the checkbox when setting up a client.

I considered trying to explain more here, but I don't think it would be helpful.