### PR TITLE
Add some basic autodoc for paginated methods

### DIFF
--- a/docs/services/transfer.rst
+++ b/docs/services/transfer.rst
@@ -43,14 +43,3 @@ Transfer Responses
 .. automodule:: globus_sdk.services.transfer.response
    :members:
    :show-inheritance:
-
-PaginatedResource Responses
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The ``PaginatedResource`` class should not typically be instantiated directly,
-but is returned from several :class:`TransferClient <globus_sdk.TransferClient>` methods.
-It is an iterable of ``GlobusRepsonse`` objects.
-
-.. autoclass:: globus_sdk.services.transfer.paging.PaginatedResource
-   :members: data
-   :show-inheritance:

--- a/src/globus_sdk/_sphinxext.py
+++ b/src/globus_sdk/_sphinxext.py
@@ -37,7 +37,11 @@ def _classname2methods(classname, include_methods):
             return False
         return True
 
-    return [name for name, value in methods if _methodname_is_good(name)]
+    return [(name, value) for name, value in methods if _methodname_is_good(name)]
+
+
+def _is_paginated(func):
+    return getattr(func, "_has_paginator", False)
 
 
 class AutoMethodList(Directive):
@@ -58,8 +62,14 @@ class AutoMethodList(Directive):
         yield ""
         yield "**Methods**"
         yield ""
-        for methodname in _classname2methods(classname, include_methods):
-            yield f"* :py:meth:`~{classname}.{methodname}`"
+        for methodname, method in _classname2methods(classname, include_methods):
+            if not _is_paginated(method):
+                yield f"* :py:meth:`~{classname}.{methodname}`"
+            else:
+                yield (
+                    f"* :py:meth:`~{classname}.{methodname}`, "
+                    f"``paginated.{methodname}()``"
+                )
 
         yield ""
 

--- a/src/globus_sdk/paging/table.py
+++ b/src/globus_sdk/paging/table.py
@@ -28,6 +28,15 @@ def has_paginator(
         func._paginator_class = paginator_class  # type: ignore
         func._paginator_items_key = items_key  # type: ignore
         func._paginator_params = paginator_params  # type: ignore
+        func.__doc__ = f"""{func.__doc__}
+
+        **Paginated Usage**
+
+        This method supports paginated access. To use the paginated variant, give the
+        same arguments as normal, but prefix the method name with ``paginated``, as in
+
+        >>> client.paginated.{func.__name__}(...)
+        """
         return func
 
     return decorate


### PR DESCRIPTION
Again, I'm going to self-merge so that the live docs will be fixed. The PR is just a public record of this change.

Paginated methods now

- automatically get a snippet added to the end of their docstring which notes paginated usage
- are listed in the automethodlist with their paginated variant