### PR TITLE
Set pytest to "filterwarnings=error"

### DIFF
--- a/globus_sdk/auth/client_types/base.py
+++ b/globus_sdk/auth/client_types/base.py
@@ -1,4 +1,4 @@
-import collections
+import collections.abc
 import json
 import logging
 
@@ -118,7 +118,7 @@ class AuthClient(BaseClient):
         """
 
         def _convert_listarg(val):
-            if isinstance(val, collections.Iterable) and not isinstance(val, str):
+            if isinstance(val, collections.abc.Iterable) and not isinstance(val, str):
                 return ",".join(safe_stringify(x) for x in val)
             else:
                 return safe_stringify(val)

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,3 +24,10 @@ warn_redundant_casts = true
 warn_return_any = true
 warn_no_return = true
 no_implicit_optional = true
+
+
+[tool:pytest]
+addopts = --cov=globus_sdk
+filterwarnings =
+    # warnings are errors, like -Werror
+    error

--- a/tests/functional/test_pyinstaller_packaging.py
+++ b/tests/functional/test_pyinstaller_packaging.py
@@ -32,6 +32,7 @@ def shared_libraries_are_available():
     not shared_libraries_are_available(),
     reason="requires that python was built with --enable-shared",
 )
+@pytest.mark.filterwarnings("ignore:The 'warn' method is deprecated")
 def test_pyinstaller_hook(tmp_path):
     appfile = tmp_path / "sample.py"
     appfile.write_text(

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ skip_missing_interpreters = true
 [testenv]
 usedevelop = true
 extras = dev
-commands = pytest -v --cov=globus_sdk {posargs}
+commands = pytest {posargs}
 
 [testenv:lint]
 deps = pre-commit~=2.9.3


### PR DESCRIPTION
Add pytest config to setup.cfg which sets 'filterwarnings=error'. This converts any warnings -- or at least, any which we don't explicitly handle -- into errors during tests.

Also, move from `-v --cov=globus_sdk` in tox.ini to `--cov=globus_sdk` via addopts only. This is more concise output and keeps configuration more together.

There's only one warning in tests right now: `Iterable` moved to `collections.abc`. So fix that too.

(NB: will conflict with #413, but I'll rebase to handle.)