### PR TITLE
move passthrough paramaters out of top level params

### DIFF
--- a/src/globus_sdk/client.py
+++ b/src/globus_sdk/client.py
@@ -111,7 +111,7 @@ class BaseClient:
         self,
         path: str,
         *,
-        params: Optional[Dict] = None,
+        query_params: Optional[Dict[str, str]] = None,
         headers: Optional[Dict] = None,
     ) -> GlobusHTTPResponse:
         """
@@ -122,14 +122,14 @@ class BaseClient:
         :return: :class:`GlobusHTTPResponse \
         <globus_sdk.response.GlobusHTTPResponse>` object
         """
-        log.debug(f"GET to {path} with params {params}")
-        return self.request("GET", path, params=params, headers=headers)
+        log.debug(f"GET to {path} with query_params {query_params}")
+        return self.request("GET", path, query_params=query_params, headers=headers)
 
     def post(
         self,
         path: str,
         *,
-        params: Optional[Dict] = None,
+        query_params: Optional[Dict[str, str]] = None,
         data: Optional[Dict] = None,
         headers: Optional[Dict] = None,
         encoding: Optional[str] = None,
@@ -142,16 +142,21 @@ class BaseClient:
         :return: :class:`GlobusHTTPResponse \
         <globus_sdk.response.GlobusHTTPResponse>` object
         """
-        log.debug(f"POST to {path} with params {params}")
+        log.debug(f"POST to {path} with query_params {query_params}")
         return self.request(
-            "POST", path, params=params, data=data, headers=headers, encoding=encoding
+            "POST",
+            path,
+            query_params=query_params,
+            data=data,
+            headers=headers,
+            encoding=encoding,
         )
 
     def delete(
         self,
         path: str,
         *,
-        params: Optional[Dict] = None,
+        query_params: Optional[Dict[str, str]] = None,
         headers: Optional[Dict] = None,
     ) -> GlobusHTTPResponse:
         """
@@ -162,14 +167,14 @@ class BaseClient:
         :return: :class:`GlobusHTTPResponse \
         <globus_sdk.response.GlobusHTTPResponse>` object
         """
-        log.debug(f"DELETE to {path} with params {params}")
-        return self.request("DELETE", path, params=params, headers=headers)
+        log.debug(f"DELETE to {path} with query_params {query_params}")
+        return self.request("DELETE", path, query_params=query_params, headers=headers)
 
     def put(
         self,
         path: str,
         *,
-        params: Optional[Dict] = None,
+        query_params: Optional[Dict[str, str]] = None,
         data: Optional[Dict] = None,
         headers: Optional[Dict] = None,
         encoding: Optional[str] = None,
@@ -182,16 +187,21 @@ class BaseClient:
         :return: :class:`GlobusHTTPResponse \
         <globus_sdk.response.GlobusHTTPResponse>` object
         """
-        log.debug(f"PUT to {path} with params {params}")
+        log.debug(f"PUT to {path} with query_params {query_params}")
         return self.request(
-            "PUT", path, params=params, data=data, headers=headers, encoding=encoding
+            "PUT",
+            path,
+            query_params=query_params,
+            data=data,
+            headers=headers,
+            encoding=encoding,
         )
 
     def patch(
         self,
         path: str,
         *,
-        params: Optional[Dict] = None,
+        query_params: Optional[Dict[str, str]] = None,
         data: Optional[Dict] = None,
         headers: Optional[Dict] = None,
         encoding: Optional[str] = None,
@@ -204,9 +214,14 @@ class BaseClient:
         :return: :class:`GlobusHTTPResponse \
         <globus_sdk.response.GlobusHTTPResponse>` object
         """
-        log.debug(f"PATCH to {path} with params {params}")
+        log.debug(f"PATCH to {path} with query_params {query_params}")
         return self.request(
-            "PATCH", path, params=params, data=data, headers=headers, encoding=encoding
+            "PATCH",
+            path,
+            query_params=query_params,
+            data=data,
+            headers=headers,
+            encoding=encoding,
         )
 
     def request(
@@ -214,7 +229,7 @@ class BaseClient:
         method: str,
         path: str,
         *,
-        params: Optional[Dict] = None,
+        query_params: Optional[Dict[str, str]] = None,
         data: Optional[Dict] = None,
         headers: Optional[Dict] = None,
         encoding: Optional[str] = None,
@@ -226,8 +241,8 @@ class BaseClient:
         :type method: str
         :param path: Path for the request, with or without leading slash
         :type path: str
-        :param params: Parameters to be encoded as a query string
-        :type params: dict
+        :param query_params: Parameters to be encoded as a query string
+        :type query_params: dict
         :param headers: HTTP headers to add to the request
         :type headers: dict
         :param data: Data to send as the request body. May pass through encoding.
@@ -259,7 +274,7 @@ class BaseClient:
             method=method,
             url=url,
             data=data,
-            params=params,
+            query_params=query_params,
             headers=rheaders,
             encoding=encoding,
             authorizer=self.authorizer,

--- a/src/globus_sdk/client.py
+++ b/src/globus_sdk/client.py
@@ -1,6 +1,6 @@
 import logging
 import urllib.parse
-from typing import Dict, Optional, Type
+from typing import Any, Dict, Optional, Type
 
 from globus_sdk import config, exc, utils
 from globus_sdk.authorizers import GlobusAuthorizer
@@ -111,7 +111,7 @@ class BaseClient:
         self,
         path: str,
         *,
-        query_params: Optional[Dict[str, str]] = None,
+        query_params: Optional[Dict[str, Any]] = None,
         headers: Optional[Dict] = None,
     ) -> GlobusHTTPResponse:
         """
@@ -129,7 +129,7 @@ class BaseClient:
         self,
         path: str,
         *,
-        query_params: Optional[Dict[str, str]] = None,
+        query_params: Optional[Dict[str, Any]] = None,
         data: Optional[Dict] = None,
         headers: Optional[Dict] = None,
         encoding: Optional[str] = None,
@@ -156,7 +156,7 @@ class BaseClient:
         self,
         path: str,
         *,
-        query_params: Optional[Dict[str, str]] = None,
+        query_params: Optional[Dict[str, Any]] = None,
         headers: Optional[Dict] = None,
     ) -> GlobusHTTPResponse:
         """
@@ -174,7 +174,7 @@ class BaseClient:
         self,
         path: str,
         *,
-        query_params: Optional[Dict[str, str]] = None,
+        query_params: Optional[Dict[str, Any]] = None,
         data: Optional[Dict] = None,
         headers: Optional[Dict] = None,
         encoding: Optional[str] = None,
@@ -201,7 +201,7 @@ class BaseClient:
         self,
         path: str,
         *,
-        query_params: Optional[Dict[str, str]] = None,
+        query_params: Optional[Dict[str, Any]] = None,
         data: Optional[Dict] = None,
         headers: Optional[Dict] = None,
         encoding: Optional[str] = None,
@@ -229,7 +229,7 @@ class BaseClient:
         method: str,
         path: str,
         *,
-        query_params: Optional[Dict[str, str]] = None,
+        query_params: Optional[Dict[str, Any]] = None,
         data: Optional[Dict] = None,
         headers: Optional[Dict] = None,
         encoding: Optional[str] = None,
@@ -242,7 +242,7 @@ class BaseClient:
         :param path: Path for the request, with or without leading slash
         :type path: str
         :param query_params: Parameters to be encoded as a query string
-        :type query_params: dict
+        :type query_params: dict, optional
         :param headers: HTTP headers to add to the request
         :type headers: dict
         :param data: Data to send as the request body. May pass through encoding.

--- a/src/globus_sdk/services/auth/client_types/base.py
+++ b/src/globus_sdk/services/auth/client_types/base.py
@@ -1,7 +1,7 @@
 import collections.abc
 import json
 import logging
-from typing import Dict, Optional, Type, TypeVar, overload
+from typing import Any, Dict, Optional, Type, TypeVar, overload
 
 import jwt
 
@@ -65,7 +65,7 @@ class AuthClient(client.BaseClient):
         usernames=None,
         ids=None,
         provision=False,
-        query_params: Optional[Dict[str, str]] = None,
+        query_params: Optional[Dict[str, Any]] = None,
     ):
         r"""
         GET /v2/api/identities
@@ -160,7 +160,7 @@ class AuthClient(client.BaseClient):
 
         return self.get("/v2/api/identities", query_params=query_params)
 
-    def oauth2_get_authorize_url(self, query_params: Optional[Dict[str, str]] = None):
+    def oauth2_get_authorize_url(self, query_params: Optional[Dict[str, Any]] = None):
         """
         Get the authorization URL to which users should be sent.
         This method may only be called after ``oauth2_start_flow``
@@ -211,7 +211,7 @@ class AuthClient(client.BaseClient):
         return self.current_oauth2_flow_manager.exchange_code_for_tokens(auth_code)
 
     def oauth2_refresh_token(
-        self, refresh_token, query_params: Optional[Dict[str, str]] = None
+        self, refresh_token, body_params: Optional[Dict[str, Any]] = None
     ):
         r"""
         Exchange a refresh token for a
@@ -230,18 +230,18 @@ class AuthClient(client.BaseClient):
         :param refresh_token: A Globus Refresh Token as a string
         :type refresh_token: str
 
-        :param query_params: A dict of extra params to encode in the refresh call.
-        :type query_params: dict, optional
+        :param body_params: A dict of extra params to encode in the refresh call.
+        :type body_params: dict, optional
         """
         log.info("Executing token refresh; typically requires client credentials")
         form_data = {"refresh_token": refresh_token, "grant_type": "refresh_token"}
 
-        if query_params:
-            form_data.update(query_params)
+        if body_params:
+            form_data.update(body_params)
         return self.oauth2_token(form_data)
 
     def oauth2_validate_token(
-        self, token, query_params: Optional[Dict[str, str]] = None
+        self, token, body_params: Optional[Dict[str, Any]] = None
     ):
         """
         Validate a token. It can be an Access Token or a Refresh token.
@@ -261,9 +261,9 @@ class AuthClient(client.BaseClient):
         :param token: The token which should be validated. Can be a refresh token or an
             access token
         :type token: str
-        :param query_params: Additional parameters to include in the validation
+        :param body_params: Additional parameters to include in the validation
             body. Primarily for internal use
-        :type query_params: dict, optional
+        :type body_params: dict, optional
 
         **Examples**
 
@@ -301,11 +301,11 @@ class AuthClient(client.BaseClient):
             log.debug("Validating token with unauthenticated client")
             body.update({"client_id": self.client_id})
 
-        if query_params:
-            body.update(query_params)
+        if body_params:
+            body.update(body_params)
         return self.post("/v2/oauth2/token/validate", data=body, encoding="form")
 
-    def oauth2_revoke_token(self, token, query_params: Optional[Dict[str, str]] = None):
+    def oauth2_revoke_token(self, token, body_params: Optional[Dict[str, Any]] = None):
         """
         Revoke a token. It can be an Access Token or a Refresh token.
 
@@ -320,9 +320,10 @@ class AuthClient(client.BaseClient):
 
         :param token: The token which should be revoked
         :type token: str
-        :param query_params: Additional parameters to include in the revocation
-            body, which can help speed the revocation process. Primarily for internal
-            use
+        :param body_params: Additional parameters to include in the revocation
+            body, which can help speed the revocation process. Primarily for
+            internal use
+        :type body_params: dict, optional
 
         **Examples**
 
@@ -342,8 +343,8 @@ class AuthClient(client.BaseClient):
             log.debug("Revoking token with unauthenticated client")
             body.update({"client_id": self.client_id})
 
-        if query_params:
-            body.update(query_params)
+        if body_params:
+            body.update(body_params)
         return self.post("/v2/oauth2/token/revoke", data=body, encoding="form")
 
     @overload

--- a/src/globus_sdk/services/auth/oauth2_authorization_code.py
+++ b/src/globus_sdk/services/auth/oauth2_authorization_code.py
@@ -76,16 +76,14 @@ class GlobusAuthorizationCodeFlowManager(GlobusOAuthFlowManager):
         logger.debug(f"state={state}")
         logger.debug(f"requested_scopes={self.requested_scopes}")
 
-    def get_authorize_url(
-        self, additional_params: Optional[Dict[str, Any]] = None
-    ) -> str:
+    def get_authorize_url(self, query_params: Optional[Dict[str, Any]] = None) -> str:
         """
         Start a Authorization Code flow by getting the authorization URL to
         which users should be sent.
 
-        :param additional_params: Additional parameters to include in the authorize URL.
+        :param query_params: Additional parameters to include in the authorize URL.
             Primarily for internal use
-        :type additional_params: dict, optional
+        :type query_params: dict, optional
         :rtype: ``string``
 
         The returned URL string is encoded to be suitable to display to users
@@ -97,7 +95,7 @@ class GlobusAuthorizationCodeFlowManager(GlobusOAuthFlowManager):
             self.auth_client.base_url, "/v2/oauth2/authorize"
         )
         logger.debug(f"Building authorization URI. Base URL: {authorize_base_url}")
