### PR TITLE
Refactor decode_id_token (decompose it)

### DIFF
--- a/globus_sdk/auth/token_response.py
+++ b/globus_sdk/auth/token_response.py
@@ -3,7 +3,6 @@ import logging
 import time
 
 import jwt
-import requests
 
 from globus_sdk.response import GlobusHTTPResponse
 
@@ -162,32 +161,40 @@ class OAuthTokenResponse(GlobusHTTPResponse):
         """
         return self._by_scopes
 
-    def decode_id_token(self):
+    def decode_id_token(self, openid_configuration=None, jwk=None):
         """
-        A parsed ID Token (OIDC) as a dict.
+        Parse the included ID Token (OIDC) as a dict and return it.
+
+        :param openid_configuration: The OIDC config as a GlobusHTTPResponse or dict.
+            When not provided, it will be fetched automatically.
+        :type openid_configuration: dict or GlobusHTTPResponse
+        :param jwk: The JWK as a cryptography public key object. When not provided, it
+            will be fetched and parsed automatically.
+        :type jwk: RSAPublicKey
         """
-        logger.info('Decoding ID Token "{}"'.format(self["id_token"]))
+        logger.info('Decoding ID Token "%s"', self["id_token"])
         auth_client = self._client
 
-        logger.debug("Fetch JWK Data: Start")
-        oidc_conf = auth_client.get("/.well-known/openid-configuration")
-        jwks_uri = oidc_conf["jwks_uri"]
-        signing_algos = oidc_conf["id_token_signing_alg_values_supported"]
+        if not openid_configuration:
+            logger.debug("No OIDC Config provided, autofetching...")
+            openid_configuration = auth_client.get_openid_configuration()
 
-        # use the auth_client's decision on ssl_verify=yes/no
-        jwk_data = requests.get(jwks_uri, verify=auth_client._verify).json()
-        logger.debug("Fetch JWK Data: Complete")
-        # decode from JWK to an RSA PEM key for JWT decoding
-        jwk_as_pem = jwt.algorithms.RSAAlgorithm.from_jwk(
-            json.dumps(jwk_data["keys"][0])
-        )
+        if not jwk:
+            logger.debug("No JWK provided, autofetching + decoding...")
+            jwk = auth_client.get_jwk(
+                openid_configuration=openid_configuration, as_pem=True
+            )
 
-        return jwt.decode(
+        logger.debug("final step: decode with JWK")
+        signing_algos = openid_configuration["id_token_signing_alg_values_supported"]
+        decoded = jwt.decode(
             self["id_token"],
-            jwk_as_pem,
+            jwk,
             algorithms=signing_algos,
             audience=auth_client.client_id,
         )
+        logger.debug("decode ID token finished successfully")
+        return decoded
 
     def __str__(self):
         # Make printing responses more convenient by only showing the

--- a/globus_sdk/auth/token_response.py
+++ b/globus_sdk/auth/token_response.py
@@ -4,6 +4,7 @@ import time
 
 import jwt
 
+from globus_sdk import exc
 from globus_sdk.response import GlobusHTTPResponse
 
 logger = logging.getLogger(__name__)
@@ -165,6 +166,8 @@ class OAuthTokenResponse(GlobusHTTPResponse):
         """
         Parse the included ID Token (OIDC) as a dict and return it.
 
+        If you provide the `jwk`, you must also provide `openid_configuration`.
+
         :param openid_configuration: The OIDC config as a GlobusHTTPResponse or dict.
             When not provided, it will be fetched automatically.
         :type openid_configuration: dict or GlobusHTTPResponse
@@ -176,6 +179,10 @@ class OAuthTokenResponse(GlobusHTTPResponse):
         auth_client = self._client
 
         if not openid_configuration:
+            if jwk:
+                raise exc.GlobusSDKUsageError(
+                    "passing jwk without openid configuration is not allowed"
+                )
             logger.debug("No OIDC Config provided, autofetching...")
             openid_configuration = auth_client.get_openid_configuration()
 

--- a/globus_sdk/base.py
+++ b/globus_sdk/base.py
@@ -430,7 +430,12 @@ class BaseClient:
             )
             self.authorizer.set_authorization_header(rheaders)
 
