### PR TITLE
Allow responses to wrap other responses

### DIFF
--- a/src/globus_sdk/__init__.py
+++ b/src/globus_sdk/__init__.py
@@ -26,7 +26,7 @@ from globus_sdk.exc import (
     TransferAPIError,
 )
 from globus_sdk.local_endpoint import LocalGlobusConnectPersonal
-from globus_sdk.response import GlobusHTTPResponse, GlobusResponse
+from globus_sdk.response import GlobusHTTPResponse
 from globus_sdk.search import SearchClient, SearchQuery
 from globus_sdk.transfer import TransferClient
 from globus_sdk.transfer.data import DeleteData, TransferData
@@ -34,7 +34,6 @@ from globus_sdk.version import __version__
 
 __all__ = (
     "__version__",
-    "GlobusResponse",
     "GlobusHTTPResponse",
     "GlobusError",
     "GlobusSDKUsageError",

--- a/src/globus_sdk/auth/client_types/base.py
+++ b/src/globus_sdk/auth/client_types/base.py
@@ -1,6 +1,8 @@
 import collections.abc
 import json
 import logging
+import typing
+from typing import Type, TypeVar
 
 import jwt
 
@@ -10,6 +12,8 @@ from globus_sdk.authorizers import NullAuthorizer
 from globus_sdk.base import BaseClient
 
 log = logging.getLogger(__name__)
+
+T = TypeVar("T")
 
 
 class AuthClient(BaseClient):
@@ -330,6 +334,14 @@ class AuthClient(BaseClient):
             body.update(additional_params)
         return self.post("/v2/oauth2/token/revoke", data=body, encoding="form")
 
+    @typing.overload
+    def oauth2_token(self, form_data, response_class: Type[T]) -> T:
+        ...
+
+    @typing.overload
+    def oauth2_token(self, form_data) -> OAuthTokenResponse:
+        ...
+
     def oauth2_token(self, form_data, response_class=OAuthTokenResponse):
         """
         This is the generic form of calling the OAuth2 Token endpoint.
@@ -351,11 +363,12 @@ class AuthClient(BaseClient):
         log.info("Fetching new token from Globus Auth")
         # use the fact that requests implicitly encodes the `data` parameter as
         # a form POST
-        return self.post(
-            "/v2/oauth2/token",
-            response_class=response_class,
-            data=form_data,
-            encoding="form",
+        return response_class(
+            self.post(
+                "/v2/oauth2/token",
+                data=form_data,
+                encoding="form",
+            )
         )
 
     def oauth2_userinfo(self):

--- a/src/globus_sdk/auth/token_response.py
+++ b/src/globus_sdk/auth/token_response.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import time
-from typing import Dict, Optional
+from typing import TYPE_CHECKING, Dict, Optional, cast
 
 import jwt
 
@@ -9,6 +9,9 @@ from globus_sdk import exc
 from globus_sdk.response import GlobusHTTPResponse
 
 logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .client_types import AuthClient
 
 
 def _convert_token_info_dict(source_dict):
@@ -102,7 +105,7 @@ class OAuthTokenResponse(GlobusHTTPResponse):
     """
 
     def __init__(self, *args, **kwargs):
-        GlobusHTTPResponse.__init__(self, *args, **kwargs)
+        super().__init__(*args, **kwargs)
         self._init_rs_dict()
         self._init_scopes_getter()
 
@@ -186,7 +189,7 @@ class OAuthTokenResponse(GlobusHTTPResponse):
         :type jwt_params: dict
         """
         logger.info('Decoding ID Token "%s"', self["id_token"])
-        auth_client = self._client
+        auth_client = cast("AuthClient", self.client)
 
         jwt_params = jwt_params or {}
 

--- a/src/globus_sdk/base.py
+++ b/src/globus_sdk/base.py
@@ -1,7 +1,6 @@
 import logging
-import typing  # needed: https://github.com/PyCQA/pyflakes/issues/561
 import urllib.parse
-from typing import Dict, Optional, Type, TypeVar
+from typing import Dict, Optional, Type
 
 from globus_sdk import config, exc, utils
 from globus_sdk.authorizers import GlobusAuthorizer
@@ -9,8 +8,6 @@ from globus_sdk.response import GlobusHTTPResponse
 from globus_sdk.transport import RequestsTransport, RetryPolicy
 
 log = logging.getLogger(__name__)
-
-Response_T = TypeVar("Response_T", bound=GlobusHTTPResponse)
 
 
 class BaseClient:
@@ -121,29 +118,13 @@ class BaseClient:
     def qjoin_path(self, *parts: str) -> str:
         return "/" + "/".join(urllib.parse.quote(part) for part in parts)
 
-    @typing.overload
     def get(
         self,
         path: str,
         *,
         params: Optional[Dict] = None,
         headers: Optional[Dict] = None,
-        response_class: Type[Response_T],
-    ) -> Response_T:
-        ...
-
-    @typing.overload
-    def get(
-        self,
-        path: str,
-        *,
-        params: Optional[Dict] = None,
-        headers: Optional[Dict] = None,
-        response_class: None = None,
     ) -> GlobusHTTPResponse:
-        ...
-
-    def get(self, path, *, params=None, headers=None, response_class=None):
         """
         Make a GET request to the specified path.
 
@@ -153,15 +134,8 @@ class BaseClient:
         <globus_sdk.response.GlobusHTTPResponse>` object
         """
         log.debug(f"GET to {path} with params {params}")
-        return self.request(
-            "GET",
-            path,
-            params=params,
-            headers=headers,
-            response_class=response_class,
-        )
+        return self.request("GET", path, params=params, headers=headers)
 
-    @typing.overload
     def post(
         self,
         path: str,
@@ -170,33 +144,7 @@ class BaseClient:
         data: Optional[Dict] = None,
         headers: Optional[Dict] = None,
         encoding: Optional[str] = None,
-        response_class: Type[Response_T],
-    ) -> Response_T:
-        ...
-
-    @typing.overload
-    def post(
-        self,
-        path: str,
-        *,
-        params: Optional[Dict] = None,
-        data: Optional[Dict] = None,
-        headers: Optional[Dict] = None,
-        encoding: Optional[str] = None,
-        response_class: None = None,
     ) -> GlobusHTTPResponse:
-        ...
-
-    def post(
-        self,
-        path,
-        *,
-        params=None,
-        data=None,
-        headers=None,
-        encoding: Optional[str] = None,
-        response_class=None,
-    ):
         """
         Make a POST request to the specified path.
 
@@ -207,38 +155,16 @@ class BaseClient:
         """
         log.debug(f"POST to {path} with params {params}")
         return self.request(
-            "POST",
-            path,
-            params=params,
-            data=data,
-            headers=headers,
-            encoding=encoding,
-            response_class=response_class,
+            "POST", path, params=params, data=data, headers=headers, encoding=encoding
         )
 
-    @typing.overload
     def delete(
         self,
         path: str,
         *,
         params: Optional[Dict] = None,
         headers: Optional[Dict] = None,
-        response_class: Type[Response_T],
-    ) -> Response_T:
-        ...
-
-    @typing.overload
-    def delete(
-        self,
-        path: str,
-        *,
-        params: Optional[Dict] = None,
-        headers: Optional[Dict] = None,
-        response_class: None = None,
     ) -> GlobusHTTPResponse:
-        ...
-
-    def delete(self, path, *, params=None, headers=None, response_class=None):
         """
         Make a DELETE request to the specified path.
 
@@ -248,15 +174,8 @@ class BaseClient:
         <globus_sdk.response.GlobusHTTPResponse>` object
         """
         log.debug(f"DELETE to {path} with params {params}")
-        return self.request(
-            "DELETE",
-            path,
-            params=params,
-            headers=headers,
-            response_class=response_class,
-        )
+        return self.request("DELETE", path, params=params, headers=headers)
 
-    @typing.overload
     def put(
         self,
         path: str,
@@ -265,33 +184,7 @@ class BaseClient:
         data: Optional[Dict] = None,
         headers: Optional[Dict] = None,
         encoding: Optional[str] = None,
-        response_class: Type[Response_T],
-    ) -> Response_T:
-        ...
-
-    @typing.overload
-    def put(
-        self,
-        path: str,
-        *,
-        params: Optional[Dict] = None,
-        data: Optional[Dict] = None,
-        headers: Optional[Dict] = None,
-        encoding: Optional[str] = None,
-        response_class: None = None,
     ) -> GlobusHTTPResponse:
-        ...
-
-    def put(
-        self,
-        path,
-        *,
-        params=None,
-        data=None,
-        headers=None,
-        encoding: Optional[str] = None,
-        response_class=None,
-    ):
         """
         Make a PUT request to the specified path.
 
@@ -302,16 +195,9 @@ class BaseClient:
         """
         log.debug(f"PUT to {path} with params {params}")
         return self.request(
-            "PUT",
-            path,
-            params=params,
-            data=data,
-            headers=headers,
-            encoding=encoding,
-            response_class=response_class,
+            "PUT", path, params=params, data=data, headers=headers, encoding=encoding
         )
 
-    @typing.overload
     def patch(
         self,
         path: str,
@@ -320,33 +206,7 @@ class BaseClient:
         data: Optional[Dict] = None,
         headers: Optional[Dict] = None,
         encoding: Optional[str] = None,
-        response_class: Type[Response_T],
-    ) -> Response_T:
-        ...
-
-    @typing.overload
-    def patch(
-        self,
-        path: str,
-        *,
-        params: Optional[Dict] = None,
-        data: Optional[Dict] = None,
-        headers: Optional[Dict] = None,
-        encoding: Optional[str] = None,
-        response_class: None = None,
     ) -> GlobusHTTPResponse:
-        ...
-
-    def patch(
-        self,
-        path,
-        *,
-        params=None,
-        data=None,
-        headers=None,
-        encoding: Optional[str] = None,
-        response_class=None,
-    ):
         """
         Make a PATCH request to the specified path.
 
@@ -357,16 +217,9 @@ class BaseClient:
         """
         log.debug(f"PATCH to {path} with params {params}")
         return self.request(
-            "PATCH",
-            path,
-            params=params,
-            data=data,
-            headers=headers,
-            encoding=encoding,
-            response_class=response_class,
+            "PATCH", path, params=params, data=data, headers=headers, encoding=encoding
         )
 
-    @typing.overload
     def request(
         self,
         method: str,
@@ -376,35 +229,7 @@ class BaseClient:
         data: Optional[Dict] = None,
         headers: Optional[Dict] = None,
         encoding: Optional[str] = None,
-        response_class: Type[Response_T],
-    ) -> Response_T:
-        ...
-
-    @typing.overload
-    def request(
-        self,
-        method: str,
-        path: str,
-        *,
-        params: Optional[Dict] = None,
-        data: Optional[Dict] = None,
-        headers: Optional[Dict] = None,
-        encoding: Optional[str] = None,
-        response_class: None = None,
     ) -> GlobusHTTPResponse:
-        ...
-
-    def request(
-        self,
-        method,
-        path,
-        *,
-        params=None,
-        data=None,
-        headers=None,
-        encoding: Optional[str] = None,
-        response_class=None,
-    ):
         """
         Send an HTTP request
 
@@ -423,9 +248,6 @@ class BaseClient:
             registered with the transport. By default, strings get "text" behavior and
             all other objects get "json".
         :type encoding: string
-        :param response_class: Class for response object, overrides the default_response
-            class
-        :type response_class: class
 
         :return: :class:`GlobusHTTPResponse \
         <globus_sdk.response.GlobusHTTPResponse>` object
@@ -457,10 +279,7 @@ class BaseClient:
 
         if 200 <= r.status_code < 400:
             log.debug(f"request completed with response code: {r.status_code}")
-            if response_class is None:
-                return GlobusHTTPResponse(r, client=self)
-            else:
-                return response_class(r, client=self)
+            return GlobusHTTPResponse(r, self)
 
         log.debug(f"request completed with (error) response code: {r.status_code}")
         raise self.error_class(r)

--- a/src/globus_sdk/response.py
+++ b/src/globus_sdk/response.py
@@ -1,39 +1,105 @@
 import logging
+from typing import TYPE_CHECKING, Any, Optional, Union
 
-logger = logging.getLogger(__name__)
+from requests import Response
+
+log = logging.getLogger(__name__)
+
+if TYPE_CHECKING:  # pragma: no cover
+    from globus_sdk.base import BaseClient
 
 
-class GlobusResponse:
+class GlobusHTTPResponse:
     """
-    Generic response object, with a single ``data`` member.
+    Response object that wraps an HTTP response from the underlying HTTP
+    library. If the response is JSON, the parsed data will be available in
+    ``data``, otherwise ``data`` will be ``None`` and ``text`` should
+    be used instead.
 
     The most common response data is a JSON dictionary. To make
     handling this type of response as seemless as possible, the
-    ``GlobusResponse`` object also supports direct dictionary item
-    access, as an alias for accessing an item of the underlying
-    ``data``. If ``data`` is not a dictionary, item access will raise
-    ``TypeError``.
+    ``GlobusHTTPResponse`` object implements the immutable mapping protocol for
+    dict-style access. This is just an alias for access to the underlying data.
+
+    If ``data`` is not a dictionary, item access will raise ``TypeError``.
 
     >>> print("Response ID": r["id"]) # alias for r.data["id"]
 
-    ``GlobusResponse`` objects *always* wrap some kind of data to
-    return to a caller. Most basic actions on a GlobusResponse are
-    just ways of interacting with this data.
+    :ivar http_status: HTTP status code returned by the server (int)
+    :ivar content_type: Content-Type header returned by the server (str)
+    :ivar client: The client instance which made the request
     """
 
-    def __init__(self, data, client=None):
-        # TODO: In v2, consider making client a required argument
-        # client is the originating client object, which can be used by
-        # advanced response classes to implement fancy methods which need to
-        # interact with the client
-        self._client = client
+    def __init__(
+        self,
+        response: Union[Response, "GlobusHTTPResponse"],
+        client: Optional["BaseClient"] = None,
+    ):
+        # init on a GlobusHTTPResponse: we are wrapping this data
+        # the _response is None
+        if isinstance(response, GlobusHTTPResponse):
+            if client is not None:
+                raise ValueError("Redundant client with wrapped response")
+            self._wrapped: Optional[GlobusHTTPResponse] = response
+            self._response: Optional[Response] = None
+            self.client: "BaseClient" = self._wrapped.client
 
-        self._data = data
+            # copy attributes off of '_wrapped'
+            self._parsed_json: Any = self._wrapped._parsed_json
+            self._text: str = self._wrapped.text
+            self.http_status: int = self._wrapped.http_status
+            self.content_type: Optional[str] = self._wrapped.content_type
 
-    def __str__(self):
+        # init on a Response object, this is the "normal" case
+        # _wrapped is None
+        else:
+            if client is None:
+                raise ValueError("Missing client with normal response")
+            self._wrapped = None
+            self._response = response
+            self.client = client
+
+            # JSON decoding may raise a ValueError due to an invalid JSON
+            # document. In the case of trying to fetch the "data" on an HTTP
+            # response, this means we didn't get a JSON response.
+            # store this as None, as in "no data"
+            #
+            # if the caller *really* wants the raw body of the response, they can
+            # always use `text`
+            try:
+                self._parsed_json = self._response.json()
+            except ValueError:
+                log.warning("response data did not parse as JSON, data=None")
+                self._parsed_json = None
+
+            self._text = self._response.text
+            self.http_status = self._response.status_code
+            self.content_type = self._response.headers.get("Content-Type")
+
+    @property
+    def data(self):
+        return self._parsed_json
+
+    @property
+    def text(self) -> str:
+        """The raw response data as a string."""
+        return self._text
+
+    def get(self, key, default=None):
+        """
+        ``get`` is just an alias for ``data.get(key, default)``, but with the added
+        check that if ``data`` is ``None``, it returns the default.
+        """
+        if self.data is None:
+            return default
+        # NB: `default` is provided as a positional because the native dict type
+        # doesn't recognize a keyword argument `default`
+        return self.data.get(key, default)
+
+    def __str__(self) -> str:
         return repr(self)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.data!r})"
 
     def __getitem__(self, key):
