### PR TITLE
Get nitpicky, Werror sphinx builds to pass

### DIFF
--- a/docs/authorization.rst
+++ b/docs/authorization.rst
@@ -28,15 +28,23 @@ The Authorizer Interface
 We define the interface for ``GlobusAuthorizer`` objects in terms of an
 Abstract Base Class:
 
-.. autoclass:: globus_sdk.authorizers.base.GlobusAuthorizer
+.. autoclass:: globus_sdk.authorizers.GlobusAuthorizer
     :members:
     :member-order: bysource
 
 ``GlobusAuthorizer`` objects that fetch new access tokens when their existing
 ones expire or a 401 is received implement the RenewingAuthorizer class
 
-.. autoclass:: globus_sdk.authorizers.renewing.RenewingAuthorizer
+.. autoclass:: globus_sdk.authorizers.RenewingAuthorizer
     :members: get_authorization_header, handle_missing_authorization
+    :member-order: bysource
+    :show-inheritance:
+
+``GlobusAuthorizer`` objects which have a static authorization header are all
+implemented using the static authorizer class:
+
+.. autoclass:: globus_sdk.authorizers.StaticGlobusAuthorizer
+    :members:
     :member-order: bysource
     :show-inheritance:
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,19 +1,36 @@
 #!/usr/bin/env python3
 
+import datetime
+
 import globus_sdk
+
+# running `tox -e docs -- -n` will pick up "nitpick" warning which we convert to build
+# errors with `-W`
+# load ignores from file
+nitpick_ignore = []
+nitpick_ignore_regex = []
+with open("nitpick_ignore.txt") as fp:
+    for line in fp:
+        line = line.strip()
+        if line == "" or line.startswith("#"):
+            continue
+        if line.startswith("re: "):
+            nitpick_ignore_regex.append(tuple(line.split()[1:]))
+        else:
+            nitpick_ignore.append(tuple(line.split()))
+
 
 # sphinx extensions (minimally, we want autodoc and viewcode to build the site)
 # plus, we have our own custom extension in the SDK to include
 extensions = [
     "sphinx.ext.autodoc",
-    "sphinx.ext.todo",
     "sphinx.ext.viewcode",
     "sphinx_issues",
     "globus_sdk._sphinxext",
 ]
 
 project = "globus-sdk-python"
-copyright = "2016, Globus"
+copyright = f"2016-{datetime.datetime.today().strftime('%Y')}, Globus"
 author = "Globus Team"
 # The short X.Y version.
 version = globus_sdk.__version__
@@ -32,9 +49,6 @@ language = "en"
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 exclude_patterns = ["_build"]
-
-# If true, `todo` and `todoList` produce output, else they produce nothing.
-todo_include_todos = True
 
 
 # HTML Theme Options

--- a/docs/core/index.rst
+++ b/docs/core/index.rst
@@ -11,3 +11,8 @@ Underlying components of the Globus SDK.
     responses
     paging
     exceptions
+
+.. toctree::
+    :hidden:
+
+    utils

--- a/docs/core/utils.rst
+++ b/docs/core/utils.rst
@@ -1,0 +1,22 @@
+Utilities
+=========
+
+.. warning::
+
+    The components in this module are *not* intended for outside use, but are
+    internal to the Globus SDK.
+
+    They may change in backwards-incompatible ways in minor or patch releases
+    of the SDK.
+
+    This documentation is included here for completeness.
+
+PayloadWrapper
+--------------
+
+The ``PayloadWrapper`` class is used as a base class for all Globus SDK
+payload datatypes to provide nicer interfaces for payload construction.
+
+The objects are a type of ``UserDict`` with no special methods.
+
+.. autoclass:: globus_sdk.utils.PayloadWrapper