-        url = slash_join(self.base_url, path)
+        # if a client is asked to make a request against a full URL, not just the path
+        # component, then do not resolve the path, simply pass it through as the URL
+        if path.startswith("https://") or path.startswith("http://"):
+            url = path
+        else:
+            url = slash_join(self.base_url, path)
         self.logger.debug(f"request will hit URL:{url}")
 
         # because a 401 can trigger retry, we need to wrap the retry-able thing

--- a/tests/functional/auth/test_id_token.py
+++ b/tests/functional/auth/test_id_token.py
@@ -1,0 +1,128 @@
+import json
+
+import jwt
+import pytest
+
+import globus_sdk
+from tests.common import register_api_route
+
+OIDC_CONFIG = {
+    "issuer": "https://auth.globus.org",
+    "authorization_endpoint": "https://auth.globus.org/v2/oauth2/authorize",
+    "userinfo_endpoint": "https://auth.globus.org/v2/oauth2/userinfo",
+    "token_endpoint": "https://auth.globus.org/v2/oauth2/token",
+    "revocation_endpoint": "https://auth.globus.org/v2/oauth2/token/revoke",
+    "jwks_uri": "https://auth.globus.org/jwk.json",
+    "response_types_supported": ["code", "token", "token id_token", "id_token"],
+    "id_token_signing_alg_values_supported": ["RS512"],
+    "scopes_supported": ["openid", "email", "profile"],
+    "token_endpoint_auth_methods_supported": ["client_secret_basic"],
+    "claims_supported": [
+        "at_hash",
+        "aud",
+        "email",
+        "exp",
+        "name",
+        "nonce",
+        "preferred_username",
+        "iat",
+        "iss",
+        "sub",
+    ],
+    "subject_types_supported": ["public"],
+}
+
+JWK = {
+    "keys": [
+        {
+            "alg": "RS512",
+            "e": "AQAB",
+            "kty": "RSA",
+            "n": "73l27Yp7WT2c0Ve7EoGJ13AuKzg-GHU7Mpgx0JKa_hO04gAXSVXRadQy7gmdLLtAK8uBVcV0fHGgsBl4J92t-I7hayiJSLbgbX-sZhI_OfegeOLcSNB9poPS9w60XGqR9buYOW2x-KXXitsmyHXNmg_-1u0uqfKHu9pmST8dcjUYXTM5F3oJpQKeJlSH8daMlDks4xb9Y83EEFRv-ppY965-WTm2NW4pwLlbgGTWFvZ6YS6GTb-mfGwGuzStI0lKZ7dOFx9ryYQ4wSoUVHtIrypT-gbuaT90Z2SkwOH-GaEZJkudctBeGpieOsyC7P40UXpwgGNFy3xoWL4vHpnHmQ",  # noqa: E501
+            "use": "sig",
+        }
+    ]
+}
+JWK_PEM = jwt.algorithms.RSAAlgorithm.from_jwk(json.dumps(JWK["keys"][0]))
+
+TOKEN_PAYLOAD = {
+    "access_token": "auth_access_token",
+    "scope": "profile email openid",
+    "expires_in": 172800,
+    "token_type": "Bearer",
+    "resource_server": "auth.globus.org",
+    "state": "_default",
+    "refresh_token": "auth_refresh_token",
+    "other_tokens": [
+        {
+            "access_token": "transfer_access_token",
+            "scope": "urn:globus:auth:scope:transfer.api.globus.org:all",
+            "expires_in": 172800,
+            "token_type": "Bearer",
+            "resource_server": "transfer.api.globus.org",
+            "state": "_default",
+            "refresh_token": "transfer_refresh",
+        }
+    ],
+    # this is a real ID token
+    # and since the JWK is real as well, it should decode correctly
+    "id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzUxMiJ9.eyJzdWIiOiJjOGFhZDQzZS1kMjc0LTExZTUtYmY5OC04YjAyODk2Y2Y3ODIiLCJvcmdhbml6YXRpb24iOiJHbG9idXMiLCJuYW1lIjoiU3RlcGhlbiBSb3NlbiIsInByZWZlcnJlZF91c2VybmFtZSI6InNpcm9zZW4yQGdsb2J1c2lkLm9yZyIsImlkZW50aXR5X3Byb3ZpZGVyIjoiNDExNDM3NDMtZjNjOC00ZDYwLWJiZGItZWVlY2FiYTg1YmQ5IiwiaWRlbnRpdHlfcHJvdmlkZXJfZGlzcGxheV9uYW1lIjoiR2xvYnVzIElEIiwiZW1haWwiOiJzaXJvc2VuQHVjaGljYWdvLmVkdSIsImxhc3RfYXV0aGVudGljYXRpb24iOjE2MjE0ODEwMDYsImlkZW50aXR5X3NldCI6W3sic3ViIjoiYzhhYWQ0M2UtZDI3NC0xMWU1LWJmOTgtOGIwMjg5NmNmNzgyIiwib3JnYW5pemF0aW9uIjoiR2xvYnVzIiwibmFtZSI6IlN0ZXBoZW4gUm9zZW4iLCJ1c2VybmFtZSI6InNpcm9zZW4yQGdsb2J1c2lkLm9yZyIsImlkZW50aXR5X3Byb3ZpZGVyIjoiNDExNDM3NDMtZjNjOC00ZDYwLWJiZGItZWVlY2FiYTg1YmQ5IiwiaWRlbnRpdHlfcHJvdmlkZXJfZGlzcGxheV9uYW1lIjoiR2xvYnVzIElEIiwiZW1haWwiOiJzaXJvc2VuQHVjaGljYWdvLmVkdSIsImxhc3RfYXV0aGVudGljYXRpb24iOjE2MjE0ODEwMDZ9LHsic3ViIjoiYjZlMjI3ZTgtZGI1Mi0xMWU1LWI2ZmYtYzNiMWNjMjU5ZTBkIiwibmFtZSI6bnVsbCwidXNlcm5hbWUiOiJzaXJvc2VuK2JhZGVtYWlsQGdsb2J1cy5vcmciLCJpZGVudGl0eV9wcm92aWRlciI6IjkyN2Q3MjM4LWY5MTctNGViMi05YWNlLWM1MjNmYTliYTM0ZSIsImlkZW50aXR5X3Byb3ZpZGVyX2Rpc3BsYXlfbmFtZSI6Ikdsb2J1cyBTdGFmZiIsImVtYWlsIjoic2lyb3NlbitiYWRlbWFpbEBnbG9idXMub3JnIiwibGFzdF9hdXRoZW50aWNhdGlvbiI6bnVsbH0seyJzdWIiOiJmN2Y4OWQwYS1kYzllLTExZTUtYWRkMC1hM2NiZDFhNTU5YjMiLCJuYW1lIjpudWxsLCJ1c2VybmFtZSI6InNpcm9zZW4rYmFkZW1haWwyQGdsb2J1cy5vcmciLCJpZGVudGl0eV9wcm92aWRlciI6IjkyN2Q3MjM4LWY5MTctNGViMi05YWNlLWM1MjNmYTliYTM0ZSIsImlkZW50aXR5X3Byb3ZpZGVyX2Rpc3BsYXlfbmFtZSI6Ikdsb2J1cyBTdGFmZiIsImVtYWlsIjoic2lyb3NlbitiYWRlbWFpbDJAZ2xvYnVzLm9yZyIsImxhc3RfYXV0aGVudGljYXRpb24iOm51bGx9XSwiaXNzIjoiaHR0cHM6Ly9hdXRoLmdsb2J1cy5vcmciLCJhdWQiOiI3ZmI1OGUwMC04MzlkLTQ0ZTMtODA0Ny0xMGE1MDI2MTJkY2EiLCJleHAiOjE2MjE2NTM4MTEsImlhdCI6MTYyMTQ4MTAxMSwiYXRfaGFzaCI6IjFQdlVhbmNFdUxfc2cxV1BsNWx1TUVGR2tjTDZQaDh1cWdpVUZzejhkZUEifQ.CtfnFtfM32ICo0euHv9GnpVHFL1jWz0NriPTXAv6w08Ylk9JBJtmB3oMKNSO-1TGoWUPFDp9TFFk6N32VyF0hsVDtT5DT3t5oq0qfqbPrZA3R04HARW0xtcK_ejNDHBmj6wysey3EzjT764XTvcGOe63CKQ_RJm97ulVaseIT0Aet7AYo5tQuOiSOQ70xzL7Oax3W6TrWi3FIAA-PIMSrAJKbsG7imGOVkaIObG9a-X5yTOcrB4IG4Wat-pN_QiCiiOw_LDCF-r455PwalmnSGUugMYfsdL2k3UxqwOMLIppHnx5-UVAzj3mygj8eZTp6imjqxNMdakS3vhG8dtxbw",  # noqa: E501
+}
+
+
+@pytest.fixture
+def client():
+    # this client ID is the audience for the above id_token
+    # the client_id must match the audience in order for the decode to work (we pass it
+    # as the audience during decoding)
+    return globus_sdk.AuthClient(client_id="7fb58e00-839d-44e3-8047-10a502612dca")
+
+
+@pytest.fixture(autouse=True)
+def register_token_response():
+    register_api_route(
+        "auth", "/v2/oauth2/token", method="POST", body=json.dumps(TOKEN_PAYLOAD)
+    )
+
+
+@pytest.fixture
+def token_response(register_token_response, client):
+    return client.oauth2_token(
+        {
+            "grant_type": "authorization_code",
+            "code": "foo",
+            "redirect_uri": "https://bar.example.org/",
+        }
+    )
+
+
+def test_decode_id_token(token_response):
+    register_api_route(
+        "auth",
+        "/.well-known/openid-configuration",
+        method="GET",
+        body=json.dumps(OIDC_CONFIG),
+    )
+    register_api_route("auth", "/jwk.json", method="GET", body=json.dumps(JWK))
+
+    decoded = token_response.decode_id_token()
+    assert decoded["preferred_username"] == "sirosen2@globusid.org"
+
+
+def test_decode_id_token_with_saved_oidc_config(token_response):
+    register_api_route("auth", "/jwk.json", method="GET", body=json.dumps(JWK))
+
+    decoded = token_response.decode_id_token(openid_configuration=OIDC_CONFIG)
+    assert decoded["preferred_username"] == "sirosen2@globusid.org"
+
+
+def test_decode_id_token_with_saved_oidc_config_and_jwk(token_response):
+    decoded = token_response.decode_id_token(
+        openid_configuration=OIDC_CONFIG, jwk=JWK_PEM
+    )
+    assert decoded["preferred_username"] == "sirosen2@globusid.org"
+
+
+def test_invalid_decode_id_token_usage(token_response):
+    with pytest.raises(globus_sdk.exc.GlobusSDKUsageError):
+        token_response.decode_id_token(jwk=JWK_PEM)