@@ -44,79 +110,21 @@ class GlobusResponse:
         try:
             return data[key]
         except TypeError:
-            logger.error(f"Can't index into responses of type {type(self)}")
-            # re-raise with an altered message -- the issue is that whatever
-            # type of GlobusResponse you're working with doesn't support
-            # indexing
+            log.error(
+                f"Can't index into responses with underlying data of type {type(data)}"
+            )
+            # re-raise with an altered message and error type -- the issue is that
+            # whatever data is in the response doesn't support indexing (e.g. a response
+            # that is just an integer, parsed as json)
+            #
             # "type" is ambiguous, but we don't know if it's the fault of the
             # class at large, or just a particular call's `data` property
-            raise TypeError(
-                "This type of GlobusResponse object does not support indexing."
-            )
+            raise ValueError("This type of response data does not support indexing.")
 
     def __contains__(self, item):
         """
-        ``x in GlobusResponse`` is an alias for ``x in GlobusResponse.data``
+        ``x in response`` is an alias for ``x in response.data``
         """
+        if self.data is None:
+            return False
         return item in self.data
-
-    @property
-    def data(self):
-        """
-        Response data as a Python data structure. Usually a dict or
-        list.
-        """
-        return self._data
-
-    def get(self, *args, **kwargs):
-        """
-        ``GlobusResponse.get`` is just an alias for ``GlobusResponse.data.get``
-        """
-        return self.data.get(*args, **kwargs)
-
-
-class GlobusHTTPResponse(GlobusResponse):
-    """
-    Response object that wraps an HTTP response from the underlying HTTP
-    library. If the response is JSON, the parsed data will be available in
-    ``data``, otherwise ``data`` will be ``None`` and ``text`` should
-    be used instead.
-
-    :ivar http_status: HTTP status code returned by the server (int)
-    :ivar content_type: Content-Type header returned by the server (str)
-    """
-
-    def __init__(self, http_response, client=None):
-        # the API response as some form of HTTP response object will be the
-        # underlying data of an API response
-        GlobusResponse.__init__(self, http_response, client=client)
-        # NB: the word 'code' is confusing because we use it in the
-        # error body, and status_code is not much better. http_code, or
-        # http_status_code if we wanted to be really explicit, is
-        # clearer, but less consistent with requests (for better and
-        # worse).
-        self.http_status = http_response.status_code
-        self.content_type = http_response.headers.get("Content-Type")
-
-    @property
-    def data(self):
-        try:
-            return self._data.json()
-        # JSON decoding may raise a ValueError due to an invalid JSON
-        # document. In the case of trying to fetch the "data" on an HTTP
-        # response, this means we didn't get a JSON response. Rather than
-        # letting the error bubble up, return None, as in "no data"
-        # if the caller *really* wants the raw body of the response, they can
-        # always use `text`
-        except ValueError:
-            logger.warning(
-                "GlobusHTTPResponse.data is null when body is not valid JSON"
-            )
-            return None
-
-    @property
-    def text(self):
-        """
-        The raw response data as a string.
-        """
-        return self._data.text

