### PR TITLE
Fix paginators with 'max_results_per_call'

### DIFF
--- a/src/globus_sdk/services/transfer/client.py
+++ b/src/globus_sdk/services/transfer/client.py
@@ -1156,7 +1156,7 @@ class TransferClient(client.BaseClient):
         paging.LimitOffsetTotalPaginator,
         items_key="DATA",
         get_page_size=_get_page_size,
-        max_results_per_call=1000,
+        max_total_results=1000,
         page_size=1000,
     )
     def task_list(self, **params) -> IterableTransferResponse:
@@ -1194,7 +1194,7 @@ class TransferClient(client.BaseClient):
         paging.LimitOffsetTotalPaginator,
         items_key="DATA",
         get_page_size=_get_page_size,
-        max_results_per_call=1000,
+        max_total_results=1000,
         page_size=1000,
     )
     def task_event_list(
@@ -1759,7 +1759,7 @@ class TransferClient(client.BaseClient):
         paging.LimitOffsetTotalPaginator,
         items_key="DATA",
         get_page_size=_get_page_size,
-        max_results_per_call=1000,
+        max_total_results=1000,
         page_size=1000,
     )
     def endpoint_manager_task_event_list(

--- a/tests/functional/transfer/test_paginated.py
+++ b/tests/functional/transfer/test_paginated.py
@@ -1,4 +1,4 @@
-import json
+import random
 
 import pytest
 import responses
@@ -6,14 +6,13 @@ import responses
 from tests.common import register_api_route
 
 # empty search
-EMPTY_SEARCH_RESULT = """{
-  "DATA_TYPE": "endpoint_list",
-  "offset": 0,
-  "limit": 100,
-  "has_next_page": false,
-  "DATA": [
-  ]
-}"""
+EMPTY_SEARCH_RESULT = {
+    "DATA_TYPE": "endpoint_list",
+    "offset": 0,
+    "limit": 100,
+    "has_next_page": False,
+    "DATA": [],
+}
 
 # single page of data
 SINGLE_PAGE_SEARCH_RESULT = {
@@ -49,7 +48,7 @@ MULTIPAGE_SEARCH_RESULTS = [
                 "DATA_TYPE": "endpoint",
                 "display_name": f"SDK Test Stub {x + 100}",
             }
-            for x in range(100)
+            for x in range(100, 200)
         ],
     },
     {
@@ -68,17 +67,48 @@ MULTIPAGE_SEARCH_RESULTS = [
 ]
 
 
+def _mk_task_doc(idx):
+    return {
+        "DATA_TYPE": "task",
+        "source_endpoint_id": "dc8e1110-b698-11eb-afd7-e1e7a67e00c1",
+        "source_endpoint_display_name": "foreign place",
+        "destination_endpoint_id": "83567b16-478d-4ead-a486-645bab0b07dc",
+        "destination_endpoint_display_name": "my home",
+        "directories": 0,
+        "effective_bytes_per_second": random.randint(0, 10000),
+        "files": 1,
+        "encrypt_data": False,
+        "label": f"autogen transfer {idx}",
+    }
+
+
+MULTIPAGE_TASK_LIST_RESULTS = [
+    {
+        "DATA_TYPE": "task_list",
+        "offset": 0,
+        "limit": 100,
+        "total": 200,
+        "DATA": [_mk_task_doc(x) for x in range(100)],
+    },
+    {
+        "DATA_TYPE": "task_list",
+        "offset": 100,
+        "limit": 200,
+        "total": 200,
+        "DATA": [_mk_task_doc(x) for x in range(100, 200)],
+    },
+]
+
+
 def test_endpoint_search_noresults(client):
-    register_api_route("transfer", "/endpoint_search", body=EMPTY_SEARCH_RESULT)
+    register_api_route("transfer", "/endpoint_search", json=EMPTY_SEARCH_RESULT)
 
     res = client.endpoint_search("search query!")
     assert res["DATA"] == []
 
 
 def test_endpoint_search_one_page(client):
-    register_api_route(
-        "transfer", "/endpoint_search", body=json.dumps(SINGLE_PAGE_SEARCH_RESULT)
-    )
+    register_api_route("transfer", "/endpoint_search", json=SINGLE_PAGE_SEARCH_RESULT)
 
     # without calling the paginated version, we only get one page
     res = client.endpoint_search("search query!")
@@ -89,23 +119,47 @@ def test_endpoint_search_one_page(client):
 
 
 @pytest.mark.parametrize("method", ("__iter__", "pages"))
-def test_endpoint_search_multipage(client, method):
+@pytest.mark.parametrize(
+    "api_methodname,paged_data",
+    [
+        ("endpoint_search", MULTIPAGE_SEARCH_RESULTS),
+        ("task_list", MULTIPAGE_TASK_LIST_RESULTS),
+    ],
+)
+def test_paginated_method_multipage(client, method, api_methodname, paged_data):
+    if api_methodname == "endpoint_search":
+        route = "/endpoint_search"
+        client_method = client.endpoint_search
+        paginated_method = client.paginated.endpoint_search
+        call_args = ("search_query",)
+        wrapper_type = "endpoint_list"
+        data_type = "endpoint"
+    elif api_methodname == "task_list":
+        route = "/task_list"
+        client_method = client.task_list
+        paginated_method = client.paginated.task_list
+        call_args = ()
+        wrapper_type = "task_list"
+        data_type = "task"
+    else:
+        raise NotImplementedError
+
     # add each page
-    for page in MULTIPAGE_SEARCH_RESULTS:
-        register_api_route("transfer", "/endpoint_search", json=page)
+    for page in paged_data:
+        register_api_route("transfer", route, json=page)
 
     # unpaginated, we'll only get one page
-    res = list(client.endpoint_search("search_query"))
+    res = list(client_method(*call_args))
     assert len(res) == 100
 
     # reset and reapply responses
     responses.reset()
-    for page in MULTIPAGE_SEARCH_RESULTS:
-        register_api_route("transfer", "/endpoint_search", json=page)
+    for page in paged_data:
+        register_api_route("transfer", route, json=page)
 
     # setup the paginator and either point at `pages()` or directly at the paginator's
     # `__iter__`
-    paginator = client.paginated.endpoint_search("search_query")
+    paginator = paginated_method(*call_args)
     if method == "pages":
         iterator = paginator.pages()
     elif method == "__iter__":
@@ -118,13 +172,13 @@ def test_endpoint_search_multipage(client, method):
     count_objects = 0
     for page in iterator:
         count_pages += 1
-        assert page["DATA_TYPE"] == "endpoint_list"
+        assert page["DATA_TYPE"] == wrapper_type
         for res_obj in page:
             count_objects += 1
-            assert res_obj["DATA_TYPE"] == "endpoint"
+            assert res_obj["DATA_TYPE"] == data_type
 
-    assert count_pages == len(MULTIPAGE_SEARCH_RESULTS)
-    assert count_objects == sum(len(x["DATA"]) for x in MULTIPAGE_SEARCH_RESULTS)
+    assert count_pages == len(paged_data)
+    assert count_objects == sum(len(x["DATA"]) for x in paged_data)
 
 
 def test_endpoint_search_multipage_iter_items(client):


### PR DESCRIPTION
I'm going to self-merge this so that I can do a new alpha release. The PR is just to show and document the change.

This argument is not valid -- these appear to be typos where the desired parameter was `max_total_results`. After validating with the API, this appears to be correct: these APIs for task_list and task_event_list support a max page size of 1000 and a total limit of 1000 (meaning you can get all results in a single page).

Add testing for `task_list` to ensure that the relevant paginator is constructed and iterated.