-        logger.debug(f"additional_params={additional_params}")
+        logger.debug(f"query_params={query_params}")
 
         params = {
             "client_id": self.client_id,
@@ -107,8 +105,8 @@ class GlobusAuthorizationCodeFlowManager(GlobusOAuthFlowManager):
             "response_type": "code",
             "access_type": (self.refresh_tokens and "offline") or "online",
         }
-        if additional_params:
-            params.update(additional_params)
+        if query_params:
+            params.update(query_params)
 
         encoded_params = urllib.parse.urlencode(params)
         return f"{authorize_base_url}?{encoded_params}"

--- a/src/globus_sdk/services/auth/oauth2_native_app.py
+++ b/src/globus_sdk/services/auth/oauth2_native_app.py
@@ -157,16 +157,14 @@ class GlobusNativeAppFlowManager(GlobusOAuthFlowManager):
         if prefill_named_grant is not None:
             logger.debug(f"prefill_named_grant={self.prefill_named_grant}")
 
-    def get_authorize_url(
-        self, additional_params: Optional[Dict[str, Any]] = None
-    ) -> str:
+    def get_authorize_url(self, query_params: Optional[Dict[str, Any]] = None) -> str:
         """
         Start a Native App flow by getting the authorization URL to which users
         should be sent.
 
-        :param additional_params: Additional query parameters to include in the
+        :param query_params: Additional query parameters to include in the
             authorize URL. Primarily for internal use
-        :type additional_params: dict, optional
+        :type query_params: dict, optional
         :rtype: ``string``
 
         The returned URL string is encoded to be suitable to display to users
@@ -178,7 +176,7 @@ class GlobusNativeAppFlowManager(GlobusOAuthFlowManager):
             self.auth_client.base_url, "/v2/oauth2/authorize"
         )
         logger.debug(f"Building authorization URI. Base URL: {authorize_base_url}")
-        logger.debug(f"additional_params={additional_params}")
+        logger.debug(f"query_params={query_params}")
 
         params = {
             "client_id": self.client_id,
@@ -192,8 +190,8 @@ class GlobusNativeAppFlowManager(GlobusOAuthFlowManager):
         }
         if self.prefill_named_grant is not None:
             params["prefill_named_grant"] = self.prefill_named_grant
-        if additional_params:
-            params.update(additional_params)
+        if query_params:
+            params.update(query_params)
 
         encoded_params = urllib.parse.urlencode(params)
         return f"{authorize_base_url}?{encoded_params}"

--- a/src/globus_sdk/services/search/client.py
+++ b/src/globus_sdk/services/search/client.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
 from globus_sdk import client, paging, response, utils
 
@@ -75,7 +75,7 @@ class SearchClient(client.BaseClient):
         offset: int = 0,
         limit: int = 10,
         advanced: bool = False,
-        query_params: Optional[Dict[str, str]] = None,
+        query_params: Optional[Dict[str, Any]] = None,
     ):
         """
         ``GET /v1/index/<index_id>/search``
@@ -100,9 +100,9 @@ class SearchClient(client.BaseClient):
         query_params.update(
             {
                 "q": q,
-                "offset": str(offset),
-                "limit": str(limit),
-                "advanced": str(advanced),
+                "offset": offset,
+                "limit": limit,
+                "advanced": advanced,
             }
         )
 
@@ -260,7 +260,7 @@ class SearchClient(client.BaseClient):
     #
 
     def get_subject(
-        self, index_id, subject: str, query_params: Optional[Dict[str, str]] = None
+        self, index_id, subject: str, query_params: Optional[Dict[str, Any]] = None
     ):
         """
         ``GET /v1/index/<index_id>/subject``
@@ -289,7 +289,7 @@ class SearchClient(client.BaseClient):
         return self.get(path, query_params=query_params)
 
     def delete_subject(
-        self, index_id, subject: str, query_params: Optional[Dict[str, str]] = None
+        self, index_id, subject: str, query_params: Optional[Dict[str, Any]] = None
     ):
         """
         ``DELETE /v1/index/<index_id>/subject``
@@ -327,7 +327,7 @@ class SearchClient(client.BaseClient):
         index_id,
         subject: str,
         entry_id: Optional[str] = None,
-        query_params: Optional[Dict[str, str]] = None,
+        query_params: Optional[Dict[str, Any]] = None,
     ):
         """
         ``GET /v1/index/<index_id>/entry``
@@ -447,7 +447,7 @@ class SearchClient(client.BaseClient):
         index_id,
         subject: str,
         entry_id: Optional[str] = None,
-        query_params: Optional[Dict[str, str]] = None,
+        query_params: Optional[Dict[str, Any]] = None,
     ):
         """
         ``DELETE  /v1/index/<index_id>/entry``
@@ -492,7 +492,7 @@ class SearchClient(client.BaseClient):
     # Task Management
     #
 
-    def get_task(self, task_id, query_params: Optional[Dict[str, str]] = None):
+    def get_task(self, task_id, query_params: Optional[Dict[str, Any]] = None):
         """
         ``GET /v1/task/<task_id>``
 
@@ -508,7 +508,7 @@ class SearchClient(client.BaseClient):
         path = self.qjoin_path("v1/task", task_id)
         return self.get(path, query_params=query_params)
 
-    def get_task_list(self, index_id, query_params: Optional[Dict[str, str]] = None):
+    def get_task_list(self, index_id, query_params: Optional[Dict[str, Any]] = None):
         """
         ``GET /v1/task_list/<index_id>``
 

--- a/src/globus_sdk/services/search/client.py
+++ b/src/globus_sdk/services/search/client.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional
+from typing import Dict, Optional
 
 from globus_sdk import client, paging, response, utils
 
@@ -32,7 +32,7 @@ class SearchClient(client.BaseClient):
     # Index Management
     #
 
-    def get_index(self, index_id, **params) -> response.GlobusHTTPResponse:
+    def get_index(self, index_id, query_params) -> response.GlobusHTTPResponse:
         """
         ``GET /v1/index/<index_id>``
 
@@ -55,7 +55,7 @@ class SearchClient(client.BaseClient):
         index_id = utils.safe_stringify(index_id)
         log.info(f"SearchClient.get_index({index_id})")
         path = self.qjoin_path("v1/index", index_id)
-        return self.get(path, params=params)
+        return self.get(path, query_params=query_params)
 
     #
     # Search queries
@@ -75,7 +75,7 @@ class SearchClient(client.BaseClient):
         offset: int = 0,
         limit: int = 10,
         advanced: bool = False,
-        **params,
+        query_params: Optional[Dict[str, str]] = None,
     ):
         """
         ``GET /v1/index/<index_id>/search``
@@ -95,18 +95,20 @@ class SearchClient(client.BaseClient):
         in the API documentation for details.
         """
         index_id = utils.safe_stringify(index_id)
-        params.update(
+        if query_params is None:
+            query_params = {}
+        query_params.update(
             {
                 "q": q,
-                "offset": offset,
-                "limit": limit,
-                "advanced": advanced,
+                "offset": str(offset),
+                "limit": str(limit),
+                "advanced": str(advanced),
             }
         )
 
         log.info(f"SearchClient.search({index_id}, ...)")
         path = self.qjoin_path("v1/index", index_id, "search")
-        return self.get(path, params=params)
+        return self.get(path, query_params=query_params)
 
     def post_search(self, index_id, data):
         """
@@ -257,7 +259,9 @@ class SearchClient(client.BaseClient):
     # Subject Operations
     #
 
-    def get_subject(self, index_id, subject: str, **params):
+    def get_subject(
+        self, index_id, subject: str, query_params: Optional[Dict[str, str]] = None
+    ):
         """
         ``GET /v1/index/<index_id>/subject``
 
@@ -277,12 +281,16 @@ class SearchClient(client.BaseClient):
         in the API documentation for details.
         """
         index_id = utils.safe_stringify(index_id)
-        params["subject"] = subject
+        if query_params is None:
+            query_params = {}
+        query_params["subject"] = subject
         log.info(f"SearchClient.get_subject({index_id}, {subject}, ...)")
         path = self.qjoin_path("v1/index", index_id, "subject")
-        return self.get(path, params=params)
+        return self.get(path, query_params=query_params)
 
-    def delete_subject(self, index_id, subject: str, **params):
+    def delete_subject(
+        self, index_id, subject: str, query_params: Optional[Dict[str, str]] = None
+    ):
         """
         ``DELETE /v1/index/<index_id>/subject``
 
@@ -302,18 +310,24 @@ class SearchClient(client.BaseClient):
         in the API documentation for details.
         """
         index_id = utils.safe_stringify(index_id)
-        params["subject"] = subject
+        if query_params is None:
+            query_params = {}
+        query_params["subject"] = subject
 
         log.info(f"SearchClient.delete_subject({index_id}, {subject}, ...)")
         path = self.qjoin_path("v1/index", index_id, "subject")
-        return self.delete(path, params=params)
+        return self.delete(path, query_params=query_params)
 
     #
     # Entry Operations
     #
 
     def get_entry(
-        self, index_id, subject: str, entry_id: Optional[str] = None, **params
+        self,
+        index_id,
+        subject: str,
+        entry_id: Optional[str] = None,
+        query_params: Optional[Dict[str, str]] = None,
     ):
         """
         ``GET /v1/index/<index_id>/entry``
@@ -341,9 +355,11 @@ class SearchClient(client.BaseClient):
         in the API documentation for details.
         """
         index_id = utils.safe_stringify(index_id)
-        params["subject"] = subject
+        if query_params is None:
+            query_params = {}
+        query_params["subject"] = subject
         if entry_id is not None:
-            params["entry_id"] = entry_id
+            query_params["entry_id"] = entry_id
 
         log.info(
             "SearchClient.get_entry({}, {}, {}, ...)".format(
@@ -351,7 +367,7 @@ class SearchClient(client.BaseClient):
             )
         )
         path = self.qjoin_path("v1/index", index_id, "entry")
-        return self.get(path, params=params)
+        return self.get(path, query_params=query_params)
 
     def create_entry(self, index_id, data):
         """
@@ -427,7 +443,11 @@ class SearchClient(client.BaseClient):
         return self.put(path, data=data)
 
     def delete_entry(
-        self, index_id, subject: str, entry_id: Optional[str] = None, **params
+        self,
+        index_id,
+        subject: str,
+        entry_id: Optional[str] = None,
+        query_params: Optional[Dict[str, str]] = None,
     ):
         """
         ``DELETE  /v1/index/<index_id>/entry``
@@ -455,22 +475,24 @@ class SearchClient(client.BaseClient):
         in the API documentation for details.
         """
         index_id = utils.safe_stringify(index_id)
-        params["subject"] = subject
+        if query_params is None:
+            query_params = {}
+        query_params["subject"] = subject
         if entry_id is not None:
-            params["entry_id"] = entry_id
+            query_params["entry_id"] = entry_id
         log.info(
             "SearchClient.delete_entry({}, {}, {}, ...)".format(
                 index_id, subject, entry_id
             )
         )
         path = self.qjoin_path("v1/index", index_id, "entry")
-        return self.delete(path, params=params)
+        return self.delete(path, query_params=query_params)
 
     #
     # Task Management
     #
 
-    def get_task(self, task_id, **params):
+    def get_task(self, task_id, query_params: Optional[Dict[str, str]] = None):
         """
         ``GET /v1/task/<task_id>``
 
@@ -484,9 +506,9 @@ class SearchClient(client.BaseClient):
         task_id = utils.safe_stringify(task_id)
         log.info(f"SearchClient.get_task({task_id})")
         path = self.qjoin_path("v1/task", task_id)
-        return self.get(path, params=params)
+        return self.get(path, query_params=query_params)
 