--- a/src/globus_sdk/transfer/client.py
+++ b/src/globus_sdk/transfer/client.py
@@ -403,9 +403,7 @@ class TransferClient(BaseClient):
         """
         endpoint_id_s = utils.safe_stringify(endpoint_id)
         path = self.qjoin_path("endpoint", endpoint_id_s, "activation_requirements")
-        return self.get(
-            path, params=params, response_class=ActivationRequirementsResponse
-        )
+        return ActivationRequirementsResponse(self.get(path, params=params))
 
     def my_effective_pause_rule_list(
         self, endpoint_id: ID_PARAM_TYPE, **params
@@ -428,7 +426,7 @@ class TransferClient(BaseClient):
         path = self.qjoin_path(
             "endpoint", endpoint_id_s, "my_effective_pause_rule_list"
         )
-        return self.get(path, params=params, response_class=IterableTransferResponse)
+        return IterableTransferResponse(self.get(path, params=params))
 
     # Shared Endpoints
 
@@ -451,7 +449,7 @@ class TransferClient(BaseClient):
         endpoint_id_s = utils.safe_stringify(endpoint_id)
         log.info(f"TransferClient.my_shared_endpoint_list({endpoint_id_s}, ...)")
         path = self.qjoin_path("endpoint", endpoint_id_s, "my_shared_endpoint_list")
-        return self.get(path, params=params, response_class=IterableTransferResponse)
+        return IterableTransferResponse(self.get(path, params=params))
 
     def create_shared_endpoint(self, data):
         """
