### PR TITLE
Add scopes as client class attributes; doc scopes

### DIFF
--- a/docs/core/base_client.rst
+++ b/docs/core/base_client.rst
@@ -13,5 +13,5 @@ BaseClient
 ----------
 
 .. autoclass:: globus_sdk.BaseClient
-   :members: get, put, post, patch, delete, request
+   :members: scopes, get, put, post, patch, delete, request
    :member-order: bysource

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,6 +30,7 @@ Table of Contents
     :maxdepth: 2
 
     services/index
+    scopes
     local_endpoints
     authorization
     tokenstorage

--- a/docs/scopes.rst
+++ b/docs/scopes.rst
@@ -1,0 +1,101 @@
+Scopes and ScopeBuilders
+========================
+
+OAuth2 Scopes for various Globus services are represented by ``ScopeBuilder``
+objects.
+
+A number of pre-set scope builders are provided and populated with useful data,
+and they are also accessible via the relevant client classes.
+
+Direct Use (as constants)
+-------------------------
+
+To use the scope builders directly, import from ``globus_sdk.scopes``.
+
+For example, one might use the Transfer "all" scope during a login flow like
+so:
+
+.. code-block:: python
+
+    import globus_sdk
+    from globus_sdk.scopes import TransferScopes
+
+    CLIENT_ID = "<YOUR_ID_HERE>"
+
+    client = globus_sdk.NativeAppAuthClient(CLIENT_ID)
+    client.oauth2_start_flow(requested_scopes=[TransferScopes.all])
+    ...
+
+As Client Class Attributes
+--------------------------
+
+Because the scopes for a token are associated with some concrete client which
+will use that token, it makes sense to associate a scope with a client class.
+
+The Globus SDK does this by providing the ``ScopeBuilder`` for a service as an
+attribute of the client. For example,
+
+.. code-block:: python
+
+    import globus_sdk
+
+    CLIENT_ID = "<YOUR_ID_HERE>"
+
+    client = globus_sdk.NativeAppAuthClient(CLIENT_ID)
+    client.oauth2_start_flow(requested_scopes=[globus_sdk.TransferClient.scopes.all])
+    ...
+
+    # or, potentially, after there is a concrete client
+    _tc = globus_sdk.TransferClient()
+    client.oauth2_start_flow(requested_scopes=[_tc.scopes.all])
+
+Using a Scope Builder to Get Matching Tokens
+--------------------------------------------
+
+A ``ScopeBuilder`` contains the resource server name used to get token data
+from a token response.
+To elaborate on the above example:
+
+.. code-block:: python
+
+    import globus_sdk
+    from globus_sdk.scopes import TransferScopes
+
+    CLIENT_ID = "<YOUR_ID_HERE>"
+
+    client = globus_sdk.NativeAppAuthClient(CLIENT_ID)
+    client.oauth2_start_flow(requested_scopes=[TransferScopes.all])
+    authorize_url = client.oauth2_get_authorize_url()
+    print("Please go to this URL and login:", authorize_url)
+    auth_code = input("Please enter the code you get after login here: ").strip()
+    token_response = client.oauth2_exchange_code_for_tokens(auth_code)
+
+    # use the `resource_server` of a ScopeBuilder to grab the associated token
+    # data from the response
+    tokendata = token_response.by_resource_server[TransferScopes.resource_server]
+
+ScopeBuilder Types and Constants
+--------------------------------
+
+.. autoclass:: globus_sdk.scopes.ScopeBuilder
+    :members:
+    :show-inheritance:
+
+.. autoclass:: globus_sdk.scopes.GCSScopeBuilder
+    :members:
+    :show-inheritance:
+
+.. autodata:: globus_sdk.scopes.AuthScopes
+    :annotation:
+
+.. autodata:: globus_sdk.scopes.GroupsScopes
+    :annotation:
+
+.. autodata:: globus_sdk.scopes.NexusScopes
+    :annotation:
+
+.. autodata:: globus_sdk.scopes.SearchScopes
+    :annotation:
+
+.. autodata:: globus_sdk.scopes.TransferScopes
+    :annotation:

