### PR TITLE
Add support for Collection POST,PATCH

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,18 @@ repos:
   hooks:
     - id: blacken-docs
       additional_dependencies: ['black==21.5b1']
+- repo: https://github.com/asottile/dead
+  rev: v1.4.0
+  hooks:
+    - id: dead
+      # run `dead` only on specific files, where
+      # (1) `dead` is passing
+      # (2) the structure of the code makes extra unused variable detection
+      #     useful (e.g. subclasses which *must* pass arguments to their
+      #     superclasses or risk silently swallowing/ignoring arguments)
+      # (3) we are prepared to commit to keeping `dead` happy and using
+      #     `# dead: disable` comments as needed
+      args: ["--files", "src/globus_sdk/services/gcs/data.py"]
 - repo: https://gitlab.com/pycqa/flake8
   rev: 3.9.2
   hooks:

--- a/docs/nitpick_ignore.txt
+++ b/docs/nitpick_ignore.txt
@@ -25,7 +25,7 @@ py:class datetime
 py:class GlobusHTTPResponse
 
 # "list of ...", "sequence of ..."
-re: py:class (sequence|iterable|list)\sof\s\w+
+re: py:class (sequence|iterable|list|tuple)\sof\s\w+
 # type vars in SDK modules
 re: py:class globus_sdk\..*\.(T|RT)
 

--- a/docs/services/gcs.rst
+++ b/docs/services/gcs.rst
@@ -21,6 +21,13 @@ The primary interface for the GCS Manager API is the ``GCSClient`` class.
    :show-inheritance:
    :exclude-members: error_class
 
+Helper Objects
+--------------
+
+.. automodule:: globus_sdk.services.gcs.data
+   :members:
+   :show-inheritance:
+
 Client Errors
 -------------
 

--- a/src/globus_sdk/__init__.py
+++ b/src/globus_sdk/__init__.py
@@ -28,7 +28,13 @@ from .services.auth import (
     OAuthDependentTokenResponse,
     OAuthTokenResponse,
 )
