### PR TITLE
Replace Sequence with Iterable

### DIFF
--- a/src/globus_sdk/services/auth/client/base.py
+++ b/src/globus_sdk/services/auth/client/base.py
@@ -7,8 +7,8 @@ from typing import (
     Any,
     AnyStr,
     Dict,
+    Iterable,
     Optional,
-    Sequence,
     Type,
     TypeVar,
     Union,
@@ -91,8 +91,8 @@ class AuthClient(client.BaseClient):
     def get_identities(
         self,
         *,
-        usernames: Union[Sequence[AnyStr], AnyStr, None] = None,
-        ids: Union[Sequence[UUIDLike], UUIDLike, None] = None,
+        usernames: Union[Iterable[AnyStr], AnyStr, None] = None,
+        ids: Union[Iterable[UUIDLike], UUIDLike, None] = None,
         provision: bool = False,
         query_params: Optional[Dict[str, Any]] = None,
     ) -> GlobusHTTPResponse:
@@ -148,9 +148,9 @@ class AuthClient(client.BaseClient):
         """
 
         def _convert_listarg(
-            val: Union[Sequence[Union[IntLike, UUIDLike]], Union[IntLike, UUIDLike]]
+            val: Union[Iterable[Union[IntLike, UUIDLike]], Union[IntLike, UUIDLike]]
         ) -> str:
-            if isinstance(val, collections.abc.Sequence) and not isinstance(
+            if isinstance(val, collections.abc.Iterable) and not isinstance(
                 val, (bytes, str)
             ):
                 return ",".join(utils.safe_stringify(x) for x in val)

--- a/src/globus_sdk/services/auth/client/confidential_client.py
+++ b/src/globus_sdk/services/auth/client/confidential_client.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Optional, Sequence, Union
+from typing import Any, Iterable, Optional, Union
 
 from globus_sdk import exc, utils
 from globus_sdk.authorizers import BasicAuthorizer
@@ -47,7 +47,7 @@ class ConfidentialAppAuthClient(AuthClient):
         log.info(f"Finished initializing client, client_id={client_id}")
 
     def oauth2_client_credentials_tokens(
-        self, requested_scopes: Optional[Union[str, Sequence[str]]] = None
+        self, requested_scopes: Optional[Union[str, Iterable[str]]] = None
     ) -> OAuthTokenResponse:
         r"""
         Perform an OAuth2 Client Credentials Grant to get access tokens which
@@ -58,7 +58,7 @@ class ConfidentialAppAuthClient(AuthClient):
 
         :param requested_scopes: Space-separated scope names being requested for the
             access token(s). Defaults to a set of commonly desired scopes for Globus.
-        :type requested_scopes: str or sequence of str, optional
+        :type requested_scopes: str or iterable of str, optional
         :rtype: :class:`OAuthTokenResponse <.OAuthTokenResponse>`
 
         For example, with a Client ID of "CID1001" and a Client Secret of
@@ -91,7 +91,7 @@ class ConfidentialAppAuthClient(AuthClient):
     def oauth2_start_flow(
         self,
         redirect_uri: str,
-        requested_scopes: Optional[Union[str, Sequence[str]]] = None,
+        requested_scopes: Optional[Union[str, Iterable[str]]] = None,
         *,
         state: str = "_default",
         refresh_tokens: bool = False,
@@ -110,7 +110,7 @@ class ConfidentialAppAuthClient(AuthClient):
         :param requested_scopes: The scopes on the token(s) being requested, as a
             space-separated string or an iterable of strings. Defaults to
             ``openid profile email urn:globus:auth:scope:transfer.api.globus.org:all``
-        :type requested_scopes: str or sequence of str, optional
+        :type requested_scopes: str or iterable of str, optional
         :param state: This string allows an application to pass information back to
             itself in the course of the OAuth flow. Because the user will navigate away
             from the application to complete the flow, this parameter lets the app pass

--- a/src/globus_sdk/services/auth/client/native_client.py
+++ b/src/globus_sdk/services/auth/client/native_client.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Dict, Optional, Sequence, Union
+from typing import Any, Dict, Iterable, Optional, Union
 
 from globus_sdk import exc, utils
 from globus_sdk.authorizers import NullAuthorizer
@@ -48,7 +48,7 @@ class NativeAppAuthClient(AuthClient):
     )
     def oauth2_start_flow(
         self,
-        requested_scopes: Optional[Union[str, Sequence[str]]] = None,
+        requested_scopes: Optional[Union[str, Iterable[str]]] = None,
         *,
         redirect_uri: Optional[str] = None,
         state: str = "_default",
@@ -68,7 +68,7 @@ class NativeAppAuthClient(AuthClient):
         :param requested_scopes: The scopes on the token(s) being requested, as a
             space-separated string or iterable of strings. Defaults to
             ``openid profile email urn:globus:auth:scope:transfer.api.globus.org:all``
-        :type requested_scopes: str or sequence of str, optional
+        :type requested_scopes: str or iterable of str, optional
         :param redirect_uri: The page that users should be directed to after
             authenticating at the authorize URL. Defaults to
             'https://auth.globus.org/v2/web/auth-code', which displays the resulting

--- a/src/globus_sdk/services/auth/flow_managers/authorization_code.py
+++ b/src/globus_sdk/services/auth/flow_managers/authorization_code.py
@@ -1,6 +1,6 @@
 import logging
 import urllib.parse
-from typing import TYPE_CHECKING, Any, Dict, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Any, Dict, Iterable, Optional, Union
 
 from globus_sdk import utils
 
@@ -41,7 +41,7 @@ class GlobusAuthorizationCodeFlowManager(GlobusOAuthFlowManager):
         ``openid profile email urn:globus:auth:scope:transfer.api.globus.org:all``
         (that is, ``DEFAULT_REQUESTED_SCOPES`` from
         ``globus_sdk.services.auth.oauth2_constants``)
-    :type requested_scopes: str or sequence of str, optional
+    :type requested_scopes: str or iterable of str, optional
     :param state: This string allows an application to pass information back to itself
         in the course of the OAuth flow. Because the user will navigate away from the
         application to complete the flow, this parameter lets the app pass an arbitrary
@@ -56,7 +56,7 @@ class GlobusAuthorizationCodeFlowManager(GlobusOAuthFlowManager):
         self,
         auth_client: "globus_sdk.AuthClient",
         redirect_uri: str,
-        requested_scopes: Optional[Union[str, Sequence[str]]] = None,
+        requested_scopes: Optional[Union[str, Iterable[str]]] = None,
         state: str = "_default",
         refresh_tokens: bool = False,
     ):

--- a/src/globus_sdk/services/auth/flow_managers/native_app.py
+++ b/src/globus_sdk/services/auth/flow_managers/native_app.py
@@ -4,7 +4,7 @@ import logging
 import os
 import re
 import urllib.parse
-from typing import TYPE_CHECKING, Any, Dict, Optional, Sequence, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, Iterable, Optional, Tuple, Union
 
 from globus_sdk import utils
 from globus_sdk.exc import GlobusSDKUsageError
@@ -80,7 +80,7 @@ class GlobusNativeAppFlowManager(GlobusOAuthFlowManager):
     :param requested_scopes: The scopes on the token(s) being requested, as a
         space-separated string or iterable of strings. Defaults to
         ``openid profile email urn:globus:auth:scope:transfer.api.globus.org:all``
-    :type requested_scopes: str or sequence of str, optional
+    :type requested_scopes: str or iterable of str, optional
     :param redirect_uri: The page that users should be directed to after authenticating
         at the authorize URL. Defaults to 'https://auth.globus.org/v2/web/auth-code',
         which displays the resulting ``auth_code`` for users to copy-paste back into
@@ -105,7 +105,7 @@ class GlobusNativeAppFlowManager(GlobusOAuthFlowManager):
     def __init__(
         self,
         auth_client: "globus_sdk.AuthClient",
-        requested_scopes: Optional[Union[str, Sequence[str]]] = None,
+        requested_scopes: Optional[Union[str, Iterable[str]]] = None,
         redirect_uri: Optional[str] = None,
         state: str = "_default",
         verifier: Optional[str] = None,

--- a/src/globus_sdk/services/gcs/client.py
+++ b/src/globus_sdk/services/gcs/client.py
@@ -1,5 +1,5 @@
 import uuid
-from typing import Any, Callable, Dict, Optional, Sequence, TypeVar, Union
+from typing import Any, Callable, Dict, Iterable, Optional, TypeVar, Union
 
 from globus_sdk import client, scopes, utils
 from globus_sdk.authorizers import GlobusAuthorizer
@@ -102,14 +102,14 @@ class GCSClient(client.BaseClient):
     def get_collection_list(
         self,
         *,
-        include: Union[str, Sequence[str], None] = None,
+        include: Union[str, Iterable[str], None] = None,
         query_params: Optional[Dict[str, Any]] = None,
     ) -> IterableGCSResponse:
         """
         ``GET /collections``
 
         :param include: Names of additional documents to include in the response
-        :type include: str or sequence of str, optional
+        :type include: str or iterable of str, optional
         :param query_params: Additional passthrough query parameters
         :type query_params: dict, optional
 

--- a/src/globus_sdk/services/groups/data.py
+++ b/src/globus_sdk/services/groups/data.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, Optional, Sequence
+from typing import Any, Iterable, Optional
 
 from globus_sdk import utils
 from globus_sdk.types import UUIDLike
@@ -44,7 +44,7 @@ class BatchMembershipActions(utils.PayloadWrapper):
     """
 
     def accept_invites(
-        self, identity_ids: Sequence[UUIDLike]
+        self, identity_ids: Iterable[UUIDLike]
     ) -> "BatchMembershipActions":
         """
         Accept invites for identities.  The identities must belong to
@@ -57,7 +57,7 @@ class BatchMembershipActions(utils.PayloadWrapper):
         return self
 
     def add_members(
-        self, identity_ids: Sequence[UUIDLike], *, role: GroupRole = GroupRole.member
+        self, identity_ids: Iterable[UUIDLike], *, role: GroupRole = GroupRole.member
     ) -> "BatchMembershipActions":
         """
         Add a list of identities to a group with the given role.
@@ -69,7 +69,7 @@ class BatchMembershipActions(utils.PayloadWrapper):
         return self
 
     def approve_pending(
-        self, identity_ids: Sequence[UUIDLike]
+        self, identity_ids: Iterable[UUIDLike]
     ) -> "BatchMembershipActions":
         """
         Approve a list of identities with pending join requests.
@@ -81,7 +81,7 @@ class BatchMembershipActions(utils.PayloadWrapper):
         return self
 
     def decline_invites(
-        self, identity_ids: Sequence[UUIDLike]
+        self, identity_ids: Iterable[UUIDLike]
     ) -> "BatchMembershipActions":
         """
         Decline an invitation for a given set of identities.
@@ -93,7 +93,7 @@ class BatchMembershipActions(utils.PayloadWrapper):
         return self
 
     def invite_members(
-        self, identity_ids: Sequence[UUIDLike], *, role: GroupRole = GroupRole.member
+        self, identity_ids: Iterable[UUIDLike], *, role: GroupRole = GroupRole.member
     ) -> "BatchMembershipActions":
         """
         Invite a list of identities to a group with the given role.
@@ -104,7 +104,7 @@ class BatchMembershipActions(utils.PayloadWrapper):
         )
         return self
 
-    def join(self, identity_ids: Sequence[UUIDLike]) -> "BatchMembershipActions":
+    def join(self, identity_ids: Iterable[UUIDLike]) -> "BatchMembershipActions":
         """
         Join a group with the given identities.  The identities must be in the
         authenticated users identity set.
@@ -115,7 +115,7 @@ class BatchMembershipActions(utils.PayloadWrapper):
         )
         return self
 
-    def leave(self, identity_ids: Sequence[UUIDLike]) -> "BatchMembershipActions":
+    def leave(self, identity_ids: Iterable[UUIDLike]) -> "BatchMembershipActions":
         """
         Leave a group that one of the identities in the authenticated user's
         identity set is a member of.
@@ -127,7 +127,7 @@ class BatchMembershipActions(utils.PayloadWrapper):
         return self
 
     def reject_join_requests(
-        self, identity_ids: Sequence[UUIDLike]
+        self, identity_ids: Iterable[UUIDLike]
     ) -> "BatchMembershipActions":
         """
         Reject a members that have requested to join the group.
@@ -139,7 +139,7 @@ class BatchMembershipActions(utils.PayloadWrapper):
         return self
 
     def remove_members(
-        self, identity_ids: Sequence[UUIDLike]
+        self, identity_ids: Iterable[UUIDLike]
     ) -> "BatchMembershipActions":
         """
         Remove members from a group.  This must be done as an admin or manager
@@ -152,7 +152,7 @@ class BatchMembershipActions(utils.PayloadWrapper):
         return self
 
     def request_join(
-        self, identity_ids: Sequence[UUIDLike]
+        self, identity_ids: Iterable[UUIDLike]
     ) -> "BatchMembershipActions":
         """
         Request to join a group.
@@ -184,7 +184,7 @@ class GroupPolicies(utils.PayloadWrapper):
         group_visibility: GroupVisibility,
         group_members_visibility: GroupMemberVisibility,
         join_requests: bool,
-        signup_fields: Sequence[GroupRequiredSignupFields],
+        signup_fields: Iterable[GroupRequiredSignupFields],
         authentication_assurance_timeout: Optional[int] = None,
     ):
         super().__init__()