-    def get_task_list(self, index_id, **params):
+    def get_task_list(self, index_id, query_params: Optional[Dict[str, str]] = None):
         """
         ``GET /v1/task_list/<index_id>``
 
@@ -500,4 +522,4 @@ class SearchClient(client.BaseClient):
         index_id = utils.safe_stringify(index_id)
         log.info(f"SearchClient.get_task_list({index_id})")
         path = self.qjoin_path("v1/task_list", index_id)
-        return self.get(path, params=params)
+        return self.get(path, query_params=query_params)

--- a/src/globus_sdk/services/transfer/client.py
+++ b/src/globus_sdk/services/transfer/client.py
@@ -69,7 +69,7 @@ class TransferClient(client.BaseClient):
     #
 
     def get_endpoint(
-        self, endpoint_id: ID_PARAM_TYPE, **params
+        self, endpoint_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, str]] = None
     ) -> response.GlobusHTTPResponse:
         """
         ``GET /endpoint/<endpoint_id>``
@@ -94,10 +94,13 @@ class TransferClient(client.BaseClient):
         endpoint_id_s = utils.safe_stringify(endpoint_id)
         log.info(f"TransferClient.get_endpoint({endpoint_id_s})")
         path = self.qjoin_path("endpoint", endpoint_id_s)
-        return self.get(path, params=params)
+        return self.get(path, query_params=query_params)
 
     def update_endpoint(
-        self, endpoint_id: ID_PARAM_TYPE, data, **params
+        self,
+        endpoint_id: ID_PARAM_TYPE,
+        data,
+        query_params: Optional[Dict[str, str]] = None,
     ) -> response.GlobusHTTPResponse:
         """
         ``PUT /endpoint/<endpoint_id>``
@@ -134,7 +137,7 @@ class TransferClient(client.BaseClient):
         endpoint_id_s = utils.safe_stringify(endpoint_id)
         log.info(f"TransferClient.update_endpoint({endpoint_id_s}, ...)")
         path = self.qjoin_path("endpoint", endpoint_id_s)
-        return self.put(path, data=data, params=params)
+        return self.put(path, data=data, query_params=query_params)
 
     def create_endpoint(self, data) -> response.GlobusHTTPResponse:
         """
@@ -213,7 +216,9 @@ class TransferClient(client.BaseClient):
         self,
         filter_fulltext: Optional[str] = None,
         filter_scope: Optional[str] = None,
-        **params,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+        query_params: Optional[Dict[str, str]] = None,
     ) -> IterableTransferResponse:
         r"""
         .. parsed-literal::
@@ -230,8 +235,13 @@ class TransferClient(client.BaseClient):
             found documented in the **External Documentation** below. Defaults to
             searching all endpoints (in which case ``filter_fulltext`` is required)
         :type filter_scope: str, optional
-        :param params: Any additional parameters will be passed through as query params.
-        :type params: dict
+        :param limit: limit the number of results
+        :type limit: int, optional
+        :param offset: offset used in paging
+        :type offset: int, optional
+        :param query_params: Any additional parameters will be passed through
+            as query params.
+        :type query_params: dict
         :rtype: :class:`IterableTransferResponse
                 <globus_sdk.transfer.response.IterableTransferResponse>`
 
@@ -257,15 +267,23 @@ class TransferClient(client.BaseClient):
         <https://docs.globus.org/api/transfer/endpoint_search>`_.
         in the REST documentation for details.
         """
+        if query_params is None:
+            query_params = {}
         if filter_scope is not None:
-            params["filter_scope"] = filter_scope
+            query_params["filter_scope"] = filter_scope
         if filter_fulltext is not None:
-            params["filter_fulltext"] = filter_fulltext
-        log.info(f"TransferClient.endpoint_search({params})")
-        return IterableTransferResponse(self.get("endpoint_search", params=params))
+            query_params["filter_fulltext"] = filter_fulltext
+        if limit is not None:
+            query_params["limit"] = str(limit)
+        if offset is not None:
+            query_params["offset"] = str(offset)
+        log.info(f"TransferClient.endpoint_search({query_params})")
+        return IterableTransferResponse(
+            self.get("endpoint_search", query_params=query_params)
+        )
 
     def endpoint_autoactivate(
-        self, endpoint_id: ID_PARAM_TYPE, **params
+        self, endpoint_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, str]] = None
     ) -> response.GlobusHTTPResponse:
         r"""
         ``POST /endpoint/<endpoint_id>/autoactivate``
@@ -329,10 +347,10 @@ class TransferClient(client.BaseClient):
         endpoint_id_s = utils.safe_stringify(endpoint_id)
         log.info(f"TransferClient.endpoint_autoactivate({endpoint_id_s})")
         path = self.qjoin_path("endpoint", endpoint_id_s, "autoactivate")
-        return self.post(path, params=params)
+        return self.post(path, query_params=query_params)
 
     def endpoint_deactivate(
-        self, endpoint_id: ID_PARAM_TYPE, **params
+        self, endpoint_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, str]] = None
     ) -> response.GlobusHTTPResponse:
         """
         ``POST /endpoint/<endpoint_id>/deactivate``
@@ -350,10 +368,13 @@ class TransferClient(client.BaseClient):
         endpoint_id_s = utils.safe_stringify(endpoint_id)
         log.info(f"TransferClient.endpoint_deactivate({endpoint_id_s})")
         path = self.qjoin_path("endpoint", endpoint_id_s, "deactivate")
-        return self.post(path, params=params)
+        return self.post(path, query_params=query_params)
 
     def endpoint_activate(
-        self, endpoint_id: ID_PARAM_TYPE, requirements_data, **params
+        self,
+        endpoint_id: ID_PARAM_TYPE,
+        requirements_data,
+        query_params: Optional[Dict[str, str]] = None,
     ) -> response.GlobusHTTPResponse:
         """
         ``POST /endpoint/<endpoint_id>/activate``
@@ -375,10 +396,10 @@ class TransferClient(client.BaseClient):
         endpoint_id_s = utils.safe_stringify(endpoint_id)
         log.info(f"TransferClient.endpoint_activate({endpoint_id_s})")
         path = self.qjoin_path("endpoint", endpoint_id_s, "activate")
-        return self.post(path, data=requirements_data, params=params)
+        return self.post(path, data=requirements_data, query_params=query_params)
 
     def endpoint_get_activation_requirements(
-        self, endpoint_id: ID_PARAM_TYPE, **params
+        self, endpoint_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, str]] = None
     ) -> ActivationRequirementsResponse:
         """
         ``GET /endpoint/<endpoint_id>/activation_requirements``
@@ -395,10 +416,10 @@ class TransferClient(client.BaseClient):
         """
         endpoint_id_s = utils.safe_stringify(endpoint_id)
         path = self.qjoin_path("endpoint", endpoint_id_s, "activation_requirements")
-        return ActivationRequirementsResponse(self.get(path, params=params))
+        return ActivationRequirementsResponse(self.get(path, query_params=query_params))
 
     def my_effective_pause_rule_list(
-        self, endpoint_id: ID_PARAM_TYPE, **params
+        self, endpoint_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, str]] = None
     ) -> IterableTransferResponse:
         """
         ``GET /endpoint/<endpoint_id>/my_effective_pause_rule_list``
@@ -418,12 +439,12 @@ class TransferClient(client.BaseClient):
         path = self.qjoin_path(
             "endpoint", endpoint_id_s, "my_effective_pause_rule_list"
         )
-        return IterableTransferResponse(self.get(path, params=params))
+        return IterableTransferResponse(self.get(path, query_params=query_params))
 
     # Shared Endpoints
 
     def my_shared_endpoint_list(
-        self, endpoint_id: ID_PARAM_TYPE, **params
+        self, endpoint_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, str]] = None
     ) -> IterableTransferResponse:
         """
         ``GET /endpoint/<endpoint_id>/my_shared_endpoint_list``
@@ -441,7 +462,7 @@ class TransferClient(client.BaseClient):
         endpoint_id_s = utils.safe_stringify(endpoint_id)
         log.info(f"TransferClient.my_shared_endpoint_list({endpoint_id_s}, ...)")
         path = self.qjoin_path("endpoint", endpoint_id_s, "my_shared_endpoint_list")
-        return IterableTransferResponse(self.get(path, params=params))
+        return IterableTransferResponse(self.get(path, query_params=query_params))
 
     def create_shared_endpoint(self, data):
         """
@@ -479,7 +500,7 @@ class TransferClient(client.BaseClient):
     # Endpoint servers
 
     def endpoint_server_list(
-        self, endpoint_id: ID_PARAM_TYPE, **params
+        self, endpoint_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, str]] = None
     ) -> IterableTransferResponse:
         """
         ``GET /endpoint/<endpoint_id>/server_list``
@@ -497,10 +518,13 @@ class TransferClient(client.BaseClient):
         endpoint_id_s = utils.safe_stringify(endpoint_id)
         log.info(f"TransferClient.endpoint_server_list({endpoint_id_s}, ...)")
         path = self.qjoin_path("endpoint", endpoint_id_s, "server_list")
-        return IterableTransferResponse(self.get(path, params=params))
+        return IterableTransferResponse(self.get(path, query_params=query_params))
 
     def get_endpoint_server(
-        self, endpoint_id: ID_PARAM_TYPE, server_id, **params
+        self,
+        endpoint_id: ID_PARAM_TYPE,
+        server_id,
+        query_params: Optional[Dict[str, str]] = None,
     ) -> response.GlobusHTTPResponse:
         """
         ``GET /endpoint/<endpoint_id>/server/<server_id>``
@@ -520,7 +544,7 @@ class TransferClient(client.BaseClient):
             "TransferClient.get_endpoint_server(%s, %s, ...)", endpoint_id_s, server_id
         )
         path = self.qjoin_path("endpoint", endpoint_id_s, "server", str(server_id))
-        return self.get(path, params=params)
+        return self.get(path, query_params=query_params)
 
     def add_endpoint_server(
         self, endpoint_id: ID_PARAM_TYPE, server_data: Dict
@@ -596,7 +620,7 @@ class TransferClient(client.BaseClient):
     #
 
     def endpoint_role_list(
-        self, endpoint_id: ID_PARAM_TYPE, **params
+        self, endpoint_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, str]] = None
     ) -> IterableTransferResponse:
         """
         ``GET /endpoint/<endpoint_id>/role_list``
@@ -614,7 +638,7 @@ class TransferClient(client.BaseClient):
         endpoint_id_s = utils.safe_stringify(endpoint_id)
         log.info(f"TransferClient.endpoint_role_list({endpoint_id_s}, ...)")
         path = self.qjoin_path("endpoint", endpoint_id_s, "role_list")
-        return IterableTransferResponse(self.get(path, params=params))
+        return IterableTransferResponse(self.get(path, query_params=query_params))
 
     def add_endpoint_role(
         self, endpoint_id: ID_PARAM_TYPE, role_data: Dict
@@ -638,7 +662,10 @@ class TransferClient(client.BaseClient):
         return self.post(path, data=role_data)
 
     def get_endpoint_role(
-        self, endpoint_id: ID_PARAM_TYPE, role_id, **params
+        self,
+        endpoint_id: ID_PARAM_TYPE,
+        role_id,
+        query_params: Optional[Dict[str, str]] = None,
     ) -> response.GlobusHTTPResponse:
         """
         ``GET /endpoint/<endpoint_id>/role/<role_id>``
@@ -656,7 +683,7 @@ class TransferClient(client.BaseClient):
         endpoint_id_s = utils.safe_stringify(endpoint_id)
         log.info(f"TransferClient.get_endpoint_role({endpoint_id_s}, {role_id}, ...)")
         path = self.qjoin_path("endpoint", endpoint_id_s, "role", role_id)
