### PR TITLE
Add first version of GCSClient

### DIFF
--- a/docs/core/responses.rst
+++ b/docs/core/responses.rst
@@ -10,3 +10,7 @@ To customize client methods with additional detail, the SDK uses subclasses of
 .. autoclass:: globus_sdk.response.GlobusHTTPResponse
    :members:
    :show-inheritance:
+
+.. autoclass:: globus_sdk.response.IterOnIterKeyMixin
+   :members:
+   :show-inheritance:

--- a/docs/services/gcs.rst
+++ b/docs/services/gcs.rst
@@ -1,0 +1,39 @@
+Globus Connect Server API
+=========================
+
+The Globus Connect Server Manager API (GCS Manager API) runs on a
+Globus Connect Server Endpoint and allows management of the Endpoint,
+Storage Gateways, Collections, and other resources.
+
+Unlike other Globus services, there is no single central API used to contact
+GCS Manager instances. Therefore, the ``GCSClient`` is always initialized with
+the FQDN (DNS name) of the GCS Endpoint.
+e.g. ``gcs = GCSClient("abc.def.data.globus.org")``
+
+Client
+------
+
+The primary interface for the GCS Manager API is the ``GCSClient`` class.
+
+.. autoclass:: globus_sdk.GCSClient
+   :members:
+   :member-order: bysource
+   :show-inheritance:
+   :exclude-members: error_class
+
+Client Errors
+-------------
+
+When an error occurs, a ``GCSClient`` will raise this specialized type of
+error, rather than a generic ``GlobusAPIError``.
+
+.. autoclass:: globus_sdk.GCSAPIError
+   :members:
+   :show-inheritance:
+
+GCS Responses
+-------------
+
+.. automodule:: globus_sdk.services.gcs.response
+   :members:
+   :show-inheritance:

--- a/docs/services/index.rst
+++ b/docs/services/index.rst
@@ -42,3 +42,4 @@ very simply::
     groups
     search
     transfer
+    gcs

--- a/src/globus_sdk/__init__.py
+++ b/src/globus_sdk/__init__.py
@@ -26,6 +26,7 @@ from .services.auth import (
     IdentityMap,
     NativeAppAuthClient,
 )
+from .services.gcs import GCSAPIError, GCSClient
 from .services.groups import (
     BatchMembershipActions,
     GroupMemberVisibility,
@@ -83,6 +84,8 @@ __all__ = (
     "GroupRole",
     "GroupVisibility",
     "GroupsManager",
+    "GCSClient",
+    "GCSAPIError",
     "LocalGlobusConnectPersonal",
 )
 

--- a/src/globus_sdk/response.py
+++ b/src/globus_sdk/response.py
@@ -1,5 +1,6 @@
+import json
 import logging
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Iterator, Mapping, Optional, Union, cast
 
 from requests import Response
 
@@ -97,7 +98,9 @@ class GlobusHTTPResponse:
         return self.data.get(key, default)
 
     def __str__(self) -> str:
-        return repr(self)
+        """The default __str__ for a response assumes that the data is valid
+        JSON-dump-able."""
+        return json.dumps(self.data, indent=2, separators=(",", ": "))
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.data!r})"
@@ -128,3 +131,13 @@ class GlobusHTTPResponse:
         if self.data is None:
             return False
         return item in self.data
+
+
+class IterOnIterKeyMixin:
+    """This mixin adds an __iter__ method on an 'iter_key' class or instance variable.
+    The assumption is that iter produces dicts or dict-like mappings."""
+
+    iter_key: str
+
+    def __iter__(self) -> Iterator[Mapping]:
+        return iter(cast(Mapping, self)[self.iter_key])

--- a/src/globus_sdk/services/gcs/__init__.py
+++ b/src/globus_sdk/services/gcs/__init__.py
@@ -1,0 +1,9 @@
+from .client import GCSClient
+from .errors import GCSAPIError
+from .response import IterableGCSResponse
+
+__all__ = (
+    "GCSClient",
+    "GCSAPIError",
+    "IterableGCSResponse",
+)