--- a/src/globus_sdk/services/groups/manager.py
+++ b/src/globus_sdk/services/groups/manager.py
@@ -1,4 +1,4 @@
-from typing import Optional, Sequence
+from typing import Iterable, Optional
 
 from globus_sdk import response, utils
 from globus_sdk.types import UUIDLike
@@ -49,7 +49,7 @@ class GroupsManager:
         group_visibility: GroupVisibility,
         group_members_visibility: GroupMemberVisibility,
         join_requests: bool,
-        signup_fields: Sequence[GroupRequiredSignupFields],
+        signup_fields: Iterable[GroupRequiredSignupFields],
         authentication_assurance_timeout: Optional[int] = None,
     ) -> response.GlobusHTTPResponse:
         """

--- a/src/globus_sdk/services/transfer/client.py
+++ b/src/globus_sdk/services/transfer/client.py
@@ -1,7 +1,7 @@
 import logging
 import time
 import uuid
-from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
 from globus_sdk import client, exc, paging, response, utils
 from globus_sdk.scopes import TransferScopes
@@ -1736,8 +1736,8 @@ class TransferClient(client.BaseClient):
     def endpoint_manager_task_list(
         self,
         *,
-        filter_status: Union[None, str, Sequence[str]] = None,
-        filter_task_id: Union[None, UUIDLike, Sequence[UUIDLike]] = None,
+        filter_status: Union[None, str, Iterable[str]] = None,
+        filter_task_id: Union[None, UUIDLike, Iterable[UUIDLike]] = None,
         filter_owner_id: Optional[UUIDLike] = None,
         filter_endpoint: Optional[UUIDLike] = None,
         filter_is_paused: Optional[bool] = None,
@@ -1759,13 +1759,13 @@ class TransferClient(client.BaseClient):
         :param filter_status: Return only tasks with any of the specified statuses
             Note that in-progress tasks will have status ``"ACTIVE"`` or ``"INACTIVE"``,
             and completed tasks will have status ``"SUCCEEDED"`` or ``"FAILED"``.
-        :type filter_status: str or sequence of str, optional
+        :type filter_status: str or iterable of str, optional
         :param filter_task_id: Return only tasks with any of the specified ids. If any
             of the specified tasks do not involve an endpoint the user has an
             appropriate role for, a ``PermissionDenied`` error will be returned. This
             filter can't be combined with any other filter.  If another filter is
             passed, a ``BadRequest`` will be returned. (limit: 50 task IDs)
-        :type filter_task_id: str, UUID, or sequence of str or UUID, optional
+        :type filter_task_id: str, UUID, or iterable of str or UUID, optional
         :param filter_owner_id: A Globus Auth identity id. Limit results to tasks
             submitted by the specified identity, or linked to the specified identity,
             at submit time.  Returns ``UserNotFound`` if the identity does not exist or

--- a/src/globus_sdk/utils.py
+++ b/src/globus_sdk/utils.py
@@ -3,7 +3,7 @@ import collections.abc
 import hashlib
 from base64 import b64encode
 from enum import Enum
-from typing import Any, Callable, Generator, Optional, Sequence, TypeVar, Union
+from typing import Any, Callable, Generator, Iterable, Optional, TypeVar, Union
 
 from .types import IntLike, UUIDLike
 
@@ -74,17 +74,17 @@ def safe_stringify(value: Union[IntLike, UUIDLike]) -> str:
     return str(value)
 
 
-def safe_strseq_iter(value: Sequence) -> Generator[str, None, None]:
+def safe_strseq_iter(value: Iterable) -> Generator[str, None, None]:
     """