-        return self.get(path, params=params)
+        return self.get(path, query_params=query_params)
 
     def delete_endpoint_role(
         self, endpoint_id: ID_PARAM_TYPE, role_id
@@ -684,7 +711,7 @@ class TransferClient(client.BaseClient):
     #
 
     def endpoint_acl_list(
-        self, endpoint_id: ID_PARAM_TYPE, **params
+        self, endpoint_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, str]] = None
     ) -> IterableTransferResponse:
         """
         ``GET /endpoint/<endpoint_id>/access_list``
@@ -702,10 +729,13 @@ class TransferClient(client.BaseClient):
         endpoint_id_s = utils.safe_stringify(endpoint_id)
         log.info(f"TransferClient.endpoint_acl_list({endpoint_id_s}, ...)")
         path = self.qjoin_path("endpoint", endpoint_id_s, "access_list")
-        return IterableTransferResponse(self.get(path, params=params))
+        return IterableTransferResponse(self.get(path, query_params=query_params))
 
     def get_endpoint_acl_rule(
-        self, endpoint_id: ID_PARAM_TYPE, rule_id, **params
+        self,
+        endpoint_id: ID_PARAM_TYPE,
+        rule_id,
+        query_params: Optional[Dict[str, str]] = None,
     ) -> response.GlobusHTTPResponse:
         """
         ``GET /endpoint/<endpoint_id>/access/<rule_id>``
@@ -725,7 +755,7 @@ class TransferClient(client.BaseClient):
             "TransferClient.get_endpoint_acl_rule(%s, %s, ...)", endpoint_id_s, rule_id
         )
         path = self.qjoin_path("endpoint", endpoint_id_s, "access", rule_id)
-        return self.get(path, params=params)
+        return self.get(path, query_params=query_params)
 
     def add_endpoint_acl_rule(
         self, endpoint_id: ID_PARAM_TYPE, rule_data: Dict
@@ -820,7 +850,9 @@ class TransferClient(client.BaseClient):
     # Bookmarks
     #
 
-    def bookmark_list(self, **params) -> IterableTransferResponse:
+    def bookmark_list(
+        self, query_params: Optional[Dict[str, str]] = None
+    ) -> IterableTransferResponse:
         """
         ``GET /bookmark_list``
 
@@ -834,8 +866,10 @@ class TransferClient(client.BaseClient):
         <https://docs.globus.org/api/transfer/endpoint_bookmarks/#get_list_of_bookmarks>`_
         in the REST documentation for details.
         """
-        log.info(f"TransferClient.bookmark_list({params})")
-        return IterableTransferResponse(self.get("bookmark_list", params=params))
+        log.info(f"TransferClient.bookmark_list({query_params})")
+        return IterableTransferResponse(
+            self.get("bookmark_list", query_params=query_params)
+        )
 
     def create_bookmark(self, bookmark_data: Dict) -> response.GlobusHTTPResponse:
         """
@@ -855,7 +889,7 @@ class TransferClient(client.BaseClient):
         return self.post("bookmark", data=bookmark_data)
 
     def get_bookmark(
-        self, bookmark_id: ID_PARAM_TYPE, **params
+        self, bookmark_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, str]] = None
     ) -> response.GlobusHTTPResponse:
         """
         ``GET /bookmark/<bookmark_id>``
@@ -873,7 +907,7 @@ class TransferClient(client.BaseClient):
         bookmark_id_s = utils.safe_stringify(bookmark_id)
         log.info(f"TransferClient.get_bookmark({bookmark_id_s})")
         path = self.qjoin_path("bookmark", bookmark_id_s)
-        return self.get(path, params=params)
+        return self.get(path, query_params=query_params)
 
     def update_bookmark(
         self, bookmark_id: ID_PARAM_TYPE, bookmark_data: Dict
@@ -922,7 +956,7 @@ class TransferClient(client.BaseClient):
     #
 
     def operation_ls(
-        self, endpoint_id: ID_PARAM_TYPE, **params
+        self, endpoint_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, str]] = None
     ) -> IterableTransferResponse:
         """
         ``GET /operation/endpoint/<endpoint_id>/ls``
@@ -944,12 +978,15 @@ class TransferClient(client.BaseClient):
         in the REST documentation for details.
         """
         endpoint_id_s = utils.safe_stringify(endpoint_id)
-        log.info(f"TransferClient.operation_ls({endpoint_id_s}, {params})")
+        log.info(f"TransferClient.operation_ls({endpoint_id_s}, {query_params})")
         path = self.qjoin_path("operation/endpoint", endpoint_id_s, "ls")
-        return IterableTransferResponse(self.get(path, params=params))
+        return IterableTransferResponse(self.get(path, query_params=query_params))
 
     def operation_mkdir(
-        self, endpoint_id: ID_PARAM_TYPE, path, **params
+        self,
+        endpoint_id: ID_PARAM_TYPE,
+        path,
+        query_params: Optional[Dict[str, str]] = None,
     ) -> response.GlobusHTTPResponse:
         """
         ``POST /operation/endpoint/<endpoint_id>/mkdir``
@@ -973,15 +1010,19 @@ class TransferClient(client.BaseClient):
         path = utils.safe_stringify(path)
         log.info(
             "TransferClient.operation_mkdir({}, {}, {})".format(
-                endpoint_id_s, path, params
+                endpoint_id_s, path, query_params
             )
         )
         resource_path = self.qjoin_path("operation/endpoint", endpoint_id_s, "mkdir")
         json_body = {"DATA_TYPE": "mkdir", "path": path}
-        return self.post(resource_path, data=json_body, params=params)
+        return self.post(resource_path, data=json_body, query_params=query_params)
 
     def operation_rename(
-        self, endpoint_id: ID_PARAM_TYPE, oldpath, newpath, **params
+        self,
+        endpoint_id: ID_PARAM_TYPE,
+        oldpath,
+        newpath,
+        query_params: Optional[Dict[str, str]] = None,
     ) -> response.GlobusHTTPResponse:
         """
         ``POST /operation/endpoint/<endpoint_id>/rename``
@@ -1007,15 +1048,19 @@ class TransferClient(client.BaseClient):
         newpath = utils.safe_stringify(newpath)
         log.info(
             "TransferClient.operation_rename({}, {}, {}, {})".format(
-                endpoint_id_s, oldpath, newpath, params
+                endpoint_id_s, oldpath, newpath, query_params
             )
         )
         resource_path = self.qjoin_path("operation/endpoint", endpoint_id_s, "rename")
         json_body = {"DATA_TYPE": "rename", "old_path": oldpath, "new_path": newpath}
-        return self.post(resource_path, data=json_body, params=params)
+        return self.post(resource_path, data=json_body, query_params=query_params)
 
     def operation_symlink(
-        self, endpoint_id: ID_PARAM_TYPE, symlink_target, path, **params
+        self,
+        endpoint_id: ID_PARAM_TYPE,
+        symlink_target,
+        path,
+        query_params: Optional[Dict[str, str]] = None,
     ) -> response.GlobusHTTPResponse:
         """
         ``POST /operation/endpoint/<endpoint_id>/symlink``
@@ -1044,7 +1089,7 @@ class TransferClient(client.BaseClient):
         path = utils.safe_stringify(path)
         log.info(
             "TransferClient.operation_symlink({}, {}, {}, {})".format(
-                endpoint_id_s, symlink_target, path, params
+                endpoint_id_s, symlink_target, path, query_params
             )
         )
         resource_path = self.qjoin_path("operation/endpoint", endpoint_id_s, "symlink")
@@ -1053,13 +1098,15 @@ class TransferClient(client.BaseClient):
             "symlink_target": symlink_target,
             "path": path,
         }
-        return self.post(resource_path, data=data, params=params)
+        return self.post(resource_path, data=data, query_params=query_params)
 
     #
     # Task Submission
     #
 
-    def get_submission_id(self, **params) -> response.GlobusHTTPResponse:
+    def get_submission_id(
+        self, query_params: Optional[Dict[str, str]] = None
+    ) -> response.GlobusHTTPResponse:
         """
         ``GET /submission_id``
 
@@ -1082,8 +1129,8 @@ class TransferClient(client.BaseClient):
         <https://docs.globus.org/api/transfer/task_submit/#get_submission_id>`_
         in the REST documentation for more details.
         """
-        log.info(f"TransferClient.get_submission_id({params})")
-        return self.get("submission_id", params=params)
+        log.info(f"TransferClient.get_submission_id({query_params})")
+        return self.get("submission_id", query_params=query_params)
 
     def submit_transfer(self, data) -> response.GlobusHTTPResponse:
         """
@@ -1159,14 +1206,24 @@ class TransferClient(client.BaseClient):
         max_total_results=1000,
         page_size=1000,
     )
-    def task_list(self, **params) -> IterableTransferResponse:
+    def task_list(
+        self,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+        query_params: Optional[Dict[str, str]] = None,
+    ) -> IterableTransferResponse:
         """
         Get an iterable of task documents owned by the current user.
 
         ``GET /task_list``
 
-        :param params: Any additional parameters will be passed through as query params.
-        :type params: dict, optional
+        :param limit: limit the number of results
+        :type limit: int, optional
+        :param offset: offset used in paging
+        :type offset: int, optional
+        :param query_params: Any additional parameters will be passed through
+            as query params.
+        :type query_params: dict, optional
         :rtype: :class:`IterableTransferResponse
                 <globus_sdk.transfer.response.IterableTransferResponse>`
 
@@ -1188,7 +1245,15 @@ class TransferClient(client.BaseClient):
         in the REST documentation for details.
         """
         log.info("TransferClient.task_list(...)")
-        return IterableTransferResponse(self.get("task_list", params=params))
+        if query_params is None:
+            query_params = {}
+        if limit is not None:
+            query_params["limit"] = str(limit)
+        if offset is not None:
+            query_params["offset"] = str(offset)
+        return IterableTransferResponse(
+            self.get("task_list", query_params=query_params)
+        )
 
     @paging.has_paginator(
         paging.LimitOffsetTotalPaginator,
@@ -1198,7 +1263,11 @@ class TransferClient(client.BaseClient):
         page_size=1000,
     )
     def task_event_list(
-        self, task_id: ID_PARAM_TYPE, **params
+        self,
+        task_id: ID_PARAM_TYPE,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+        query_params: Optional[Dict[str, str]] = None,
     ) -> IterableTransferResponse:
         r"""
         List events (for example, faults and errors) for a given Task.
@@ -1207,8 +1276,13 @@ class TransferClient(client.BaseClient):
 
         :param task_id: The ID of the task to inspect.
         :type task_id: str
-        :param params: Any additional parameters will be passed through as query params.
-        :type params: dict, optional
+        :param limit: limit the number of results
+        :type limit: int, optional
+        :param offset: offset used in paging
+        :type offset: int, optional
+        :param query_params: Any additional parameters will be passed through
+            as query params.
+        :type query_params: dict, optional
         :rtype: :class:`IterableTransferResponse
                 <globus_sdk.transfer.response.IterableTransferResponse>`
 
@@ -1232,9 +1306,17 @@ class TransferClient(client.BaseClient):
         task_id_s = utils.safe_stringify(task_id)
         log.info(f"TransferClient.task_event_list({task_id_s}, ...)")
         path = self.qjoin_path("task", task_id_s, "event_list")
-        return IterableTransferResponse(self.get(path, params=params))
+        if query_params is None:
+            query_params = {}
+        if limit is not None:
+            query_params["limit"] = str(limit)
+        if offset is not None:
+            query_params["offset"] = str(offset)
+        return IterableTransferResponse(self.get(path, query_params=query_params))
 
-    def get_task(self, task_id: ID_PARAM_TYPE, **params) -> response.GlobusHTTPResponse:
+    def get_task(
+        self, task_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, str]] = None
+    ) -> response.GlobusHTTPResponse:
         """
         ``GET /task/<task_id>``
 
@@ -1251,10 +1333,13 @@ class TransferClient(client.BaseClient):
         task_id_s = utils.safe_stringify(task_id)
         log.info(f"TransferClient.get_task({task_id_s}, ...)")
         resource_path = self.qjoin_path("task", task_id_s)
-        return self.get(resource_path, params=params)
+        return self.get(resource_path, query_params=query_params)
 
     def update_task(
-        self, task_id: ID_PARAM_TYPE, data: Dict, **params
+        self,
+        task_id: ID_PARAM_TYPE,
+        data: Dict,
+        query_params: Optional[Dict[str, str]] = None,
     ) -> response.GlobusHTTPResponse:
         """
         ``PUT /task/<task_id>``
@@ -1272,7 +1357,7 @@ class TransferClient(client.BaseClient):
         task_id_s = utils.safe_stringify(task_id)
         log.info(f"TransferClient.update_task({task_id_s}, ...)")
         resource_path = self.qjoin_path("task", task_id_s)
-        return self.put(resource_path, data=data, params=params)
+        return self.put(resource_path, data=data, query_params=query_params)
 
     def cancel_task(self, task_id: ID_PARAM_TYPE) -> response.GlobusHTTPResponse:
         """