### PR DESCRIPTION
decode_id_token() previously did two round-trips to Auth + a decoding step on the JWK prior to handling the ID token. This is prohibitively expensive if anyone were to try to build a service using decode_id_token. Instead, you would have to rewrite the function yourself.

So this is now broken down into two fetch methods, one of which can optionally do a decoding step, and their results *may* be passed to decode_id_token. As a result, loading data over the network can always be taken care of separately from parsing an id token, and parsing a JWK to a public key object can also be included in those steps.

AuthClient.get_openid_configuration is a new method for fetching OIDC config.
AuthClient.get_jwk is a new method for getting, and optionally parsing the JWK.

Unfortunately, the JWK URI provided by OIDC config is a full string including `https://`, not just the path component. We could strip the leading `https://auth.globus.org` from it, but I chose to allow `BaseClient._request` to handle requests to full URLs. It's a single line of dispatch there vs parsing and unparsing the JWK URI.

get_jwk can take OIDC config as a parameter, or fetch it automatically.

decode_id_token can take both the OIDC config and the JWK as paramters, or fetch and use both automatically (and it will pass OIDC config to the JWK to avoid a double-fetch of that data).

If an application wants to cache the parsed JWK and OIDC config, that is possible, and they should simply be passed back to the decode_id_token function. Caching the parsed JWK would require defining some serialization format, but that's not the SDK's problem to solve. And we could make things more variable by letting parsing of the JWK to a public key be separated out even further, but that does not seem to be necessary.

closes #298

---

I'm submitting this as a draft so that I can ask if this is the right interface to provide. I haven't added new tests yet but I think this may actually simplify testing of `decode_id_token`. At the very least, I think it doesn't make things worse, although maybe that full-URI handling in BaseClient is a mistake.

I'd like to split this up because right now I don't think `decode_id_token` is very useful.