--- a/src/globus_sdk/_sphinxext.py
+++ b/src/globus_sdk/_sphinxext.py
@@ -12,6 +12,11 @@ from docutils.statemachine import ViewList
 from sphinx.util.nodes import nested_parse_with_titles
 
 
+def _extract_known_scopes(scope_builder_name):
+    sb = locate(scope_builder_name)
+    return sb._known_scopes
+
+
 def _classname2methods(classname, include_methods):
     """resolve a class name to a list of (public) method names
     takes a classname and a list of method names to avoid filtering out"""
@@ -44,9 +49,39 @@ def _is_paginated(func):
     return getattr(func, "_has_paginator", False)
 
 
-class AutoMethodList(Directive):
+class AddContentDirective(Directive):
     # Directive source:
     #   https://sourceforge.net/p/docutils/code/HEAD/tree/trunk/docutils/docutils/parsers/rst/__init__.py
+    def gen_rst(self):
+        return []
+
+    def run(self):
+        # implementation is based on the docs for parsing directive content as ReST doc:
+        #   https://www.sphinx-doc.org/en/master/extdev/markupapi.html#parsing-directive-content-as-rest
+        # which is how we will create rst here and have sphinx parse it
+
+        # we need to add content lines into a ViewList which represents the content
+        # of this directive, each one is appended with a "source" name
+        # the best documentation for docutils is the source, so for ViewList, see...
+        #   https://sourceforge.net/p/docutils/code/HEAD/tree/trunk/docutils/docutils/statemachine.py
+        # writing the source name with angle-brackets seems to be the norm, but it's not
+        # clear why -- perhaps docutils will care about the source in some way
+        viewlist = ViewList()
+        linemarker = "<" + self.__class__.__name__.lower() + ">"
+        for line in self.gen_rst():
+            viewlist.append(line, linemarker)
+
+        # create a section node (it doesn't really matter what node type we use here)
+        # and add the viewlist we just created as the children of the new node via the
+        # nested_parse method
+        # then return the children (i.e. discard the docutils node)
+        node = nodes.section()
+        node.document = self.state.document
+        nested_parse_with_titles(self.state, viewlist, node)
+        return node.children
+
+
+class AutoMethodList(AddContentDirective):
     has_content = False
     required_arguments = 1
     optional_arguments = 1
@@ -73,30 +108,41 @@ class AutoMethodList(Directive):
 
         yield ""
 
-    def run(self):
-        # implementation is based on the docs for parsing directive content as ReST doc:
-        #   https://www.sphinx-doc.org/en/master/extdev/markupapi.html#parsing-directive-content-as-rest
-        # which is how we will create rst here and have sphinx parse it
 
-        # we need to add content lines into a ViewList which represents the content
-        # of this directive, each one is appended with a "source" name
-        # the best documentation for docutils is the source, so for ViewList, see...
-        #   https://sourceforge.net/p/docutils/code/HEAD/tree/trunk/docutils/docutils/statemachine.py
-        # writing the source name with angle-brackets seems to be the norm, but it's not
-        # clear why -- perhaps docutils will care about the source in some way
-        viewlist = ViewList()
-        for line in self.gen_rst():
-            viewlist.append(line, "<automethodlist>")
+class ListKnownScopes(AddContentDirective):
+    has_content = False
+    required_arguments = 1
+    optional_arguments = 2
 
-        # create a section node (it doesn't really matter what node type we use here)
-        # and add the viewlist we just created as the children of the new node via the
-        # nested_parse method
-        # then return the children (i.e. discard the docutils node)
-        node = nodes.section()
-        node.document = self.state.document
-        nested_parse_with_titles(self.state, viewlist, node)
-        return node.children
+    def gen_rst(self):
+        sb_name = self.arguments[0]
+        sb_basename = sb_name.split(".")[-1]
+
+        add_scopes = []
+        example_scope = None
+        for arg in self.arguments[1:]:
+            if arg.startswith("add_scopes="):
+                add_scopes = [x for x in arg.split("=")[1].split(",")]
+            if arg.startswith("example_scope="):
+                example_scope = arg.split("=")[1]
+        known_scopes = _extract_known_scopes(sb_name) + add_scopes
+        if example_scope is None:
+            example_scope = known_scopes[0]
+
+        yield ""
+        yield "Various scopes are available as attributes of this object."
+        yield f"For example, access the ``{example_scope}`` scope with"
+        yield ""
+        yield f">>> {sb_basename}.{example_scope}"
+        yield ""
+        yield "**Supported Scopes**"
+        yield ""
+        for s in known_scopes:
+            yield f"* ``{s}``"
+        yield ""
+        yield ""
 
 
 def setup(app):
     app.add_directive("automethodlist", AutoMethodList)