--- a/src/globus_sdk/services/gcs/client.py
+++ b/src/globus_sdk/services/gcs/client.py
@@ -1,0 +1,84 @@
+from typing import Any, Callable, Dict, Optional, TypeVar
+
+from globus_sdk import client, utils
+from globus_sdk.authorizers import GlobusAuthorizer
+
+from .errors import GCSAPIError
+from .response import IterableGCSResponse
+
+RT = TypeVar("RT")
+
+
+def _gcsdoc(
+    message: str, link: str
+) -> Callable[[Callable[..., RT]], Callable[..., RT]]:
+    # do not use functools.partial because it doesn't preserve type information
+    # see: https://github.com/python/mypy/issues/1484
+    def partial(func: Callable) -> Callable:
+        return utils.doc_api_method(
+            message,
+            link,
+            external_base_url="https://docs.globus.org/globus-connect-server/v5/api",
+        )(func)
+
+    return partial
+
+
+class GCSClient(client.BaseClient):
+    """
+    A GCSClient provides communication with the GCS Manager API of a Globus Connect
+    Server instance.
+    For full reference, see the `documentation for the GCS Manager API
+    <https://docs.globus.org/globus-connect-server/v5/api/>`_.
+
+    Unlike other client types, this must be provided with an address for the GCS
+    Manager. All other arguments are the same as those for `~globus_sdk.BaseClient`.
+
+    :param gcs_address: The FQDN (DNS name) or HTTPS URL for the GCS Manager API.
+    :type gcs_address: str
+
+    .. automethodlist:: globus_sdk.GCSClient
+    """
+
+    service_name = "globus_connect_server"
+    error_class = GCSAPIError
+
+    def __init__(
+        self,
+        gcs_address: str,
+        *,
+        environment: Optional[str] = None,
+        authorizer: Optional[GlobusAuthorizer] = None,
+        app_name: Optional[str] = None,
+        transport_params: Optional[Dict] = None,
+    ):
+        # check if the provided address was a DNS name or an HTTPS URL
+        # if it was a URL, do not modify, but if it's a DNS name format it accordingly
+        # as a heuristic for this: just check if string starts with "https://" (this is
+        # sufficient to distinguish between the two for valid inputs)
+        if not gcs_address.startswith("https://"):
+            gcs_address = f"https://{gcs_address}/api/"
+        super().__init__(
+            base_url=gcs_address,
+            environment=environment,
+            authorizer=authorizer,
+            app_name=app_name,
+            transport_params=transport_params,
+        )
+
+    @_gcsdoc("List Collections", "openapi_Collections/#ListCollections")
+    def get_collection_list(
+        self,
+        include: Optional[str] = None,
+        query_params: Optional[Dict[str, Any]] = None,
+    ) -> IterableGCSResponse:
+        """
+        ``GET /collections``
+
+        List the Collections on an Endpoint
+        """
+        if query_params is None:
+            query_params = {}
+        if include is not None:
+            query_params["include"] = include
+        return IterableGCSResponse(self.get("collections", query_params=query_params))

--- a/src/globus_sdk/services/gcs/errors.py
+++ b/src/globus_sdk/services/gcs/errors.py
@@ -1,0 +1,33 @@
+from typing import Any, List, Optional, Union
+
+import requests
+
+from globus_sdk import exc
+
+
+class GCSAPIError(exc.GlobusAPIError):
+    """
+    Error class for the GCS Manager API client
+    """
+
+    def __init__(self, r: requests.Response) -> None:
+        self.detail_data_type: Optional[str] = None
+        self.detail: Union[None, str, dict] = None
+        super().__init__(r)
+
+    def _get_args(self) -> List[Any]:
+        args = super()._get_args()
+        args.append(self.detail_data_type)
+        # only add detail if it's a string (don't want to put a large object into
+        # stacktraces)
+        if isinstance(self.detail, str):
+            args.append(self.detail)
+        return args
+
+    def _load_from_json(self, data: dict) -> None:
+        super()._load_from_json(data)
+        # detail can be a full document, so fetch, then look for a DATA_TYPE
+        # and expose it as a top-level attribute for easy access
+        self.detail = data.get("detail")
+        if self.detail and "DATA_TYPE" in self.detail:
+            self.detail_data_type = self.detail["DATA_TYPE"]

--- a/src/globus_sdk/services/gcs/response.py
+++ b/src/globus_sdk/services/gcs/response.py
@@ -1,9 +1,7 @@
-from typing import Any
-
-from globus_sdk.response import GlobusHTTPResponse, IterOnIterKeyMixin
+from globus_sdk.response import IterableResponse
 
 
-class IterableGCSResponse(GlobusHTTPResponse, IterOnIterKeyMixin):
+class IterableGCSResponse(IterableResponse):
     """
     Response class for non-paged list oriented resources. Allows top level
     fields to be accessed normally via standard item access, and also
@@ -16,6 +14,4 @@ class IterableGCSResponse(GlobusHTTPResponse, IterOnIterKeyMixin):
     >>>     print(item["name"], item["type"])
     """
 