@@ -1397,7 +1482,7 @@ class TransferClient(client.BaseClient):
         # unreachable -- end of task_wait
 
     def task_pause_info(
-        self, task_id: ID_PARAM_TYPE, **params
+        self, task_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, str]] = None
     ) -> response.GlobusHTTPResponse:
         """
         ``GET /task/<task_id>/pause_info``
@@ -1415,11 +1500,11 @@ class TransferClient(client.BaseClient):
         task_id_s = utils.safe_stringify(task_id)
         log.info(f"TransferClient.task_pause_info({task_id_s}, ...)")
         resource_path = self.qjoin_path("task", task_id_s, "pause_info")
-        return self.get(resource_path, params=params)
+        return self.get(resource_path, query_params=query_params)
 
     @paging.has_paginator(paging.MarkerPaginator, items_key="DATA")
     def task_successful_transfers(
-        self, task_id: ID_PARAM_TYPE, **params
+        self, task_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, str]] = None
     ) -> IterableTransferResponse:
         """
         Get the successful file transfers for a completed Task.
@@ -1435,8 +1520,9 @@ class TransferClient(client.BaseClient):
 
         :param task_id: The ID of the task to inspect.
         :type task_id: str
-        :param params: Any additional parameters will be passed through as query params.
-        :type params: dict, optional
+        :param query_params: Any additional parameters will be passed through
+            as query params.
+        :type query_params: dict, optional
         :rtype: :class:`IterableTransferResponse
                 <globus_sdk.transfer.response.IterableTransferResponse>`
 
@@ -1460,11 +1546,11 @@ class TransferClient(client.BaseClient):
         task_id_s = utils.safe_stringify(task_id)
         log.info(f"TransferClient.task_successful_transfers({task_id_s}, ...)")
         path = self.qjoin_path("task", task_id_s, "successful_transfers")
-        return IterableTransferResponse(self.get(path, params=params))
+        return IterableTransferResponse(self.get(path, query_params=query_params))
 
     @paging.has_paginator(paging.MarkerPaginator, items_key="DATA")
     def task_skipped_errors(
-        self, task_id: ID_PARAM_TYPE, **params
+        self, task_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, str]] = None
     ) -> IterableTransferResponse:
         """
         Get path and error information for all paths that were skipped due
@@ -1474,8 +1560,9 @@ class TransferClient(client.BaseClient):
 
         :param task_id: The ID of the task to inspect.
         :type task_id: str
-        :param params: Any additional parameters will be passed through as query params.
-        :type params: dict, optional
+        :param query_params: Any additional parameters will be passed through
+            as query params.
+        :type query_params: dict, optional
         :rtype: :class:`IterableTransferResponse
                 <globus_sdk.transfer.response.IterableTransferResponse>`
 
@@ -1501,14 +1588,16 @@ class TransferClient(client.BaseClient):
             "TransferClient.endpoint_manager_task_skipped_errors(%s, ...)", task_id_s
         )
         resource_path = self.qjoin_path("task", task_id_s, "skipped_errors")
-        return IterableTransferResponse(self.get(resource_path, params=params))
+        return IterableTransferResponse(
+            self.get(resource_path, query_params=query_params)
+        )
 
     #
     # advanced endpoint management (requires endpoint manager role)
     #
 
     def endpoint_manager_monitored_endpoints(
-        self, **params
+        self, query_params: Optional[Dict[str, str]] = None
     ) -> IterableTransferResponse:
         """
         Get endpoints the current user is a monitor or manager on.
@@ -1523,12 +1612,12 @@ class TransferClient(client.BaseClient):
         <https://docs.globus.org/api/transfer/advanced_endpoint_management/#get_monitored_endpoints>`_
         in the REST documentation for details.
         """
-        log.info(f"TransferClient.endpoint_manager_monitored_endpoints({params})")
+        log.info(f"TransferClient.endpoint_manager_monitored_endpoints({query_params})")
         path = self.qjoin_path("endpoint_manager", "monitored_endpoints")
-        return IterableTransferResponse(self.get(path, params=params))
+        return IterableTransferResponse(self.get(path, query_params=query_params))
 
     def endpoint_manager_hosted_endpoint_list(
-        self, endpoint_id: ID_PARAM_TYPE, **params
+        self, endpoint_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, str]] = None
     ) -> IterableTransferResponse:
         """
         Get shared endpoints hosted on the given endpoint.
@@ -1550,10 +1639,10 @@ class TransferClient(client.BaseClient):
         path = self.qjoin_path(
             "endpoint_manager", "endpoint", endpoint_id_s, "hosted_endpoint_list"
         )
-        return IterableTransferResponse(self.get(path, params=params))
+        return IterableTransferResponse(self.get(path, query_params=query_params))
 
     def endpoint_manager_get_endpoint(
-        self, endpoint_id: ID_PARAM_TYPE, **params
+        self, endpoint_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, str]] = None
     ) -> response.GlobusHTTPResponse:
         """
         Get endpoint details as an admin.
@@ -1573,10 +1662,10 @@ class TransferClient(client.BaseClient):
         endpoint_id_s = utils.safe_stringify(endpoint_id)
         log.info(f"TransferClient.endpoint_manager_get_endpoint({endpoint_id_s})")
         path = self.qjoin_path("endpoint_manager", "endpoint", endpoint_id_s)
-        return self.get(path, params=params)
+        return self.get(path, query_params=query_params)
 
     def endpoint_manager_acl_list(
-        self, endpoint_id: ID_PARAM_TYPE, **params
+        self, endpoint_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, str]] = None
     ) -> IterableTransferResponse:
         """
         Get a list of access control rules on specified endpoint as an admin.
@@ -1600,31 +1689,34 @@ class TransferClient(client.BaseClient):
         path = self.qjoin_path(
             "endpoint_manager", "endpoint", endpoint_id_s, "access_list"
         )
-        return IterableTransferResponse(self.get(path, params=params))
+        return IterableTransferResponse(self.get(path, query_params=query_params))
 
     #
     # endpoint manager task methods
     #
 
     @paging.has_paginator(paging.LastKeyPaginator, items_key="DATA")
-    def endpoint_manager_task_list(self, **params) -> IterableTransferResponse:
+    def endpoint_manager_task_list(
+        self, query_params: Optional[Dict[str, str]] = None
+    ) -> IterableTransferResponse:
         r"""
         Get a list of tasks visible via ``activity_monitor`` role, as opposed
         to tasks owned by the current user.
 
         ``GET endpoint_manager/task_list``
 
-        :param params: Any additional parameters will be passed through as query params.
-        :type params: dict, optional
+        :param query_params: Any additional parameters will be passed through
+            as query params.
+        :type query_params: dict, optional
         :rtype: :class:`IterableTransferResponse
                 <globus_sdk.transfer.response.IterableTransferResponse>`
 
         **Filters**
 
-        The following filters are supported (passed as keyword arguments in ``params``).
-        For any query that doesn’t specify a filter_status that is a subset of
-        ("ACTIVE", "INACTIVE"), at least one of filter_task_id or filter_endpoint is
-        required.
+        The following filters are supported (passed as keyword arguments in
+        ``query_params``). For any query that doesn’t specify a filter_status
+        that is a subset of ("ACTIVE", "INACTIVE"), at least one of
+        filter_task_id or filter_endpoint is required.
 
         ====================== ================ ========================
         Query Parameter        Filter Type      Description
@@ -1731,9 +1823,11 @@ class TransferClient(client.BaseClient):
         """
         log.info("TransferClient.endpoint_manager_task_list(...)")
         path = self.qjoin_path("endpoint_manager", "task_list")
-        return IterableTransferResponse(self.get(path, params=params))
+        return IterableTransferResponse(self.get(path, query_params=query_params))
 
-    def endpoint_manager_get_task(self, task_id: ID_PARAM_TYPE, **params):
+    def endpoint_manager_get_task(
+        self, task_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, str]] = None
+    ):
         """
         Get task info as an admin. Requires activity monitor effective role on
         the destination endpoint of the task.
@@ -1753,7 +1847,7 @@ class TransferClient(client.BaseClient):
         task_id_s = utils.safe_stringify(task_id)
         log.info(f"TransferClient.endpoint_manager_get_task({task_id_s}, ...)")
         path = self.qjoin_path("endpoint_manager", "task", task_id_s)
-        return self.get(path, params=params)
+        return self.get(path, query_params=query_params)
 
     @paging.has_paginator(
         paging.LimitOffsetTotalPaginator,
@@ -1763,7 +1857,11 @@ class TransferClient(client.BaseClient):
         page_size=1000,
     )
     def endpoint_manager_task_event_list(
-        self, task_id: ID_PARAM_TYPE, **params
+        self,
+        task_id: ID_PARAM_TYPE,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+        query_params: Optional[Dict[str, str]] = None,
     ) -> IterableTransferResponse:
         """
         List events (for example, faults and errors) for a given task as an
@@ -1774,8 +1872,12 @@ class TransferClient(client.BaseClient):
 
         :param task_id: The ID of the task to inspect.
         :type task_id: str
-        :param params: Any additional parameters will be passed through as query params.
-        :type params: dict, optional
+        :param limit: limit the number of results
+        :type limit: int, optional
+        :param offset: offset used in paging
+        :param query_params: Any additional parameters will be passed through
+            as query params.
+        :type query_params: dict, optional
         :rtype: :class:`IterableTransferResponse
                 <globus_sdk.transfer.response.IterableTransferResponse>`
 
@@ -1789,10 +1891,16 @@ class TransferClient(client.BaseClient):
         task_id_s = utils.safe_stringify(task_id)
         log.info(f"TransferClient.endpoint_manager_task_event_list({task_id_s}, ...)")
         path = self.qjoin_path("endpoint_manager", "task", task_id_s, "event_list")
-        return IterableTransferResponse(self.get(path, params=params))
+        if query_params is None:
+            query_params = {}
+        if limit is not None:
+            query_params["limit"] = str(limit)
+        if offset is not None:
+            query_params["offset"] = str(offset)
+        return IterableTransferResponse(self.get(path, query_params=query_params))
 
     def endpoint_manager_task_pause_info(
-        self, task_id: ID_PARAM_TYPE, **params
+        self, task_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, str]] = None
     ) -> response.GlobusHTTPResponse:
         """
         Get details about why a task is paused as an admin. Requires activity
@@ -1813,11 +1921,11 @@ class TransferClient(client.BaseClient):
         task_id_s = utils.safe_stringify(task_id)
         log.info(f"TransferClient.endpoint_manager_task_pause_info({task_id_s}, ...)")
         path = self.qjoin_path("endpoint_manager", "task", task_id_s, "pause_info")
-        return self.get(path, params=params)
+        return self.get(path, query_params=query_params)
 
     @paging.has_paginator(paging.MarkerPaginator, items_key="DATA")
     def endpoint_manager_task_successful_transfers(
-        self, task_id: ID_PARAM_TYPE, **params
+        self, task_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, str]] = None
     ) -> IterableTransferResponse:
         """
         Get the successful file transfers for a completed Task as an admin.
@@ -1826,8 +1934,9 @@ class TransferClient(client.BaseClient):
 
         :param task_id: The ID of the task to inspect.
         :type task_id: str
-        :param params: Any additional parameters will be passed through as query params.
-        :type params: dict, optional
+        :param query_params: Any additional parameters will be passed through
+            as query params.
+        :type query_params: dict, optional
         :rtype: :class:`IterableTransferResponse
                 <globus_sdk.transfer.response.IterableTransferResponse>`
 
@@ -1846,10 +1955,10 @@ class TransferClient(client.BaseClient):
         path = self.qjoin_path(
             "endpoint_manager", "task", task_id_s, "successful_transfers"
         )