@@ -507,7 +505,7 @@ class TransferClient(BaseClient):
         endpoint_id_s = utils.safe_stringify(endpoint_id)
         log.info(f"TransferClient.endpoint_server_list({endpoint_id_s}, ...)")
         path = self.qjoin_path("endpoint", endpoint_id_s, "server_list")
-        return self.get(path, params=params, response_class=IterableTransferResponse)
+        return IterableTransferResponse(self.get(path, params=params))
 
     def get_endpoint_server(
         self, endpoint_id: ID_PARAM_TYPE, server_id, **params
@@ -624,7 +622,7 @@ class TransferClient(BaseClient):
         endpoint_id_s = utils.safe_stringify(endpoint_id)
         log.info(f"TransferClient.endpoint_role_list({endpoint_id_s}, ...)")
         path = self.qjoin_path("endpoint", endpoint_id_s, "role_list")
-        return self.get(path, params=params, response_class=IterableTransferResponse)
+        return IterableTransferResponse(self.get(path, params=params))
 
     def add_endpoint_role(
         self, endpoint_id: ID_PARAM_TYPE, role_data: Dict
@@ -712,7 +710,7 @@ class TransferClient(BaseClient):
         endpoint_id_s = utils.safe_stringify(endpoint_id)
         log.info(f"TransferClient.endpoint_acl_list({endpoint_id_s}, ...)")
         path = self.qjoin_path("endpoint", endpoint_id_s, "access_list")
-        return self.get(path, params=params, response_class=IterableTransferResponse)
+        return IterableTransferResponse(self.get(path, params=params))
 
     def get_endpoint_acl_rule(
         self, endpoint_id: ID_PARAM_TYPE, rule_id, **params
@@ -830,7 +828,7 @@ class TransferClient(BaseClient):
     # Bookmarks
     #
 
-    def bookmark_list(self, **params) -> response.GlobusHTTPResponse:
+    def bookmark_list(self, **params) -> IterableTransferResponse:
         """
         ``GET /bookmark_list``
 
@@ -845,9 +843,7 @@ class TransferClient(BaseClient):
         in the REST documentation for details.
         """
         log.info(f"TransferClient.bookmark_list({params})")
-        return self.get(
-            "bookmark_list", params=params, response_class=IterableTransferResponse
-        )
+        return IterableTransferResponse(self.get("bookmark_list", params=params))
 
     def create_bookmark(self, bookmark_data: Dict) -> response.GlobusHTTPResponse:
         """
@@ -958,7 +954,7 @@ class TransferClient(BaseClient):
         endpoint_id_s = utils.safe_stringify(endpoint_id)
         log.info(f"TransferClient.operation_ls({endpoint_id_s}, {params})")
         path = self.qjoin_path("operation/endpoint", endpoint_id_s, "ls")
-        return self.get(path, params=params, response_class=IterableTransferResponse)
+        return IterableTransferResponse(self.get(path, params=params))
 
     def operation_mkdir(
         self, endpoint_id: ID_PARAM_TYPE, path, **params
@@ -1558,7 +1554,7 @@ class TransferClient(BaseClient):
 
     def endpoint_manager_monitored_endpoints(
         self, **params
-    ) -> response.GlobusHTTPResponse:
+    ) -> IterableTransferResponse:
         """
         Get endpoints the current user is a monitor or manager on.
 
@@ -1574,7 +1570,7 @@ class TransferClient(BaseClient):
         """
         log.info(f"TransferClient.endpoint_manager_monitored_endpoints({params})")
         path = self.qjoin_path("endpoint_manager", "monitored_endpoints")
-        return self.get(path, params=params, response_class=IterableTransferResponse)
+        return IterableTransferResponse(self.get(path, params=params))
 
     def endpoint_manager_hosted_endpoint_list(
         self, endpoint_id: ID_PARAM_TYPE, **params
@@ -1599,7 +1595,7 @@ class TransferClient(BaseClient):
         path = self.qjoin_path(
             "endpoint_manager", "endpoint", endpoint_id_s, "hosted_endpoint_list"
         )
-        return self.get(path, params=params, response_class=IterableTransferResponse)
+        return IterableTransferResponse(self.get(path, params=params))
 
     def endpoint_manager_get_endpoint(
         self, endpoint_id: ID_PARAM_TYPE, **params
@@ -1649,7 +1645,7 @@ class TransferClient(BaseClient):
         path = self.qjoin_path(
             "endpoint_manager", "endpoint", endpoint_id_s, "access_list"
         )
-        return self.get(path, params=params, response_class=IterableTransferResponse)
+        return IterableTransferResponse(self.get(path, params=params))
 
     #
     # endpoint manager task methods
@@ -2132,7 +2128,7 @@ class TransferClient(BaseClient):
         path = self.qjoin_path("endpoint_manager", "pause_rule_list")
         if filter_endpoint is not None:
             params["filter_endpoint"] = utils.safe_stringify(filter_endpoint)
-        return self.get(path, params=params, response_class=IterableTransferResponse)
+        return IterableTransferResponse(self.get(path, params=params))
 
     def endpoint_manager_create_pause_rule(self, data) -> response.GlobusHTTPResponse:
         """

--- a/src/globus_sdk/transfer/paging.py
+++ b/src/globus_sdk/transfer/paging.py
@@ -1,7 +1,6 @@
 import logging
 
 from globus_sdk.exc import GlobusSDKUsageError
-from globus_sdk.response import GlobusResponse
 from globus_sdk.transfer.response import IterableTransferResponse
 
 logger = logging.getLogger(__name__)
@@ -151,7 +150,6 @@ class PaginatedResource:
 
         self.client_path = path
         self.client_kwargs = client_kwargs
-        self.client_kwargs["response_class"] = IterableTransferResponse
 
         # convert the iterable_func method into a generator expression by
         # calling it
@@ -321,8 +319,10 @@ class PaginatedResource:
             # nicely, the __getitem__ for GlobusResponse will work on raw
             # dicts, so these handle well
             res = self.client_method(self.client_path, **self.client_kwargs)
+            if not isinstance(res, IterableTransferResponse):
+                res = IterableTransferResponse(res)
             for item in res:
-                yield GlobusResponse(item, client=self.client_object)
+                yield item
                 # increment the "num results" counter
                 self.num_results_fetched += 1
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -171,7 +171,7 @@ class PickleableMockResponse(mock.NonCallableMock):
 
 
 def make_response(
-    response_class=globus_sdk.GlobusHTTPResponse,
+    response_class=None,
     status=200,
     headers=None,
     json_body=None,
@@ -185,4 +185,7 @@ def make_response(
     want to directly create the response.
     """
     r = PickleableMockResponse(status, headers=headers, json_body=json_body, text=text)
-    return response_class(r, client=client)
+    http_res = globus_sdk.GlobusHTTPResponse(r, client=client)
+    if response_class is not None:
+        return response_class(http_res)
+    return http_res

--- a/tests/functional/transfer/test_iterable.py
+++ b/tests/functional/transfer/test_iterable.py
@@ -34,8 +34,8 @@ def test_server_list(client):
     )
 
     res = client.endpoint_server_list(epid)
-    # it should still be a subclass of GlobusResponse
-    assert isinstance(res, globus_sdk.GlobusResponse)
+    # it should still be a subclass of GlobusHTTPResponse
+    assert isinstance(res, globus_sdk.GlobusHTTPResponse)
 
     # fetch top-level attrs
     assert res["DATA_TYPE"] == "endpoint_server_list"

--- a/tests/unit/responses/conftest.py
+++ b/tests/unit/responses/conftest.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import pytest
 
 import globus_sdk
@@ -41,7 +43,7 @@ def make_oauth_token_response():
                     },
                 ],
             },
-            client=client,
+            client=client if client else mock.Mock(),
         )
 
     return f

--- a/tests/unit/responses/test_activation_response.py
+++ b/tests/unit/responses/test_activation_response.py
@@ -1,9 +1,11 @@
 import json
 import time
+from unittest import mock
 
 import pytest
 import requests
 
+from globus_sdk.response import GlobusHTTPResponse
 from globus_sdk.transfer.response import ActivationRequirementsResponse
 
 
@@ -28,7 +30,9 @@ def make_response(
     response = requests.Response()
     response.headers["Content-Type"] = "application/json"
     response._content = json.dumps(data).encode("utf-8")
-    return ActivationRequirementsResponse(response)
+    return ActivationRequirementsResponse(
+        GlobusHTTPResponse(response, client=mock.Mock())
+    )
 
 
 def test_expires_at():

--- a/tests/unit/test_transfer_paging.py
+++ b/tests/unit/test_transfer_paging.py
@@ -1,8 +1,10 @@
 import json
+from unittest import mock
 
 import pytest
 import requests
 
+from globus_sdk.response import GlobusHTTPResponse
 from globus_sdk.transfer.paging import PaginatedResource
 from globus_sdk.transfer.response import IterableTransferResponse
 
@@ -13,9 +15,7 @@ class PagingSimulator:
     def __init__(self, n):
         self.n = n  # the number of simulated items
 
-    def simulate_get(
-        self, path, params=None, headers=None, response_class=None, retry_401=True
-    ):
+    def simulate_get(self, path, params=None, headers=None, retry_401=True):
         """
         Simulates a paginated response from a Globus API get supporting limit,
         offset, and has next page
@@ -36,7 +36,9 @@ class PagingSimulator:
         response = requests.Response()
         response._content = json.dumps(data).encode("utf-8")
         response.headers["Content-Type"] = "application/json"
-        return IterableTransferResponse(response)
+        return IterableTransferResponse(
+            GlobusHTTPResponse(response, client=mock.Mock())
+        )
 
 
 @pytest.fixture


### PR DESCRIPTION
This implementation is an alternative to #424

The main difference is that in this variant, there is no dedicated `GlobusHTTPResponseProxy` class and no common base class of `GlobusResponse`. Instead, there is only one class, `GlobusHTTPResponse`, and it dispatches in `__init__` based on whether it is being created from a `requests.Response` or another `GlobusHTTPResponse` object.

The same basic logic is being expressed -- an `IterableTransferResponse` or other custom response class now wraps a base response object -- but in a slightly different form.

---

This rewrite net-simplifies the combination of responses and various HTTP methods. The overall gist is that base client methods always return GlobusHTTPResponse objects, and the ability to pass `response_class` is removed. In order to still support advanced response types (ActivationRequirementsResponse, OAuthTokenResponse, etc), GlobusHTTPResponse now supports initialization from some other "wrapped" response object.

During init, `GlobusHTTPResponse` checks if its input is a `GlobusHTTPResponse` and dispatches on that for all of its logic. Either it stores the `_wrapped` response or the `_response` (raw requests.Response object). The various attributes of the response are either copied from the wrapped response or are pulled off of the response object as before.

As a result, where we would previously provide a desirable response class like so:

    self.get("/foo", response_class=FooResponse)

The same idea is expressed in a more "ordinary" and idiomatic way like so:

    FooResponse(self.get("/foo"))

The following included changes are related to this:

- PaginatedResponse no longer needs to take a `response_class` to pass through -- it just wraps data in IterableTransferResponse

- The once-optional `client` argument to GlobusHTTPResponse is now required, since all of this was being refactored anyway

- Type overloads for the BaseClient methods are all removed, because they now are guaranteed to always return GlobusHTTPResponse

- AuthClient.oauth2_token needs to allow the use of variable wrapper types to support dependent token responses while still returning a default of an OAuthTokenResponse. It therefore implements and has type overloads for `response_class`, similar to what was previously done in BaseClient