-    def __init__(self, *args: Any, iter_key: str = "data", **kwargs: Any) -> None:
-        self.iter_key = iter_key
-        super().__init__(*args, **kwargs)
+    default_iter_key = "data"

--- a/src/globus_sdk/services/gcs/response.py
+++ b/src/globus_sdk/services/gcs/response.py
@@ -3,19 +3,19 @@ from typing import Any
 from globus_sdk.response import GlobusHTTPResponse, IterOnIterKeyMixin
 
 
-class IterableTransferResponse(GlobusHTTPResponse, IterOnIterKeyMixin):
+class IterableGCSResponse(GlobusHTTPResponse, IterOnIterKeyMixin):
     """
     Response class for non-paged list oriented resources. Allows top level
     fields to be accessed normally via standard item access, and also
-    provides a convenient way to iterate over the sub-item list in a specified
-    key:
+    provides a convenient way to iterate over the sub-item list in the
+    ``data`` key:
 
     >>> print("Path:", r["path"])
-    >>> # Equivalent to: for item in r["DATA"]
+    >>> # Equivalent to: for item in r["data"]
     >>> for item in r:
     >>>     print(item["name"], item["type"])
     """
 
-    def __init__(self, *args: Any, iter_key: str = "DATA", **kwargs: Any) -> None:
+    def __init__(self, *args: Any, iter_key: str = "data", **kwargs: Any) -> None:
         self.iter_key = iter_key
         super().__init__(*args, **kwargs)

--- a/src/globus_sdk/services/search/client.py
+++ b/src/globus_sdk/services/search/client.py
@@ -38,7 +38,7 @@ class SearchClient(client.BaseClient):
 
     @utils.doc_api_method("Get Index Metadata", "search/reference/index_show/")
     def get_index(
-        self, index_id: UUIDLike, query_params: Optional[Dict[str, Any]]
+        self, index_id: UUIDLike, query_params: Optional[Dict[str, Any]] = None
     ) -> response.GlobusHTTPResponse:
         """
         ``GET /v1/index/<index_id>``

--- a/src/globus_sdk/services/transfer/response/iterable.py
+++ b/src/globus_sdk/services/transfer/response/iterable.py
@@ -1,9 +1,7 @@
-from typing import Any
-
-from globus_sdk.response import GlobusHTTPResponse, IterOnIterKeyMixin
+from globus_sdk.response import IterableResponse
 
 
-class IterableTransferResponse(GlobusHTTPResponse, IterOnIterKeyMixin):
+class IterableTransferResponse(IterableResponse):
     """
     Response class for non-paged list oriented resources. Allows top level
     fields to be accessed normally via standard item access, and also