-from .services.gcs import GCSAPIError, GCSClient
+from .services.gcs import (
+    CollectionDocument,
+    GCSAPIError,
+    GCSClient,
+    GuestCollectionDocument,
+    MappedCollectionDocument,
+)
 from .services.groups import (
     BatchMembershipActions,
     GroupMemberVisibility,
@@ -89,6 +95,9 @@ __all__ = (
     "GroupVisibility",
     "GroupsManager",
     "GCSClient",
+    "CollectionDocument",
+    "GuestCollectionDocument",
+    "MappedCollectionDocument",
     "GCSAPIError",
     "GlobusConnectPersonalOwnerInfo",
     "LocalGlobusConnectPersonal",

--- a/src/globus_sdk/services/gcs/__init__.py
+++ b/src/globus_sdk/services/gcs/__init__.py
@@ -1,9 +1,13 @@
 from .client import GCSClient
+from .data import CollectionDocument, GuestCollectionDocument, MappedCollectionDocument
 from .errors import GCSAPIError
 from .response import IterableGCSResponse, UnpackingGCSResponse
 
 __all__ = (
     "GCSClient",
+    "CollectionDocument",
+    "GuestCollectionDocument",
+    "MappedCollectionDocument",
     "GCSAPIError",
     "IterableGCSResponse",
     "UnpackingGCSResponse",

--- a/src/globus_sdk/services/gcs/client.py
+++ b/src/globus_sdk/services/gcs/client.py
@@ -5,6 +5,7 @@ from globus_sdk import client, response, scopes, utils
 from globus_sdk.authorizers import GlobusAuthorizer
 from globus_sdk.types import UUIDLike
 
+from .data import CollectionDocument
 from .errors import GCSAPIError
 from .response import IterableGCSResponse, UnpackingGCSResponse
 
@@ -146,6 +147,60 @@ class GCSClient(client.BaseClient):
             r"collection#1\.\d+\.\d+",
         )
 
+    @_gcsdoc("Create Collection", "openapi_Collections/#createCollection")
+    def create_collection(
+        self,
+        collection_data: Union[Dict[str, Any], CollectionDocument],
+    ) -> UnpackingGCSResponse:
+        """
+        ``POST /collections``
+
+        Create a collection. This is used to create either a mapped or a guest
+        collection. When created, a ``collection:administrator`` role for that
+        collection will be created using the caller’s identity.
+
+        In order to create a guest collection, the caller must have an identity that
+        matches the Storage Gateway policies.
+
+        In order to create a mapped collection, the caller must have an
+        ``endpoint:administrator`` or ``endpoint:owner`` role.
+
+        :param collection_data: The collection document for the new collection
+        :type collection_data: dict or CollectionDocument
+        """
+        return UnpackingGCSResponse(
+            self.post("/collections", data=collection_data), r"collection#1\.\d+\.\d+"
+        )
+
+    @_gcsdoc("Update Collection", "openapi_Collections/#patchCollection")
+    def update_collection(
+        self,
+        collection_id: UUIDLike,
+        collection_data: Union[Dict[str, Any], CollectionDocument],
+        *,
+        query_params: Optional[Dict[str, Any]] = None,
+    ) -> UnpackingGCSResponse:
+        """
+        ``PATCH /collections/{collection_id}``
+
+        :param collection_id: The ID of the collection to update
+        :type collection_id: str or UUID
+        :param collection_data: The collection document for the modified collection
+        :type collection_data: dict or CollectionDocument
+        :param query_params: Additional passthrough query parameters
+        :type query_params: dict, optional
+        """
+        collection_id = utils.safe_stringify(collection_id)
+        return UnpackingGCSResponse(
+            self.patch(
+                f"/collections/{collection_id}",
+                data=collection_data,
+                query_params=query_params,
+            ),
+            r"collection#1\.\d+\.\d+",
+        )
+
+    @_gcsdoc("Delete Collection", "openapi_Collections/#deleteCollection")
     def delete_collection(
         self,
         collection_id: UUIDLike,

--- a/src/globus_sdk/services/gcs/data.py
+++ b/src/globus_sdk/services/gcs/data.py
@@ -1,0 +1,452 @@
+import abc
+from typing import Any, Callable, Dict, Iterable, Optional, Tuple
+
+from globus_sdk import utils
+from globus_sdk.types import UUIDLike
+
+#
+# NOTE -- on the organization of arguments in this module --
+#
+# The arguments to each collection type are defined explicitly for good type annotations
+# and documentation.
+# However, it's easy for things to get out of sync or different between the various
+# locations, so we need to impose some order on things to make comparisons easy.
+#
+# Complicating this, there are some arguments to specific types which aren't shared
+# by the common base.
+#
+# The rule and rationale used is as follows:
+# - DATA_TYPE is special, and always first
+# - next, the common optional arguments (shared by all)
+# - after that, the specific optional arguments for this type/subtype
+# - 'additional_fileds' is special, and always last
+#
+# within those listings of common and specific arguments, the following ordering is
+# maintained:
+# - strings, sorted alphabetically
+# - string lists, sorted alphabetically
+# - bools, sorted alphabetically
+# - dicts and other types, sorted alphabetically
+#
+# This makes it possible to do side-by-side comparison of common arguments, to ensure
+# that they are all present and accounted-for in all contexts, and allows us to compare
+# definition lists for param docs and arguments against usage sites to ensure that all
+# arguments which are passed are actually used
+#
+
+
+class CollectionDocument(utils.PayloadWrapper, abc.ABC):
+    """
+    This is the base class for :class:`~.MappedCollectionDocument` and
+    :class:`~.GuestCollectionDocument`.
+
+    Parameters common to both of those are defined and documented here.
+
+    :param data_type: Explicitly set the ``DATA_TYPE`` value for this collection.
+        Normally ``DATA_TYPE`` is deduced from the provided parameters and should not be
+        set. To maximize compatibility with different versions of GCS, only set this
+        value when necessary.
+    :type data_type: str, optional
+
+    :param collection_base_path: The location of the collection on its underlying
+        storage. For a mapped collection, this is an absolute path on the storage system
+        named by the ``storage_gateway_id``. For a guest collection, this is a path
+        relative to the value of the ``root_path`` attribute on the mapped collection
+        identified by the ``mapped_collection_id``. This parameter is optional for
+        updates but required when creating a new collection.
+    :type collection_base_path: str, optional
+    :param contact_email: Email address of the support contact for the collection
+    :type contact_email: str, optional
+    :param contact_info: Other contact information for the collection, e.g. phone number
+        or mailing address
+    :type contact_info: str, optional
+    :param default_directory: Default directory when using the collection
+    :type default_directory: str, optional
+    :param department: The department which operates the collection
+    :type department: str, optional
+    :param description: A text description of the collection
+    :type description: str, optional
+    :param display_name: Friendly name for the collection
+    :type display_name: str, optional
+    :param identity_id: The Globus Auth identity which acts as the owner of the
+        collection
+    :type identity_id: str or UUID, optional
+    :param info_link: Link for more info about the collection
+    :type info_link: str, optional
+    :param organization: The organization which maintains the collection
+    :type organization: str, optional
+    :param user_message: A message to display to users when interacting with this
+        collection
+    :type user_message: str, optional
+    :param user_message_link: A link to additional messaging for users when interacting
+        with this collection
+    :type user_message_link: str, optional
+
+    :param keywords: A list of keywords used to help searches for the collection
+    :type keywords: iterable of str, optional
+
+    :param disable_verify: Disable verification checksums on transfers to and from this
+        collection
+    :type disable_verify: bool, optional
+    :param enable_https: Enable or disable HTTPS support (requires a managed endpoint)
+    :type enable_https: bool, optional
+    :param force_encryption: When set to True, all transfers to and from the collection
+        are always encrypted
+    :type force_encryption: bool, optional
+    :param force_verify: Force verification checksums on transfers to and from this
+        collection
+    :type force_verify: bool, optional
+    :param public: If True, the collection will be visible to other Globus users
+    :type public: bool, optional
+
+    :param additional_fields: Additional data for inclusion in the collection document
+    :type additional_fields: dict, optional
+    """
+
+    DATATYPE_VERSION_IMPLICATIONS: Dict[str, Tuple[int, int, int]] = {
+        "disable_anonymous_writes": (1, 5, 0),
+        "force_verify": (1, 4, 0),
+        "sharing_users_allow": (1, 2, 0),
+        "sharing_users_deny": (1, 2, 0),
+        "enable_https": (1, 1, 0),
+        "user_message": (1, 1, 0),
+        "user_message_link": (1, 1, 0),
+    }
+
+    def __init__(
+        self,
+        *,
+        # data_type
+        data_type: Optional[str] = None,
+        # strs
+        collection_base_path: Optional[str] = None,
+        contact_email: Optional[str] = None,
+        contact_info: Optional[str] = None,
+        default_directory: Optional[str] = None,
+        department: Optional[str] = None,
+        description: Optional[str] = None,
+        display_name: Optional[str] = None,
+        identity_id: Optional[UUIDLike] = None,
+        info_link: Optional[str] = None,
+        organization: Optional[str] = None,
+        user_message: Optional[str] = None,
+        user_message_link: Optional[str] = None,
+        # str lists
+        keywords: Optional[Iterable[str]] = None,
+        # bools
+        disable_verify: Optional[bool] = None,
+        enable_https: Optional[bool] = None,
+        force_encryption: Optional[bool] = None,
+        force_verify: Optional[bool] = None,
+        public: Optional[bool] = None,
+        # additional fields
+        additional_fields: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        super().__init__()
+        self["collection_type"] = self.collection_type
+        self._set_optstrs(
+            DATA_TYPE=data_type,
+            collection_base_path=collection_base_path,
+            contact_email=contact_email,
+            contact_info=contact_info,
+            default_directory=default_directory,
+            department=department,
+            description=description,
+            display_name=display_name,
+            identity_id=identity_id,
+            info_link=info_link,
+            organization=organization,
+            user_message=user_message,
+            user_message_link=user_message_link,
+        )
+        self._set_optstrlists(
+            keywords=keywords,
+        )
+        self._set_optbools(
+            disable_verify=disable_verify,
+            enable_https=enable_https,
+            force_encryption=force_encryption,
+            force_verify=force_verify,
+            public=public,
+        )
+        if additional_fields is not None:
+            self.update(additional_fields)
+
+    @property
+    @abc.abstractmethod
+    def collection_type(self) -> str:
+        raise NotImplementedError
+
+    def _deduce_datatype_version(self) -> str:
+        max_deduced_version = (1, 0, 0)
+        for fieldname, version in self.DATATYPE_VERSION_IMPLICATIONS.items():
+            if fieldname not in self:
+                continue
+            if version > max_deduced_version:
+                max_deduced_version = version
+        return ".".join(str(x) for x in max_deduced_version)
+
+    def _ensure_datatype(self) -> None:
+        if "DATA_TYPE" not in self:
+            self["DATA_TYPE"] = f"collection#{self._deduce_datatype_version()}"
+
+    def _set_value(
+        self, key: str, val: Any, callback: Optional[Callable] = None
+    ) -> None:
+        if val is not None:
+            self[key] = callback(val) if callback else val
+
+    def _set_optstrs(self, **kwargs: Any) -> None:
+        for k, v in kwargs.items():
+            self._set_value(k, v, callback=utils.safe_stringify)
+
+    def _set_optstrlists(self, **kwargs: Optional[Iterable]) -> None:
+        for k, v in kwargs.items():
+            self._set_value(k, v, callback=lambda x: list(utils.safe_strseq_iter(x)))
+
+    def _set_optbools(self, **kwargs: Optional[bool]) -> None:
+        for k, v in kwargs.items():
+            self._set_value(k, v, callback=bool)
+
+
+class MappedCollectionDocument(CollectionDocument):
+    """
+    An object used to represent a Mapped Collection for creation or update operations.
+    The initializer supports all writable fields on Mapped Collections but does not
+    include read-only fields like ``id``.
+
+    Because these documents may be used for updates, no fields are strictly required.
+    However, GCS will require the following fields for creation:
+
+    - ``storage_gateway_id``
+    - ``collection_base_path``
+
+    All parameters for :class:`~.CollectionDocument` are supported in addition to the
+    parameters below.
+
+    :param storage_gateway_id: The ID of the storage gateway which hosts this mapped
+        collection. This parameter is required when creating a collection.
+    :type storage_gateway_id: str or UUID, optional
+
+    :param domain_name: DNS name of the virtual host serving this collection
+    :type domain_name: str, optional
+
+    :param sharing_users_allow: Connector-specific usernames allowed to create guest
+        collections
+    :type sharing_users_allow: iterable of str, optional
+    :param sharing_users_deny: Connector-specific usernames forbidden from creating
+        guest collections
+    :type sharing_users_deny: iterable of str, optional
+
+    :param allow_guest_collections: Enable or disable creation and use of Guest
+        Collections on this Mapped Collection
+    :type allow_guest_collections: bool, optional
+    :param disable_anonymous_writes: Allow anonymous write ACLs on Guest Collections
+        attached to this Mapped Collection. This option is only usable on non
+        high-assurance collections
+    :type disable_anonymous_writes: bool, optional
+
+    :param policies: Connector-specific collection policies
+    :type policies: dict, optional
+    :param sharing_restrict_paths: A PathRestrictions document
+    :type sharing_restrict_paths: dict, optional
+    """
+
+    @property
+    def collection_type(self) -> str:
+        return "mapped"
+
+    def __init__(
+        self,
+        *,
+        # data type
+        data_type: Optional[str] = None,
+        # > common args start <
+        # strs
+        collection_base_path: Optional[str] = None,
+        contact_email: Optional[str] = None,
+        contact_info: Optional[str] = None,
+        default_directory: Optional[str] = None,
+        department: Optional[str] = None,
+        description: Optional[str] = None,
+        display_name: Optional[str] = None,
+        identity_id: Optional[UUIDLike] = None,
+        info_link: Optional[str] = None,
+        organization: Optional[str] = None,
+        user_message: Optional[str] = None,
+        user_message_link: Optional[str] = None,
+        # str lists
+        keywords: Optional[Iterable[str]] = None,
+        # bools
+        disable_verify: Optional[bool] = None,
+        enable_https: Optional[bool] = None,
+        force_encryption: Optional[bool] = None,
+        force_verify: Optional[bool] = None,
+        public: Optional[bool] = None,
+        # > common args end <
+        # > specific args start <
+        storage_gateway_id: Optional[UUIDLike] = None,
+        # strs
+        domain_name: Optional[str] = None,
+        # str lists
+        sharing_users_allow: Optional[Iterable[str]] = None,
+        sharing_users_deny: Optional[Iterable[str]] = None,
+        sharing_restrict_paths: Optional[Dict[str, Any]] = None,
+        # bools
+        allow_guest_collections: Optional[bool] = None,
+        disable_anonymous_writes: Optional[bool] = None,
+        # dicts
+        policies: Optional[Dict[str, Any]] = None,
+        # > specific args end <
+        # additional fields
+        additional_fields: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        super().__init__(
+            # data type
+            data_type=data_type,
+            # strings
+            collection_base_path=collection_base_path,
+            contact_email=contact_email,
+            contact_info=contact_info,
+            default_directory=default_directory,
+            department=department,
+            description=description,
+            display_name=display_name,
+            identity_id=identity_id,
+            info_link=info_link,
+            organization=organization,
+            user_message=user_message,
+            user_message_link=user_message_link,
+            # bools
+            disable_verify=disable_verify,
+            enable_https=enable_https,
+            force_encryption=force_encryption,
+            force_verify=force_verify,
+            public=public,
+            # str lists
+            keywords=keywords,
+            # additional fields
+            additional_fields=additional_fields,
+        )
+        self._set_optstrs(
+            storage_gateway_id=storage_gateway_id,
+            domain_name=domain_name,
+        )
+        self._set_optstrlists(
+            sharing_users_allow=sharing_users_allow,
+            sharing_users_deny=sharing_users_deny,
+        )
+        self._set_optbools(
+            allow_guest_collections=allow_guest_collections,
+            disable_anonymous_writes=disable_anonymous_writes,
+        )
+        self._set_value("sharing_restrict_paths", sharing_restrict_paths)
+        self._set_value("policies", policies)
+        self._ensure_datatype()
+
+
+class GuestCollectionDocument(CollectionDocument):
+    """
+    An object used to represent a Guest Collection for creation or update operations.
+    The initializer supports all writable fields on Guest Collections but does not
+    include read-only fields like ``id``.
+
+    Because these documents may be used for updates, no fields are strictly required.
+    However, GCS will require the following fields for creation:
+
+    - ``mapped_collection_id``
+    - ``user_credential_id``
+    - ``collection_base_path``
+
+    All parameters for :class:`~.CollectionDocument` are supported in addition to the
+    parameters below.
+
+    :param mapped_collection_id: The ID of the mapped collection which hosts this guest
+        collection
+    :type mapped_collection_id: str or UUID
+    :param user_credential_id: The ID of the User Credential which is used to access
+        data on this collection. This credential must be owned by the collection’s
+        ``identity_id``.
+    :type user_credential_id: str or UUID
+    """
+
+    @property
+    def collection_type(self) -> str:
+        return "guest"
+
+    def __init__(
+        self,
+        *,
+        # data type
+        data_type: Optional[str] = None,
+        # > common args start <
+        # strs
+        collection_base_path: Optional[str] = None,
+        contact_email: Optional[str] = None,
+        contact_info: Optional[str] = None,
+        default_directory: Optional[str] = None,
+        department: Optional[str] = None,
+        description: Optional[str] = None,
+        display_name: Optional[str] = None,
+        identity_id: Optional[UUIDLike] = None,
+        info_link: Optional[str] = None,
+        organization: Optional[str] = None,
+        user_message: Optional[str] = None,
+        user_message_link: Optional[str] = None,
+        # str lists
+        keywords: Optional[Iterable[str]] = None,
+        # bools
+        disable_verify: Optional[bool] = None,
+        enable_https: Optional[bool] = None,
+        force_encryption: Optional[bool] = None,
+        force_verify: Optional[bool] = None,
+        public: Optional[bool] = None,
+        # > common args end <
+        # > specific args start <
+        mapped_collection_id: Optional[UUIDLike] = None,
+        user_credential_id: Optional[UUIDLike] = None,
+        # > specific args end <
+        # additional fields
+        additional_fields: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        super().__init__(
+            # data type
+            data_type=data_type,
+            # strings
+            collection_base_path=collection_base_path,
+            contact_email=contact_email,
+            contact_info=contact_info,
+            default_directory=default_directory,
+            department=department,
+            description=description,
+            display_name=display_name,
+            identity_id=identity_id,
+            info_link=info_link,
+            organization=organization,
+            user_message=user_message,
+            user_message_link=user_message_link,
+            # bools
+            disable_verify=disable_verify,
+            enable_https=enable_https,
+            force_encryption=force_encryption,
+            force_verify=force_verify,
+            public=public,
+            # str lists
+            keywords=keywords,
+            # additional fields
+            additional_fields=additional_fields,
+        )
+        self._set_optstrs(
+            mapped_collection_id=mapped_collection_id,
+            user_credential_id=user_credential_id,
+        )
+        self._ensure_datatype()
+
+
+# an __all__ declaration ensures that `dead` passes on this module, which is quite
+# useful
+__all__ = (
+    "CollectionDocument",
+    "MappedCollectionDocument",
+    "GuestCollectionDocument",
+)

--- a/tests/functional/gcs/fixture_data/create_collection.json
+++ b/tests/functional/gcs/fixture_data/create_collection.json
@@ -1,0 +1,59 @@
+{
+  "code": "success",
+  "data": [
+    {
+      "id": "18d367d5-45cf-4724-a53e-5a685e45c942",
+      "manager_url": "https://gcs.data.globus.org/",
+      "domain_name": "i-f3c83.123.globus.org",
+      "high_assurance": true,
+      "https_url": "https://i-f3c83.123.globus.org",
+      "tlsftp_url": "tlsftp://i-f3c83.123.globus.org",
+      "collection_type": "mapped",
+      "display_name": "Project Foo Research Data",
+      "connector_id": "c8b7ab5c-595c-43c9-8e43-9e8a3debfe4c",
+      "identity_id": "c8b7ab5c-595c-43c9-8e43-9e8a3debfe4c",
+      "storage_gateway_id": "fc1f3ba0-1fa4-42b2-8bb3-53983774fa5f",
+      "root_path": "/",
+      "collection_base_path": "/",
+      "default_directory": "/projects",
+      "public": true,
+      "force_encryption": false,
+      "disable_verify": false,
+      "organization": "University of Example",
+      "department": "Data Science",
+      "keywords": [
+        "Project Foo",
+        "Data Intensive Science"
+      ],
+      "description": "Information related to the \"Foo\" project.",
+      "contact_email": "project-foo@example.edu",
+      "contact_info": "+1 (555) 555-1234",
+      "info_link": "https://project-foo.example.edu/info",
+      "authentication_timeout_mins": 30,
+      "policies": {
+        "DATA_TYPE": "blackpearl_collection_policies#1.0.0"
+      },
+      "DATA_TYPE": "collection#1.0.0",
+      "allow_guest_collections": true,
+      "sharing_restrict_paths": {
+        "DATA_TYPE": "path_restrictions#1.0.0",
+        "read": [
+          "/public"
+        ],
+        "read_write": [
+          "/home",
+          "/projects"
+        ],
+        "none": [
+          "/private"
+        ]
+      }
+    }
+  ],
+  "DATA_TYPE": "result#1.0.0",
+  "http_response_code": 200,
+  "detail": null,
+  "message": "Operation successful",
+  "has_next_page": false,
+  "marker": "string"
+}

--- a/tests/functional/gcs/fixture_data/update_collection.json
+++ b/tests/functional/gcs/fixture_data/update_collection.json
@@ -1,0 +1,47 @@
+{
+  "code": "success",
+  "data": [
+    {
+      "id": "18d367d5-45cf-4724-a53e-5a685e45c942",
+      "manager_url": "https://gcs.data.globus.org/",
+      "domain_name": "i-f3c83.123.globus.org",
+      "high_assurance": true,
+      "https_url": "https://i-f3c83.123.globus.org",
+      "tlsftp_url": "tlsftp://i-f3c83.123.globus.org",
+      "collection_type": "guest",
+      "display_name": "Project Foo Research Data",
+      "connector_id": "c8b7ab5c-595c-43c9-8e43-9e8a3debfe4c",
+      "identity_id": "c8b7ab5c-595c-43c9-8e43-9e8a3debfe4c",
+      "storage_gateway_id": "fc1f3ba0-1fa4-42b2-8bb3-53983774fa5f",
+      "root_path": "/",
+      "collection_base_path": "/",
+      "default_directory": "/projects",
+      "public": true,
+      "force_encryption": false,
+      "disable_verify": false,
+      "organization": "University of Example",
+      "department": "Data Science",
+      "keywords": [
+        "Project Foo",
+        "Data Intensive Science"
+      ],
+      "description": "Information related to the \"Foo\" project.",
+      "contact_email": "project-foo@example.edu",
+      "contact_info": "+1 (555) 555-1234",
+      "info_link": "https://project-foo.example.edu/info",
+      "authentication_timeout_mins": 30,
+      "policies": {
+        "DATA_TYPE": "blackpearl_collection_policies#1.0.0"
+      },
+      "DATA_TYPE": "collection#1.0.0",
+      "user_credential_id": "1ce95432-73c7-4060-8fb2-5d61d627f164",
+      "mapped_collection_id": "14326300-5a33-4387-9bb0-7f85c3dc3185"
+    }
+  ],
+  "DATA_TYPE": "result#1.0.0",
+  "http_response_code": 200,
+  "detail": null,
+  "message": "Operation successful",
+  "has_next_page": false,
+  "marker": "string"
+}

--- a/tests/functional/gcs/test_collections.py
+++ b/tests/functional/gcs/test_collections.py
@@ -1,6 +1,6 @@
 import pytest
 
-from globus_sdk import GCSAPIError
+from globus_sdk import GCSAPIError, GuestCollectionDocument, MappedCollectionDocument
 from tests.common import get_last_request, register_api_route_fixture_file
 
 
@@ -132,3 +132,48 @@ def test_delete_collection(client):
     assert res["DATA_TYPE"] == "result#1.0.0"
     assert "detail" in res.data
     assert res.data["detail"] == "success"
+
+
+def test_create_mapped_collection(client):
+    register_api_route_fixture_file(
+        "gcs", "/collections", "create_collection.json", method="POST"
+    )
+    collection = MappedCollectionDocument(
+        domain_name="i-f3c83.123.globus.org",
+        display_name="Project Foo Research Data",
+        identity_id="c8b7ab5c-595c-43c9-8e43-9e8a3debfe4c",
+        storage_gateway_id="fc1f3ba0-1fa4-42b2-8bb3-53983774fa5f",
+        collection_base_path="/",
+        default_directory="/projects",
+        public=True,
+        force_encryption=False,
+        disable_verify=False,
+        organization="University of Example",
+        department="Data Science",
+        keywords=["Project Foo", "Data Intensive Science"],
+        description='Information related to the "Foo" project.',
+        contact_email="project-foo@example.edu",
+        contact_info="+1 (555) 555-1234",
+        info_link="https://project-foo.example.edu/info",
+        policies={"DATA_TYPE": "blackpearl_collection_policies#1.0.0"},
+        allow_guest_collections=True,
+        sharing_restrict_paths={
+            "DATA_TYPE": "path_restrictions#1.0.0",
+            "read": ["/public"],
+            "read_write": ["/home", "/projects"],
+            "none": ["/private"],
+        },
+    )
+    res = client.create_collection(collection)
+    assert res["DATA_TYPE"] == "collection#1.0.0"
+    assert res["display_name"] == "Project Foo Research Data"
+
+
+def test_update_guest_collection(client):
+    register_api_route_fixture_file(
+        "gcs", "/collections/COLLECTION_ID", "update_collection.json", method="PATCH"
+    )
+    collection = GuestCollectionDocument(display_name="Project Foo Research Data")
+    res = client.update_collection("COLLECTION_ID", collection)
+    assert res["DATA_TYPE"] == "collection#1.0.0"
+    assert res["display_name"] == "Project Foo Research Data"

--- a/tests/unit/helpers/test_gcs.py
+++ b/tests/unit/helpers/test_gcs.py
@@ -1,0 +1,88 @@
+import uuid
+
+import pytest
+
+from globus_sdk import (
+    CollectionDocument,
+    GuestCollectionDocument,
+    MappedCollectionDocument,
+)
+
+STUB_SG_ID = uuid.uuid1()  # storage gateway
+STUB_MC_ID = uuid.uuid1()  # mapped collection
+STUB_UC_ID = uuid.uuid1()  # user credential
+
+
+def test_collection_base_abstract():
+    with pytest.raises(TypeError):
+        CollectionDocument()
+
+
+def test_collection_type_field():
+    m = MappedCollectionDocument(
+        storage_gateway_id=STUB_SG_ID, collection_base_path="/"
+    )
+    g = GuestCollectionDocument(
+        mapped_collection_id=STUB_MC_ID,
+        user_credential_id=STUB_UC_ID,
+        collection_base_path="/",
+    )
+    assert m["collection_type"] == "mapped"
+    assert g["collection_type"] == "guest"
+
+
+@pytest.mark.parametrize(
+    "use_kwargs,doc_version",
+    [
+        ({}, "1.0.0"),
+        ({"user_message_link": "https://example.net/"}, "1.1.0"),
+        ({"user_message": "kthxbye"}, "1.1.0"),
+        ({"user_message": ""}, "1.1.0"),
+        ({"enable_https": True}, "1.1.0"),
+        ({"enable_https": False}, "1.1.0"),
+    ],
+)
+def test_datatype_version_deduction(use_kwargs, doc_version):
+    m = MappedCollectionDocument(**use_kwargs)
+    assert m["DATA_TYPE"] == f"collection#{doc_version}"
+    g = GuestCollectionDocument(**use_kwargs)
+    assert g["DATA_TYPE"] == f"collection#{doc_version}"
+
+
+@pytest.mark.parametrize(
+    "use_kwargs,doc_version",
+    [
+        ({"sharing_users_allow": "sirosen"}, "1.2.0"),
+        ({"sharing_users_allow": ["sirosen", "aaschaer"]}, "1.2.0"),
+        ({"sharing_users_deny": "sirosen"}, "1.2.0"),
+        ({"sharing_users_deny": ["sirosen", "aaschaer"]}, "1.2.0"),
+        ({"force_verify": True}, "1.4.0"),
+        ({"force_verify": False}, "1.4.0"),
+        ({"disable_anonymous_writes": True}, "1.5.0"),
+        ({"disable_anonymous_writes": False}, "1.5.0"),
+    ],
+)
+def test_datatype_version_deduction_mapped_specific_fields(use_kwargs, doc_version):
+    d = MappedCollectionDocument(**use_kwargs)
+    assert d["DATA_TYPE"] == f"collection#{doc_version}"
+
+
+def test_datatype_version_deduction_add_custom(monkeypatch):
+    custom_field = "foo-made-up-field"
+    monkeypatch.setitem(
+        CollectionDocument.DATATYPE_VERSION_IMPLICATIONS, custom_field, (1, 20, 0)
+    )
+
+    m = MappedCollectionDocument(
+        storage_gateway_id=STUB_SG_ID,
+        collection_base_path="/",
+        additional_fields={custom_field: "foo"},
+    )
+    assert m["DATA_TYPE"] == "collection#1.20.0"
+    g = GuestCollectionDocument(
+        mapped_collection_id=STUB_MC_ID,
+        user_credential_id=STUB_UC_ID,
+        collection_base_path="/",
+        additional_fields={custom_field: "foo"},
+    )
+    assert g["DATA_TYPE"] == "collection#1.20.0"


### PR DESCRIPTION
This may look rather big, as it adds ~500 physical lines to the `src/` tree, but a *lot* of that is either documentation or mindlessly repetitive lists of options. In terms of logical lines, I think there's less than 50 new lines added.

This adds
- `GCSClient.create_collection`
- `GCSClient.update_collection`
- `MappedCollectionDocument`
- `GuestCollectionDocument`

Importantly, the collection document helpers automatically deduce `DATA_TYPE` (more on this below) based on the fields which are present. This makes it ~trivial~ ~easy~ straightforward to write code which is compatible with a broad range of GCS API versions for these operations, even if (in the future) new document versions are added. In particular, I wanted to make sure we're well prepared if we need to do a CLI update in a hurry, without doing a corresponding SDK release.

On that note... these changes are needed for collection create and update operations in the CLI. Without the `DATA_TYPE` deduction work here, the CLI would need a repeat of these same efforts, which is obviously undesirable. I think we should get this in and cut another beta so that we can use this in the CLI `main` right away.

---

These are the create and update operations for GCS Collections.
There is also API support for PUT, but as it is harder to use correctly than PATCH, and does not support operations which cannot be accomplished via the PATCH endpoint, no SDK method is added for it here. One can easily be added later if necessary.

With respect to the payload helpers, this introduces three new classes: a base class, and a class for each of Mapped and Guest collection types.

Because the same payload helpers will be used for POST and PATCH behaviors, none of the arguments are required. Documentation covers the fact that some arguments are needed during creation.

Many arguments are repeated verbatim between the mapped and guest collection types and their base class. For this reason, the `dead` code analyzer is particularly helpful. Unlike code coverage analysis, or `pycqa`'s unused variable checks, `dead` will insist that each variable in a function definition is used. However, `dead` is easily misled, e.g. by signature lines which are needed to match some external specification. For this reason, `dead` is being enabled as a
selective linting step, only against the GCS helper module for now.

Some unusual conventions around commenting on options and specifying an ordering are used to ensure that the module is internally consistent, and they are documented in a block comment in that module.

GCS API requires that the `DATA_TYPE` field be set based on the newest field used in a payload. That is, if `foo` was added in v1.5.0, then the `DATA_TYPE` field must be v1.5.0 or higher. However, SDK users and clients (e.g. globus-cli) will want to maintain compatibility with as many GCS servers as is possible at any given time. For this reason, `DATA_TYPE` should not be aggressively set to the highest known version. In support of these requirements, `CollectionDocument` will inspect the fields which are present and set `DATA_TYPE` to the lowest possible version number. In support of new fields which require higher version numbers, this is exposed as a modifiable mapping on the CollectionDocument, `DATATYPE_VERSION_IMPLICATIONS`. Additionally, `DATA_TYPE` can be passed explicitly to set a known value. This usage is to be considered secondary to use of `DATATYPE_VERSION_IMPLICATIONS`, which is the preferred way to set `DATA_TYPE`.
See `test_datatype_version_deduction` and related tests for a demonstration of this behavior.