-        return IterableTransferResponse(self.get(path, params=params))
+        return IterableTransferResponse(self.get(path, query_params=query_params))
 
     def endpoint_manager_task_skipped_errors(
-        self, task_id: ID_PARAM_TYPE, **params
+        self, task_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, str]] = None
     ) -> IterableTransferResponse:
         """
         Get skipped errors for a completed Task as an admin.
@@ -1858,8 +1967,9 @@ class TransferClient(client.BaseClient):
 
         :param task_id: The ID of the task to inspect.
         :type task_id: str
-        :param params: Any additional parameters will be passed through as query params.
-        :type params: dict, optional
+        :param query_params: Any additional parameters will be passed through
+            as query params.
+        :type query_params: dict, optional
         :rtype: :class:`IterableTransferResponse
                 <globus_sdk.transfer.response.IterableTransferResponse>`
 
@@ -1875,10 +1985,13 @@ class TransferClient(client.BaseClient):
             f"TransferClient.endpoint_manager_task_skipped_errors({task_id_s}, ...)"
         )
         path = self.qjoin_path("endpoint_manager", "task", task_id_s, "skipped_errors")
-        return IterableTransferResponse(self.get(path, params=params))
+        return IterableTransferResponse(self.get(path, query_params=query_params))
 
     def endpoint_manager_cancel_tasks(
-        self, task_ids: Iterable[ID_PARAM_TYPE], message, **params
+        self,
+        task_ids: Iterable[ID_PARAM_TYPE],
+        message,
+        query_params: Optional[Dict[str, str]] = None,
     ) -> response.GlobusHTTPResponse:
         """
         Cancel a list of tasks as an admin. Requires activity manager effective
@@ -1890,8 +2003,9 @@ class TransferClient(client.BaseClient):
         :type task_ids: iterable of str
         :param message: Message given to all users who's tasks have been canceled.
         :type message: str
-        :param params: Any additional parameters will be passed through as query params.
-        :type params: dict, optional
+        :param query_params: Any additional parameters will be passed through
+            as query params.
+        :type query_params: dict, optional
         :rtype: :class:`TransferResponse
                 <globus_sdk.services.transfer.response.TransferResponse>`
 
@@ -1909,10 +2023,10 @@ class TransferClient(client.BaseClient):
         )
         data = {"message": utils.safe_stringify(message), "task_id_list": str_task_ids}
         path = self.qjoin_path("endpoint_manager", "admin_cancel")
-        return self.post(path, data=data, params=params)
+        return self.post(path, data=data, query_params=query_params)
 
     def endpoint_manager_cancel_status(
-        self, admin_cancel_id, **params
+        self, admin_cancel_id, query_params: Optional[Dict[str, str]] = None
     ) -> response.GlobusHTTPResponse:
         """
         Get the status of an an admin cancel (result of
@@ -1922,8 +2036,9 @@ class TransferClient(client.BaseClient):
 
         :param admin_cancel_id: The ID of the the cancel job to inspect.
         :type admin_cancel_id: str
-        :param params: Any additional parameters will be passed through as query params.
-        :type params: dict, optional
+        :param query_params: Any additional parameters will be passed through
+            as query params.
+        :type query_params: dict, optional
         :rtype: :class:`TransferResponse
                 <globus_sdk.services.transfer.response.TransferResponse>`
 
@@ -1936,10 +2051,13 @@ class TransferClient(client.BaseClient):
         """
         log.info(f"TransferClient.endpoint_manager_cancel_status({admin_cancel_id})")
         path = self.qjoin_path("endpoint_manager", "admin_cancel", admin_cancel_id)
-        return self.get(path, params=params)
+        return self.get(path, query_params=query_params)
 
     def endpoint_manager_pause_tasks(
-        self, task_ids: Iterable[ID_PARAM_TYPE], message, **params
+        self,
+        task_ids: Iterable[ID_PARAM_TYPE],
+        message,
+        query_params: Optional[Dict[str, str]] = None,
     ) -> response.GlobusHTTPResponse:
         """
         Pause a list of tasks as an admin. Requires activity manager effective
@@ -1951,8 +2069,9 @@ class TransferClient(client.BaseClient):
         :type task_ids: iterable of str
         :param message: Message given to all users who's tasks have been paused.
         :type message: str
-        :param params: Any additional parameters will be passed through as query params.
-        :type params: dict, optional
+        :param query_params: Any additional parameters will be passed through
+            as query params.
+        :type query_params: dict, optional
         :rtype: :class:`TransferResponse
                 <globus_sdk.services.transfer.response.TransferResponse>`
 
@@ -1973,10 +2092,12 @@ class TransferClient(client.BaseClient):
             "task_id_list": str_task_ids,
         }
         path = self.qjoin_path("endpoint_manager", "admin_pause")
-        return self.post(path, data=data, params=params)
+        return self.post(path, data=data, query_params=query_params)
 
     def endpoint_manager_resume_tasks(
-        self, task_ids: Iterable[ID_PARAM_TYPE], **params
+        self,
+        task_ids: Iterable[ID_PARAM_TYPE],
+        query_params: Optional[Dict[str, str]] = None,
     ) -> response.GlobusHTTPResponse:
         """
         Resume a list of tasks as an admin. Requires activity manager effective
@@ -1986,8 +2107,9 @@ class TransferClient(client.BaseClient):
 
         :param task_ids: List of task ids to resume.
         :type task_ids: iterable of str
-        :param params: Any additional parameters will be passed through as query params.
-        :type params: dict, optional
+        :param query_params: Any additional parameters will be passed through
+            as query params.
+        :type query_params: dict, optional
         :rtype: :class:`TransferResponse
                 <globus_sdk.services.transfer.response.TransferResponse>`
 
@@ -2002,14 +2124,16 @@ class TransferClient(client.BaseClient):
         log.info(f"TransferClient.endpoint_manager_resume_tasks({str_task_ids})")
         data = {"task_id_list": str_task_ids}
         path = self.qjoin_path("endpoint_manager", "admin_resume")
-        return self.post(path, data=data, params=params)
+        return self.post(path, data=data, query_params=query_params)
 
     #
     # endpoint manager pause rule methods
     #
 
     def endpoint_manager_pause_rule_list(
-        self, filter_endpoint: Optional[ID_PARAM_TYPE] = None, **params
+        self,
+        filter_endpoint: Optional[ID_PARAM_TYPE] = None,
+        query_params: Optional[Dict[str, str]] = None,
     ) -> IterableTransferResponse:
         """
         Get a list of pause rules on endpoints that the current user has the
@@ -2021,8 +2145,9 @@ class TransferClient(client.BaseClient):
             hosted by this endpoint. Must be activity monitor on this endpoint, not just
             the hosted endpoints.
         :type filter_endpoint: str
-        :param params: Any additional parameters will be passed through as query params.
-        :type params: dict, optional
+        :param query_params: Any additional parameters will be passed through
+            as query params.
+        :type query_params: dict, optional
         :rtype: :class:`IterableTransferResponse
                 <globus_sdk.services.transfer.response.IterableTransferResponse>`
 
@@ -2035,9 +2160,11 @@ class TransferClient(client.BaseClient):
         """
         log.info("TransferClient.endpoint_manager_pause_rule_list(...)")
         path = self.qjoin_path("endpoint_manager", "pause_rule_list")
+        if query_params is None:
+            query_params = {}
         if filter_endpoint is not None:
-            params["filter_endpoint"] = utils.safe_stringify(filter_endpoint)
-        return IterableTransferResponse(self.get(path, params=params))
+            query_params["filter_endpoint"] = utils.safe_stringify(filter_endpoint)
+        return IterableTransferResponse(self.get(path, query_params=query_params))
 
     def endpoint_manager_create_pause_rule(self, data) -> response.GlobusHTTPResponse:
         """
@@ -2074,7 +2201,7 @@ class TransferClient(client.BaseClient):
         return self.post(path, data=data)
 
     def endpoint_manager_get_pause_rule(
-        self, pause_rule_id, **params
+        self, pause_rule_id, query_params: Optional[Dict[str, str]] = None
     ) -> response.GlobusHTTPResponse:
         """
         Get an existing pause rule by ID. Requires the activity manager
@@ -2084,8 +2211,9 @@ class TransferClient(client.BaseClient):
 
         :param pause_rule_id: ID of pause rule to get.
         :type pause_rule_id: str
-        :param params: Any additional parameters will be passed through as query params.
-        :type params: dict, optional
+        :param query_params: Any additional parameters will be passed through
+            as query params.
+        :type query_params: dict, optional
         :rtype: :class:`TransferResponse
                 <globus_sdk.services.transfer.response.TransferResponse>`
 
@@ -2099,7 +2227,7 @@ class TransferClient(client.BaseClient):
         pause_rule_id = utils.safe_stringify(pause_rule_id)
         log.info(f"TransferClient.endpoint_manager_get_pause_rule({pause_rule_id})")
         path = self.qjoin_path("endpoint_manager", "pause_rule", pause_rule_id)
-        return self.get(path, params=params)
+        return self.get(path, query_params=query_params)
 
     def endpoint_manager_update_pause_rule(
         self, pause_rule_id, data
@@ -2137,7 +2265,7 @@ class TransferClient(client.BaseClient):
         return self.put(path, data=data)
 
     def endpoint_manager_delete_pause_rule(
-        self, pause_rule_id, **params
+        self, pause_rule_id, query_params: Optional[Dict[str, str]] = None
     ) -> response.GlobusHTTPResponse:
         """
         Delete an existing pause rule by ID. Requires the user to see the
@@ -2148,8 +2276,9 @@ class TransferClient(client.BaseClient):
 
         :param pause_rule_id: The ID of the pause rule to delete.
         :type pause_rule_id: str
-        :param params: Any additional parameters will be passed through as query params.
-        :type params: dict, optional
+        :param query_params: Any additional parameters will be passed through
+            as query params.
+        :type query_params: dict, optional
         :rtype: :class:`TransferResponse
                 <globus_sdk.services.transfer.response.TransferResponse>`
 
@@ -2163,4 +2292,4 @@ class TransferClient(client.BaseClient):
         pause_rule_id = utils.safe_stringify(pause_rule_id)
         log.info(f"TransferClient.endpoint_manager_delete_pause_rule({pause_rule_id})")
         path = self.qjoin_path("endpoint_manager", "pause_rule", pause_rule_id)
-        return self.delete(path, params=params)
+        return self.delete(path, query_params=query_params)

--- a/src/globus_sdk/services/transfer/client.py
+++ b/src/globus_sdk/services/transfer/client.py
@@ -1,7 +1,7 @@
 import logging
 import time
 import uuid
-from typing import Dict, Iterable, Optional, Union
+from typing import Any, Dict, Iterable, Optional, Union
 
 from globus_sdk import client, exc, paging, response, utils
 
@@ -69,7 +69,7 @@ class TransferClient(client.BaseClient):
     #
 
     def get_endpoint(
-        self, endpoint_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, str]] = None
+        self, endpoint_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, Any]] = None
     ) -> response.GlobusHTTPResponse:
         """
         ``GET /endpoint/<endpoint_id>``
@@ -100,7 +100,7 @@ class TransferClient(client.BaseClient):
         self,
         endpoint_id: ID_PARAM_TYPE,
         data,
-        query_params: Optional[Dict[str, str]] = None,
+        query_params: Optional[Dict[str, Any]] = None,
     ) -> response.GlobusHTTPResponse:
         """
         ``PUT /endpoint/<endpoint_id>``
@@ -218,7 +218,7 @@ class TransferClient(client.BaseClient):
         filter_scope: Optional[str] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
-        query_params: Optional[Dict[str, str]] = None,
+        query_params: Optional[Dict[str, Any]] = None,
     ) -> IterableTransferResponse:
         r"""
         .. parsed-literal::
@@ -241,7 +241,7 @@ class TransferClient(client.BaseClient):
         :type offset: int, optional
         :param query_params: Any additional parameters will be passed through
             as query params.
-        :type query_params: dict
+        :type query_params: dict, optional
         :rtype: :class:`IterableTransferResponse
                 <globus_sdk.transfer.response.IterableTransferResponse>`
 
@@ -274,16 +274,16 @@ class TransferClient(client.BaseClient):
         if filter_fulltext is not None:
             query_params["filter_fulltext"] = filter_fulltext
         if limit is not None:
-            query_params["limit"] = str(limit)
+            query_params["limit"] = limit
         if offset is not None:
-            query_params["offset"] = str(offset)
+            query_params["offset"] = offset
         log.info(f"TransferClient.endpoint_search({query_params})")
         return IterableTransferResponse(
             self.get("endpoint_search", query_params=query_params)
         )
 
     def endpoint_autoactivate(
-        self, endpoint_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, str]] = None
+        self, endpoint_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, Any]] = None
     ) -> response.GlobusHTTPResponse:
         r"""
         ``POST /endpoint/<endpoint_id>/autoactivate``
@@ -350,7 +350,7 @@ class TransferClient(client.BaseClient):
         return self.post(path, query_params=query_params)
 
     def endpoint_deactivate(
-        self, endpoint_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, str]] = None
+        self, endpoint_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, Any]] = None
     ) -> response.GlobusHTTPResponse:
         """
         ``POST /endpoint/<endpoint_id>/deactivate``
