### PR TITLE
Remove 'allowed_authorizer_types' restriction

### DIFF
--- a/globus_sdk/auth/client_types/confidential_client.py
+++ b/globus_sdk/auth/client_types/confidential_client.py
@@ -31,11 +31,6 @@ class ConfidentialAppAuthClient(AuthClient):
     .. automethodlist:: globus_sdk.ConfidentialAppAuthClient
     """
 
-    # checked by BaseClient to see what authorizers are allowed for this client
-    # subclass
-    # only allow basic auth -- anything else means you're misusing the client
-    allowed_authorizer_types = [BasicAuthorizer]
-
     def __init__(self, client_id, client_secret, **kwargs):
         if "authorizer" in kwargs:
             logger.error("ArgumentError(ConfidentialAppClient.authorizer)")

--- a/globus_sdk/auth/client_types/native_client.py
+++ b/globus_sdk/auth/client_types/native_client.py
@@ -25,10 +25,6 @@ class NativeAppAuthClient(AuthClient):
     .. automethodlist:: globus_sdk.NativeAppAuthClient
     """
 
-    # don't allow any authorizer to be used on a native app client
-    # it can't authorize it's calls, and shouldn't try to
-    allowed_authorizer_types = [NullAuthorizer]
-
     def __init__(self, client_id, **kwargs):
         if "authorizer" in kwargs:
             logger.error("ArgumentError(NativeAppClient.authorizer)")

--- a/globus_sdk/base.py
+++ b/globus_sdk/base.py
@@ -59,8 +59,6 @@ class BaseClient:
     # Can be overridden by subclasses, but must be a subclass of GlobusError
     error_class: typing.Type[exc.GlobusAPIError] = exc.GlobusAPIError
     default_response_class: typing.Type[GlobusHTTPResponse] = GlobusHTTPResponse
-    # a collection of authorizer types, or None to indicate "any"
-    allowed_authorizer_types: typing.Optional[typing.List[typing.Type]] = None
 
     BASE_USER_AGENT = f"globus-sdk-py-{__version__}"
 
@@ -80,21 +78,6 @@ class BaseClient:
         self.logger.info(
             'Creating client of type {} for service "{}"'.format(type(self), service)
         )
-        # if restrictions have been placed by a child class on the allowed
-        # authorizer types, make sure we are not in violation of those
-        # constraints
-        if self.allowed_authorizer_types is not None and (
-            authorizer is not None
-            and type(authorizer) not in self.allowed_authorizer_types
-        ):
-            self.logger.error(
-                "{} doesn't support authorizer={}".format(type(self), type(authorizer))
-            )
-            raise exc.GlobusSDKUsageError(
-                (
-                    "{} can only take authorizers from {}, but you have provided {}"
-                ).format(type(self), self.allowed_authorizer_types, type(authorizer))
-            )
 
         # if an environment was passed, it will be used, but otherwise lookup
         # the env var -- and in the special case of `production` translate to

--- a/globus_sdk/search/client.py
+++ b/globus_sdk/search/client.py
@@ -1,11 +1,6 @@
 import logging
 
 from globus_sdk import exc
-from globus_sdk.authorizers import (
-    AccessTokenAuthorizer,
-    ClientCredentialsAuthorizer,
-    RefreshTokenAuthorizer,
-)
 from globus_sdk.base import BaseClient, merge_params, safe_stringify
 from globus_sdk.response import GlobusHTTPResponse
 
@@ -29,12 +24,6 @@ class SearchClient(BaseClient):
 
     .. automethodlist:: globus_sdk.SearchClient
     """
-    # disallow basic auth
-    allowed_authorizer_types = [
-        AccessTokenAuthorizer,
-        RefreshTokenAuthorizer,
-        ClientCredentialsAuthorizer,
-    ]
     error_class = exc.SearchAPIError
     default_response_class = GlobusHTTPResponse
 

--- a/globus_sdk/transfer/client.py
+++ b/globus_sdk/transfer/client.py
@@ -2,11 +2,6 @@ import logging
 import time
 
 from globus_sdk import exc
-from globus_sdk.authorizers import (
-    AccessTokenAuthorizer,
-    ClientCredentialsAuthorizer,
-    RefreshTokenAuthorizer,
-)
 from globus_sdk.base import BaseClient, merge_params, safe_stringify
 from globus_sdk.transfer.paging import PaginatedResource
 from globus_sdk.transfer.response import (
@@ -52,12 +47,6 @@ class TransferClient(BaseClient):
 
     .. automethodlist:: globus_sdk.TransferClient
     """
-    # disallow basic auth
-    allowed_authorizer_types = [
-        AccessTokenAuthorizer,
-        RefreshTokenAuthorizer,
-        ClientCredentialsAuthorizer,
-    ]
     error_class = exc.TransferAPIError
     default_response_class = TransferResponse
 


### PR DESCRIPTION
Instead, the clients themselves should allow any authorizer (including, for example, custom ones constructed by the user) to be passed.

Inevitably, *someone* will pass a basic authorizer to a TransferClient. Then it won't work, they'll get errors back from Transfer, and they'll sort it out. I don't think I still buy the reasoning behind this restriction, especially since it runs counter to the surrounding design (that a client is agnostic towards the inner workings of its authorizer).

In the very worst case, if we do want to keep this, I would invert it and make it a `forbidden_authorizers` list, so we can specify

    TransferClient.forbidden_authorizers = [
        NullAuthorizer, BasicAuthorizer
    ]

and call it a day.