-    Given a Sequence (typically of strings), produce an iterator over it of strings.
+    Given an Iterable (typically of strings), produce an iterator over it of strings.
     This is a passthrough with two caveats:
     - if the value is a solitary string, yield only that value
-    - any value in the sequence which is not a string will be passed through
+    - any value in the iterable which is not a string will be passed through
       safe_stringify
 
-    This helps handle cases where a string is passed to a function expecting a sequence
-    of strings, as well as cases where a sequence of UUID objects is accepted for a list
-    of IDs, or something similar.
+    This helps handle cases where a string is passed to a function expecting an iterable
+    of strings, as well as cases where an iterable of UUID objects is accepted for a
+    list of IDs, or something similar.
     """
     if isinstance(value, (str, bytes)):
         yield safe_stringify(value)
@@ -97,14 +97,14 @@ def render_enums_for_api(value: Any) -> Any:
     """
     Convert enum values to their underlying value.
 
-    If a value is a sequence type, it will be converted to a list and the values will
+    If a value is an iterable type, it will be converted to a list and the values will
     also be converted if they are enum values.
     """
-    # special-case: handle str and bytes because these types are technically sequence
+    # special-case: handle str and bytes because these types are technically iterable
     # types (of bytes or str values) which could trip someone up
     if isinstance(value, (str, bytes)):
         return value
-    if isinstance(value, collections.abc.Sequence):
+    if isinstance(value, collections.abc.Iterable):
         return [render_enums_for_api(x) for x in value]
     return value.value if isinstance(value, Enum) else value
 


### PR DESCRIPTION
In type annotations for all SDK methods consuming `Sequence[T]`, accept `Iterable[T]` instead. This allows for usages (admittedly rare ones) in which a generator or other non-sequence iterable type is used.

There are no cases in which we really wanted Sequence; they are all only used as iterables.