@@ -374,7 +374,7 @@ class TransferClient(client.BaseClient):
         self,
         endpoint_id: ID_PARAM_TYPE,
         requirements_data,
-        query_params: Optional[Dict[str, str]] = None,
+        query_params: Optional[Dict[str, Any]] = None,
     ) -> response.GlobusHTTPResponse:
         """
         ``POST /endpoint/<endpoint_id>/activate``
@@ -399,7 +399,7 @@ class TransferClient(client.BaseClient):
         return self.post(path, data=requirements_data, query_params=query_params)
 
     def endpoint_get_activation_requirements(
-        self, endpoint_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, str]] = None
+        self, endpoint_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, Any]] = None
     ) -> ActivationRequirementsResponse:
         """
         ``GET /endpoint/<endpoint_id>/activation_requirements``
@@ -419,7 +419,7 @@ class TransferClient(client.BaseClient):
         return ActivationRequirementsResponse(self.get(path, query_params=query_params))
 
     def my_effective_pause_rule_list(
-        self, endpoint_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, str]] = None
+        self, endpoint_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, Any]] = None
     ) -> IterableTransferResponse:
         """
         ``GET /endpoint/<endpoint_id>/my_effective_pause_rule_list``
@@ -444,7 +444,7 @@ class TransferClient(client.BaseClient):
     # Shared Endpoints
 
     def my_shared_endpoint_list(
-        self, endpoint_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, str]] = None
+        self, endpoint_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, Any]] = None
     ) -> IterableTransferResponse:
         """
         ``GET /endpoint/<endpoint_id>/my_shared_endpoint_list``
@@ -500,7 +500,7 @@ class TransferClient(client.BaseClient):
     # Endpoint servers
 
     def endpoint_server_list(
-        self, endpoint_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, str]] = None
+        self, endpoint_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, Any]] = None
     ) -> IterableTransferResponse:
         """
         ``GET /endpoint/<endpoint_id>/server_list``
@@ -524,7 +524,7 @@ class TransferClient(client.BaseClient):
         self,
         endpoint_id: ID_PARAM_TYPE,
         server_id,
-        query_params: Optional[Dict[str, str]] = None,
+        query_params: Optional[Dict[str, Any]] = None,
     ) -> response.GlobusHTTPResponse:
         """
         ``GET /endpoint/<endpoint_id>/server/<server_id>``
@@ -620,7 +620,7 @@ class TransferClient(client.BaseClient):
     #
 
     def endpoint_role_list(
-        self, endpoint_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, str]] = None
+        self, endpoint_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, Any]] = None
     ) -> IterableTransferResponse:
         """
         ``GET /endpoint/<endpoint_id>/role_list``
@@ -665,7 +665,7 @@ class TransferClient(client.BaseClient):
         self,
         endpoint_id: ID_PARAM_TYPE,
         role_id,
-        query_params: Optional[Dict[str, str]] = None,
+        query_params: Optional[Dict[str, Any]] = None,
     ) -> response.GlobusHTTPResponse:
         """
         ``GET /endpoint/<endpoint_id>/role/<role_id>``
@@ -711,7 +711,7 @@ class TransferClient(client.BaseClient):
     #
 
     def endpoint_acl_list(
-        self, endpoint_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, str]] = None
+        self, endpoint_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, Any]] = None
     ) -> IterableTransferResponse:
         """
         ``GET /endpoint/<endpoint_id>/access_list``
@@ -735,7 +735,7 @@ class TransferClient(client.BaseClient):
         self,
         endpoint_id: ID_PARAM_TYPE,
         rule_id,
-        query_params: Optional[Dict[str, str]] = None,
+        query_params: Optional[Dict[str, Any]] = None,
     ) -> response.GlobusHTTPResponse:
         """
         ``GET /endpoint/<endpoint_id>/access/<rule_id>``
@@ -851,7 +851,7 @@ class TransferClient(client.BaseClient):
     #
 
     def bookmark_list(
-        self, query_params: Optional[Dict[str, str]] = None
+        self, query_params: Optional[Dict[str, Any]] = None
     ) -> IterableTransferResponse:
         """
         ``GET /bookmark_list``
@@ -889,7 +889,7 @@ class TransferClient(client.BaseClient):
         return self.post("bookmark", data=bookmark_data)
 
     def get_bookmark(
-        self, bookmark_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, str]] = None
+        self, bookmark_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, Any]] = None
     ) -> response.GlobusHTTPResponse:
         """
         ``GET /bookmark/<bookmark_id>``
@@ -956,7 +956,7 @@ class TransferClient(client.BaseClient):
     #
 
     def operation_ls(
-        self, endpoint_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, str]] = None
+        self, endpoint_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, Any]] = None
     ) -> IterableTransferResponse:
         """
         ``GET /operation/endpoint/<endpoint_id>/ls``
@@ -986,7 +986,7 @@ class TransferClient(client.BaseClient):
         self,
         endpoint_id: ID_PARAM_TYPE,
         path,
-        query_params: Optional[Dict[str, str]] = None,
+        query_params: Optional[Dict[str, Any]] = None,
     ) -> response.GlobusHTTPResponse:
         """
         ``POST /operation/endpoint/<endpoint_id>/mkdir``
@@ -1022,7 +1022,7 @@ class TransferClient(client.BaseClient):
         endpoint_id: ID_PARAM_TYPE,
         oldpath,
         newpath,
-        query_params: Optional[Dict[str, str]] = None,
+        query_params: Optional[Dict[str, Any]] = None,
     ) -> response.GlobusHTTPResponse:
         """
         ``POST /operation/endpoint/<endpoint_id>/rename``
@@ -1060,7 +1060,7 @@ class TransferClient(client.BaseClient):
         endpoint_id: ID_PARAM_TYPE,
         symlink_target,
         path,
-        query_params: Optional[Dict[str, str]] = None,
+        query_params: Optional[Dict[str, Any]] = None,
     ) -> response.GlobusHTTPResponse:
         """
         ``POST /operation/endpoint/<endpoint_id>/symlink``
@@ -1105,7 +1105,7 @@ class TransferClient(client.BaseClient):
     #
 
     def get_submission_id(
-        self, query_params: Optional[Dict[str, str]] = None
+        self, query_params: Optional[Dict[str, Any]] = None
     ) -> response.GlobusHTTPResponse:
         """
         ``GET /submission_id``
@@ -1210,7 +1210,7 @@ class TransferClient(client.BaseClient):
         self,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
-        query_params: Optional[Dict[str, str]] = None,
+        query_params: Optional[Dict[str, Any]] = None,
     ) -> IterableTransferResponse:
         """
         Get an iterable of task documents owned by the current user.
@@ -1248,9 +1248,9 @@ class TransferClient(client.BaseClient):
         if query_params is None:
             query_params = {}
         if limit is not None:
-            query_params["limit"] = str(limit)
+            query_params["limit"] = limit
         if offset is not None:
-            query_params["offset"] = str(offset)
+            query_params["offset"] = offset
         return IterableTransferResponse(
             self.get("task_list", query_params=query_params)
         )
@@ -1267,7 +1267,7 @@ class TransferClient(client.BaseClient):
         task_id: ID_PARAM_TYPE,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
-        query_params: Optional[Dict[str, str]] = None,
+        query_params: Optional[Dict[str, Any]] = None,
     ) -> IterableTransferResponse:
         r"""
         List events (for example, faults and errors) for a given Task.
@@ -1309,13 +1309,13 @@ class TransferClient(client.BaseClient):
         if query_params is None:
             query_params = {}
         if limit is not None:
-            query_params["limit"] = str(limit)
+            query_params["limit"] = limit
         if offset is not None:
-            query_params["offset"] = str(offset)
+            query_params["offset"] = offset
         return IterableTransferResponse(self.get(path, query_params=query_params))
 
     def get_task(
-        self, task_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, str]] = None
+        self, task_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, Any]] = None
     ) -> response.GlobusHTTPResponse:
         """
         ``GET /task/<task_id>``
@@ -1339,7 +1339,7 @@ class TransferClient(client.BaseClient):
         self,
         task_id: ID_PARAM_TYPE,
         data: Dict,
-        query_params: Optional[Dict[str, str]] = None,
+        query_params: Optional[Dict[str, Any]] = None,
     ) -> response.GlobusHTTPResponse:
         """
         ``PUT /task/<task_id>``
@@ -1482,7 +1482,7 @@ class TransferClient(client.BaseClient):
         # unreachable -- end of task_wait
 
     def task_pause_info(
-        self, task_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, str]] = None
+        self, task_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, Any]] = None
     ) -> response.GlobusHTTPResponse:
         """
         ``GET /task/<task_id>/pause_info``
@@ -1504,7 +1504,7 @@ class TransferClient(client.BaseClient):
 
     @paging.has_paginator(paging.MarkerPaginator, items_key="DATA")
     def task_successful_transfers(
-        self, task_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, str]] = None
+        self, task_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, Any]] = None
     ) -> IterableTransferResponse:
         """
         Get the successful file transfers for a completed Task.
@@ -1550,7 +1550,7 @@ class TransferClient(client.BaseClient):
 
     @paging.has_paginator(paging.MarkerPaginator, items_key="DATA")
     def task_skipped_errors(
-        self, task_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, str]] = None
+        self, task_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, Any]] = None
     ) -> IterableTransferResponse:
         """
         Get path and error information for all paths that were skipped due
@@ -1597,7 +1597,7 @@ class TransferClient(client.BaseClient):
     #
 
     def endpoint_manager_monitored_endpoints(
-        self, query_params: Optional[Dict[str, str]] = None
+        self, query_params: Optional[Dict[str, Any]] = None
     ) -> IterableTransferResponse:
         """
         Get endpoints the current user is a monitor or manager on.
@@ -1617,7 +1617,7 @@ class TransferClient(client.BaseClient):
         return IterableTransferResponse(self.get(path, query_params=query_params))
 
     def endpoint_manager_hosted_endpoint_list(
-        self, endpoint_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, str]] = None
+        self, endpoint_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, Any]] = None
     ) -> IterableTransferResponse:
         """
         Get shared endpoints hosted on the given endpoint.
@@ -1642,7 +1642,7 @@ class TransferClient(client.BaseClient):
         return IterableTransferResponse(self.get(path, query_params=query_params))
 
     def endpoint_manager_get_endpoint(
-        self, endpoint_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, str]] = None
+        self, endpoint_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, Any]] = None
     ) -> response.GlobusHTTPResponse:
         """
         Get endpoint details as an admin.
@@ -1665,7 +1665,7 @@ class TransferClient(client.BaseClient):
         return self.get(path, query_params=query_params)
 
     def endpoint_manager_acl_list(
-        self, endpoint_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, str]] = None
+        self, endpoint_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, Any]] = None
     ) -> IterableTransferResponse:
         """
         Get a list of access control rules on specified endpoint as an admin.
@@ -1697,7 +1697,7 @@ class TransferClient(client.BaseClient):
 
     @paging.has_paginator(paging.LastKeyPaginator, items_key="DATA")
     def endpoint_manager_task_list(
-        self, query_params: Optional[Dict[str, str]] = None
+        self, query_params: Optional[Dict[str, Any]] = None
     ) -> IterableTransferResponse:
         r"""
         Get a list of tasks visible via ``activity_monitor`` role, as opposed
@@ -1826,7 +1826,7 @@ class TransferClient(client.BaseClient):
         return IterableTransferResponse(self.get(path, query_params=query_params))
 
     def endpoint_manager_get_task(
-        self, task_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, str]] = None
+        self, task_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, Any]] = None
     ):
         """
         Get task info as an admin. Requires activity monitor effective role on
@@ -1861,7 +1861,7 @@ class TransferClient(client.BaseClient):
         task_id: ID_PARAM_TYPE,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