--- a/docs/nitpick_ignore.txt
+++ b/docs/nitpick_ignore.txt
@@ -1,0 +1,35 @@
+# define nitpick ignores in a file with the following rules:
+# lines starting with '#' and empty lines are ignored
+# lines are split and added to nitpick_ignore
+# lines starting with 're: ' are split and added to nitpick_ignore_regex
+
+# standard ways of writing type information (e.g. 'Optional[str]' -> 'str, optional')
+py:class optional
+py:class callable
+py:class class
+
+# True/False as class because they appear in Literal type annotations
+py:class True
+py:class False
+
+# nitpick can fail on stdlib modules, skip these...
+py:class uuid.UUID
+py:class UUID
+py:class abc.ABC
+py:class datetime.datetime
+py:class datetime
+
+# inheritance can break cross-references in inherited signatures, so ignore these
+# SDK classes
+# see: https://github.com/sphinx-doc/sphinx/issues/6211
+py:class GlobusHTTPResponse
+
+# "list of ...", "sequence of ..."
+re: py:class (sequence|iterable|list)\sof\s\w+
+# type vars in SDK modules
+re: py:class globus_sdk\..*\.(T|RT)
+
+# cryptography and requests types
+py:class RSAPublicKey
+re: py:class cryptography\..*
+re: py:class requests\..*

--- a/src/globus_sdk/authorizers/__init__.py
+++ b/src/globus_sdk/authorizers/__init__.py
@@ -3,6 +3,7 @@ from .base import GlobusAuthorizer, NullAuthorizer, StaticGlobusAuthorizer
 from .basic import BasicAuthorizer
 from .client_credentials import ClientCredentialsAuthorizer
 from .refresh_token import RefreshTokenAuthorizer
