### PR TITLE
Add `oauth2_scopes` with constants and functions for templating scopes

### DIFF
--- a/src/globus_sdk/scopes.py
+++ b/src/globus_sdk/scopes.py
@@ -1,0 +1,117 @@
+from typing import List, Optional
+
+
+class ScopeBuilder:
+    """
+    Utility class for creating scope strings for a specified resource server.
+
+    :param resource_server: The identifier, usually a domain name or a UUID, for the
+        resource server to return scopes for.
+    :type resource_server: str
+    :param known_scopes: A list of scope names to pre-populate on this instance. This
+        will set attributes on the instance using the URN scope format.
+    :type known_scopes: list, optional
+    """
+
+    def __init__(self, resource_server: str, known_scopes: Optional[List[str]] = None):
+        self.resource_server = resource_server
+        if known_scopes:
+            for scope_name in known_scopes:
+                setattr(self, scope_name, self.urn_scope_string(scope_name))
+
+    def urn_scope_string(self, scope_name: str) -> str:
+        """
+        Return a complete string representing the scope with a given name for this
+        client, in the Globus Auth URN format.
+
+        Note that this module already provides many such scope strings for use with
+        Globus services.
+
+        **Examples**
+
+        >>> sb = scope_builder("transfer.api.globus.org")
+        >>> sb.urn_scope_string("transfer.api.globus.org", "all")
+        "urn:globus:auth:scope:transfer.api.globus.org:all"
+
+        :param scope_name: The short name for the scope involved.
+        :type scope_name: str
+        """
+        return f"urn:globus:auth:scope:{self.resource_server}:{scope_name}"
+
+    def url_scope_string(self, scope_name: str) -> str:
+        """
+        Return a complete string representing the scope with a given name for this
+        client, in URL format.
+
+        **Examples**
+
+        >>> sb = scope_builder("actions.globus.org")
+        >>> sb.url_scope_string("actions.globus.org", "hello_world")
+        "https://auth.globus.org/scopes/actions.globus.org/hello_world"
+
+        :param scope_name: The short name for the scope involved.
+        :type scope_name: str
+        """
+        return f"https://auth.globus.org/scopes/{self.resource_server}/{scope_name}"
+
+
+class GCSScopeBuilder(ScopeBuilder):
+    @property
+    def data_access_scope(self) -> str:
+        return self.url_scope_string("data_access")
+
+
+class _AuthScopesBuilder(ScopeBuilder):
+    openid: str = "openid"
+    email: str = "email"
+    profile: str = "profile"
+
+
+AuthScopes = _AuthScopesBuilder(
+    "auth.globus.org",
+    known_scopes=[
+        "view_authentications",
+        "view_clients",
+        "view_clients_and_scopes",
+        "view_identities",
+        "view_identity_set",
+    ],
+)
+
+
+GroupsScopes = ScopeBuilder(
+    "groups.api.globus.org",
+    known_scopes=[
+        "all",
+        "view_my_groups_and_memberships",
+    ],
+)
+
+
+NexusScopes = ScopeBuilder(
+    "nexus.api.globus.org",
+    known_scopes=[
+        "groups",
+    ],
+)
+
+
+SearchScopes = ScopeBuilder(
+    "search.api.globus.org",
+    known_scopes=[
+        "all",
+        "globus_connect_server",
+        "ingest",
+        "search",
+    ],
+)
+
+
+TransferScopes = ScopeBuilder(
+    "transfer.api.globus.org",
+    known_scopes=[
+        "all",
+        "gcp_install",
+        "monitor_ongoing",
+    ],
+)

--- a/src/globus_sdk/services/auth/oauth2_authorization_code.py
+++ b/src/globus_sdk/services/auth/oauth2_authorization_code.py
@@ -37,6 +37,8 @@ class GlobusAuthorizationCodeFlowManager(GlobusOAuthFlowManager):
     :param requested_scopes: The scopes on the token(s) being requested, as a
         space-separated string or iterable of strings. Defaults to
         ``openid profile email urn:globus:auth:scope:transfer.api.globus.org:all``
+        (that is, ``DEFAULT_REQUESTED_SCOPES`` from
+        ``globus_sdk.services.auth.oauth2_constants``)
     :type requested_scopes: str or iterable of str, optional
     :param state: This string allows an application to pass information back to itself
         in the course of the OAuth flow. Because the user will navigate away from the

--- a/src/globus_sdk/services/auth/oauth2_constants.py
+++ b/src/globus_sdk/services/auth/oauth2_constants.py
@@ -1,9 +1,10 @@
+from globus_sdk.scopes import AuthScopes, TransferScopes
+
 __all__ = ["DEFAULT_REQUESTED_SCOPES"]
 
-
 DEFAULT_REQUESTED_SCOPES = (
-    "openid",
-    "profile",
-    "email",
-    "urn:globus:auth:scope:transfer.api.globus.org:all",
+    AuthScopes.openid,
+    AuthScopes.profile,
+    AuthScopes.email,
+    TransferScopes.all,  # type: ignore[attr-defined]
 )

--- a/tests/unit/test_scopes.py
+++ b/tests/unit/test_scopes.py
@@ -1,0 +1,18 @@
+import uuid
+
+from globus_sdk.scopes import ScopeBuilder
+
+
+def test_url_scope_string():
+    sb = ScopeBuilder(str(uuid.UUID(int=0)))
+    assert sb.url_scope_string("data_access") == (
+        "https://auth.globus.org/scopes/00000000-0000-0000-0000-000000000000"
+        "/data_access"
+    )
+
+
+def test_urn_scope_string():
+    sb = ScopeBuilder("example.globus.org")
+    assert (
+        sb.urn_scope_string("scope") == "urn:globus:auth:scope:example.globus.org:scope"
+    )


### PR DESCRIPTION
- Add `oauth2_scopes.py` with a bunch of scope constants as well as some simple functions for templating scopes as URNs or URLs.

I didn't want to get clever with dynamically assigning attributes on the `XScopes` objects. One might argue for all caps: `XScopes.SOME_SCOPE`.

Does the `XScopes.some_scope` interface seem useful and easy to follow?