### PR TITLE
Add method to get local GCP owner from gridmap

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -13,3 +13,5 @@ exclude_lines =
     if __name__ == .__main__.:
     # don't check coverage on type checking conditionals
     if TYPE_CHECKING:
+    # skip overloads
+    @overload

--- a/docs/local_endpoints.rst
+++ b/docs/local_endpoints.rst
@@ -21,7 +21,10 @@ Globus Connect Personal
 Globus Connect Personal endpoints belonging to the current user may be accessed
 via instances of the following class:
 
-
 .. autoclass:: globus_sdk.LocalGlobusConnectPersonal
+   :members:
+   :member-order: bysource
+
+.. autoclass:: globus_sdk.GlobusConnectPersonalOwnerInfo
    :members:
    :member-order: bysource

--- a/src/globus_sdk/__init__.py
+++ b/src/globus_sdk/__init__.py
@@ -17,7 +17,7 @@ from .exc import (
     GlobusTimeoutError,
     NetworkError,
 )
-from .local_endpoint import LocalGlobusConnectPersonal
+from .local_endpoint import GlobusConnectPersonalOwnerInfo, LocalGlobusConnectPersonal
 from .response import GlobusHTTPResponse
 from .services.auth import (
     AuthAPIError,
@@ -90,6 +90,7 @@ __all__ = (
     "GroupsManager",
     "GCSClient",
     "GCSAPIError",
+    "GlobusConnectPersonalOwnerInfo",
     "LocalGlobusConnectPersonal",
 )
 

--- a/src/globus_sdk/local_endpoint/__init__.py
+++ b/src/globus_sdk/local_endpoint/__init__.py
@@ -1,3 +1,6 @@
-from globus_sdk.local_endpoint.personal import LocalGlobusConnectPersonal
+from .personal import GlobusConnectPersonalOwnerInfo, LocalGlobusConnectPersonal
 
-__all__ = ("LocalGlobusConnectPersonal",)
+__all__ = (
+    "GlobusConnectPersonalOwnerInfo",
+    "LocalGlobusConnectPersonal",
+)

--- a/src/globus_sdk/local_endpoint/personal.py
+++ b/src/globus_sdk/local_endpoint/personal.py
@@ -111,6 +111,12 @@ class LocalGlobusConnectPersonal:
         In either case, the result may be ``None`` if the data is missing or cannot be
         parsed.
 
+        .. note::
+
+            The data returned by this method is not checked for accuracy. It is
+            possible for a user to modify the files used by GCP to list a different
+            user.
+
         :param auth_client: An AuthClient to use to lookup the full identity information
             for the GCP owner
         :type auth_client: globus_sdk.AuthClient
@@ -189,6 +195,11 @@ class LocalGlobusConnectPersonal:
 
         This value is loaded whenever it is first accessed, but saved after
         that.
+
+        .. note::
+
+            This attribute is not checked for accuracy. It is possible for a user to
+            modify the files used by GCP to list a different ``endpoint_id``.
 
         Usage:
 

--- a/src/globus_sdk/local_endpoint/personal.py
+++ b/src/globus_sdk/local_endpoint/personal.py
@@ -1,7 +1,40 @@
+import base64
 import os
-from typing import Optional
+import shlex
+import uuid
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Union, cast, overload
 
 from globus_sdk.exc import GlobusSDKUsageError
+
+if TYPE_CHECKING:
+    import globus_sdk
+
+
+_GRIDMAP_DN_START = '"/C=US/O=Globus Consortium/OU=Globus Connect User/CN='
+
+
+class _B32DecodeError(ValueError):
+    """custom exception type"""
+
+
+def _b32decode(v: str) -> str:
+    # should start with "u_"
+    if not v.startswith("u_"):
+        raise _B32DecodeError("should start with 'u_'")
+    v = v[2:]
+    # wrong length
+    if len(v) != 26:
+        raise _B32DecodeError("wrong length")
+
+    # append padding and uppercase so that b32decode will work
+    v = v.upper() + (6 * "=")
+
+    # try to decode
+    try:
+        return str(uuid.UUID(bytes=base64.b32decode(v)))
+    # if it fails, then it can't be a b32-encoded identity
+    except ValueError:
+        raise _B32DecodeError("decode and load as UUID failed")
 
 
 def _on_windows() -> bool:
@@ -24,6 +57,127 @@ class LocalGlobusConnectPersonal:
 
     def __init__(self) -> None:
         self._endpoint_id: Optional[str] = None
+        self._cached_local_data_dir: Optional[str] = None
+
+    # because fetching the local data dir can error, defer finding it into a property
+    # with caching behavior
+    @property
+    def _local_data_dir(self) -> str:
+        if self._cached_local_data_dir is None:
+            if _on_windows():
+                appdata = os.getenv("LOCALAPPDATA")
+                if appdata is None:
+                    raise GlobusSDKUsageError(
+                        "LOCALAPPDATA not detected in Windows environment"
+                    )
+                self._cached_local_data_dir = os.path.join(appdata, "Globus Connect")
+            else:
+                self._cached_local_data_dir = os.path.expanduser("~/.globusonline/lta")
+
+        return self._cached_local_data_dir
+
+    def _ensure_local_data_dir(self) -> None:
+        # force property evaluation to catch any errors
+        # this wrapper is just an "imperative looking" way of doing this
+        self._local_data_dir
+
+    @overload
+    def get_owner_info(self) -> Optional[Tuple[str, bool]]:
+        ...
+
+    @overload
+    def get_owner_info(self, auth_client: None) -> Optional[Tuple[str, bool]]:
+        ...
+
+    @overload
+    def get_owner_info(
+        self, auth_client: "globus_sdk.AuthClient"
+    ) -> Optional[Dict[str, Any]]:
+        ...
+
+    def get_owner_info(
+        self, auth_client: Optional["globus_sdk.AuthClient"] = None
+    ) -> Union[None, Tuple[str, bool], Dict[str, Any]]:
+        """
+        Look up the local GCP information.
+        This method may return a username or a user ID. For that reason, the result is a
+        tuple: (user, is_id).
+
+        If you pass an AuthClient, this method will return a dict from the Get
+        Identities API instead of the tuple. This can fail (e.g. with network errors if
+        there is no connectivity), so passing this value should be coupled with
+        additional error handling.
+
+        In either case, the result may be ``None`` if the data is missing or cannot be
+        parsed.
+
+        :param auth_client: An AuthClient to use to lookup the full identity information
+            for the GCP owner
+        :type auth_client: globus_sdk.AuthClient
+
+        **Examples**
+
+        Getting a username:
+
+        >>> from globus_sdk import LocalGlobusConnectPersonal
+        >>> local_gcp = LocalGlobusConnectPersonal()
+        >>> local_gcp.get_owner_info()
+        ('foo@globusid.org', False)
+
+        or you may get back an ID:
+
+        >>> local_gcp = LocalGlobusConnectPersonal()
+        >>> local_gcp.get_owner_info()
+        ('7deda7cc-077b-11ec-a137-67523ecffd4b', True)
+        """
+        self._ensure_local_data_dir()
+
+        fname = os.path.join(self._local_data_dir, "gridmap")
+        try:
+            # extract the first line which looks like a gridmap CN for GCP
+            # all other lines will be ignored to accommodate cases where users have
+            # modified their gridmap files in various ways (which GCP may or may not
+            # support)
+            data = None
+            with open(fname) as fp:
+                for line in fp:
+                    if line.startswith(_GRIDMAP_DN_START):
+                        data = line.strip()
+                        break
+        except OSError as e:
+            # no such file or directory
+            if e.errno == 2:
+                return None
+            raise
+
+        # a gridmap CN line was not found
+        if not data:
+            return None
+
+        lineinfo = shlex.split(data)
+        if len(lineinfo) != 2:
+            return None
+
+        dn, _local_username = lineinfo
+        username_or_id = dn.split("=", 4)[-1]
+
+        try:
+            user, is_id = _b32decode(username_or_id), True
+        except _B32DecodeError:
+            user, is_id = f"{username_or_id}@globusid.org", False
+
+        if auth_client is None:
+            return (user, is_id)
+
+        if is_id:
+            res = auth_client.get_identities(ids=user)
+        else:
+            res = auth_client.get_identities(usernames=user)
+
+        try:  # could get no data back in theory, if the identity isn't visible
+            return cast(Dict[str, Any], res["identities"][0])
+        except (KeyError, IndexError):
+            return None
 
     @property
     def endpoint_id(self) -> Optional[str]:
@@ -49,23 +203,15 @@ class LocalGlobusConnectPersonal:
         with ``del local_ep.endpoint_id``
         """
         if self._endpoint_id is None:
+            self._ensure_local_data_dir()
+
+            fname = os.path.join(self._local_data_dir, "client-id.txt")
             try:
-                if _on_windows():
-                    appdata = os.getenv("LOCALAPPDATA")
-                    if appdata is None:
-                        raise GlobusSDKUsageError(
-                            "LOCALAPPDATA not detected in Windows environment"
-                        )
-                    fname = os.path.join(appdata, "Globus Connect\\client-id.txt")
-                else:
-                    fname = os.path.expanduser("~/.globusonline/lta/client-id.txt")
                 with open(fname) as fp:
                     self._endpoint_id = fp.read().strip()
             except OSError as e:
-                # no such file or directory
-                if e.errno == 2:
-                    pass
-                else:
+                # no such file or directory gets ignored, everything else reraise
+                if e.errno != 2:
                     raise
         return self._endpoint_id
 

--- a/src/globus_sdk/local_endpoint/personal/__init__.py
+++ b/src/globus_sdk/local_endpoint/personal/__init__.py
@@ -1,0 +1,7 @@
+from .endpoint import LocalGlobusConnectPersonal
+from .owner_info import GlobusConnectPersonalOwnerInfo
+
+__all__ = (
+    "LocalGlobusConnectPersonal",
+    "GlobusConnectPersonalOwnerInfo",
+)

--- a/src/globus_sdk/local_endpoint/personal/owner_info.py
+++ b/src/globus_sdk/local_endpoint/personal/owner_info.py
@@ -1,0 +1,99 @@
+import base64
+import shlex
+import uuid
+from typing import Optional, Tuple
+
+
+class _B32DecodeError(ValueError):
+    """custom exception type"""
+
+
+def _b32decode(v: str) -> str:
+    # should start with "u_"
+    if not v.startswith("u_"):
+        raise _B32DecodeError("should start with 'u_'")
+    v = v[2:]
+    # wrong length
+    if len(v) != 26:
+        raise _B32DecodeError("wrong length")
+
+    # append padding and uppercase so that b32decode will work
+    v = v.upper() + (6 * "=")
+
+    # try to decode
+    try:
+        return str(uuid.UUID(bytes=base64.b32decode(v)))
+    # if it fails, then it can't be a b32-encoded identity
+    except ValueError:
+        raise _B32DecodeError("decode and load as UUID failed")
+
+
+def _parse_dn_username(s: str) -> Tuple[str, bool]:
+    try:
+        user, is_id = _b32decode(s), True
+    except _B32DecodeError:
+        user, is_id = f"{s}@globusid.org", False
+    return (user, is_id)
+
+
+class GlobusConnectPersonalOwnerInfo:
+    """
+    Information about the owner of the local Globus Connect Personal endpoint.
+
+    Users should never create these objects directly, but instead rely upon
+    :meth:`LocalGlobusConnectPersonal.get_owner_info()`.
+
+    The info object contains ether ``id`` or ``username``.
+    Parsing an info object from local data cannot guarantee that the ``id`` or
+    ``username`` value will be found. Whichever one is present will be set and the
+    other attribute will be ``None``.
+
+    :ivar id: The Globus Auth ID of the endpoint owner
+    :vartype id: str or None
+    :ivar username: The Globus Auth Username of the endpoint owner
+    :vartype username: str or None
+    :param config_dn: A DN value from GCP configuration, which will be parsed into
+        username or ID
+    :type config_dn: str
+    """
+
+    _GRIDMAP_DN_START = '"/C=US/O=Globus Consortium/OU=Globus Connect User/CN='
+
+    username: Optional[str]
+    id: Optional[str]
+
+    def __init__(self, *, config_dn: str) -> None:
+        lineinfo = shlex.split(config_dn)
+        if len(lineinfo) != 2:
+            raise ValueError("Malformed DN: not right length")
+        dn, _local_username = lineinfo
+        username_or_id = dn.split("=", 4)[-1]
+
+        user, is_id = _parse_dn_username(username_or_id)
+
+        if is_id:
+            self.username = None
+            self.id = user
+        else:
+            self.username = user
+            self.id = None
+
+    def __str__(self) -> str:
+        return (
+            "GlobusConnectPersonalOwnerInfo("
+            + (
+                f"username={self.username}"
+                if self.username is not None
+                else f"id={self.id}"
+            )
+            + ")"
+        )
+
+    # private methods for SDK usage only
+    @classmethod
+    def _from_file(cls, filename: str) -> "GlobusConnectPersonalOwnerInfo":
+        with open(filename) as fp:
+            for line in fp:
+                if line.startswith(cls._GRIDMAP_DN_START):
+                    return cls(config_dn=line.strip())
+        raise ValueError("Could not find GCP DN in data stream")

--- a/tests/functional/local_endpoint/test_personal.py
+++ b/tests/functional/local_endpoint/test_personal.py
@@ -1,47 +1,66 @@
 import os
 import shutil
 import tempfile
-from unittest import mock
 
 import pytest
 
 import globus_sdk
+from tests.common import register_api_route
 
 _IS_WINDOWS = os.name == "nt"
 
+BASE32_ID = "u_vy2bvggsoqi6loei3oxdvc5fiu"
+
+
+def _compute_confdir(homedir):
+    if _IS_WINDOWS:
+        return os.path.join(homedir, "Globus Connect")
+    else:
+        return os.path.join(homedir, ".globusonline/lta")
+
 
 @pytest.fixture(autouse=True)
-def mocked_homedir():
+def mocked_homedir(monkeypatch):
     tempdir = tempfile.mkdtemp()
 
     def mock_expanduser(path):
         return os.path.join(tempdir, path.replace("~/", ""))
 
     try:
+        confdir = _compute_confdir(tempdir)
+        os.makedirs(confdir)
         if _IS_WINDOWS:
-            os.mkdir(os.path.join(tempdir, "Globus Connect"))
-            with mock.patch.dict(os.environ):
-                os.environ["LOCALAPPDATA"] = tempdir
-                yield tempdir
+            monkeypatch.setitem(os.environ, "LOCALAPPDATA", tempdir)
         else:
-            os.makedirs(os.path.join(tempdir, ".globusonline/lta"))
-            with mock.patch("os.path.expanduser", mock_expanduser):
-                yield tempdir
+            monkeypatch.setattr(os.path, "expanduser", mock_expanduser)
+        yield tempdir
 
     finally:
         shutil.rmtree(tempdir)
 
 
 @pytest.fixture
-def write_gcp_id_file(mocked_homedir):
+def mocked_confdir(mocked_homedir):
+    return _compute_confdir(mocked_homedir)
+
+
+@pytest.fixture
+def write_gcp_id_file(mocked_confdir):
     def _func_fixture(epid):
-        if _IS_WINDOWS:
-            fpath = os.path.join(mocked_homedir, "Globus Connect", "client-id.txt")
-        else:
-            fpath = os.path.join(mocked_homedir, ".globusonline/lta/client-id.txt")
+        fpath = os.path.join(mocked_confdir, "client-id.txt")
         with open(fpath, "w") as f:
             f.write(epid)
             f.write("\n")
+
+    return _func_fixture
+
+
+@pytest.fixture
+def write_gridmap(mocked_confdir):
+    def _func_fixture(data):
+        fpath = os.path.join(mocked_confdir, "gridmap")
+        with open(fpath, "w") as f:
+            f.write(data)
 
     return _func_fixture
 
@@ -51,12 +70,16 @@ def local_gcp():
     return globus_sdk.LocalGlobusConnectPersonal()
 
 
+@pytest.fixture
+def auth_client():
+    return globus_sdk.AuthClient()
+
+
 @pytest.mark.skipif(not _IS_WINDOWS, reason="test requires Windows")
-def test_localep_localappdata_notset(local_gcp):
-    with mock.patch.dict(os.environ):
-        del os.environ["LOCALAPPDATA"]
-        with pytest.raises(globus_sdk.GlobusSDKUsageError):
-            local_gcp.endpoint_id
+def test_localep_localappdata_notset(local_gcp, monkeypatch):
+    monkeypatch.delitem(os.environ, "LOCALAPPDATA")
+    with pytest.raises(globus_sdk.GlobusSDKUsageError):
+        local_gcp.endpoint_id
 
 
 def test_localep_load_id(local_gcp, write_gcp_id_file):
@@ -67,3 +90,182 @@ def test_localep_load_id(local_gcp, write_gcp_id_file):
     assert local_gcp.endpoint_id == "foobar"
     del local_gcp.endpoint_id
     assert local_gcp.endpoint_id == "xyz"
+
+
+def test_load_id_no_confdir(local_gcp, mocked_confdir):
+    shutil.rmtree(mocked_confdir)
+    assert local_gcp.endpoint_id is None
+
+
+def test_get_owner_info(local_gcp, write_gridmap, auth_client):
+    write_gridmap(
+        '"/C=US/O=Globus Consortium/OU=Globus Connect User/CN=sirosen" sirosen\n'
+    )
+    assert local_gcp.get_owner_info() == ("sirosen@globusid.org", False)
+
+    register_api_route(
+        "auth",
+        "/v2/api/identities",
+        json={
+            "identities": [
+                {
+                    "email": "sirosen@globus.org",
+                    "id": "ae332d86-d274-11e5-b885-b31714a110e9",
+                    "identity_provider": "41143743-f3c8-4d60-bbdb-eeecaba85bd9",
+                    "identity_type": "login",
+                    "name": "Stephen Rosen",
+                    "organization": "Globus Team",
+                    "status": "used",
+                    "username": "sirosen@globusid.org",
+                }
+            ]
+        },
+    )
+    data = local_gcp.get_owner_info(auth_client)
+    assert isinstance(data, dict)
+    assert data["id"] == "ae332d86-d274-11e5-b885-b31714a110e9"
+
+
+def test_get_owner_info_b32_mode(local_gcp, write_gridmap, auth_client):
+    write_gridmap(
+        f'"/C=US/O=Globus Consortium/OU=Globus Connect User/CN={BASE32_ID}" sirosen\n'
+    )
+    assert local_gcp.get_owner_info() == ("ae341a98-d274-11e5-b888-dbae3a8ba545", True)
+
+    register_api_route(
+        "auth",
+        "/v2/api/identities",
+        json={
+            "identities": [
+                {
+                    "email": "sirosen@globus.org",
+                    "id": "ae341a98-d274-11e5-b888-dbae3a8ba545",
+                    "identity_provider": "927d7238-f917-4eb2-9ace-c523fa9ba34e",
+                    "identity_type": "login",
+                    "name": "Stephen Rosen",
+                    "organization": "Globus Team",
+                    "status": "used",
+                    "username": "sirosen@globus.org",
+                }
+            ]
+        },
+    )
+    data = local_gcp.get_owner_info(auth_client)
+    assert isinstance(data, dict)
+    assert data["id"] == "ae341a98-d274-11e5-b888-dbae3a8ba545"
+
+
+# these things are close to the right thing, but each is somehow wrong
+@pytest.mark.parametrize(
+    "cn",
+    [
+        # no 'u_'
+        BASE32_ID[2:],
+        # short one char
+        BASE32_ID[:-1],
+        # invalid b32 char included
+        BASE32_ID[:-1] + "/",
+    ],
+)
+def test_get_owner_info_b32_mode_invalid_data(
+    local_gcp, write_gridmap, cn, auth_client
+):
+    write_gridmap(
+        f'"/C=US/O=Globus Consortium/OU=Globus Connect User/CN={cn}" sirosen\n'
+    )
+    assert local_gcp.get_owner_info() == (f"{cn}@globusid.org", False)
+
+
+@pytest.mark.parametrize(
+    "bad_cn_line",
+    [
+        '"/C=US/O=Globus Consortium/OU=Globus Connect User/CN=sirosen"',
+        '"/C=US/O=Globus Consortium/OU=Globus Connect User/CN=sirosen" sirosen sirosen',
+        "",
+        '"" sirosen',
+    ],
+)
+def test_get_owner_info_malformed_entry(local_gcp, write_gridmap, bad_cn_line):
+    write_gridmap(bad_cn_line + "\n")
+    assert local_gcp.get_owner_info() is None
+
+
+def test_get_owner_info_no_conf(local_gcp):
+    assert local_gcp.get_owner_info() is None
+    assert local_gcp.get_owner_info(auth_client) is None
+
+
+def test_get_owner_info_no_confdir(local_gcp, mocked_confdir, auth_client):
+    shutil.rmtree(mocked_confdir)
+    assert local_gcp.get_owner_info() is None
+    assert local_gcp.get_owner_info(auth_client) is None
+
+
+def test_get_owner_info_multiline_data(local_gcp, write_gridmap, auth_client):
+    write_gridmap(
+        "\n".join(
+            [
+                f'"/C=US/O=Globus Consortium/OU=Globus Connect User/CN=sirosen{x}" sirosen{x}'  # noqa: E501
+                for x in ["", "2", "3"]
+            ]
+        )
+        + "\n"
+    )
+    assert local_gcp.get_owner_info() == ("sirosen@globusid.org", False)
+
+    register_api_route(
+        "auth",
+        "/v2/api/identities",
+        json={
+            "identities": [
+                {
+                    "email": "sirosen@globus.org",
+                    "id": "ae332d86-d274-11e5-b885-b31714a110e9",
+                    "identity_provider": "41143743-f3c8-4d60-bbdb-eeecaba85bd9",
+                    "identity_type": "login",
+                    "name": "Stephen Rosen",
+                    "organization": "Globus Team",
+                    "status": "used",
+                    "username": "sirosen@globusid.org",
+                }
+            ]
+        },
+    )
+    data = local_gcp.get_owner_info(auth_client)
+    assert isinstance(data, dict)
+    assert data["id"] == "ae332d86-d274-11e5-b885-b31714a110e9"
+
+
+def test_get_owner_info_no_auth_data(local_gcp, write_gridmap, auth_client):
+    write_gridmap(
+        '"/C=US/O=Globus Consortium/OU=Globus Connect User/CN=sirosen" sirosen\n'
+    )
+    assert local_gcp.get_owner_info() == ("sirosen@globusid.org", False)
+
+    register_api_route("auth", "/v2/api/identities", json={"identities": []})
+    data = local_gcp.get_owner_info(auth_client)
+    assert data is None
+
+
+def test_get_owner_info_gridmap_permission_denied(local_gcp, mocked_confdir):
+    fpath = os.path.join(mocked_confdir, "gridmap")
+    with open(fpath, "w"):  # "touch"
+        pass
+    os.chmod(fpath, 0o000)
+
+    with pytest.raises(OSError) as excinfo:
+        local_gcp.get_owner_info()
+    # permission denied
+    assert excinfo.value.errno == 13
+
+
+def test_get_endpoint_id_permission_denied(local_gcp, mocked_confdir):
+    fpath = os.path.join(mocked_confdir, "client-id.txt")
+    with open(fpath, "w"):  # "touch"
+        pass
+    os.chmod(fpath, 0o000)
+
+    with pytest.raises(OSError) as excinfo:
+        local_gcp.endpoint_id
+    # permission denied
+    assert excinfo.value.errno == 13

--- a/tests/functional/local_endpoint/test_personal.py
+++ b/tests/functional/local_endpoint/test_personal.py
@@ -101,7 +101,11 @@ def test_get_owner_info(local_gcp, write_gridmap, auth_client):
     write_gridmap(
         '"/C=US/O=Globus Consortium/OU=Globus Connect User/CN=sirosen" sirosen\n'
     )
-    assert local_gcp.get_owner_info() == ("sirosen@globusid.org", False)
+    info = local_gcp.get_owner_info()
+    assert isinstance(info, globus_sdk.GlobusConnectPersonalOwnerInfo)
+    assert info.username == "sirosen@globusid.org"
+    assert info.id is None
+    assert str(info) == "GlobusConnectPersonalOwnerInfo(username=sirosen@globusid.org)"
 
     register_api_route(
         "auth",
@@ -130,7 +134,10 @@ def test_get_owner_info_b32_mode(local_gcp, write_gridmap, auth_client):
     write_gridmap(
         f'"/C=US/O=Globus Consortium/OU=Globus Connect User/CN={BASE32_ID}" sirosen\n'
     )
-    assert local_gcp.get_owner_info() == ("ae341a98-d274-11e5-b888-dbae3a8ba545", True)
+    info = local_gcp.get_owner_info()
+    assert isinstance(info, globus_sdk.GlobusConnectPersonalOwnerInfo)
+    assert info.username is None
+    assert info.id == "ae341a98-d274-11e5-b888-dbae3a8ba545"
 
     register_api_route(
         "auth",
@@ -173,7 +180,9 @@ def test_get_owner_info_b32_mode_invalid_data(
     write_gridmap(
         f'"/C=US/O=Globus Consortium/OU=Globus Connect User/CN={cn}" sirosen\n'
     )
-    assert local_gcp.get_owner_info() == (f"{cn}@globusid.org", False)
+    info = local_gcp.get_owner_info()
+    assert isinstance(info, globus_sdk.GlobusConnectPersonalOwnerInfo)
+    assert info.username == f"{cn}@globusid.org"
 
 
 @pytest.mark.parametrize(
@@ -211,7 +220,9 @@ def test_get_owner_info_multiline_data(local_gcp, write_gridmap, auth_client):
         )
         + "\n"
     )
-    assert local_gcp.get_owner_info() == ("sirosen@globusid.org", False)
+    info = local_gcp.get_owner_info()
+    assert isinstance(info, globus_sdk.GlobusConnectPersonalOwnerInfo)
+    assert info.username == "sirosen@globusid.org"
 
     register_api_route(
         "auth",
@@ -240,7 +251,9 @@ def test_get_owner_info_no_auth_data(local_gcp, write_gridmap, auth_client):
     write_gridmap(
         '"/C=US/O=Globus Consortium/OU=Globus Connect User/CN=sirosen" sirosen\n'
     )
-    assert local_gcp.get_owner_info() == ("sirosen@globusid.org", False)
+    info = local_gcp.get_owner_info()
+    assert isinstance(info, globus_sdk.GlobusConnectPersonalOwnerInfo)
+    assert info.username == "sirosen@globusid.org"
 
     register_api_route("auth", "/v2/api/identities", json={"identities": []})
     data = local_gcp.get_owner_info(auth_client)

--- a/tests/functional/local_endpoint/test_personal.py
+++ b/tests/functional/local_endpoint/test_personal.py
@@ -249,23 +249,29 @@ def test_get_owner_info_no_auth_data(local_gcp, write_gridmap, auth_client):
 
 def test_get_owner_info_gridmap_permission_denied(local_gcp, mocked_confdir):
     fpath = os.path.join(mocked_confdir, "gridmap")
-    with open(fpath, "w"):  # "touch"
-        pass
-    os.chmod(fpath, 0o000)
+    if not _IS_WINDOWS:
+        with open(fpath, "w"):  # "touch"
+            pass
+        os.chmod(fpath, 0o000)
+    else:
+        # on windows, trying to read a directory gets a permission error
+        # this is just an easy way for tests to simulate bad permissions
+        os.makedirs(fpath)
 
-    with pytest.raises(OSError) as excinfo:
+    with pytest.raises(PermissionError):
         local_gcp.get_owner_info()
-    # permission denied
-    assert excinfo.value.errno == 13
 
 
 def test_get_endpoint_id_permission_denied(local_gcp, mocked_confdir):
     fpath = os.path.join(mocked_confdir, "client-id.txt")
-    with open(fpath, "w"):  # "touch"
-        pass
-    os.chmod(fpath, 0o000)
+    if not _IS_WINDOWS:
+        with open(fpath, "w"):  # "touch"
+            pass
+        os.chmod(fpath, 0o000)
+    else:
+        # on windows, trying to read a directory gets a permission error
+        # this is just an easy way for tests to simulate bad permissions
+        os.makedirs(fpath)
 
-    with pytest.raises(OSError) as excinfo:
+    with pytest.raises(PermissionError):
         local_gcp.endpoint_id
-    # permission denied
-    assert excinfo.value.errno == 13


### PR DESCRIPTION
Minimally parse the gridmap file, find a GCP DN, and then handle the result. It can be a globusid.org username or auth ID, so these are flagged on return. If users want a uniform(ish) interface, they can pass in an AuthClient, which is used to do an get-identities call to lookup the user info.

Skip coverage reporting on overloads for more accurate coverage info.

---

@michaellink, this is the feature we discussed the other day, as implemented by the SDK.
If you can spare a minute to look at how I've handled the GCP gridmap file, any feedback or info you can give would be helpful.