### PR TITLE
Make args to endpoint_manager_task_list explicit

### DIFF
--- a/src/globus_sdk/types.py
+++ b/src/globus_sdk/types.py
@@ -1,5 +1,7 @@
+import datetime
 import uuid
 from typing import Union
 
 IntLike = Union[int, str]
 UUIDLike = Union[uuid.UUID, str, bytes]
+DateLike = Union[str, datetime.datetime]

--- a/tests/functional/transfer/endpoint_manager/test_task_list.py
+++ b/tests/functional/transfer/endpoint_manager/test_task_list.py
@@ -1,0 +1,83 @@
+import datetime
+import uuid
+
+import pytest
+
+from tests.common import get_last_request, register_api_route
+
+ZERO_ID = uuid.UUID(int=0)
+
+
+def get_last_params():
+    return get_last_request().params
+
+
+# stub in empty data, this can be explicitly replaced if a test wants specific data
+@pytest.fixture(autouse=True)
+def empty_response():
+    register_api_route("transfer", "/endpoint_manager/task_list", json={"DATA": []})
+
+
+@pytest.mark.parametrize(
+    "paramname, paramvalue",
+    [
+        ("filter_task_id", ZERO_ID),
+        ("filter_task_id", "foo"),
+        ("filter_owner_id", ZERO_ID),
+        ("filter_owner_id", "foo"),
+        ("filter_endpoint", ZERO_ID),
+        ("filter_endpoint", "foo"),
+        ("filter_is_paused", True),
+        ("filter_is_paused", False),
+        ("filter_min_faults", 0),
+        ("filter_min_faults", 10),
+        ("filter_local_user", "foouser"),
+        ("filter_status", "ACTIVE"),
+        ("filter_completion_time", "2020-08-25T00:00:00,2021-08-25T16:05:28"),
+    ],
+)
+def test_strsafe_params(client, paramname, paramvalue):
+    paramstr = str(paramvalue)
+    client.endpoint_manager_task_list(**{paramname: paramvalue})
+    params = get_last_params()
+    assert paramname in params
+    assert params[paramname] == paramstr
+
+
+def test_filter_status_list(client):
+    client.endpoint_manager_task_list(filter_status=["ACTIVE", "INACTIVE"])
+    params = get_last_params()
+    assert "filter_status" in params
+    assert params["filter_status"] == "ACTIVE,INACTIVE"
+
+
+def test_filter_task_id_list(client):
+    # mixed list of str and UUID
+    client.endpoint_manager_task_list(filter_task_id=["foo", ZERO_ID, "bar"])
+    params = get_last_params()
+    assert "filter_task_id" in params
+    assert params["filter_task_id"] == f"foo,{str(ZERO_ID)},bar"
+
+
+def _fromisoformat(datestr):  # for py3.6, datetime.fromisoformat was added in py3.7
+    return datetime.datetime.strptime(datestr, "%Y-%m-%dT%H:%M:%S")
+
+
+def test_filter_completion_time_datetime_tuple(client):
+    dt1 = _fromisoformat("2020-08-25T00:00:00")
+    dt2 = _fromisoformat("2021-08-25T16:05:28")
+
+    client.endpoint_manager_task_list(filter_completion_time=(dt1, dt2))
+    params = get_last_params()
+    assert "filter_completion_time" in params
+    assert params["filter_completion_time"] == "2020-08-25T00:00:00,2021-08-25T16:05:28"
+
+    # mixed tuples work, important for passing `""`
+    client.endpoint_manager_task_list(filter_completion_time=(dt1, ""))
+    params = get_last_params()
+    assert "filter_completion_time" in params
+    assert params["filter_completion_time"] == "2020-08-25T00:00:00,"
+    client.endpoint_manager_task_list(filter_completion_time=("", dt1))
+    params = get_last_params()
+    assert "filter_completion_time" in params
+    assert params["filter_completion_time"] == ",2020-08-25T00:00:00"


### PR DESCRIPTION
Rather than putting all of the various supported options in `query_params`, make each filter type a keyword argument, annotated with supported types.
Each argument is tested and passed into the inner dict as appropriate, in some cases with some encoding or comma-joining steps.

Tests do not worry about response payloads, but ensure that the expected parameters are sent as query params.

Docs are converted from a table to standard `:param:` docs. Some wording was adjusted, but mostly it is copy-paste and reindent.

As it is more relevant than usual in this case, here is what the rendered docs look like after this change:
![image](https://user-images.githubusercontent.com/1300022/130830418-0e9fa4b8-ce84-4c2f-b0e1-92de5606d6d0.png)

The type annotation makes for a hard to read method signature. I might check in on the latest options in furo for better presentation. When I last mentioned this issue, the author told me that the sphinx-generated HTML makes it hard to do a better job with this (e.g. black-like parameter per line styling).