+    app.add_directive("listknownscopes", ListKnownScopes)

--- a/src/globus_sdk/_sphinxext.py
+++ b/src/globus_sdk/_sphinxext.py
@@ -125,7 +125,7 @@ class ListKnownScopes(AddContentDirective):
                 add_scopes = [x for x in arg.split("=")[1].split(",")]
             if arg.startswith("example_scope="):
                 example_scope = arg.split("=")[1]
-        known_scopes = _extract_known_scopes(sb_name) + add_scopes
+        known_scopes = add_scopes + _extract_known_scopes(sb_name)
         if example_scope is None:
             example_scope = known_scopes[0]
 

--- a/src/globus_sdk/client.py
+++ b/src/globus_sdk/client.py
@@ -6,6 +6,7 @@ from globus_sdk import config, exc, utils
 from globus_sdk.authorizers import GlobusAuthorizer
 from globus_sdk.paging import PaginatorTable
 from globus_sdk.response import GlobusHTTPResponse
+from globus_sdk.scopes import ScopeBuilder
 from globus_sdk.transport import RequestsTransport
 
 log = logging.getLogger(__name__)
@@ -38,6 +39,9 @@ class BaseClient:
 
     #: the type of Transport which will be used, defaults to ``RequestsTransport``
     transport_class: Type = RequestsTransport
+
+    #: the scopes for this client may be present as a ``ScopeBuilder``
+    scopes: Optional[ScopeBuilder] = None
 
     def __init__(
         self,

--- a/src/globus_sdk/scopes.py
+++ b/src/globus_sdk/scopes.py
@@ -15,6 +15,7 @@ class ScopeBuilder:
 
     def __init__(self, resource_server: str, known_scopes: Optional[List[str]] = None):
         self.resource_server = resource_server
+        self._known_scopes = known_scopes
         if known_scopes:
             for scope_name in known_scopes:
                 setattr(self, scope_name, self.urn_scope_string(scope_name))
@@ -29,7 +30,7 @@ class ScopeBuilder:
 
         **Examples**
 
-        >>> sb = scope_builder("transfer.api.globus.org")
+        >>> sb = ScopeBuilder("transfer.api.globus.org")
         >>> sb.urn_scope_string("transfer.api.globus.org", "all")
         "urn:globus:auth:scope:transfer.api.globus.org:all"
 
@@ -45,7 +46,7 @@ class ScopeBuilder:
 
         **Examples**
 
-        >>> sb = scope_builder("actions.globus.org")
+        >>> sb = ScopeBuilder("actions.globus.org")
         >>> sb.url_scope_string("actions.globus.org", "hello_world")
         "https://auth.globus.org/scopes/actions.globus.org/hello_world"
 
@@ -56,6 +57,15 @@ class ScopeBuilder:
 
 
 class GCSScopeBuilder(ScopeBuilder):
+    """
+    A ScopeBuilder with a named property for the GCS data_access scope.
+
+    **Examples**
+
+    >>> sb = GCSScopeBuilder("xyz")
+    >>> da_scope = sb.data_access_scope
+    """
+
     @property
     def data_access_scope(self) -> str:
         return self.url_scope_string("data_access")
@@ -77,6 +87,12 @@ AuthScopes = _AuthScopesBuilder(
         "view_identity_set",
     ],
 )
+"""Globus Auth scopes.
+
+.. listknownscopes:: globus_sdk.scopes.AuthScopes
+    add_scopes=openid,email,profile
+    example_scope=view_identity_set
+"""
 
 
 GroupsScopes = ScopeBuilder(
@@ -86,6 +102,10 @@ GroupsScopes = ScopeBuilder(
         "view_my_groups_and_memberships",
     ],
 )
