### PR TITLE
Convert data helper classes to "PayloadWrapper"

### DIFF
--- a/src/globus_sdk/client.py
+++ b/src/globus_sdk/client.py
@@ -274,7 +274,7 @@ class BaseClient:
         r = self.transport.request(
             method=method,
             url=url,
-            data=data.to_dict() if isinstance(data, utils.PayloadWrapper) else data,
+            data=data.data if isinstance(data, utils.PayloadWrapper) else data,
             query_params=query_params,
             headers=rheaders,
             encoding=encoding,

--- a/src/globus_sdk/client.py
+++ b/src/globus_sdk/client.py
@@ -1,6 +1,6 @@
 import logging
 import urllib.parse
-from typing import Any, Dict, Optional, Type
+from typing import Any, Dict, Optional, Type, Union
 
 from globus_sdk import config, exc, utils
 from globus_sdk.authorizers import GlobusAuthorizer
@@ -131,7 +131,7 @@ class BaseClient:
         path: str,
         *,
         query_params: Optional[Dict[str, Any]] = None,
-        data: Optional[Dict] = None,
+        data: Union[None, Dict, utils.PayloadWrapper] = None,
         headers: Optional[Dict] = None,
         encoding: Optional[str] = None,
     ) -> GlobusHTTPResponse:
@@ -176,7 +176,7 @@ class BaseClient:
         path: str,
         *,
         query_params: Optional[Dict[str, Any]] = None,
-        data: Optional[Dict] = None,
+        data: Union[None, Dict, utils.PayloadWrapper] = None,
         headers: Optional[Dict] = None,
         encoding: Optional[str] = None,
     ) -> GlobusHTTPResponse:
@@ -203,7 +203,7 @@ class BaseClient:
         path: str,
         *,
         query_params: Optional[Dict[str, Any]] = None,
-        data: Optional[Dict] = None,
+        data: Union[None, Dict, utils.PayloadWrapper] = None,
         headers: Optional[Dict] = None,
         encoding: Optional[str] = None,
     ) -> GlobusHTTPResponse:
@@ -231,7 +231,7 @@ class BaseClient:
         path: str,
         *,
         query_params: Optional[Dict[str, Any]] = None,
-        data: Optional[Dict] = None,
+        data: Union[None, Dict, utils.PayloadWrapper] = None,
         headers: Optional[Dict] = None,
         encoding: Optional[str] = None,
     ) -> GlobusHTTPResponse:
