### PR TITLE
Add method and URL to stack traces

### DIFF
--- a/src/globus_sdk/services/search/errors.py
+++ b/src/globus_sdk/services/search/errors.py
@@ -14,9 +14,6 @@ class SearchAPIError(exc.GlobusAPIError):
         self.error_data = None
         super().__init__(r)
 
-    def _get_args(self):
-        return (self.http_status, self.code, self.message)
-
     def _load_from_json(self, data):
         self.code = data["code"]
         self.message = data["message"]

--- a/src/globus_sdk/services/transfer/errors.py
+++ b/src/globus_sdk/services/transfer/errors.py
@@ -15,7 +15,9 @@ class TransferAPIError(exc.GlobusAPIError):
         super().__init__(r)
 
     def _get_args(self):
-        return (self.http_status, self.code, self.message, self.request_id)
+        args = super()._get_args()
+        args.append(self.request_id)
+        return args
 
     def _load_from_json(self, data):
         self.code = data["code"]


### PR DESCRIPTION
- Change args passed to `Exception` to include method and URL
- Update tests for the different _get_args interface.

I would characterize this PR as slightly draft-ish in that suggestions for any other `Exception` arguments to include are welcome. As is this just adds the method and URL.

I wondered if checking for the response to have a request and URL attached would be necessary, but looking at the requests code it seems [a request object is always attached to the response](https://github.com/psf/requests/blob/33cf965f7271ab4978ed551754db37865c4085db/requests/adapters.py#L286-L287).