### PR TITLE
Update dependencies for pre-commit (linting) and development

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,40 +1,40 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks.git
-  rev: v3.4.0
+  rev: v4.0.1
   hooks:
     - id: check-merge-conflict
     - id: trailing-whitespace
 - repo: https://github.com/sirosen/check-jsonschema
-  rev: 0.3.0
+  rev: 0.3.1
   hooks:
     - id: check-github-workflows
 - repo: https://github.com/python/black
-  rev: 20.8b1
+  rev: 21.5b1
   hooks:
     - id: black
       name: "Autoformat python files"
 - repo: https://github.com/asottile/blacken-docs
-  rev: v1.9.2
+  rev: v1.10.0
   hooks:
     - id: blacken-docs
-      additional_dependencies: ['black==20.8b1']
+      additional_dependencies: ['black==21.5b1']
 - repo: https://gitlab.com/pycqa/flake8
-  rev: 3.8.4
+  rev: 3.9.2
   hooks:
     - id: flake8
       name: "Lint python files"
-      additional_dependencies: ['flake8-bugbear==20.11.1']
+      additional_dependencies: ['flake8-bugbear==21.4.3']
 - repo: https://github.com/timothycrosley/isort
-  rev: 5.7.0
+  rev: 5.8.0
   hooks:
     - id: isort
       name: "Sort python imports"
 - repo: https://github.com/asottile/pyupgrade
-  rev: v2.7.4
+  rev: v2.17.0
   hooks:
     - id: pyupgrade
       args: ["--py36-plus"]
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.800
+  rev: v0.812
   hooks:
     - id: mypy

--- a/globus_sdk/auth/oauth2_flow_manager.py
+++ b/globus_sdk/auth/oauth2_flow_manager.py
@@ -30,7 +30,7 @@ class GlobusOAuthFlowManager:
         :rtype: ``string``
         """
         raise NotImplementedError(
-            "{} does not implement get_authorize_url()".format(type(self))
+            f"{type(self)} does not implement get_authorize_url()"
         )
 
     def exchange_code_for_tokens(self, auth_code):
@@ -50,5 +50,5 @@ class GlobusOAuthFlowManager:
         :rtype: :class:`OAuthTokenResponse <globus_sdk.OAuthTokenResponse>`
         """
         raise NotImplementedError(
-            "{} does not implement exchange_code_for_tokens()".format(type(self))
+            f"{type(self)} does not implement exchange_code_for_tokens()"
         )

--- a/globus_sdk/auth/oauth2_native_app.py
+++ b/globus_sdk/auth/oauth2_native_app.py
@@ -34,7 +34,7 @@ def make_native_app_challenge(verifier=None):
     if verifier:
         if not 43 <= len(verifier) <= 128:
             raise GlobusSDKUsageError(
-                "verifier must be 43-128 characters long: {}".format(len(verifier))
+                f"verifier must be 43-128 characters long: {len(verifier)}"
             )
         if bool(re.search(r"[^a-zA-Z0-9~_.-]", verifier)):
             raise GlobusSDKUsageError("verifier contained invalid characters")

--- a/globus_sdk/response.py
+++ b/globus_sdk/response.py
@@ -44,7 +44,7 @@ class GlobusResponse:
         try:
             return data[key]
         except TypeError:
-            logger.error("Can't index into responses of type {}".format(type(self)))
+            logger.error(f"Can't index into responses of type {type(self)}")
             # re-raise with an altered message -- the issue is that whatever
             # type of GlobusResponse you're working with doesn't support
             # indexing

--- a/setup.py
+++ b/setup.py
@@ -22,26 +22,26 @@ setup(
         # the dev extra is for SDK developers only
         "dev": [
             # drive testing with tox
-            "tox>=3.5.3,<4.0",
+            "tox<4",
             # linting
-            "flake8>=3.0,<4.0",
-            "isort>=5.6.4,<6.0",
-            "black==20.8b1",
-            "flake8-bugbear==20.11.1",
-            "mypy==0.800",
+            "flake8<4",
+            "isort<6",
+            "black==21.5b1",
+            "flake8-bugbear==21.4.3",
+            "mypy==0.812",
             # testing
-            "pytest<5.0",
-            "pytest-cov<3.0",
-            "pytest-xdist<2.0",
+            "pytest<7",
+            "pytest-cov<3",
+            "pytest-xdist<3",
             # mocking HTTP responses
-            "responses==0.12.1",
+            "responses==0.13.3",
             # pyinstaller is needed in order to test the pyinstaller hook
             "pyinstaller",
             # builds + uploads to pypi
-            "twine>=3,<4",
+            "twine<4",
             "wheel==0.36.2",
             # docs
-            "sphinx==3.4.3",
+            "sphinx<5",
             "sphinx-material==0.0.32",
         ]
     },

--- a/tests/functional/transfer/test_paginated.py
+++ b/tests/functional/transfer/test_paginated.py
@@ -50,7 +50,7 @@ MULTIPAGE_SEARCH_RESULTS = [
         "DATA": [
             {
                 "DATA_TYPE": "endpoint",
-                "display_name": "SDK Test Stub {}".format(x + 100),
+                "display_name": f"SDK Test Stub {x + 100}",
             }
             for x in range(100)
         ],
@@ -63,7 +63,7 @@ MULTIPAGE_SEARCH_RESULTS = [
         "DATA": [
             {
                 "DATA_TYPE": "endpoint",
-                "display_name": "SDK Test Stub {}".format(x + 200),
+                "display_name": f"SDK Test Stub {x + 200}",
             }
             for x in range(100)
         ],

--- a/tests/unit/test_base_client.py
+++ b/tests/unit/test_base_client.py
@@ -55,7 +55,7 @@ def test_client_log_adapter(base_client):
     base_client.logger.info(in_msg)
     # confirm results
     out_msg = memory_handler.buffer[0].getMessage()
-    expected_msg = "[instance:{}] {}".format(id(base_client), in_msg)
+    expected_msg = f"[instance:{id(base_client)}] {in_msg}"
     assert expected_msg == out_msg
 
     memory_handler.close()


### PR DESCRIPTION
This is just a housekeeping update; not a change to any of the "real" library versions we use.

`responses` added some new methods; maybe that will be useful. And Sphinx made a bunch of changes (major version), but I checked a local build and nothing appears changed or broken.