### PR TITLE
Import and adapt globus-sdk-tokenstorage

### DIFF
--- a/src/globus_sdk/__init__.py
+++ b/src/globus_sdk/__init__.py
@@ -66,5 +66,4 @@ __all__ = (
 
 # configure logging for a library, per python best practices:
 # https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library
-# NB: this won't work on py2.6 because `logging.NullHandler` wasn't added yet
 logging.getLogger("globus_sdk").addHandler(logging.NullHandler())

--- a/src/globus_sdk/auth/__init__.py
+++ b/src/globus_sdk/auth/__init__.py
@@ -6,6 +6,10 @@ from globus_sdk.auth.client_types import (
 from globus_sdk.auth.identity_map import IdentityMap
 from globus_sdk.auth.oauth2_authorization_code import GlobusAuthorizationCodeFlowManager
 from globus_sdk.auth.oauth2_native_app import GlobusNativeAppFlowManager
+from globus_sdk.auth.token_response import (
+    OAuthDependentTokenResponse,
+    OAuthTokenResponse,
+)
 
 __all__ = [
     "AuthClient",
@@ -14,4 +18,6 @@ __all__ = [
     "IdentityMap",
     "GlobusNativeAppFlowManager",
     "GlobusAuthorizationCodeFlowManager",
+    "OAuthDependentTokenResponse",
+    "OAuthTokenResponse",
 ]

--- a/src/globus_sdk/tokenstorage/__init__.py
+++ b/src/globus_sdk/tokenstorage/__init__.py
@@ -1,0 +1,5 @@
+from globus_sdk.tokenstorage.base import FileAdapter, StorageAdapter
+from globus_sdk.tokenstorage.file_adapters import SimpleJSONFileAdapter
+from globus_sdk.tokenstorage.sqlite_adapter import SQLiteAdapter
+
+__all__ = ("SimpleJSONFileAdapter", "SQLiteAdapter", "StorageAdapter", "FileAdapter")

--- a/src/globus_sdk/tokenstorage/base.py
+++ b/src/globus_sdk/tokenstorage/base.py
@@ -1,0 +1,51 @@
+import abc
+import contextlib
+import os
+import typing
+
+
+class StorageAdapter(metaclass=abc.ABCMeta):
+    @abc.abstractmethod
+    def store(self, token_response) -> None:
+        pass
+
+    def on_refresh(self, token_response) -> None:
+        """
+        By default, the on_refresh handler for a token storage adapter simply
+        stores the token response.
+        """
+        self.store(token_response)
+
+
+class FileAdapter(StorageAdapter, metaclass=abc.ABCMeta):
+    """
+    File adapters are for single-user cases, where we can assume that there's a
+    simple file-per-user and users are only ever attempting to read their own
+    files.
+    """
+
+    filename: str
+
+    @abc.abstractmethod
+    def read_as_dict(self) -> typing.Dict:
+        raise NotImplementedError
+
+    def file_exists(self) -> bool:
+        """
+        Check if the file used by this file storage adapter exists.
+        """
+        return os.path.exists(self.filename)
+
+    @contextlib.contextmanager
+    def user_only_umask(self):
+        """
+        a context manager to deny rwx to Group and World, x to User
+
+        this does not create a file, but ensures that if a file is created while in the
+        context manager, its permissions will be correct on unix systems
+        """
+        old_umask = os.umask(0o177)
+        try:
+            yield
+        finally:
+            os.umask(old_umask)

--- a/src/globus_sdk/tokenstorage/base.py
+++ b/src/globus_sdk/tokenstorage/base.py
@@ -1,12 +1,23 @@
 import abc
 import contextlib
 import os
-import typing
+from typing import Dict, Optional
 
 
 class StorageAdapter(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def store(self, token_response) -> None:
+        pass
+
+    @abc.abstractmethod
+    def get_token_data(self, resource_server: str) -> Optional[Dict]:
+        """
+        Lookup token data for a resource server
+
+        Either returns a dict with the access token, refresh token (optional), and
+        expiration time, or returns ``None``, indicating that there was no data for that
+        resource server.
+        """
         pass
 
     def on_refresh(self, token_response) -> None:
@@ -25,10 +36,6 @@ class FileAdapter(StorageAdapter, metaclass=abc.ABCMeta):
     """
 
     filename: str
-
-    @abc.abstractmethod
-    def read_as_dict(self) -> typing.Dict:
-        raise NotImplementedError
 
     def file_exists(self) -> bool:
         """

--- a/src/globus_sdk/tokenstorage/file_adapters.py
+++ b/src/globus_sdk/tokenstorage/file_adapters.py
@@ -1,0 +1,90 @@
+import json
+import typing
+
+from globus_sdk.auth import OAuthTokenResponse
+from globus_sdk.tokenstorage.base import FileAdapter
+from globus_sdk.version import __version__
+
+
+class SimpleJSONFileAdapter(FileAdapter):
+    """
+    :param filename: the name of the file to write to and read from
+    :param resource_server: the resource server name for tokens to look up
+                            in a token response object
+    :param scopes: a list of scope names for tokens to look up in a token
+                   response object
+
+    A storage adapter for storing tokens in JSON files.
+    Callers must provide exactly one of ``resource_server`` and ``scopes``
+    """
+
+    def __init__(
+        self,
+        filename: str,
+        resource_server: typing.Optional[str] = None,
+        scopes: typing.Optional[str] = None,
+    ):
+        if resource_server and scopes:
+            raise ValueError("cannot take both resource_server and scopes")
+        elif not resource_server and not scopes:
+            raise ValueError("you must pass resource_server or scopes")
+
+        self.filename = filename
+        self.resource_server = resource_server
+        self.scopes = scopes
+
+    def _lookup_data_from_response(
+        self, token_response: "OAuthTokenResponse"
+    ) -> typing.Dict:
+        """
+        Given a token response, extract the token data for the configured
+        scopes or resource servers of this adapter
+        """
+        # extract desired data and copy as a new dict
+        if self.resource_server:
+            return dict(token_response.by_resource_server[self.resource_server])
+        elif self.scopes:
+            # NOTE: this can fail if `self.scopes` isn't for exactly one
+            # resource server, but then the failure will simply propagate up
+            return dict(token_response.by_scopes[self.scopes])
+        else:
+            raise NotImplementedError("neither resource_server nor scopes are set")
+
+    def store(self, token_response: "OAuthTokenResponse"):
+        """
+        By default, ``self.on_refresh`` is just an alias for this function.
+
+        Given a token response, extract the token data for the configured
+        scopes or resource servers of this file adapter and write it to
+        ``self.filename`` as JSON data.
+        Additionally will write the version of ``globus_sdk_tokenstorage``
+        which was in use.
+
+        Under the assumption that this may be running on a system with multiple
+        local users, this sets the umask such that only the owner of the
+        resulting file can read or write it.
+        """
+        to_write = self._lookup_data_from_response(token_response)
+
+        # deny rwx to Group and World, exec to User
+        with self.user_only_umask():
+            # add the version as an attribute at the top level of the JSON
+            # structure
+            to_write["globus-sdk.version"] = __version__
+            with open(self.filename, "w") as f:
+                json.dump(to_write, f)
+
+    def read_as_dict(self) -> typing.Dict:
+        """
+        Load the config file contents as JSON and return the resulting dict
+        object.
+
+        Although the whole token response is passed in for ``self.store``, this
+        will only return the token data for the particular scopes or resource
+        server for which this File Adapter is configured.
+        """
+        with open(self.filename) as f:
+            val = json.load(f)
+        if not isinstance(val, dict):
+            raise ValueError("reading from json file got non-dict data")
+        return val

--- a/src/globus_sdk/tokenstorage/file_adapters.py
+++ b/src/globus_sdk/tokenstorage/file_adapters.py
@@ -1,5 +1,5 @@
 import json
-import typing
+from typing import Dict, Optional, cast
 
 from globus_sdk.auth import OAuthTokenResponse
 from globus_sdk.tokenstorage.base import FileAdapter
@@ -9,82 +9,110 @@ from globus_sdk.version import __version__
 class SimpleJSONFileAdapter(FileAdapter):
     """
     :param filename: the name of the file to write to and read from
-    :param resource_server: the resource server name for tokens to look up
-                            in a token response object
-    :param scopes: a list of scope names for tokens to look up in a token
-                   response object
 
     A storage adapter for storing tokens in JSON files.
-    Callers must provide exactly one of ``resource_server`` and ``scopes``
     """
 
-    def __init__(
-        self,
-        filename: str,
-        resource_server: typing.Optional[str] = None,
-        scopes: typing.Optional[str] = None,
-    ):
-        if resource_server and scopes:
-            raise ValueError("cannot take both resource_server and scopes")
-        elif not resource_server and not scopes:
-            raise ValueError("you must pass resource_server or scopes")
+    # the version for the current data format used by the file adapter
+    #
+    # if the format needs to be changed in the future, the adapter can dispatch on
+    # the declared format version in the file to decide how to handle the data
+    format_version = "1.0"
+    # the supported versions (data not in these versions causes an error)
+    supported_versions = ("1.0",)
 
+    def __init__(self, filename: str):
         self.filename = filename
-        self.resource_server = resource_server
-        self.scopes = scopes
 
-    def _lookup_data_from_response(
-        self, token_response: "OAuthTokenResponse"
-    ) -> typing.Dict:
+    def _raw_load(self) -> Dict:
         """
-        Given a token response, extract the token data for the configured
-        scopes or resource servers of this adapter
-        """
-        # extract desired data and copy as a new dict
-        if self.resource_server:
-            return dict(token_response.by_resource_server[self.resource_server])
-        elif self.scopes:
-            # NOTE: this can fail if `self.scopes` isn't for exactly one
-            # resource server, but then the failure will simply propagate up
-            return dict(token_response.by_scopes[self.scopes])
-        else:
-            raise NotImplementedError("neither resource_server nor scopes are set")
-
-    def store(self, token_response: "OAuthTokenResponse"):
-        """
-        By default, ``self.on_refresh`` is just an alias for this function.
-
-        Given a token response, extract the token data for the configured
-        scopes or resource servers of this file adapter and write it to
-        ``self.filename`` as JSON data.
-        Additionally will write the version of ``globus_sdk_tokenstorage``
-        which was in use.
-
-        Under the assumption that this may be running on a system with multiple
-        local users, this sets the umask such that only the owner of the
-        resulting file can read or write it.
-        """
-        to_write = self._lookup_data_from_response(token_response)
-
-        # deny rwx to Group and World, exec to User
-        with self.user_only_umask():
-            # add the version as an attribute at the top level of the JSON
-            # structure
-            to_write["globus-sdk.version"] = __version__
-            with open(self.filename, "w") as f:
-                json.dump(to_write, f)
-
-    def read_as_dict(self) -> typing.Dict:
-        """
-        Load the config file contents as JSON and return the resulting dict
-        object.
-
-        Although the whole token response is passed in for ``self.store``, this
-        will only return the token data for the particular scopes or resource
-        server for which this File Adapter is configured.
+        Load the file contents as JSON and return the resulting dict
+        object. If a dict is not found, raises an error.
         """
         with open(self.filename) as f:
             val = json.load(f)
         if not isinstance(val, dict):
             raise ValueError("reading from json file got non-dict data")
         return val
+
+    def _handle_formats(self, read_data: Dict) -> Dict:
+        """Handle older data formats supported by globus_sdk.tokenstorage
+
+        if the data is not in a known/recognized format, this will error
+        otherwise, reshape the data to the current supported format and return it
+        """
+        format_version = read_data.get("format_version")
+        if format_version not in self.supported_versions:
+            raise ValueError(
+                f"cannot store data using SimpleJSONFileAdapter({self.filename} "
+                "existing data file is in an unknown format "
+                f"(format_version={format_version})"
+            )
+        if not isinstance(read_data.get("by_rs"), dict):
+            raise ValueError(
+                f"cannot store data using SimpleJSONFileAdapter({self.filename} "
+                "existing data file is malformed"
+            )
+        return read_data
+
+    def _load(self) -> Dict:
+        """
+        Load data from the file and ensure that the data is in a modern format which can
+        be handled by the rest of the adapter.
+
+        If the file is missing, this will return a "skeleton" for new data.
+        """
+        try:
+            data = self._raw_load()
+        except FileNotFoundError:
+            return {
+                "by_rs": {},
+                "format_version": self.format_version,
+                "globus-sdk.version": __version__,
+            }
+        return self._handle_formats(data)
+
+    def store(self, token_response: "OAuthTokenResponse"):
+        """
+        By default, ``self.on_refresh`` is just an alias for this function.
+
+        Given a token response, extract all the token data and write it to
+        ``self.filename`` as JSON data.
+        Additionally will write the version of ``globus_sdk.tokenstorage``
+        which was in use.
+
+        Under the assumption that this may be running on a system with multiple
+        local users, this sets the umask such that only the owner of the
+        resulting file can read or write it.
+        """
+        to_write = self._load()
+
+        # copy the data from the by_resource_server attribute
+        #
+        # if the file did not exist and we're handling the initial token response, this
+        # is a full copy of all of the token data
+        #
+        # if the file already exists and we're handling a token refresh, we only modify
+        # newly received tokens
+        to_write["by_rs"].update(token_response.by_resource_server)
+
+        # deny rwx to Group and World, exec to User
+        with self.user_only_umask():
+            with open(self.filename, "w") as f:
+                json.dump(to_write, f)
+
+    def get_by_resource_server(self) -> Dict:
+        """
+        Read only the by_resource_server formatted data from the file, discarding any
+        other keys.
+
+        This returns a dict in the same format as
+        ``OAuthTokenResponse.by_resource_server``
+        """
+        # TODO: when the Globus SDK drops support for py3.6 and py3.7, we can update
+        # `_load` to return a TypedDict which guarantees that `by_rs` is a dict
+        # see: https://www.python.org/dev/peps/pep-0589/
+        return cast(dict, self._load()["by_rs"])
+
+    def get_token_data(self, resource_server: str) -> Optional[Dict]:
+        return self.get_by_resource_server().get(resource_server)

--- a/src/globus_sdk/tokenstorage/sqlite_adapter.py
+++ b/src/globus_sdk/tokenstorage/sqlite_adapter.py
@@ -1,0 +1,203 @@
+import json
+import sqlite3
+import typing
+
+from globus_sdk.auth import OAuthTokenResponse
+from globus_sdk.tokenstorage.base import FileAdapter
+from globus_sdk.version import __version__
+
+
+class SQLiteAdapter(FileAdapter):
+    """
+    :param dbname: the name of the DB file to write to and read from
+    :param namespace: A "namespace" to use within the database. All operations will
+                      be performed indexed under this string, so that multiple distinct
+                      sets of tokens may be stored in the database. You might use
+                      usernames as the namespace to implement a multi-user system, or
+                      profile names to allow multiple Globus accounts to be used by a
+                      single user.
+
+    A storage adapter for storing tokens in sqlite databases.
+
+    SQLite adapters are for more complex cases, where there may be multiple users or
+    "profiles" in play, and additionally a dynamic set of resource servers which need to
+    be stored in an extensible way.
+
+    The ``namespace`` is a user-supplied way of partitioning data, and any token
+    responses passed to the storage adapter are broken apart and stored indexed by
+    *resource_server*. If you have a more complex use-case in which this scheme will be
+    insufficient, you should encode that in your choice of ``namespace`` values.
+    """
+
+    def __init__(self, dbname: str, namespace: str = "DEFAULT"):
+        self.filename = self.dbname = dbname
+        self.namespace = namespace
+        self._connection = self._init_and_connect()
+
+    def _is_memory_db(self):
+        return self.dbname == ":memory:"
+
+    def _init_and_connect(self):
+        init_tables = self._is_memory_db() or not self.file_exists()
+        if init_tables and not self._is_memory_db():  # real file needs to be created
+            with self.user_only_umask():
+                conn = sqlite3.connect(self.dbname)
+        else:
+            conn = sqlite3.connect(self.dbname)
+        if init_tables:
+            conn.executescript(
+                """
+CREATE TABLE config_storage (
+    namespace VARCHAR NOT NULL,
+    config_name VARCHAR NOT NULL,
+    config_data_json VARCHAR NOT NULL,
+    PRIMARY KEY (namespace, config_name)
+);
+CREATE TABLE token_storage (
+    namespace VARCHAR NOT NULL,
+    resource_server VARCHAR NOT NULL,
+    token_data_json VARCHAR NOT NULL,
+    PRIMARY KEY (namespace, resource_server)
+);
+CREATE TABLE sdk_storage_adapter_internal (
+    attribute VARCHAR NOT NULL,
+    value VARCHAR NOT NULL,
+    PRIMARY KEY (attribute)
+);
+            """
+            )
+            # mark the version which was used to create the DB
+            # also mark the "database schema version" in case we ever need to handle
+            # graceful upgrades
+            conn.executemany(
+                """
+INSERT INTO sdk_storage_adapter_internal(attribute, value) VALUES (?, ?);
+            """,
+                [
+                    ("globus-sdk.version", __version__),
+                    ("globus-sdk.database_schema_version", "1"),
+                ],
+            )
+            conn.commit()
+        return conn
+
+    def store_config(self, config_name: str, config_dict: typing.Mapping) -> None:
+        """
+        :param config_name: A string name for the configuration value
+        :param config_dict: A dict of config which will be stored serialized as JSON
+
+        Store a config dict under the current namespace in the config table.
+        Allows arbitrary configuration data to be namespaced under the namespace, so
+        that application config may be associated with the stored tokens.
+
+        Uses sqlite "REPLACE" to perform the operation.
+        """
+        self._connection.execute(
+            """
+REPLACE INTO config_storage(namespace, config_name, config_data_json)
+VALUES (?, ?, ?)
+            """,
+            (self.namespace, config_name, json.dumps(config_dict)),
+        )
+        self._connection.commit()
+
+    def read_config(self, config_name: str) -> typing.Optional[typing.Dict]:
+        """
+        :param config_name: A string name for the configuration value
+
+        Load a config dict under the current namespace in the config table.
+        If no value is found, returns None
+        """
+        row = self._connection.execute(
+            """
+SELECT config_data_json FROM config_storage WHERE namespace=? AND config_name=?
+        """,
+            (self.namespace, config_name),
+        ).fetchone()
+
+        if row is None:
+            return None
+        config_data_json = row[0]
+        val = json.loads(config_data_json)
+        if not isinstance(val, dict):
+            raise ValueError("reading config data and got non-dict result")
+        return val
+
+    def remove_config(self, config_name: str) -> bool:
+        """
+        :param config_name: A string name for the configuration value
+
+        Delete a previously stored configuration value.
+
+        Returns True if data was deleted, False if none was found to delete.
+        """
+        rowcount = self._connection.execute(
+            """
+DELETE FROM config_storage WHERE namespace=? AND config_name=?;
+            """,
+            (self.namespace, config_name),
+        ).rowcount
+        self._connection.commit()
+        return typing.cast(bool, rowcount != 0)
+
+    def store(self, token_response: "OAuthTokenResponse") -> None:
+        """
+        :param token_response: a globus_sdk.OAuthTokenResponse object containing token
+                               data to store
+
+        By default, ``self.on_refresh`` is just an alias for this function.
+
+        Given a token response, extract the token data for the resource servers and
+        write it to ``self.dbname``, stored under the adapter's namespace
+        """
+        pairs = []
+        for rs_name, token_data in token_response.by_resource_server.items():
+            pairs.append((rs_name, token_data))
+
+        self._connection.executemany(
+            """
+REPLACE INTO token_storage(namespace, resource_server, token_data_json)
+VALUES(?, ?, ?);
+            """,
+            [
+                (self.namespace, rs_name, json.dumps(token_data))
+                for (rs_name, token_data) in pairs
+            ],
+        )
+        self._connection.commit()
+
+    def read_as_dict(self) -> typing.Dict[str, typing.Any]:
+        """
+        Load the token data JSON and return the resulting dict objects, indexed by
+        resource server.
+        This should look identical to an OAuthTokenResponse.by_resource_server in format
+        and content. (But it is not attached to a token response object.)
+        """
+        data = {}
+        for row in self._connection.execute(
+            """
+SELECT resource_server, token_data_json FROM token_storage WHERE namespace=?
+        """,
+            (self.namespace,),
+        ):
+            resource_server, token_data_json = row
+            data[resource_server] = json.loads(token_data_json)
+        return data
+
+    def remove_tokens_for_resource_server(self, resource_server: str) -> bool:
+        """
+        Given a resource server to target, delete tokens for that resource server from
+        the database (limited to the current namespace).
+        You can use this as part of a logout command implementation, loading token data
+        as a dict, and then deleting the data for each resource server.
+
+        Returns True if token data was deleted, False if none was found to delete.
+        """
+        rowcount = self._connection.execute(
+            """
+DELETE FROM token_storage WHERE namespace=? AND resource_server=?;
+            """,
+            (self.namespace, resource_server),
+        ).rowcount
+        self._connection.commit()
+        return typing.cast(bool, rowcount != 0)

--- a/tests/functional/tokenstorage/conftest.py
+++ b/tests/functional/tokenstorage/conftest.py
@@ -1,0 +1,38 @@
+import shutil
+import tempfile
+import time
+from unittest import mock
+
+import pytest
+
+
+@pytest.fixture
+def tempdir():
+    d = tempfile.mkdtemp()
+    yield d
+    shutil.rmtree(d)
+
+
+@pytest.fixture
+def mock_response():
+    res = mock.Mock()
+    expiration_time = int(time.time()) + 3600
+    res.by_resource_server = {
+        "resource_server_1": {
+            "access_token": "access_token_1",
+            "expires_at_seconds": expiration_time,
+            "refresh_token": "refresh_token_1",
+            "resource_server": "resource_server_1",
+            "scope": "scope1",
+            "token_type": "bearer",
+        },
+        "resource_server_2": {
+            "access_token": "access_token_2",
+            "expires_in": expiration_time,
+            "refresh_token": "refresh_token_2",
+            "resource_server": "resource_server_2",
+            "scope": "scope2 scope2:0 scope2:1",
+            "token_type": "bearer",
+        },
+    }
+    return res

--- a/tests/functional/tokenstorage/conftest.py
+++ b/tests/functional/tokenstorage/conftest.py
@@ -36,3 +36,20 @@ def mock_response():
         },
     }
     return res
+
+
+@pytest.fixture
+def mock_refresh_response():
+    res = mock.Mock()
+    expiration_time = int(time.time()) + 3600
+    res.by_resource_server = {
+        "resource_server_2": {
+            "access_token": "access_token_2_refreshed",
+            "expires_in": expiration_time,
+            "refresh_token": "refresh_token_2",
+            "resource_server": "resource_server_2",
+            "scope": "scope2 scope2:0 scope2:1",
+            "token_type": "bearer",
+        }
+    }
+    return res

--- a/tests/functional/tokenstorage/test_simplejson_file.py
+++ b/tests/functional/tokenstorage/test_simplejson_file.py
@@ -1,0 +1,76 @@
+import json
+import os
+
+import pytest
+
+from globus_sdk.tokenstorage import SimpleJSONFileAdapter
+from globus_sdk.version import __version__
+
+IS_WINDOWS = os.name == "nt"
+
+
+@pytest.fixture
+def filename(tempdir):
+    return os.path.join(tempdir, "mydata.json")
+
+
+@pytest.mark.parametrize(
+    "success, kwargs",
+    [
+        (False, {}),
+        (False, {"resource_server": "foo", "scopes": ["bar"]}),
+        (True, {"resource_server": "foo"}),
+        (True, {"scopes": ["bar"]}),
+    ],
+)
+def test_constructor(filename, success, kwargs):
+    if success:
+        assert SimpleJSONFileAdapter(filename, **kwargs)
+    else:
+        with pytest.raises(ValueError):
+            SimpleJSONFileAdapter(filename, **kwargs)
+
+
+def test_file_dne(filename):
+    adapter = SimpleJSONFileAdapter(filename, scopes=["x"])
+    assert not adapter.file_exists()
+
+
+def test_file_exists(filename):
+    open(filename, "w").close()  # open and close to touch
+    adapter = SimpleJSONFileAdapter(filename, scopes=["x"])
+    assert adapter.file_exists()
+
+
+def test_read_as_dict(filename):
+    with open(filename, "w") as f:
+        json.dump({"x": 1}, f)
+    adapter = SimpleJSONFileAdapter(filename, scopes=["x"])
+    assert adapter.file_exists()
+
+    d = adapter.read_as_dict()
+
+    assert d == {"x": 1}
+
+
+def test_store(filename, mock_response):
+    adapter = SimpleJSONFileAdapter(filename, resource_server="resource_server_1")
+    assert not adapter.file_exists()
+    adapter.store(mock_response)
+
+    with open(filename) as f:
+        data = json.load(f)
+    assert data["globus-sdk.version"] == __version__
+    assert data["access_token"] == "access_token_1"
+
+
+@pytest.mark.xfail(IS_WINDOWS, reason="cannot set umask perms on Windows")
+def test_store_perms(filename, mock_response):
+    adapter = SimpleJSONFileAdapter(filename, resource_server="resource_server_1")
+    assert not adapter.file_exists()
+    adapter.store(mock_response)
+
+    # mode|0600 should be 0600 -- meaning that those are the maximal
+    # permissions given
+    st_mode = os.stat(filename).st_mode & 0o777  # & 777 to remove extra bits
+    assert st_mode | 0o600 == 0o600

--- a/tests/functional/tokenstorage/test_sqlite.py
+++ b/tests/functional/tokenstorage/test_sqlite.py
@@ -1,0 +1,127 @@
+import os
+
+import pytest
+
+from globus_sdk.tokenstorage import SQLiteAdapter
+
+
+@pytest.fixture
+def db_filename(tempdir):
+    return os.path.join(tempdir, "test.db")
+
+
+MEMORY_DBNAME = ":memory:"
+
+
+@pytest.mark.parametrize(
+    "success, use_file, kwargs",
+    [
+        (False, False, {}),
+        (False, False, {"namespace": "foo"}),
+        (True, False, {"dbname": MEMORY_DBNAME}),
+        (True, False, {"dbname": MEMORY_DBNAME, "namespace": "foo"}),
+        (True, True, {}),
+        (True, True, {"namespace": "foo"}),
+        (False, True, {"dbname": MEMORY_DBNAME}),
+        (False, True, {"dbname": MEMORY_DBNAME, "namespace": "foo"}),
+    ],
+)
+def test_constructor(success, use_file, kwargs, db_filename):
+    if success:
+        if use_file:
+            assert SQLiteAdapter(db_filename, **kwargs)
+        else:
+            assert SQLiteAdapter(**kwargs)
+    else:
+        with pytest.raises(TypeError):
+            if use_file:
+                SQLiteAdapter(db_filename, **kwargs)
+            else:
+                SQLiteAdapter(**kwargs)
+
+
+def test_store_and_retrieve_simple_config():
+    adapter = SQLiteAdapter(MEMORY_DBNAME)
+    store_val = {"val1": True, "val2": None, "val3": 1.4}
+    adapter.store_config("myconf", store_val)
+    read_val = adapter.read_config("myconf")
+    assert read_val == store_val
+    assert read_val is not store_val
+
+
+def test_store_and_retrieve(mock_response):
+    adapter = SQLiteAdapter(MEMORY_DBNAME)
+    adapter.store(mock_response)
+
+    data = adapter.read_as_dict()
+    assert data == mock_response.by_resource_server
+
+
+def test_on_refresh_and_retrieve(mock_response):
+    """just confirm that the aliasing of these functions does not change anything"""
+    adapter = SQLiteAdapter(MEMORY_DBNAME)
+    adapter.on_refresh(mock_response)
+
+    data = adapter.read_as_dict()
+    assert data == mock_response.by_resource_server
+
+
+def test_multiple_adapters_store_and_retrieve(mock_response, db_filename):
+    adapter1 = SQLiteAdapter(db_filename)
+    adapter2 = SQLiteAdapter(db_filename)
+    adapter1.store(mock_response)
+
+    data = adapter2.read_as_dict()
+    assert data == mock_response.by_resource_server
+
+
+def test_multiple_adapters_store_and_retrieve_different_namespaces(
+    mock_response, db_filename
+):
+    adapter1 = SQLiteAdapter(db_filename, namespace="foo")
+    adapter2 = SQLiteAdapter(db_filename, namespace="bar")
+    adapter1.store(mock_response)
+
+    data = adapter2.read_as_dict()
+    assert data == {}
+
+
+def test_load_missing_config_data():
+    adapter = SQLiteAdapter(MEMORY_DBNAME)
+    assert adapter.read_config("foo") is None
+
+
+def test_load_missing_token_data():
+    adapter = SQLiteAdapter(MEMORY_DBNAME)
+    assert adapter.read_as_dict() == {}
+
+
+def test_remove_tokens(mock_response):
+    adapter = SQLiteAdapter(MEMORY_DBNAME)
+    adapter.store(mock_response)
+
+    removed = adapter.remove_tokens_for_resource_server("resource_server_1")
+    assert removed
+    data = adapter.read_as_dict()
+    assert data == {
+        "resource_server_2": mock_response.by_resource_server["resource_server_2"]
+    }
+
+    removed = adapter.remove_tokens_for_resource_server("resource_server_1")
+    assert not removed
+
+
+def test_remove_config():
+    adapter = SQLiteAdapter(MEMORY_DBNAME)
+    store_val = {"val1": True, "val2": None, "val3": 1.4}
+    adapter.store_config("myconf", store_val)
+    adapter.store_config("myconf2", store_val)
+    removed = adapter.remove_config("myconf")
+    assert removed
+    read_val = adapter.read_config("myconf")
+    assert read_val is None
+    read_val = adapter.read_config("myconf2")
+    assert read_val == store_val
+
+    removed = adapter.remove_config("myconf")
+    assert not removed


### PR DESCRIPTION
For the most part, this is

    globus_sdk_tokenstorage -> globus_sdk.tokenstorage

But there are some notable caveats. One is that the StorageAdapter and FileAdapter are public parts of the module and explicitly set their metaclass to "abc.ABCMeta" (which marks them as abstract). With that change in hand we can drop "Abstract" from their names for an overall tidier appearance.

A StorageAdapter is literally any object implementing `on_refresh` and `store` methods. And the default implementation of `on_refresh` just calls `store`. FileAdapter just extends this with some notion that the storage is in a file somewhere.

The other main thing that is new here is that fairly comprehensive type annotations are now in place, at least enough to note the argument and return types of the new interfaces.
I've tried to strike a balance on the annotations between flexibility (e.g. mapping vs dict) and simplicity. So maybe some methods would accept types other than `str`, but they're all noted as `str` and that's what should be used.

The tests are pretty much a verbatim port of the globus-sdk-tokenstorage tests.

One potential issue is that FileAdapter still only sets umask appropriately for a unix environment. I would be happy to work on changes to add windows compatibility, but for now there is no attempt at doing so. (globus-sdk-tokenstorage does not solve this problem either)

Also notable: SQLiteAdapter inherits from FileAdapter (this was not the case in the standalone lib) so that we can control the mode of the created db via `FileAdapter.user_only_umask()`.

<details><summary>it may be too large to be useful, but here's a diff between the original implementation and this sdk-ized version</summary>

```diff

diff -r sdk/globus_sdk/tokenstorage/__init__.py tokenstore/src/globus_sdk_tokenstorage/__init__.py
1,3c1,3
< from globus_sdk.tokenstorage.base import FileAdapter, StorageAdapter
< from globus_sdk.tokenstorage.file_adapters import SimpleJSONFileAdapter
< from globus_sdk.tokenstorage.sqlite_adapter import SQLiteAdapter
---
> from .file_adapters import SimpleJSONFileAdapter
> from .sqlite_adapter import SQLiteAdapter
> from .version import __version__
5c5
< __all__ = ("SimpleJSONFileAdapter", "SQLiteAdapter", "StorageAdapter", "FileAdapter")
---
> __all__ = ("__version__", "SimpleJSONFileAdapter", "SQLiteAdapter")
Only in tokenstore/src/globus_sdk_tokenstorage/: abstract_base.py
Only in sdk/globus_sdk/tokenstorage: base.py
diff -r sdk/globus_sdk/tokenstorage/file_adapters.py tokenstore/src/globus_sdk_tokenstorage/file_adapters.py
2c2
< import typing
---
> import os
4,5c4,5
< from globus_sdk.tokenstorage.base import FileAdapter
< from globus_sdk.version import __version__
---
> from .abstract_base import AbstractStorageAdapter
> from .version import __version__
7,8d6
< if typing.TYPE_CHECKING:  # conditional imports reduce the risk of dependency cycles
<     from globus_sdk.auth import OAuthTokenResponse
9a8,22
> class AbstractFileAdapter(AbstractStorageAdapter):
>     """
>     File adapters are for single-user cases, where we can assume that there's a
>     simple file-per-user and users are only ever attempting to read their own
>     files.
>     """
>
>     def file_exists(self):
>         """
>         Check if the file used by this file storage adapter exists.
>         """
>         return os.path.exists(self.filename)
>
>     def read_as_dict(self):
>         raise NotImplementedError
11c24,25
< class SimpleJSONFileAdapter(FileAdapter):
---
>
> class SimpleJSONFileAdapter(AbstractFileAdapter):
23,28c37,52
<     def __init__(
<         self,
<         filename: str,
<         resource_server: typing.Optional[str] = None,
<         scopes: typing.Optional[str] = None,
<     ):
---
>     def __init__(self, filename, resource_server=None, scopes=None):
>         self.filename = filename
>         self._set_resource_server_or_scopes(
>             resource_server=resource_server, scopes=scopes
>         )
>
>     def _set_resource_server_or_scopes(self, resource_server=None, scopes=None):
>         """
>         :param resource_server: the resource server name for tokens to look up
>                                 in a token response object
>         :param scopes: a list of scope names for tokens to look up in a token
>                        response object
>
>         Set the scopes or resource server used to look up tokens in a response object.
>         Callers must pass exactly one of ``resource_server`` and ``scopes``.
>         """
33,34d56
<
<         self.filename = filename
38,40c60
<     def _lookup_data_from_response(
<         self, token_response: "OAuthTokenResponse"
<     ) -> typing.Dict:
---
>     def _lookup_data_from_response(self, token_response):
55c75
<     def store(self, token_response: "OAuthTokenResponse"):
---
>     def store(self, token_response):
72c92,93
<         with self.user_only_umask():
---
>         old_umask = os.umask(0o177)
>         try:
75c96
<             to_write["globus-sdk.version"] = __version__
---
>             to_write["globus-sdk-tokenstorage.version"] = __version__
77a99,101
>         finally:
>             # reset umask
>             os.umask(old_umask)
79c103
<     def read_as_dict(self) -> typing.Dict:
---
>     def read_as_dict(self):
88,92c112,113
<         with open(self.filename) as f:
<             val = json.load(f)
<         if not isinstance(val, dict):
<             raise ValueError("reading from json file got non-dict data")
<         return val
---
>         with open(self.filename, "r") as f:
>             return json.load(f)
diff -r sdk/globus_sdk/tokenstorage/sqlite_adapter.py tokenstore/src/globus_sdk_tokenstorage/sqlite_adapter.py
1a2
> import os
3d3
< import typing
5,6c5,6
< from globus_sdk.tokenstorage.base import FileAdapter
< from globus_sdk.version import __version__
---
> from .abstract_base import AbstractStorageAdapter
> from .version import __version__
8,9d7
< if typing.TYPE_CHECKING:  # conditional imports reduce the risk of dependency cycles
<     from globus_sdk.auth import OAuthTokenResponse
11,12c9
<
< class SQLiteAdapter(FileAdapter):
---
> class SQLiteAdapter(AbstractStorageAdapter):
34,35c31,32
<     def __init__(self, dbname: str, namespace: str = "DEFAULT"):
<         self.filename = self.dbname = dbname
---
>     def __init__(self, dbname, namespace="DEFAULT"):
>         self.dbname = dbname
39,41d35
<     def _is_memory_db(self):
<         return self.dbname == ":memory:"
<
43,48c37,38
<         init_tables = self._is_memory_db() or not self.file_exists()
<         if init_tables and not self._is_memory_db():  # real file needs to be created
<             with self.user_only_umask():
<                 conn = sqlite3.connect(self.dbname)
<         else:
<             conn = sqlite3.connect(self.dbname)
---
>         init_tables = self.dbname == ":memory:" or not os.path.exists(self.dbname)
>         conn = sqlite3.connect(self.dbname)
72,73c62
<             # also mark the "database schema version" in case we ever need to handle
<             # graceful upgrades
---
>             # also mark the "database schema version", useful for upgrades
79,80c68,69
<                     ("globus-sdk.version", __version__),
<                     ("globus-sdk.database_schema_version", "1"),
---
>                     ("globus-sdk-tokenstorage.version", __version__),
>                     ("globus-sdk-tokenstorage.database_schema_version", "1"),
86c75
<     def store_config(self, config_name: str, config_dict: typing.Mapping) -> None:
---
>     def store_config(self, config_name, config_dict):
106c95
<     def read_config(self, config_name: str) -> typing.Optional[typing.Dict]:
---
>     def read_config(self, config_name):
123,126c112
<         val = json.loads(config_data_json)
<         if not isinstance(val, dict):
<             raise ValueError("reading config data and got non-dict result")
<         return val
---
>         return json.loads(config_data_json)
128c114
<     def remove_config(self, config_name: str) -> bool:
---
>     def remove_config(self, config_name):
143c129
<         return typing.cast(bool, rowcount != 0)
---
>         return rowcount != 0
145c131
<     def store(self, token_response: "OAuthTokenResponse") -> None:
---
>     def store(self, token_response):
171c157
<     def read_as_dict(self) -> typing.Dict[str, typing.Any]:
---
>     def read_as_dict(self):
189c175
<     def remove_tokens_for_resource_server(self, resource_server: str) -> bool:
---
>     def remove_tokens_for_resource_server(self, resource_server):
205c191
<         return typing.cast(bool, rowcount != 0)
---
>         return rowcount != 0
Only in tokenstore/src/globus_sdk_tokenstorage/: version.py
```
</details>