### PR TITLE
Improve tox config for multipython coverage

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,7 +34,7 @@ jobs:
         if: ${{ matrix.python-version == '3.9' }}
         run: python -m tox -e lint
       - name: Run Tests
-        run: python -m tox -e py
+        run: python -m tox -e py -- --cov-report="term-missing:skip-covered"
       - name: Ensure docs build
         # docs are only ever built on a linux 3.9 box (readthedocs)
         if: ${{ matrix.python-version == '3.9' && matrix.os == 'ubuntu-latest' }}

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,6 @@ no_implicit_optional = true
 
 
 [tool:pytest]
-addopts = --cov=globus_sdk
 filterwarnings =
     # warnings are errors, like -Werror
     error

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,24 @@
 [tox]
-envlist = py{39,38,37,36}
+envlist = cov-clean,py{39,38,37,36},cov-report
 skip_missing_interpreters = true
 
 [testenv]
 usedevelop = true
 extras = dev
-commands = pytest {posargs}
+commands = pytest --cov-append --cov-report= {posargs}
+depends =
+    {py36,py37,py38,py39}: cov-clean
+    cov-report: py36,py37,py38,py39
+
+[testenv:cov-clean]
+deps = coverage
+skip_install = true
+commands = coverage erase
+
+[testenv:cov-report]
+deps = coverage
+skip_install = true
+commands = coverage report
 
 [testenv:lint]
 deps = pre-commit<3

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ commands = coverage erase
 [testenv:cov-report]
 deps = coverage
 skip_install = true
-commands = coverage report
+commands = coverage report --skip-covered
 
 [testenv:lint]
 deps = pre-commit<3

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ skip_missing_interpreters = true
 [testenv]
 usedevelop = true
 extras = dev
-commands = pytest --cov-append --cov-report= {posargs}
+commands = pytest --cov=src --cov-append --cov-report= {posargs}
 depends =
     {py36,py37,py38,py39}: cov-clean
     cov-report: py36,py37,py38,py39


### PR DESCRIPTION
'--cov-append' must be used to gather coverage info from multiple python versions. e.g. If we have code which conditionally executes on some versions and not others, it will only be properly recorded in this way.

Tox invocation via github actions will still produce distinct coverage reports by passing a `--cov-report=...` option.
However, local runs of `tox` should run tests on all interpreters and only print a final coverage report.