+"""Groups scopes.
+
+.. listknownscopes:: globus_sdk.scopes.GroupsScopes
+"""
 
 
 NexusScopes = ScopeBuilder(
@@ -94,7 +114,10 @@ NexusScopes = ScopeBuilder(
         "groups",
     ],
 )
+"""Nexus scopes (internal use only).
 
+.. listknownscopes:: globus_sdk.scopes.NexusScopes
+"""
 
 SearchScopes = ScopeBuilder(
     "search.api.globus.org",
@@ -105,7 +128,10 @@ SearchScopes = ScopeBuilder(
         "search",
     ],
 )
+"""Globus Search scopes.
 
+.. listknownscopes:: globus_sdk.scopes.SearchScopes
+"""
 
 TransferScopes = ScopeBuilder(
     "transfer.api.globus.org",
@@ -115,3 +141,7 @@ TransferScopes = ScopeBuilder(
         "monitor_ongoing",
     ],
 )
+"""Globus Transfer scopes.
+
+.. listknownscopes:: globus_sdk.scopes.TransferScopes
+"""

--- a/src/globus_sdk/services/auth/client_types/base.py
+++ b/src/globus_sdk/services/auth/client_types/base.py
@@ -7,6 +7,7 @@ import jwt
 
 from globus_sdk import client, exc, utils
 from globus_sdk.authorizers import NullAuthorizer
+from globus_sdk.scopes import AuthScopes
 
 from ..errors import AuthAPIError
 from ..token_response import OAuthTokenResponse
@@ -51,6 +52,7 @@ class AuthClient(client.BaseClient):
 
     service_name = "auth"
     error_class = AuthAPIError
+    scopes = AuthScopes
 
     def __init__(self, client_id=None, **kwargs):
         super().__init__(**kwargs)

--- a/src/globus_sdk/services/groups/client.py
+++ b/src/globus_sdk/services/groups/client.py
@@ -1,4 +1,5 @@
 from globus_sdk import client
+from globus_sdk.scopes import GroupsScopes
 
 from .errors import GroupsAPIError
 
@@ -13,3 +14,4 @@ class GroupsClient(client.BaseClient):
 
     error_class = GroupsAPIError
     service_name = "groups"
+    scopes = GroupsScopes

--- a/src/globus_sdk/services/search/client.py
+++ b/src/globus_sdk/services/search/client.py
@@ -2,6 +2,7 @@ import logging
 from typing import Any, Dict, Optional
 
 from globus_sdk import client, paging, response, utils
+from globus_sdk.scopes import SearchScopes
 
 from .errors import SearchAPIError
 
@@ -27,6 +28,7 @@ class SearchClient(client.BaseClient):
     """
     error_class = SearchAPIError
     service_name = "search"
+    scopes = SearchScopes
 
     #
     # Index Management

--- a/src/globus_sdk/services/transfer/client.py
+++ b/src/globus_sdk/services/transfer/client.py
@@ -4,6 +4,7 @@ import uuid
 from typing import Any, Dict, Iterable, List, Optional, Union
 
 from globus_sdk import client, exc, paging, response, utils
+from globus_sdk.scopes import TransferScopes
 
 from .errors import TransferAPIError
 from .response import ActivationRequirementsResponse, IterableTransferResponse
@@ -60,6 +61,7 @@ class TransferClient(client.BaseClient):
     service_name = "transfer"
     base_path = "/v0.10/"
     error_class = TransferAPIError
+    scopes = TransferScopes
 
     # Convenience methods, providing more pythonic access to common REST
     # resources


### PR DESCRIPTION
- Add `.scopes` to client classes, pointing back at the relevant ScopeBuilder objects
- Document use of `globus_sdk.scopes` in a new doc page, adjacent to service client docs
- Add a custom sphinx directive for extracting "known_scopes" from a ScopeBuilder into a doc list and decorating the resulting doc
- Update `globus_sdk.scopes` to use the new `listknownscopes` directive to generate doc comments on all scope builder constants

Example doc screenshot:
![image](https://user-images.githubusercontent.com/1300022/125141895-459cc780-e0e4-11eb-9703-94c4fd46bf53.png)