@@ -274,7 +274,7 @@ class BaseClient:
         r = self.transport.request(
             method=method,
             url=url,
-            data=data,
+            data=data.to_dict() if isinstance(data, utils.PayloadWrapper) else data,
             query_params=query_params,
             headers=rheaders,
             encoding=encoding,

--- a/src/globus_sdk/services/search/__init__.py
+++ b/src/globus_sdk/services/search/__init__.py
@@ -1,5 +1,5 @@
 from .client import SearchClient
+from .data import SearchQuery
 from .errors import SearchAPIError
-from .query import SearchQuery
 
 __all__ = ("SearchClient", "SearchQuery", "SearchAPIError")

--- a/src/globus_sdk/services/search/client.py
+++ b/src/globus_sdk/services/search/client.py
@@ -1,9 +1,10 @@
 import logging
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 
 from globus_sdk import client, paging, response, utils
 from globus_sdk.scopes import SearchScopes
 
+from .data import SearchQuery
 from .errors import SearchAPIError
 
 log = logging.getLogger(__name__)
@@ -112,7 +113,7 @@ class SearchClient(client.BaseClient):
         path = self.qjoin_path("v1/index", index_id, "search")
         return self.get(path, query_params=query_params)
 
-    def post_search(self, index_id, data):
+    def post_search(self, index_id, data: Union[Dict[str, Any], SearchQuery]):
         """
         ``POST /v1/index/<index_id>/search``
 

--- a/src/globus_sdk/services/search/data.py
+++ b/src/globus_sdk/services/search/data.py
@@ -1,4 +1,9 @@
-class SearchQuery(dict):
+from typing import Any, Dict, Optional
+
+from globus_sdk import utils
+
+
+class SearchQuery(utils.PayloadWrapper):
     """
     A specialized dict which has helpers for creating and modifying a Search
     Query document.
@@ -14,19 +19,39 @@ class SearchQuery(dict):
     >>> result = sc.post_search(index_id, query)
     """
 
-    def set_query(self, query):
+    def __init__(
+        self,
+        q: Optional[str] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+        advanced: Optional[bool] = None,
+        additional_fields: Optional[Dict[str, Any]] = None,
+    ):
+        super().__init__()
+        if q is not None:
+            self["q"] = q
+        if limit is not None:
+            self["limit"] = limit
+        if offset is not None:
+            self["offset"] = offset
+        if advanced is not None:
+            self["advanced"] = advanced
+        if additional_fields is not None:
+            self.update(additional_fields)
+
+    def set_query(self, query: str) -> "SearchQuery":
         self["q"] = query
         return self
 
-    def set_limit(self, limit):
+    def set_limit(self, limit: int) -> "SearchQuery":
         self["limit"] = limit
         return self
 
-    def set_offset(self, offset):
+    def set_offset(self, offset: int) -> "SearchQuery":
         self["offset"] = offset
         return self
 
-    def set_advanced(self, advanced):
+    def set_advanced(self, advanced: bool) -> "SearchQuery":
         self["advanced"] = advanced
         return self
 
@@ -39,7 +64,7 @@ class SearchQuery(dict):
         date_interval=None,
         histogram_range=None,
         **kwargs
-    ):
+    ) -> "SearchQuery":
         self["facets"] = self.get("facets", [])
         facet = {"name": name, "field_name": field_name, "type": type}
         facet.update(kwargs)
@@ -53,21 +78,23 @@ class SearchQuery(dict):
         self["facets"].append(facet)
         return self
 
-    def add_filter(self, field_name, values, type="match_all", **kwargs):
+    def add_filter(
+        self, field_name, values, type="match_all", **kwargs
+    ) -> "SearchQuery":
         self["filters"] = self.get("filters", [])
         new_filter = {"field_name": field_name, "values": values, "type": type}
         new_filter.update(kwargs)
         self["filters"].append(new_filter)
         return self
 
-    def add_boost(self, field_name, factor, **kwargs):
+    def add_boost(self, field_name, factor, **kwargs) -> "SearchQuery":
         self["boosts"] = self.get("boosts", [])
         boost = {"field_name": field_name, "factor": factor}
         boost.update(kwargs)
         self["boosts"].append(boost)
         return self
 
-    def add_sort(self, field_name, order=None, **kwargs):
+    def add_sort(self, field_name, order=None, **kwargs) -> "SearchQuery":
         self["sort"] = self.get("sort", [])
         sort = {"field_name": field_name}
         sort.update(kwargs)

--- a/src/globus_sdk/services/transfer/client.py
+++ b/src/globus_sdk/services/transfer/client.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, Iterable, List, Optional, Union
 from globus_sdk import client, exc, paging, response, utils
 from globus_sdk.scopes import TransferScopes
 
+from .data import DeleteData, TransferData
 from .errors import TransferAPIError
 from .response import ActivationRequirementsResponse, IterableTransferResponse
 
@@ -1255,7 +1256,9 @@ class TransferClient(client.BaseClient):
         log.info(f"TransferClient.get_submission_id({query_params})")
         return self.get("submission_id", query_params=query_params)
 
-    def submit_transfer(self, data) -> response.GlobusHTTPResponse:
+    def submit_transfer(
+        self, data: Union[Dict[str, Any], TransferData]
+    ) -> response.GlobusHTTPResponse:
         """
         ``POST /transfer``
 
@@ -1289,7 +1292,9 @@ class TransferClient(client.BaseClient):
         log.info("TransferClient.submit_transfer(...)")
         return self.post("/transfer", data=data)
 
-    def submit_delete(self, data) -> response.GlobusHTTPResponse:
+    def submit_delete(
+        self, data: Union[Dict[str, Any], DeleteData]
+    ) -> response.GlobusHTTPResponse:
         """
         ``POST /delete``
 

--- a/src/globus_sdk/services/transfer/data/__init__.py
+++ b/src/globus_sdk/services/transfer/data/__init__.py
@@ -1,0 +1,11 @@
+"""
+Data helper classes for constructing Transfer API documents. All classes should
+be PayloadWrapper types, so they can be passed seamlessly to
+:class:`TransferClient <globus_sdk.TransferClient>` methods without
+conversion.
+"""
+
+from .delete_data import DeleteData
+from .transfer_data import TransferData
+
+__all__ = ("TransferData", "DeleteData")

--- a/src/globus_sdk/services/transfer/data/delete_data.py
+++ b/src/globus_sdk/services/transfer/data/delete_data.py
@@ -1,0 +1,119 @@
+import logging
+from typing import Any, Dict, Optional
+
+from globus_sdk import utils
+
+log = logging.getLogger(__name__)
+
+
+class DeleteData(utils.PayloadWrapper):
+    r"""
+    Convenience class for constructing a delete document, to use as the
+    `data` parameter to
+    :meth:`submit_delete <globus_sdk.TransferClient.submit_delete>`.
+
+    At least one item must be added using
+    :meth:`add_item <globus_sdk.DeleteData.add_item>`.
+
+    If ``submission_id`` isn't passed, one will be fetched automatically. The
+    submission ID can be pulled out of here to inspect, but the document
+    can be used as-is multiple times over to retry a potential submission
+    failure (so there shouldn't be any need to inspect it).
+
+    :param transfer_client: A ``TransferClient`` instance which will be used to get a
+        submission ID if one is not supplied. Should be the same instance that is used
+        to submit the deletion.
+    :type transfer_client: :class:`TransferClient <globus_sdk.TransferClient>`
+    :param endpoint: The endpoint ID which is targeted by this deletion Task
+    :type endpoint: str
+    :param label: A string label for the Task
+    :type label: str, optional
+    :param submission_id: A submission ID value fetched via
+        :meth:`get_submission_id <globus_sdk.TransferClient.get_submission_id>`.
+        Defaults to using ``transfer_client.get_submission_id``
+    :type submission_id: str, optional
+    :param recursive: Recursively delete subdirectories on the target endpoint
+      [default: ``False``]
+    :type recursive: bool
+    :param deadline: An ISO-8601 timestamp (as a string) or a datetime object which
+        defines a deadline for the deletion. At the deadline, even if the data deletion
+        is not complete, the job will be canceled. We recommend ensuring that the
+        timestamp is in UTC to avoid confusion and ambiguity. Examples of ISO-8601
+        timestamps include ``2017-10-12 09:30Z``, ``2017-10-12 12:33:54+00:00``, and
+        ``2017-10-12``
+    :type deadline: str or datetime, optional
+    :param additional_fields: additional fields to be added to the delete
+        document. Mostly intended for internal use
+    :type additional_fields: dict, optional
+
+    **Examples**
+
+    See the :meth:`submit_delete <globus_sdk.TransferClient.submit_delete>`
+    documentation for example usage.
+
+    **External Documentation**
+
+    See the
+    `Task document definition \
+    <https://docs.globus.org/api/transfer/task_submit/#document_types>`_
+    and
+    `Delete specific fields \
+    <https://docs.globus.org/api/transfer/task_submit/#delete_specific_fields>`_
+    in the REST documentation for more details on Delete Task documents.
+
+    .. automethodlist:: globus_sdk.TransferData
+    """
+
+    def __init__(
+        self,
+        transfer_client,
+        endpoint,
+        label=None,
+        submission_id=None,
+        recursive=False,
+        deadline=None,
+        additional_fields: Optional[Dict[str, Any]] = None,
+    ):
+        super().__init__()
+        endpoint = utils.safe_stringify(endpoint)
+        log.info("Creating a new DeleteData object")
+        self["DATA_TYPE"] = "delete"
+        self["submission_id"] = (
+            submission_id or transfer_client.get_submission_id()["value"]
+        )
+        log.info("DeleteData.submission_id = {}".format(self["submission_id"]))
+        self["endpoint"] = endpoint
+        log.info(f"DeleteData.endpoint = {endpoint}")
+        self["recursive"] = recursive
+        log.info(f"DeleteData.recursive = {recursive}")
+
+        if label is not None:
+            self["label"] = label
+            log.debug(f"DeleteData.label = {label}")
+
+        if deadline is not None:
+            self["deadline"] = str(deadline)
+            log.debug(f"DeleteData.deadline = {deadline}")
+
+        self["DATA"] = []
+
+        if additional_fields is not None:
+            self.update(additional_fields)
+            for option, value in additional_fields.items():
+                log.info(f"DeleteData.{option} = {value} (option passed in via kwargs)")
+
+    def add_item(self, path, additional_fields: Optional[Dict[str, Any]] = None):
+        """
+        Add a file or directory or symlink to be deleted. If any of the paths
+        are directories, ``recursive`` must be set True on the top level
+        ``DeleteData``. Symlinks will never be followed, only deleted.
+
+        Appends a delete_item document to the DATA key of the delete
+        document.
+        """
+        path = utils.safe_stringify(path)
+        item_data = {"DATA_TYPE": "delete_item", "path": path}
+        if additional_fields is not None:
+            item_data.update(additional_fields)
+        log.debug('DeleteData[{}].add_item: "{}"'.format(self["endpoint"], path))
+        self["DATA"].append(item_data)

--- a/src/globus_sdk/utils.py
+++ b/src/globus_sdk/utils.py
@@ -1,7 +1,6 @@
 import hashlib
 from base64 import b64encode
-from collections.abc import MutableMapping
-from typing import Any, Dict
+from collections import UserDict
 
 
 def sha256_string(s):
@@ -46,29 +45,20 @@ def safe_stringify(value):
     return str(value)
 
 
-class PayloadWrapper(MutableMapping):
+class PayloadWrapper(UserDict):
     """
     A class for defining helper objects which wrap some kind of "payload" dict.
     Typical for helper objects which formulate a request payload, e.g. as JSON.
     """
 
-    def __init__(self):
-        self._payload: Dict[str, Any] = {}
-
-    def __getitem__(self, key: str):
-        return self._payload[key]
-
-    def __setitem__(self, key: str, value: Any):
-        self._payload[key] = value
-
-    def __delitem__(self, key: str):
-        del self._payload[key]
-
-    def __iter__(self):
-        return iter(self._payload)
-
-    def __len__(self):
-        return len(self._payload)
-
-    def to_dict(self) -> Dict[str, Any]:
-        return self._payload
+    # note: this class doesn't actually define any methods, properties, or attributes
+    # it's just our own flavor of UserDict, which wraps a 'data' dict
+    #
+    # use UserDict rather than subclassing dict so that our API is always consistent
+    # e.g. `dict.pop` does not invoke `dict.__delitem__`. Overriding `__delitem__` on a
+    # dict subclass can lead to inconsistent behavior between usages like these:
+    #   x = d["k"]; del d["k"]
+    #   x = d.pop("k")
+    #
+    # UserDict inherits from MutableMapping and only defines the dunder methods, so
+    # changing its behavior safely/consistently is simpler

--- a/src/globus_sdk/utils.py
+++ b/src/globus_sdk/utils.py
@@ -1,5 +1,7 @@
 import hashlib
 from base64 import b64encode
+from collections.abc import MutableMapping
+from typing import Any, Dict
 
 
 def sha256_string(s):
@@ -42,3 +44,31 @@ def safe_stringify(value):
     if isinstance(value, bytes):
         return value.decode("utf-8")
     return str(value)
+
+
+class PayloadWrapper(MutableMapping):
+    """
+    A class for defining helper objects which wrap some kind of "payload" dict.
+    Typical for helper objects which formulate a request payload, e.g. as JSON.
+    """
+
+    def __init__(self):
+        self._payload: Dict[str, Any] = {}
+
+    def __getitem__(self, key: str):
+        return self._payload[key]
+
+    def __setitem__(self, key: str, value: Any):
+        self._payload[key] = value
+
+    def __delitem__(self, key: str):
+        del self._payload[key]
+
+    def __iter__(self):
+        return iter(self._payload)
+
+    def __len__(self):
+        return len(self._payload)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return self._payload

--- a/tests/unit/helpers/test_search.py
+++ b/tests/unit/helpers/test_search.py
@@ -12,11 +12,17 @@ def test_init():
     query = SearchQuery()
     assert len(query) == 0
 
-    # init with params
-    params = {"param1": "value1", "param2": "value2"}
+    # init with supported fields
+    params = {"q": "foo", "limit": 10, "offset": 0, "advanced": False}
     param_query = SearchQuery(**params)
     for par in params:
         assert param_query[par] == params[par]
+
+    # init with additional_fields
+    add_params = {"param1": "value1", "param2": "value2"}
+    param_query = SearchQuery(additional_fields=add_params)
+    for par in add_params:
+        assert param_query[par] == add_params[par]
 
 
 @pytest.mark.parametrize("attrname", ["q", "limit", "offset", "advanced"])

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -57,29 +57,21 @@ def test_safe_stringify(value):
 
 
 def test_payload_wrapper_methods():
-    # comment on first use of each MutableMapping method to note which ones are ours
-    # (explicit) and which ones are inherited from MutableMapping
+    # just make sure that PayloadWrapper acts like a dict...
     data = utils.PayloadWrapper()
-
-    assert "foo" not in data  # __contains__() inherited
+    assert "foo" not in data
     with pytest.raises(KeyError):
-        data["foo"]  # __getitem__ explicitly defined
-
-    data["foo"] = 1  # __setitem__ explicitly defined
+        data["foo"]
+    data["foo"] = 1
     assert "foo" in data
-    assert data["foo"] == 1  # __delitem__ explicitly defined
+    assert data["foo"] == 1
     del data["foo"]
     assert "foo" not in data
-
-    assert len(data) == 0  # __len__ explicitly defined
-    assert list(data) == []  # __iter__ explicitly defined
-
+    assert len(data) == 0
+    assert list(data) == []
     data["foo"] = 1
     data["bar"] = 2
     assert len(data) == 2
-
-    # to_dict() is the only custom method we have added to MutableMapping
-    assert data.to_dict() == {"foo": 1, "bar": 2}
-
-    data.update({"x": "hello", "y": "world"})  # update() inherited
-    assert data.to_dict() == {"foo": 1, "bar": 2, "x": "hello", "y": "world"}
+    assert data.data == {"foo": 1, "bar": 2}
+    data.update({"x": "hello", "y": "world"})
+    assert data.data == {"foo": 1, "bar": 2, "x": "hello", "y": "world"}

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -54,3 +54,32 @@ def test_safe_stringify(value):
     safe_value = utils.safe_stringify(value)
     assert safe_value == "1"
     assert type(safe_value) == str
+
+
+def test_payload_wrapper_methods():
+    # comment on first use of each MutableMapping method to note which ones are ours
+    # (explicit) and which ones are inherited from MutableMapping
+    data = utils.PayloadWrapper()
+
+    assert "foo" not in data  # __contains__() inherited
+    with pytest.raises(KeyError):
+        data["foo"]  # __getitem__ explicitly defined
+
+    data["foo"] = 1  # __setitem__ explicitly defined
+    assert "foo" in data
+    assert data["foo"] == 1  # __delitem__ explicitly defined
+    del data["foo"]
+    assert "foo" not in data
+
+    assert len(data) == 0  # __len__ explicitly defined
+    assert list(data) == []  # __iter__ explicitly defined
+
+    data["foo"] = 1
+    data["bar"] = 2
+    assert len(data) == 2
+
+    # to_dict() is the only custom method we have added to MutableMapping
+    assert data.to_dict() == {"foo": 1, "bar": 2}
+
+    data.update({"x": "hello", "y": "world"})  # update() inherited
+    assert data.to_dict() == {"foo": 1, "bar": 2, "x": "hello", "y": "world"}


### PR DESCRIPTION
Inspired by #435 and from discussion of getting rid of `dict` inheritance.

Rather than defining classes which inherit from `dict` directly, define PayloadWrapper, a utility class which wraps a `_payload` dict.
The PayloadWrapper inherits from MutableMapping and implements methods against its underlying dict, meaning that the range of usages for these objects is not diminished.

TransferData, DeleteData, and SearchQuery are all updated to inherit from this object and, other than invoking `super().__init__()`, they are almost entirely unchanged.
In the case of SearchData, __init__ needed to be defined to allow passing known parameters as keyword args. (Some previously valid usages will now require the use of `additional_fields`).

In terms of methods which pass data as a dict, the changes made are to allow any PayloadWrapper object to pass down to
BaseClient.request(...). At that stage, `PayloadWrapper`s will render with a `to_dict()` call. As a result, almost no concrete code, only type annotations needed changes. Mostly of the form `Optional[Dict]` -> `Union[None, Dict, PayloadWrapper]`

A new test exercises the methods of PayloadWrapper to make sure they all function as expected, and a minor update ensures that SearchQuery is well-tested.

The Transfer data module has been split in two, to make it easier to read/maintain the two helper classes.