@@ -16,6 +14,4 @@ class IterableTransferResponse(GlobusHTTPResponse, IterOnIterKeyMixin):
     >>>     print(item["name"], item["type"])
     """
 
-    def __init__(self, *args: Any, iter_key: str = "DATA", **kwargs: Any) -> None:
-        self.iter_key = iter_key
-        super().__init__(*args, **kwargs)
+    default_iter_key = "DATA"

--- a/tests/common.py
+++ b/tests/common.py
@@ -47,6 +47,7 @@ def register_api_route(
         "groups": "https://groups.api.globus.org/",
         "transfer": "https://transfer.api.globus.org/v0.10",
         "search": "https://search.api.globus.org/",
+        "gcs": "https://abc.xyz.data.globus.org/api/",
     }
     assert service in base_url_map
     base_url = base_url_map.get(service)

--- a/tests/functional/gcs/conftest.py
+++ b/tests/functional/gcs/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+
+from globus_sdk import GCSClient
+
+
+@pytest.fixture
+def client():
+    # default fqdn for GCS client testing
+    return GCSClient("abc.xyz.data.globus.org")

--- a/tests/functional/gcs/fixture_data/collection_list.json
+++ b/tests/functional/gcs/fixture_data/collection_list.json
@@ -1,0 +1,34 @@
+{
+  "DATA_TYPE": "result#1.0.0",
+  "code": "success",
+  "detail": "success",
+  "http_response_code": 200,
+  "data": [
+    {
+      "DATA_TYPE": "collection#1.0.0",
+      "public": true,
+      "id": "{collection_id_1}",
+      "display_name": "Happy Fun Collection Name 1",
+      "identity_id": "e926d510-cb98-11e5-a6ac-0b0216052512",
+      "collection_type": "mapped",
+      "storage_gateway_id": "{storage_gateway_id_1}",
+      "require_high_assurance": false,
+      "high_assurance": false,
+      "authentication_assurance_timeout": 15840,
+      "authentication_timeout_mins": 15840
+    },
+    {
+      "DATA_TYPE": "collection#1.0.0",
+      "public": true,
+      "id": "{collection_id_2}",
+      "display_name": "Happy Fun Collection Name 2",
+      "identity_id": "e926d510-cb98-11e5-a6ac-0b0216052512",
+      "collection_type": "mapped",
+      "storage_gateway_id": "{storage_gateway_id_2}",
+      "require_high_assurance": false,
+      "high_assurance": false,
+      "authentication_assurance_timeout": 15840,
+      "authentication_timeout_mins": 15840
+    }
+  ]
+}

--- a/tests/functional/gcs/fixture_data/forbidden_error_data.json
+++ b/tests/functional/gcs/fixture_data/forbidden_error_data.json
@@ -1,0 +1,10 @@
+{
+  "code": "permission_denied",
+  "http_response_code": 403,
+  "DATA_TYPE": "result#1.0.0",
+  "detail": null,
+  "message": "Could not list collections. Insufficient permissions",
+  "data": [],
+  "has_next_page": false,
+  "marker": ""
+}

--- a/tests/functional/gcs/test_collections.py
+++ b/tests/functional/gcs/test_collections.py
@@ -1,0 +1,32 @@
+import pytest
+
+from globus_sdk import GCSAPIError
+from tests.common import register_api_route_fixture_file
+
+
+def test_get_collection_list(client):
+    register_api_route_fixture_file("gcs", "/collections", "collection_list.json")
+    res = client.get_collection_list()
+
+    assert len(list(res)) == 2
+    # sanity check some fields
+    assert res["DATA_TYPE"] == "result#1.0.0"
+    for item in res:
+        assert item["DATA_TYPE"] == "collection#1.0.0"
+        assert "id" in item
+        assert item["id"] in ("{collection_id_1}", "{collection_id_2}")
+        assert "display_name" in item
+
+
+def test_error_parsing_forbidden(client):
+    register_api_route_fixture_file(
+        "gcs", "/collections", "forbidden_error_data.json", status=403
+    )
+    with pytest.raises(GCSAPIError) as excinfo:
+        client.get_collection_list()
+
+    err = excinfo.value
+    assert err.detail is None
+    assert err.detail_data_type is None
+    assert err.message.startswith("Could not list collections")
+    assert err.code == "permission_denied"

--- a/tests/unit/responses/test_response.py
+++ b/tests/unit/responses/test_response.py
@@ -5,7 +5,7 @@ from unittest import mock
 import pytest
 import requests
 
-from globus_sdk.response import GlobusHTTPResponse
+from globus_sdk.response import GlobusHTTPResponse, IterableResponse
 
 _TestResponse = namedtuple("_TestResponse", ("data", "r"))
 
@@ -176,3 +176,9 @@ def test_value_error_indexing_on_non_json_data():
 
     with pytest.raises(ValueError):
         res["foo"]
+
+
+def test_cannot_construct_base_iterable_response():
+    r = _response(b"foo: bar, baz: buzz")
+    with pytest.raises(TypeError):
+        IterableResponse(r, client=mock.Mock())

--- a/tests/unit/test_gcs_client.py
+++ b/tests/unit/test_gcs_client.py
@@ -1,0 +1,12 @@
+from globus_sdk import GCSClient
+
+
+def test_client_address_handling():
+    # check on address parsing abilities
+    c1 = GCSClient("foo.data.globus.org")
+    c2 = GCSClient("https://foo.data.globus.org")
+    c3 = GCSClient("https://foo.data.globus.org/api")
+
+    assert c1.base_url == c3.base_url
+    assert c2.base_url != c1.base_url
+    assert c1.base_url.startswith(c2.base_url)


### PR DESCRIPTION
GCSClient supports only one operation (collection listing). Test rigging is put in place with a test for collection listing and one for error parsing.

The iterable GCS response implementation overlaps with IterableTransferResponse, so the commonality is factored out into a shared mixin class for responses.

One change of broader scope: the GCSResponse class in the gcs-cli currently defines `__str__` of a response object as an indented JSON-dump of its data attribute. Rather than making this a specialized behavior, this is a reasonable improvement for all response objects. str() of a response will JSON dump the data, and repr() remains the same. (This makes str() and repr() different.)

For now, `GCSClient.scopes` is `None`. We would like for the scopes of a GCS to be accessible via `GCSClient(...).scopes` (pointing to a `GCSScopeBuilder`). This will involve a callout to the info endpoint of the GCS manager and some thinking around error handling and whether the callout should be eager or lazy. I'd like to solve this in a dedicated PR, rather than make it part of the first version of `GCSClient`.