### PR TITLE
Add filter_is_error to advanced task event list

### DIFF
--- a/src/globus_sdk/services/transfer/client.py
+++ b/src/globus_sdk/services/transfer/client.py
@@ -1910,6 +1910,7 @@ class TransferClient(client.BaseClient):
         *,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
+        filter_is_error: Optional[bool] = None,
         query_params: Optional[Dict[str, Any]] = None,
     ) -> IterableTransferResponse:
         """
@@ -1924,6 +1925,10 @@ class TransferClient(client.BaseClient):
         :param limit: limit the number of results
         :type limit: int, optional
         :param offset: offset used in paging
+        :param filter_is_error: Return only events that are errors. A value of ``False``
+            (returning only non-errors) is not supported. By default all events are
+            returned.
+        :type filter_is_error: bool, optional
         :param query_params: Additional passthrough query parameters
         :type query_params: dict, optional
         """
@@ -1935,6 +1940,8 @@ class TransferClient(client.BaseClient):
             query_params["limit"] = limit
         if offset is not None:
             query_params["offset"] = offset
+        if filter_is_error is not None:
+            query_params["filter_is_error"] = 1 if filter_is_error else 0
         return IterableTransferResponse(
             self.get(
                 f"endpoint_manager/task/{task_id}/event_list", query_params=query_params

--- a/tests/functional/transfer/endpoint_manager/test_task_event_list.py
+++ b/tests/functional/transfer/endpoint_manager/test_task_event_list.py
@@ -1,0 +1,37 @@
+import uuid
+
+import pytest
+
+from tests.common import get_last_request, register_api_route
+
+ZERO_ID = uuid.UUID(int=0)
+
+
+def get_last_params():
+    return get_last_request().params
+
+
+@pytest.fixture
+def task_id():
+    return uuid.uuid1()
+
+
+# stub in empty data, this can be explicitly replaced if a test wants specific data
+@pytest.fixture(autouse=True)
+def empty_response(task_id):
+    register_api_route(
+        "transfer", f"/endpoint_manager/task/{task_id}/event_list", json={"DATA": []}
+    )
+
+
+# although int values are not supported based on the type annotations, users may already
+# be passing ints -- it's good to support this usage and test it even if it's not
+# documented and desirable
+@pytest.mark.parametrize(
+    "paramvalue, paramstr", [(True, "1"), (False, "0"), (1, "1"), (0, "0")]
+)
+def test_filter_is_error(client, task_id, paramvalue, paramstr):
+    client.endpoint_manager_task_event_list(task_id, filter_is_error=paramvalue)
+    params = get_last_params()
+    assert "filter_is_error" in params
+    assert params["filter_is_error"] == paramstr


### PR DESCRIPTION
A user reported this parameter missing in 3.0b4. It's a casualty of the `**params` => `query_params={...}` passthrough change, so this adds it as an explicit parameter.

The param is added as a bool. However, testing covers setting it as an int. This is the usage which was seen in the wild under SDK v2.x which prompted this addition, and checking that it is supported (although not documented and not to be encouraged) is simple enough.