+from .renewing import RenewingAuthorizer
 
 __all__ = [
     "GlobusAuthorizer",
@@ -12,4 +13,5 @@ __all__ = [
     "AccessTokenAuthorizer",
     "RefreshTokenAuthorizer",
     "ClientCredentialsAuthorizer",
+    "RenewingAuthorizer",
 ]

--- a/src/globus_sdk/authorizers/client_credentials.py
+++ b/src/globus_sdk/authorizers/client_credentials.py
@@ -46,14 +46,13 @@ class ClientCredentialsAuthorizer(RenewingAuthorizer):
     :type expires_at: int, optional
     :param on_refresh: A callback which is triggered any time this authorizer fetches a
         new access_token. The ``on_refresh`` callable is invoked on the
-        :class:`OAuthTokenResponse \
-        <globus_sdk.services.auth.token_response.OAuthTokenResponse>`
+        :class:`OAuthTokenResponse <globus_sdk.OAuthTokenResponse>`
         object resulting from the token being refreshed. It should take only one
         argument, the token response object.
         This is useful for implementing storage for Access Tokens, as the
         ``on_refresh`` callback can be used to update the Access Tokens and
         their expiration times.
-    :type on_refresh: callable, optiona
+    :type on_refresh: callable, optional
     """
 
     def __init__(

--- a/src/globus_sdk/authorizers/refresh_token.py
+++ b/src/globus_sdk/authorizers/refresh_token.py
@@ -41,8 +41,7 @@ class RefreshTokenAuthorizer(RenewingAuthorizer):
     :type expires_at: int, optional
     :param on_refresh: A callback which is triggered any time this authorizer fetches a
         new access_token. The ``on_refresh`` callable is invoked on the
-        :class:`OAuthTokenResponse \
-        <globus_sdk.services.auth.token_response.OAuthTokenResponse>`
+        :class:`OAuthTokenResponse <globus_sdk.OAuthTokenResponse>`
         object resulting from the token being refreshed. It should take only one
         argument, the token response object.
         This is useful for implementing storage for Access Tokens, as the

--- a/src/globus_sdk/authorizers/renewing.py
+++ b/src/globus_sdk/authorizers/renewing.py
@@ -37,14 +37,13 @@ class RenewingAuthorizer(GlobusAuthorizer, metaclass=abc.ABCMeta):
     :type expires_at: int, optional
     :param on_refresh: A callback which is triggered any time this authorizer fetches a
         new access_token. The ``on_refresh`` callable is invoked on the
-        :class:`OAuthTokenResponse \
-        <globus_sdk.services.auth.token_response.OAuthTokenResponse>`
+        :class:`OAuthTokenResponse <globus_sdk.OAuthTokenResponse>`
         object resulting from the token being refreshed. It should take only one
         argument, the token response object.
         This is useful for implementing storage for Access Tokens, as the
         ``on_refresh`` callback can be used to update the Access Tokens and
         their expiration times.
-    :type on_refresh: callable, optiona
+    :type on_refresh: callable, optional
     """
 
     def __init__(

--- a/src/globus_sdk/client.py
+++ b/src/globus_sdk/client.py
@@ -247,12 +247,12 @@ class BaseClient:
         :param headers: HTTP headers to add to the request
         :type headers: dict
         :param data: Data to send as the request body. May pass through encoding.
-        :type data: dict or string
+        :type data: dict or str
         :param encoding: A way to encode request data. "json", "form", and "text"
             are all valid values. Custom encodings can be used only if they are
             registered with the transport. By default, strings get "text" behavior and
             all other objects get "json".
-        :type encoding: string
+        :type encoding: str
 
         :return: :class:`GlobusHTTPResponse \
         <globus_sdk.response.GlobusHTTPResponse>` object

--- a/src/globus_sdk/exc/err_info.py
+++ b/src/globus_sdk/exc/err_info.py
@@ -29,13 +29,13 @@ class AuthorizationParameterInfo(ErrorInfo):
     'authorization_parameters' data.
 
     :ivar session_message: A message from the server
-    :vartype session_message: optional str
+    :vartype session_message: str, optional
     :ivar session_required_identities: A list of identity IDs as strings which are being
         requested by the server
-    :vartype session_required_identities: optional list of str
+    :vartype session_required_identities: list of str, optional
     :ivar session_required_single_domain: A list of domains which are being requested by
         the server ("single domain" because the user should choose one)
-    :vartype session_required_single_domain: optional list of str
+    :vartype session_required_single_domain: list of str, optional
 
     **Examples**
 
@@ -70,7 +70,7 @@ class ConsentRequiredInfo(ErrorInfo):
     test as truthy if the error was marked as a ConsentRequired error.
 
     :ivar required_scopes: A list of scopes requested by the server
-    :vartype required_scopes: optional list of str
+    :vartype required_scopes: list of str, optional
     """
 
     def __init__(self, error_data: Dict[str, Any]):

--- a/src/globus_sdk/local_endpoint/personal.py
+++ b/src/globus_sdk/local_endpoint/personal.py
@@ -28,7 +28,7 @@ class LocalGlobusConnectPersonal:
     @property
     def endpoint_id(self) -> Optional[str]:
         """
-        :type: string
+        :type: str
 
         The endpoint ID of the local Globus Connect Personal endpoint
         installation.

--- a/src/globus_sdk/response.py
+++ b/src/globus_sdk/response.py
@@ -16,7 +16,7 @@ from requests import Response
 log = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
-    from globus_sdk import BaseClient
+    import globus_sdk
 
 
 class GlobusHTTPResponse:
@@ -43,7 +43,7 @@ class GlobusHTTPResponse:
     def __init__(
         self,
         response: Union[Response, "GlobusHTTPResponse"],
-        client: Optional["BaseClient"] = None,
+        client: Optional["globus_sdk.BaseClient"] = None,
     ):
         # init on a GlobusHTTPResponse: we are wrapping this data
         # the _response is None
@@ -52,7 +52,7 @@ class GlobusHTTPResponse:
                 raise ValueError("Redundant client with wrapped response")
             self._wrapped: Optional[GlobusHTTPResponse] = response
             self._response: Optional[Response] = None
-            self.client: "BaseClient" = self._wrapped.client
+            self.client: "globus_sdk.BaseClient" = self._wrapped.client
 
             # copy attributes off of '_wrapped'
             self._parsed_json: Any = self._wrapped._parsed_json
@@ -154,7 +154,7 @@ class IterableResponse(GlobusHTTPResponse):
     def __init__(
         self,
         response: Union[Response, "GlobusHTTPResponse"],
-        client: Optional["BaseClient"] = None,
+        client: Optional["globus_sdk.BaseClient"] = None,
         *,
         iter_key: Optional[str] = None,
     ) -> None:

--- a/src/globus_sdk/services/auth/client/confidential_client.py
+++ b/src/globus_sdk/services/auth/client/confidential_client.py
@@ -18,8 +18,8 @@ class ConfidentialAppAuthClient(AuthClient):
     This is a specialized type of ``AuthClient`` used to represent an App with
     a Client ID and Client Secret wishing to communicate with Globus Auth.
     It must be given a Client ID and a Client Secret, and furthermore, these
-    will be used to establish a :class:`BasicAuthorizer
-    <globus_sdk.authorizers.BasicAuthorizer` for authorization purposes.
+    will be used to establish a :class:`BasicAuthorizer <globus_sdk.BasicAuthorizer>`
+    for authorization purposes.
     Additionally, the Client ID is stored for use in various calls.
 
     Confidential Applications (i.e. Applications with are not Native Apps) are
@@ -58,7 +58,7 @@ class ConfidentialAppAuthClient(AuthClient):
 
         :param requested_scopes: Space-separated scope names being requested for the
             access token(s). Defaults to a set of commonly desired scopes for Globus.
-        :type requested_scopes: str or iterable of str, optional
+        :type requested_scopes: str or sequence of str, optional
         :rtype: :class:`OAuthTokenResponse <.OAuthTokenResponse>`
 
         For example, with a Client ID of "CID1001" and a Client Secret of
@@ -109,7 +109,7 @@ class ConfidentialAppAuthClient(AuthClient):
         :param requested_scopes: The scopes on the token(s) being requested, as a
             space-separated string or an iterable of strings. Defaults to
             ``openid profile email urn:globus:auth:scope:transfer.api.globus.org:all``
-        :type requested_scopes: str or iterable of str, optional
+        :type requested_scopes: str or sequence of str, optional
         :param state: This string allows an application to pass information back to
             itself in the course of the OAuth flow. Because the user will navigate away
             from the application to complete the flow, this parameter lets the app pass

--- a/src/globus_sdk/services/auth/client/native_client.py
+++ b/src/globus_sdk/services/auth/client/native_client.py
@@ -67,7 +67,7 @@ class NativeAppAuthClient(AuthClient):
         :param requested_scopes: The scopes on the token(s) being requested, as a
             space-separated string or iterable of strings. Defaults to
             ``openid profile email urn:globus:auth:scope:transfer.api.globus.org:all``
-        :type requested_scopes: str or iterable of str, optional
+        :type requested_scopes: str or sequence of str, optional
         :param redirect_uri: The page that users should be directed to after
             authenticating at the authorize URL. Defaults to
             'https://auth.globus.org/v2/web/auth-code', which displays the resulting

--- a/src/globus_sdk/services/auth/flow_managers/authorization_code.py
+++ b/src/globus_sdk/services/auth/flow_managers/authorization_code.py
@@ -9,7 +9,7 @@ from ..response import OAuthTokenResponse
 from .base import GlobusOAuthFlowManager
 
 if TYPE_CHECKING:
-    from ..client import AuthClient
+    import globus_sdk
 
 logger = logging.getLogger(__name__)
 
@@ -41,7 +41,7 @@ class GlobusAuthorizationCodeFlowManager(GlobusOAuthFlowManager):
         ``openid profile email urn:globus:auth:scope:transfer.api.globus.org:all``
         (that is, ``DEFAULT_REQUESTED_SCOPES`` from
         ``globus_sdk.services.auth.oauth2_constants``)
-    :type requested_scopes: str or iterable of str, optional
+    :type requested_scopes: str or sequence of str, optional
     :param state: This string allows an application to pass information back to itself
         in the course of the OAuth flow. Because the user will navigate away from the
         application to complete the flow, this parameter lets the app pass an arbitrary
@@ -54,7 +54,7 @@ class GlobusAuthorizationCodeFlowManager(GlobusOAuthFlowManager):
 
     def __init__(
         self,
-        auth_client: "AuthClient",
+        auth_client: "globus_sdk.AuthClient",
         redirect_uri: str,
         requested_scopes: Optional[Union[str, Sequence[str]]] = None,
         state: str = "_default",

--- a/src/globus_sdk/services/auth/flow_managers/native_app.py
+++ b/src/globus_sdk/services/auth/flow_managers/native_app.py
@@ -14,7 +14,7 @@ from ..response import OAuthTokenResponse
 from .base import GlobusOAuthFlowManager
 
 if TYPE_CHECKING:
-    from ..client import AuthClient
+    import globus_sdk
 
 logger = logging.getLogger(__name__)
 
@@ -80,7 +80,7 @@ class GlobusNativeAppFlowManager(GlobusOAuthFlowManager):
     :param requested_scopes: The scopes on the token(s) being requested, as a
         space-separated string or iterable of strings. Defaults to
         ``openid profile email urn:globus:auth:scope:transfer.api.globus.org:all``
-    :type requested_scopes: str or iterable of str, optional
+    :type requested_scopes: str or sequence of str, optional
     :param redirect_uri: The page that users should be directed to after authenticating
         at the authorize URL. Defaults to 'https://auth.globus.org/v2/web/auth-code',
         which displays the resulting ``auth_code`` for users to copy-paste back into
@@ -104,7 +104,7 @@ class GlobusNativeAppFlowManager(GlobusOAuthFlowManager):
 
     def __init__(
         self,
-        auth_client: "AuthClient",
+        auth_client: "globus_sdk.AuthClient",
         requested_scopes: Optional[Union[str, Sequence[str]]] = None,
         redirect_uri: Optional[str] = None,
         state: str = "_default",

--- a/src/globus_sdk/services/auth/identity_map.py
+++ b/src/globus_sdk/services/auth/identity_map.py
@@ -116,7 +116,7 @@ class IdentityMap:
     :param identity_ids: A list or other iterable of usernames or identity IDs (potentially
         mixed together) which will be used to seed the ``IdentityMap`` 's tracking of
         unresolved Identities.
-    :type identity_ids: iterable of str
+    :type identity_ids: iterable of str, optional
     :param id_batch_size: A non-default batch size to use when communicating with Globus
         Auth. Leaving this set to the default is strongly recommended.
     :type id_batch_size: int, optional

--- a/src/globus_sdk/services/transfer/client.py
+++ b/src/globus_sdk/services/transfer/client.py
@@ -1717,7 +1717,7 @@ class TransferClient(client.BaseClient):
         ``POST /endpoint_manager/admin_cancel``
 
         :param task_ids: List of task ids to cancel.
-        :type task_ids: iterable of str
+        :type task_ids: iterable of str or UUID
         :param message: Message given to all users who's tasks have been canceled.
         :type message: str
         :param query_params: Any additional parameters will be passed through
@@ -1773,7 +1773,7 @@ class TransferClient(client.BaseClient):
         ``POST /endpoint_manager/admin_pause``
 
         :param task_ids: List of task ids to pause.
-        :type task_ids: iterable of str
+        :type task_ids: iterable of str or UUID
         :param message: Message given to all users who's tasks have been paused.
         :type message: str
         :param query_params: Any additional parameters will be passed through
@@ -1804,7 +1804,7 @@ class TransferClient(client.BaseClient):
         ``POST /endpoint_manager/admin_resume``
 
         :param task_ids: List of task ids to resume.
-        :type task_ids: iterable of str
+        :type task_ids: iterable of str or UUID
         :param query_params: Any additional parameters will be passed through
             as query params.
         :type query_params: dict, optional

--- a/src/globus_sdk/services/transfer/data/delete_data.py
+++ b/src/globus_sdk/services/transfer/data/delete_data.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 from globus_sdk import utils
 
 if TYPE_CHECKING:
-    from ..client import TransferClient
+    import globus_sdk
 
 log = logging.getLogger(__name__)
 
@@ -70,7 +70,7 @@ class DeleteData(utils.PayloadWrapper):
 
     def __init__(
         self,
-        transfer_client: "TransferClient",
+        transfer_client: "globus_sdk.TransferClient",
         endpoint: str,
         label: Optional[str] = None,
         submission_id: Optional[str] = None,

--- a/src/globus_sdk/services/transfer/data/transfer_data.py
+++ b/src/globus_sdk/services/transfer/data/transfer_data.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 from globus_sdk import utils
 
 if TYPE_CHECKING:
-    from ..client import TransferClient
+    import globus_sdk
 
 log = logging.getLogger(__name__)
 
@@ -131,7 +131,7 @@ class TransferData(utils.PayloadWrapper):
 
     def __init__(
         self,
-        transfer_client: "TransferClient",
+        transfer_client: "globus_sdk.TransferClient",
         source_endpoint: str,
         destination_endpoint: str,
         label: Optional[str] = None,

--- a/src/globus_sdk/transport/requests.py
+++ b/src/globus_sdk/transport/requests.py
@@ -62,25 +62,25 @@ class RequestsTransport:
         defaults to True, but can be set via the ``GLOBUS_SDK_VERIFY_SSL`` environment
         variable. Any non-``None`` setting via this parameter takes precedence over the
         environment variable.
-    :type verify_ssl: bool
+    :type verify_ssl: bool, optional
     :param http_timeout: Explicitly set an HTTP timeout value in seconds. This parameter
         defaults to 60s but can be set via the ``GLOBUS_SDK_HTTP_TIMEOUT`` environment
         variable. Any value set via this parameter takes precedence over the environment
         variable.
-    :type http_timeout: int
+    :type http_timeout: int, optional
     :param retry_backoff: A function which determines how long to sleep between calls
         based on the RetryContext. Defaults to expontential backoff with jitter based on
         the context ``attempt`` number.
-    :type retry_backoff: callable
+    :type retry_backoff: callable, optional
     :param retry_checks: A list of initial retry checks. Any hooks registered,
         including the default hooks, will run after these checks.
-    :type retry_checks: list of callables
+    :type retry_checks: list of callable, optional
     :param max_sleep: The maximum sleep time between retries (in seconds). If the
         computed sleep time or the backoff requested by a retry check exceeds this
         value, this amount of time will be used instead
-    :type max_sleep: int
+    :type max_sleep: int, optional
     :param max_retries: The maximum number of retries allowed by this transport
-    :type max_retries: int
+    :type max_retries: int, optional
     """
 
     #: default maximum number of retries
@@ -204,12 +204,12 @@ class RequestsTransport:
         :param headers: HTTP headers to add to the request
         :type headers: dict
         :param data: Data to send as the request body. May pass through encoding.
-        :type data: dict or string
+        :type data: dict or str
         :param encoding: A way to encode request data. "json", "form", and "text"
             are all valid values. Custom encodings can be used only if they are
             registered with the transport. By default, strings get "text" behavior and
             all other objects get "json".
-        :type encoding: string
+        :type encoding: str
 
         :return: ``requests.Response`` object
         """

--- a/src/globus_sdk/utils.py
+++ b/src/globus_sdk/utils.py
@@ -113,6 +113,11 @@ class PayloadWrapper(collections.UserDict):
     """
     A class for defining helper objects which wrap some kind of "payload" dict.
     Typical for helper objects which formulate a request payload, e.g. as JSON.
+
+    Payload types inheriting from this class can be passed directly to the client
+    ``post()``, ``put()``, and ``patch()`` methods instead of a dict. These methods will
+    recognize a ``PayloadWrapper`` and convert it to a dict for serialization with the
+    requested encoder (e.g. as a JSON request body).
     """
 
     # note: this class doesn't actually define any methods, properties, or attributes

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ whitelist_externals = rm
 changedir = docs/
 # clean the build dir before rebuilding
 commands_pre = rm -rf _build/
-commands = sphinx-build . -d _build/doctrees -b dirhtml _build/dirhtml
+commands = sphinx-build -d _build/doctrees -b dirhtml -W . _build/dirhtml {posargs}
 
 [testenv:publish-release]
 skip_install = true


### PR DESCRIPTION
The sphinx build now runs with `-W`, which sets warning-is-error on the build. Sphinx builds with warnings will no longer pass.

The tox config has been modified to allow posargs to be passed to the docs build, so that `tox -e docs -- -n` will set `-n` (nitpick mode).
With nitpick enabled, any cross reference which fails to resolve will be flagged as an error. This is very aggressive, and leads to many spurious warnings.

For this reason, `-n` is omitted from the standard build. However, add a list of nitpick ignore rules which get the build to pass under `-n` for now. This is not guaranteed to keep working, but the nitpick build did discover several missed or malformed annotations. It also flags type annotations which are perfectly correct/valid, but which sphinx can't use for correct cross references because of their ambiguity.

The state-of-the-art with respect to nitpick_ignore and nitpick_ignore_regex appears to be to load these data from a file in the docs dir. This is the approach taken by astropy [1], and it is shamelessly imitated here. Regex ignores are so useful, they are included in this implementation.

[1] astropy doc nitpick ignores:
https://github.com/astropy/astropy/blob/a7cf66db8ed95ca448ffb5a4c65f0a4a681ec220/docs/conf.py#L292-L297