### PR TITLE
Cleanup client class attrs

### DIFF
--- a/globus_sdk/auth/client_types/base.py
+++ b/globus_sdk/auth/client_types/base.py
@@ -42,17 +42,16 @@ class AuthClient(BaseClient):
     .. automethodlist:: globus_sdk.AuthClient
     """
 
+    service_name = "auth"
     error_class = exc.AuthAPIError
 
-    def __init__(self, client_id=None, authorizer=None, **kwargs):
+    def __init__(self, client_id=None, **kwargs):
+        super().__init__(**kwargs)
         self.client_id = client_id
-
         # an AuthClient may contain a GlobusOAuth2FlowManager in order to
         # encapsulate the functionality of various different types of flow
         # managers
         self.current_oauth2_flow_manager = None
-
-        BaseClient.__init__(self, "auth", authorizer=authorizer, **kwargs)
 
     def get_identities(self, usernames=None, ids=None, provision=False, **params):
         r"""

--- a/globus_sdk/auth/client_types/confidential_client.py
+++ b/globus_sdk/auth/client_types/confidential_client.py
@@ -37,8 +37,7 @@ class ConfidentialAppAuthClient(AuthClient):
             raise GlobusSDKUsageError(
                 "Cannot give a ConfidentialAppAuthClient an authorizer"
             )
-
-        AuthClient.__init__(
+        super().__init__(
             self,
             client_id=client_id,
             authorizer=BasicAuthorizer(client_id, client_secret),

--- a/globus_sdk/auth/client_types/native_client.py
+++ b/globus_sdk/auth/client_types/native_client.py
@@ -30,9 +30,7 @@ class NativeAppAuthClient(AuthClient):
             logger.error("ArgumentError(NativeAppClient.authorizer)")
             raise GlobusSDKUsageError("Cannot give a NativeAppAuthClient an authorizer")
 
-        AuthClient.__init__(
-            self, client_id=client_id, authorizer=NullAuthorizer(), **kwargs
-        )
+        super().__init__(client_id=client_id, authorizer=NullAuthorizer(), **kwargs)
         self.logger.info(f"Finished initializing client, client_id={client_id}")
 
     def oauth2_start_flow(

--- a/globus_sdk/authorizers/base.py
+++ b/globus_sdk/authorizers/base.py
@@ -10,7 +10,7 @@ class GlobusAuthorizer(metaclass=abc.ABCMeta):
     """
 
     @abc.abstractmethod
-    def set_authorization_header(header_dict):
+    def set_authorization_header(self, header_dict):
         """
         Takes a dict of headers, and adds to it a mapping of
         ``{"Authorization": "..."}`` per this object's type of Authorization.

--- a/globus_sdk/transfer/client.py
+++ b/globus_sdk/transfer/client.py
@@ -47,13 +47,10 @@ class TransferClient(BaseClient):
 
     .. automethodlist:: globus_sdk.TransferClient
     """
+    service_name = "transfer"
+    base_path = "/v0.10/"
     error_class = exc.TransferAPIError
     default_response_class = TransferResponse
-
-    def __init__(self, authorizer=None, **kwargs):
-        BaseClient.__init__(
-            self, "transfer", base_path="/v0.10/", authorizer=authorizer, **kwargs
-        )
 
     # Convenience methods, providing more pythonic access to common REST
     # resources

--- a/tests/unit/test_base_client.py
+++ b/tests/unit/test_base_client.py
@@ -16,7 +16,11 @@ def auth_client():
 
 @pytest.fixture
 def base_client():
-    return BaseClient("transfer", base_path="/v0.10/")
+    class CustomClient(BaseClient):
+        base_path = "/v0.10/"
+        service_name = "transfer"
+
+    return CustomClient()
 
 
 # not particularly special, just a handy array of codes which should raise
@@ -56,12 +60,11 @@ def test_set_app_name(base_client):
     Sets app name, confirms results
     """
     # set app name
-    app_name = "SDK Test"
-    base_client.set_app_name(app_name)
+    base_client.app_name = "SDK Test"
     # confirm results
-    assert base_client.app_name == app_name
+    assert base_client.app_name == "SDK Test"
     assert base_client._headers["User-Agent"] == "{}/{}".format(
-        base_client.BASE_USER_AGENT, app_name
+        base_client.BASE_USER_AGENT, "SDK Test"
     )
 
 

--- a/tests/unit/test_base_client.py
+++ b/tests/unit/test_base_client.py
@@ -35,6 +35,12 @@ class testObject:
         return "1"
 
 
+def test_cannot_instantiate_plain_base_client():
+    # attempting to instantiate a BaseClient errors
+    with pytest.raises(NotImplementedError):
+        BaseClient()
+
+
 def test_client_log_adapter(base_client):
     """
     Logs a test message with the base client's logger,


### PR DESCRIPTION
This is some cleanup that I did during my work on automatic retries, backported into an independent branch so that it can be reviewed separately.

Several attributes make more sense as class attributes than instance attributes. Namely, `service_name` and `base_path` are both more sensible as class attrs.

Additionally,
- `app_name` works more simply as a property
- use `super()` rather than explicitly invoking base class methods
- fix the signature for `GlobusAUthorizer.set_authorization_header`