### PR TITLE
Update to pyjwt 2.x and fix jwt tests

### DIFF
--- a/globus_sdk/auth/token_response.py
+++ b/globus_sdk/auth/token_response.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import time
+import typing
 
 import jwt
 
@@ -162,7 +163,13 @@ class OAuthTokenResponse(GlobusHTTPResponse):
         """
         return self._by_scopes
 
-    def decode_id_token(self, openid_configuration=None, jwk=None):
+    def decode_id_token(
+        self,
+        openid_configuration=None,
+        jwk=None,
+        jwt_params: typing.Optional[typing.Dict] = None,
+    ):
+
         """
         Parse the included ID Token (OIDC) as a dict and return it.
 
@@ -174,9 +181,14 @@ class OAuthTokenResponse(GlobusHTTPResponse):
         :param jwk: The JWK as a cryptography public key object. When not provided, it
             will be fetched and parsed automatically.
         :type jwk: RSAPublicKey
+        :param jwt_params: An optional dict of parameters to pass to the jwt decode
+            step. These are passed verbatim to the jwt library.
+        :type jwt_params: dict
         """
         logger.info('Decoding ID Token "%s"', self["id_token"])
         auth_client = self._client
+
+        jwt_params = jwt_params or {}
 
         if not openid_configuration:
             if jwk:
@@ -199,6 +211,7 @@ class OAuthTokenResponse(GlobusHTTPResponse):
             jwk,
             algorithms=signing_algos,
             audience=auth_client.client_id,
+            options=jwt_params,
         )
         logger.debug("decode ID token finished successfully")
         return decoded

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     url="https://github.com/globus/globus-sdk-python",
     packages=find_packages(exclude=["tests", "tests.*"]),
     python_requires=">=3.6",
-    install_requires=["requests>=2.9.2,<3.0.0", "pyjwt[crypto]>=1.5.3,<2.0.0"],
+    install_requires=["requests>=2.9.2,<3.0.0", "pyjwt[crypto]>=2.0.0,<3.0.0"],
     extras_require={
         # the dev extra is for SDK developers only
         "dev": [

--- a/tests/functional/auth/test_id_token.py
+++ b/tests/functional/auth/test_id_token.py
@@ -105,24 +105,28 @@ def test_decode_id_token(token_response):
     )
     register_api_route("auth", "/jwk.json", method="GET", body=json.dumps(JWK))
 
-    decoded = token_response.decode_id_token()
+    decoded = token_response.decode_id_token(jwt_params={"verify_exp": False})
     assert decoded["preferred_username"] == "sirosen2@globusid.org"
 
 
 def test_decode_id_token_with_saved_oidc_config(token_response):
     register_api_route("auth", "/jwk.json", method="GET", body=json.dumps(JWK))
 
-    decoded = token_response.decode_id_token(openid_configuration=OIDC_CONFIG)
+    decoded = token_response.decode_id_token(
+        openid_configuration=OIDC_CONFIG, jwt_params={"verify_exp": False}
+    )
     assert decoded["preferred_username"] == "sirosen2@globusid.org"
 
 
 def test_decode_id_token_with_saved_oidc_config_and_jwk(token_response):
     decoded = token_response.decode_id_token(
-        openid_configuration=OIDC_CONFIG, jwk=JWK_PEM
+        openid_configuration=OIDC_CONFIG,
+        jwk=JWK_PEM,
+        jwt_params={"verify_exp": False},
     )
     assert decoded["preferred_username"] == "sirosen2@globusid.org"
 
 
 def test_invalid_decode_id_token_usage(token_response):
     with pytest.raises(globus_sdk.exc.GlobusSDKUsageError):
-        token_response.decode_id_token(jwk=JWK_PEM)
+        token_response.decode_id_token(jwk=JWK_PEM, jwt_params={"verify_exp": False})


### PR DESCRIPTION
`decode_id_token` tests are now failing because the token is expired. This was an oversight -- we weren't doing this testing before because of this issue. The simplest fix is to allow verification of `exp` (the expiration information) to be disabled and then use that in the testsuite.

---

Add passthrough parameters for "the jwt library" (pyjwt) to decode_id_token. This allows the testsuite to pass `verify_exp=False` as one of the pyjwt options.

After testing, this works on both pyjwt v1.x and v2.x , as the option name is unchanged. Since the testing is done, do the library update as well.