-        query_params: Optional[Dict[str, str]] = None,
+        query_params: Optional[Dict[str, Any]] = None,
     ) -> IterableTransferResponse:
         """
         List events (for example, faults and errors) for a given task as an
@@ -1894,13 +1894,13 @@ class TransferClient(client.BaseClient):
         if query_params is None:
             query_params = {}
         if limit is not None:
-            query_params["limit"] = str(limit)
+            query_params["limit"] = limit
         if offset is not None:
-            query_params["offset"] = str(offset)
+            query_params["offset"] = offset
         return IterableTransferResponse(self.get(path, query_params=query_params))
 
     def endpoint_manager_task_pause_info(
-        self, task_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, str]] = None
+        self, task_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, Any]] = None
     ) -> response.GlobusHTTPResponse:
         """
         Get details about why a task is paused as an admin. Requires activity
@@ -1925,7 +1925,7 @@ class TransferClient(client.BaseClient):
 
     @paging.has_paginator(paging.MarkerPaginator, items_key="DATA")
     def endpoint_manager_task_successful_transfers(
-        self, task_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, str]] = None
+        self, task_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, Any]] = None
     ) -> IterableTransferResponse:
         """
         Get the successful file transfers for a completed Task as an admin.
@@ -1958,7 +1958,7 @@ class TransferClient(client.BaseClient):
         return IterableTransferResponse(self.get(path, query_params=query_params))
 
     def endpoint_manager_task_skipped_errors(
-        self, task_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, str]] = None
+        self, task_id: ID_PARAM_TYPE, query_params: Optional[Dict[str, Any]] = None
     ) -> IterableTransferResponse:
         """
         Get skipped errors for a completed Task as an admin.
@@ -1991,7 +1991,7 @@ class TransferClient(client.BaseClient):
         self,
         task_ids: Iterable[ID_PARAM_TYPE],
         message,
-        query_params: Optional[Dict[str, str]] = None,
+        query_params: Optional[Dict[str, Any]] = None,
     ) -> response.GlobusHTTPResponse:
         """
         Cancel a list of tasks as an admin. Requires activity manager effective
@@ -2026,7 +2026,7 @@ class TransferClient(client.BaseClient):
         return self.post(path, data=data, query_params=query_params)
 
     def endpoint_manager_cancel_status(
-        self, admin_cancel_id, query_params: Optional[Dict[str, str]] = None
+        self, admin_cancel_id, query_params: Optional[Dict[str, Any]] = None
     ) -> response.GlobusHTTPResponse:
         """
         Get the status of an an admin cancel (result of
@@ -2057,7 +2057,7 @@ class TransferClient(client.BaseClient):
         self,
         task_ids: Iterable[ID_PARAM_TYPE],
         message,
-        query_params: Optional[Dict[str, str]] = None,
+        query_params: Optional[Dict[str, Any]] = None,
     ) -> response.GlobusHTTPResponse:
         """
         Pause a list of tasks as an admin. Requires activity manager effective
@@ -2097,7 +2097,7 @@ class TransferClient(client.BaseClient):
     def endpoint_manager_resume_tasks(
         self,
         task_ids: Iterable[ID_PARAM_TYPE],
-        query_params: Optional[Dict[str, str]] = None,
+        query_params: Optional[Dict[str, Any]] = None,
     ) -> response.GlobusHTTPResponse:
         """
         Resume a list of tasks as an admin. Requires activity manager effective
@@ -2133,7 +2133,7 @@ class TransferClient(client.BaseClient):
     def endpoint_manager_pause_rule_list(
         self,
         filter_endpoint: Optional[ID_PARAM_TYPE] = None,
-        query_params: Optional[Dict[str, str]] = None,
+        query_params: Optional[Dict[str, Any]] = None,
     ) -> IterableTransferResponse:
         """
         Get a list of pause rules on endpoints that the current user has the
@@ -2201,7 +2201,7 @@ class TransferClient(client.BaseClient):
         return self.post(path, data=data)
 
     def endpoint_manager_get_pause_rule(
-        self, pause_rule_id, query_params: Optional[Dict[str, str]] = None
+        self, pause_rule_id, query_params: Optional[Dict[str, Any]] = None
     ) -> response.GlobusHTTPResponse:
         """
         Get an existing pause rule by ID. Requires the activity manager
@@ -2265,7 +2265,7 @@ class TransferClient(client.BaseClient):
         return self.put(path, data=data)
 
     def endpoint_manager_delete_pause_rule(
-        self, pause_rule_id, query_params: Optional[Dict[str, str]] = None
+        self, pause_rule_id, query_params: Optional[Dict[str, Any]] = None
     ) -> response.GlobusHTTPResponse:
         """
         Delete an existing pause rule by ID. Requires the user to see the

--- a/src/globus_sdk/services/transfer/data.py
+++ b/src/globus_sdk/services/transfer/data.py
@@ -6,7 +6,7 @@ conversion.
 """
 
 import logging
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
 from globus_sdk import utils
 
@@ -147,7 +147,7 @@ class TransferData(dict):
         skip_source_errors=False,
         fail_on_quota_errors=False,
         recursive_symlinks="ignore",
-        additional_fields: Optional[Dict[str, str]] = None,
+        additional_fields: Optional[Dict[str, Any]] = None,
     ):
         source_endpoint = utils.safe_stringify(source_endpoint)
         destination_endpoint = utils.safe_stringify(destination_endpoint)
@@ -214,7 +214,7 @@ class TransferData(dict):
         recursive=False,
         external_checksum=None,
         checksum_algorithm=None,
-        additional_fields: Optional[Dict[str, str]] = None,
+        additional_fields: Optional[Dict[str, Any]] = None,
     ):
         """
         Add a file or directory to be transfered. If the item is a symlink

--- a/src/globus_sdk/services/transfer/data.py
+++ b/src/globus_sdk/services/transfer/data.py
@@ -203,8 +203,8 @@ class TransferData(dict):
             self.update(additional_fields)
             for option, value in additional_fields.items():
                 logger.info(
-                    "TransferData.{} = {} (option passed in via "
-                    "additional_fields)".format(option, value)
+                    f"TransferData.{option} = {value} (option passed "
+                    "in via additional_fields)"
                 )
 
     def add_item(
@@ -369,7 +369,7 @@ class DeleteData(dict):
         submission_id=None,
         recursive=False,
         deadline=None,
-        additional_fields: Optional[Dict[str, str]] = None,
+        additional_fields: Optional[Dict[str, Any]] = None,
     ):
         endpoint = utils.safe_stringify(endpoint)
         logger.info("Creating a new DeleteData object")
@@ -400,7 +400,7 @@ class DeleteData(dict):
                     f"DeleteData.{option} = {value} (option passed in via kwargs)"
                 )
 
-    def add_item(self, path, additional_fields: Optional[Dict[str, str]] = None):
+    def add_item(self, path, additional_fields: Optional[Dict[str, Any]] = None):
         """
         Add a file or directory or symlink to be deleted. If any of the paths
         are directories, ``recursive`` must be set True on the top level

--- a/src/globus_sdk/transport/requests.py
+++ b/src/globus_sdk/transport/requests.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 import requests
 
@@ -76,7 +76,7 @@ class RequestsTransport:
         self,
         method: str,
         url: str,
-        query_params: Optional[Dict[str, str]] = None,
+        query_params: Optional[Dict[str, Any]] = None,
         data: Union[Dict, List, str, None] = None,
         headers: Optional[Dict[str, str]] = None,
         encoding: Optional[str] = None,
@@ -102,7 +102,7 @@ class RequestsTransport:
         self,
         method,
         url,
-        query_params: Optional[Dict[str, str]] = None,
+        query_params: Optional[Dict[str, Any]] = None,
         data=None,
         headers=None,
         encoding: Optional[str] = None,
@@ -116,7 +116,7 @@ class RequestsTransport:
         :param method: HTTP request method, as an all caps string
         :type method: str
         :param query_params: Parameters to be encoded as a query string
-        :type query_params: dict
+        :type query_params: dict, optional
         :param headers: HTTP headers to add to the request
         :type headers: dict
         :param data: Data to send as the request body. May pass through encoding.

--- a/src/globus_sdk/transport/requests.py
+++ b/src/globus_sdk/transport/requests.py
@@ -76,7 +76,7 @@ class RequestsTransport:
         self,
         method: str,
         url: str,
-        params: Optional[Dict] = None,
+        query_params: Optional[Dict[str, str]] = None,
         data: Union[Dict, List, str, None] = None,
         headers: Optional[Dict[str, str]] = None,
         encoding: Optional[str] = None,
@@ -96,13 +96,13 @@ class RequestsTransport:
                 f"Unknown encoding '{encoding}' is not supported by this transport."
             )
 
-        return self.encoders[encoding].encode(method, url, params, data, headers)
+        return self.encoders[encoding].encode(method, url, query_params, data, headers)
 
     def request(
         self,
         method,
         url,
-        params=None,
+        query_params: Optional[Dict[str, str]] = None,
         data=None,
         headers=None,
         encoding: Optional[str] = None,
@@ -115,8 +115,8 @@ class RequestsTransport:
         :type path: str
         :param method: HTTP request method, as an all caps string
         :type method: str
-        :param params: Parameters to be encoded as a query string
-        :type params: dict
+        :param query_params: Parameters to be encoded as a query string
+        :type query_params: dict
         :param headers: HTTP headers to add to the request
         :type headers: dict
         :param data: Data to send as the request body. May pass through encoding.
@@ -131,7 +131,7 @@ class RequestsTransport:
         """
         resp: Optional[requests.Response] = None
         retry_state: Dict = {}
-        req = self._encode(method, url, params, data, headers, encoding)
+        req = self._encode(method, url, query_params, data, headers, encoding)
         for attempt in range(self.max_retries):
             # add Authorization header, or (if it's a NullAuthorizer) possibly
             # explicitly remove the Authorization header

--- a/tests/functional/transfer/test_task_submit.py
+++ b/tests/functional/transfer/test_task_submit.py
@@ -93,7 +93,10 @@ def test_transfer_submit_success(client, transfer_data):
     )
 
     tdata = transfer_data(
-        label="mytask", sync_level="exists", deadline="2018-06-01", custom_param="foo"
+        label="mytask",
+        sync_level="exists",
+        deadline="2018-06-01",
+        additional_fields={"custom_param": "foo"},
     )
     assert tdata["custom_param"] == "foo"
     assert tdata["sync_level"] == 0
@@ -113,7 +116,9 @@ def test_delete_submit_success(client, delete_data):
         "transfer", "/delete", method="POST", body=DELETE_SUBMISSION_SUCCESS
     )
 
-    ddata = delete_data(label="mytask", deadline="2018-06-01", custom_param="foo")
+    ddata = delete_data(
+        label="mytask", deadline="2018-06-01", additional_fields={"custom_param": "foo"}
+    )
     assert ddata["custom_param"] == "foo"
 
     ddata.add_item("/path/to/foo")

--- a/tests/unit/helpers/test_transfer.py
+++ b/tests/unit/helpers/test_transfer.py
@@ -48,7 +48,9 @@ def test_tranfer_init(transfer_data):
     # init with params
     label = "label"
     params = {"param1": "value1", "param2": "value2"}
-    param_tdata = transfer_data(label=label, sync_level="exists", **params)
+    param_tdata = transfer_data(
+        label=label, sync_level="exists", additional_fields=params
+    )
     assert param_tdata["label"] == label
     # sync_level of "exists" should be converted to 0
     assert param_tdata["sync_level"] == 0
@@ -134,7 +136,7 @@ def test_delete_init(delete_data):
     # init with params
     label = "label"
     params = {"param1": "value1", "param2": "value2"}
-    param_ddata = delete_data(label=label, recursive="True", **params)
+    param_ddata = delete_data(label=label, recursive="True", additional_fields=params)
     assert param_ddata["label"] == label
     assert param_ddata["recursive"] == "True"
     for par in params:


### PR DESCRIPTION
A few questions / notes

- Is `Dict[str, str]` better than just `Dict` or `Dict[str, Any]` for the type here? I had to do a decent amount of `str()` casting and I'm not sure it affected anything other than making the type checker happy.
- A lot of functions that need to add their own query params previously assumed that the dictionary existed and now need `if query_params is None: query_params = {}` logic for that assumption to hold. Is there a cleaner way of doing that without running into issues with mutable defaults?
- I also changed the passthrough behavior for `TransferData` and `DeleteData` with the name of `additional_fields` since they're not query params. Not sure if we wanted this work to extend to there or not but it seemed reasonable?
- I added `limit` and `offset` as named parameters to several functions since their paginators expected them to accepted at the top level. Might have been cleaner to just have the paginateor use `query_params`?
