### PR TITLE
Do not declare wheel as universal (no py2)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[bdist_wheel]
-universal = 1
-
 [isort]
 profile = black
 known_first_party = tests, globus_sdk


### PR DESCRIPTION
Universal wheels are wheels designated for py2/py3 usage. In fact, this designation _means_ that the wheel supports py2 ( [doc](https://packaging.python.org/guides/distributing-packages-using-setuptools/#wheels) ), so this is technically a bug being fixed. It's just a bug that doesn't manifest on any supported platforms... So it's low impact, but still wrong.

I'll open an analogous PR against the CLI.