### PR TITLE
Remove 'safe_stringify'; remove support for bytes

### DIFF
--- a/src/globus_sdk/services/auth/client/base.py
+++ b/src/globus_sdk/services/auth/client/base.py
@@ -5,7 +5,6 @@ import sys
 from typing import (
     TYPE_CHECKING,
     Any,
-    AnyStr,
     Dict,
     Iterable,
     Optional,
@@ -91,7 +90,7 @@ class AuthClient(client.BaseClient):
     def get_identities(
         self,
         *,
-        usernames: Union[Iterable[AnyStr], AnyStr, None] = None,
+        usernames: Union[Iterable[str], str, None] = None,
         ids: Union[Iterable[UUIDLike], UUIDLike, None] = None,
         provision: bool = False,
         query_params: Optional[Dict[str, Any]] = None,
@@ -150,12 +149,9 @@ class AuthClient(client.BaseClient):
         def _convert_listarg(
             val: Union[Iterable[Union[IntLike, UUIDLike]], Union[IntLike, UUIDLike]]
         ) -> str:
-            if isinstance(val, collections.abc.Iterable) and not isinstance(
-                val, (bytes, str)
-            ):
-                return ",".join(utils.safe_stringify(x) for x in val)
-            else:
-                return utils.safe_stringify(val)
+            if isinstance(val, collections.abc.Iterable):
+                return ",".join(utils.safe_strseq_iter(val))
+            return str(val)
 
         log.info("Looking up Globus Auth Identities")
 

--- a/src/globus_sdk/services/gcs/client.py
+++ b/src/globus_sdk/services/gcs/client.py
@@ -141,7 +141,6 @@ class GCSClient(client.BaseClient):
 
         Lookup a Collection on an Endpoint
         """
-        collection_id = utils.safe_stringify(collection_id)
         return UnpackingGCSResponse(
             self.get(f"/collections/{collection_id}", query_params=query_params),
             r"collection#1\.\d+\.\d+",
@@ -190,7 +189,6 @@ class GCSClient(client.BaseClient):
         :param query_params: Additional passthrough query parameters
         :type query_params: dict, optional
         """
-        collection_id = utils.safe_stringify(collection_id)
         return UnpackingGCSResponse(
             self.patch(
                 f"/collections/{collection_id}",
@@ -215,5 +213,4 @@ class GCSClient(client.BaseClient):
         :param query_params: Additional passthrough query parameters
         :type query_params: dict, optional
         """
-        collection_id = utils.safe_stringify(collection_id)
         return self.delete(f"/collections/{collection_id}", query_params=query_params)

--- a/src/globus_sdk/services/gcs/data.py
+++ b/src/globus_sdk/services/gcs/data.py
@@ -198,7 +198,7 @@ class CollectionDocument(utils.PayloadWrapper, abc.ABC):
 
     def _set_optstrs(self, **kwargs: Any) -> None:
         for k, v in kwargs.items():
-            self._set_value(k, v, callback=utils.safe_stringify)
+            self._set_value(k, v, callback=str)
 
     def _set_optstrlists(self, **kwargs: Optional[Iterable]) -> None:
         for k, v in kwargs.items():

--- a/src/globus_sdk/services/groups/client.py
+++ b/src/globus_sdk/services/groups/client.py
@@ -61,7 +61,6 @@ class GroupsClient(client.BaseClient):
         """
         Get details about a specific group
         """
-        group_id = utils.safe_stringify(group_id)
         return self.get(f"/groups/{group_id}", query_params=query_params)
 
     @_groupdoc("Delete a group", "delete_group_v2_groups__group_id__delete")
@@ -71,7 +70,6 @@ class GroupsClient(client.BaseClient):
         """
         Delete a group.
         """
-        group_id = utils.safe_stringify(group_id)
         return self.delete(f"/groups/{group_id}", query_params=query_params)
 
     @_groupdoc("Create a group", "create_group_v2_groups_post")
@@ -93,7 +91,6 @@ class GroupsClient(client.BaseClient):
         """
         Get policies for the given group
         """
-        group_id = utils.safe_stringify(group_id)
         return self.get(f"/groups/{group_id}/policies", query_params=query_params)
 
     @_groupdoc(
@@ -110,7 +107,6 @@ class GroupsClient(client.BaseClient):
         """
         Set policies for the group.
         """
-        group_id = utils.safe_stringify(group_id)
         return self.put(
             f"/groups/{group_id}/policies", data=data, query_params=query_params
         )
@@ -157,7 +153,6 @@ class GroupsClient(client.BaseClient):
         """
         Get membership fields for your identities.
         """
-        group_id = utils.safe_stringify(group_id)
         return self.get(
             f"/groups/{group_id}/membership_fields", query_params=query_params
         )
@@ -176,7 +171,6 @@ class GroupsClient(client.BaseClient):
         """
         Get membership fields for your identities.
         """
-        group_id = utils.safe_stringify(group_id)
         return self.put(
             f"/groups/{group_id}/membership_fields",
             data=data,
@@ -197,5 +191,4 @@ class GroupsClient(client.BaseClient):
         """
         Execute a batch of actions against several group memberships.
         """
-        group_id = utils.safe_stringify(group_id)
         return self.post(f"/groups/{group_id}", data=actions, query_params=query_params)

--- a/src/globus_sdk/services/groups/manager.py
+++ b/src/globus_sdk/services/groups/manager.py
@@ -1,6 +1,6 @@
 from typing import Iterable, Optional
 
-from globus_sdk import response, utils
+from globus_sdk import response
 from globus_sdk.types import UUIDLike
 
 from .client import GroupsClient
@@ -35,9 +35,7 @@ class GroupsManager:
         data = {
             "name": name,
             "description": description,
-            "parent_id": utils.safe_stringify(parent_id)
-            if parent_id is not None
-            else None,
+            "parent_id": str(parent_id) if parent_id is not None else None,
         }
         return self.client.create_group(data=data)
 

--- a/src/globus_sdk/services/search/client.py
+++ b/src/globus_sdk/services/search/client.py
@@ -52,7 +52,6 @@ class SearchClient(client.BaseClient):
         >>>       "(" + index_id + "):",
         >>>       index["description"])
         """
-        index_id = utils.safe_stringify(index_id)
         log.info(f"SearchClient.get_index({index_id})")
         return self.get(f"/v1/index/{index_id}", query_params=query_params)
 
@@ -88,7 +87,6 @@ class SearchClient(client.BaseClient):
         >>> advanced_result = sc.search(index_id, 'author: "Ada Lovelace"',
         >>>                             advanced=True)
         """
-        index_id = utils.safe_stringify(index_id)
         if query_params is None:
             query_params = {}
         query_params.update(
@@ -139,7 +137,6 @@ class SearchClient(client.BaseClient):
         >>> }
         >>> search_result = sc.post_search(index_id, query_data)
         """
-        index_id = utils.safe_stringify(index_id)
         log.info(f"SearchClient.post_search({index_id}, ...)")
         return self.post(f"v1/index/{index_id}/search", data=data)
 
@@ -196,7 +193,6 @@ class SearchClient(client.BaseClient):
         >>> }
         >>> sc.ingest(index_id, ingest_data)
         """
-        index_id = utils.safe_stringify(index_id)
         log.info(f"SearchClient.ingest({index_id}, ...)")
         return self.post(f"/v1/index/{index_id}/ingest", data=data)
 
@@ -229,7 +225,6 @@ class SearchClient(client.BaseClient):
         >>> }
         >>> sc.delete_by_query(index_id, query_data)
         """
-        index_id = utils.safe_stringify(index_id)
         log.info(f"SearchClient.delete_by_query({index_id}, ...)")
         return self.post(f"/v1/index/{index_id}/delete_by_query", data=data)
 
@@ -256,7 +251,6 @@ class SearchClient(client.BaseClient):
         >>> sc = globus_sdk.SearchClient(...)
         >>> subject_data = sc.get_subject(index_id, 'http://example.com/abc')
         """
-        index_id = utils.safe_stringify(index_id)
         if query_params is None:
             query_params = {}
         query_params["subject"] = subject
@@ -282,7 +276,6 @@ class SearchClient(client.BaseClient):
         >>> sc = globus_sdk.SearchClient(...)
         >>> subject_data = sc.get_subject(index_id, 'http://example.com/abc')
         """
-        index_id = utils.safe_stringify(index_id)
         if query_params is None:
             query_params = {}
         query_params["subject"] = subject
@@ -321,7 +314,6 @@ class SearchClient(client.BaseClient):
         >>> entry_data = sc.get_entry(index_id, 'http://example.com/foo/bar',
         >>>                           entry_id='foo/bar')
         """
-        index_id = utils.safe_stringify(index_id)
         if query_params is None:
             query_params = {}
         query_params["subject"] = subject
@@ -369,7 +361,6 @@ class SearchClient(client.BaseClient):
         >>>     }
         >>> })
         """
-        index_id = utils.safe_stringify(index_id)
         log.info(f"SearchClient.create_entry({index_id}, ...)")
         return self.post(f"/v1/index/{index_id}/entry", data=data)
 
@@ -394,7 +385,6 @@ class SearchClient(client.BaseClient):
         >>>     }
         >>> })
         """
-        index_id = utils.safe_stringify(index_id)
         log.info(f"SearchClient.update_entry({index_id}, ...)")
         return self.put(f"/v1/index/{index_id}/entry", data=data)
 
@@ -425,7 +415,6 @@ class SearchClient(client.BaseClient):
         >>> sc.delete_entry(index_id, "https://example.com/foo/bar",
         >>>                 entry_id="foo/bar")
         """
-        index_id = utils.safe_stringify(index_id)
         if query_params is None:
             query_params = {}
         query_params["subject"] = subject
@@ -456,7 +445,6 @@ class SearchClient(client.BaseClient):
         >>> assert task['index_id'] == known_index_id
         >>> print(task["task_id"] + " | " + task['state'])
         """
-        task_id = utils.safe_stringify(task_id)
         log.info(f"SearchClient.get_task({task_id})")
         return self.get(f"/v1/task/{task_id}", query_params=query_params)
 
@@ -474,6 +462,5 @@ class SearchClient(client.BaseClient):
         >>> for task in task_list['tasks']:
         >>>     print(task["task_id"] + " | " + task['state'])
         """
-        index_id = utils.safe_stringify(index_id)
         log.info(f"SearchClient.get_task_list({index_id})")
         return self.get(f"/v1/task_list/{index_id}", query_params=query_params)

--- a/src/globus_sdk/services/transfer/client.py
+++ b/src/globus_sdk/services/transfer/client.py
@@ -94,7 +94,6 @@ class TransferClient(client.BaseClient):
         >>> print("Endpoint name:",
         >>>       endpoint["display_name"] or endpoint["canonical_name"])
         """
-        endpoint_id = utils.safe_stringify(endpoint_id)
         log.info(f"TransferClient.get_endpoint({endpoint_id})")
         return self.get(f"endpoint/{endpoint_id}", query_params=query_params)
 
@@ -138,7 +137,6 @@ class TransferClient(client.BaseClient):
         elif data.get("oauth_server"):
             data["myproxy_server"] = None
 
-        endpoint_id = utils.safe_stringify(endpoint_id)
         log.info(f"TransferClient.update_endpoint({endpoint_id}, ...)")
         return self.put(f"endpoint/{endpoint_id}", data=data, query_params=query_params)
 
@@ -191,7 +189,6 @@ class TransferClient(client.BaseClient):
         >>> tc = globus_sdk.TransferClient(...)
         >>> delete_result = tc.delete_endpoint(endpoint_id)
         """
-        endpoint_id = utils.safe_stringify(endpoint_id)
         log.info(f"TransferClient.delete_endpoint({endpoint_id})")
         return self.delete(f"endpoint/{endpoint_id}")
 
@@ -274,9 +271,7 @@ class TransferClient(client.BaseClient):
         if filter_owner_id is not None:
             query_params["filter_owner_id"] = filter_owner_id
         if filter_host_endpoint is not None:  # convert to str (may be UUID)
-            query_params["filter_host_endpoint"] = utils.safe_stringify(
-                filter_host_endpoint
-            )
+            query_params["filter_host_endpoint"] = str(filter_host_endpoint)
         if filter_non_functional is not None:  # convert to int (expect bool input)
             query_params["filter_non_functional"] = 1 if filter_non_functional else 0
         if limit is not None:
@@ -357,7 +352,6 @@ class TransferClient(client.BaseClient):
         >>>     print('Endpoint({}) already active until at least {}'
         >>>           .format(ep_id, 3600))
         """
-        endpoint_id = utils.safe_stringify(endpoint_id)
         if query_params is None:
             query_params = {}
         if if_expires_in is not None:
@@ -382,7 +376,6 @@ class TransferClient(client.BaseClient):
             as query params.
         :type query_params: dict, optional
         """
-        endpoint_id = utils.safe_stringify(endpoint_id)
         log.info(f"TransferClient.endpoint_deactivate({endpoint_id})")
         return self.post(
             f"endpoint/{endpoint_id}/deactivate", query_params=query_params
@@ -414,7 +407,6 @@ class TransferClient(client.BaseClient):
         Consider using autoactivate and web activation instead, described
         in the example for :meth:`~endpoint_autoactivate`.
         """
-        endpoint_id = utils.safe_stringify(endpoint_id)
         log.info(f"TransferClient.endpoint_activate({endpoint_id})")
         return self.post(
             f"endpoint/{endpoint_id}/activate",
@@ -439,7 +431,6 @@ class TransferClient(client.BaseClient):
             as query params.
         :type query_params: dict, optional
         """
-        endpoint_id = utils.safe_stringify(endpoint_id)
         return ActivationRequirementsResponse(
             self.get(
                 f"endpoint/{endpoint_id}/activation_requirements",
@@ -463,7 +454,6 @@ class TransferClient(client.BaseClient):
         :param query_params: Additional passthrough query parameters
         :type query_params: dict, optional
         """
-        endpoint_id = utils.safe_stringify(endpoint_id)
         log.info(f"TransferClient.my_effective_pause_rule_list({endpoint_id}, ...)")
         return IterableTransferResponse(
             self.get(
@@ -491,7 +481,6 @@ class TransferClient(client.BaseClient):
         Get a list of shared endpoints for which the user has ``administrator`` or
         ``access_manager`` on a given host endpoint.
         """
-        endpoint_id = utils.safe_stringify(endpoint_id)
         log.info(f"TransferClient.my_shared_endpoint_list({endpoint_id}, ...)")
         return IterableTransferResponse(
             self.get(
@@ -527,7 +516,6 @@ class TransferClient(client.BaseClient):
 
         Get a list of all shared endpoints on a given host endpoint.
         """
-        endpoint_id = utils.safe_stringify(endpoint_id)
         log.info(f"TransferClient.get_shared_endpoint_list({endpoint_id}, ...)")
         if query_params is None:
             query_params = {}
@@ -586,7 +574,6 @@ class TransferClient(client.BaseClient):
         :param endpoint_id: The endpoint whose servers are being listed
         :type endpoint_id: str or UUID
         """
-        endpoint_id = utils.safe_stringify(endpoint_id)
         log.info(f"TransferClient.endpoint_server_list({endpoint_id}, ...)")
         return IterableTransferResponse(
             self.get(f"endpoint/{endpoint_id}/server_list", query_params=query_params)
@@ -612,12 +599,11 @@ class TransferClient(client.BaseClient):
         :param query_params: Additional passthrough query parameters
         :type query_params: dict, optional
         """
-        endpoint_id = utils.safe_stringify(endpoint_id)
         log.info(
             "TransferClient.get_endpoint_server(%s, %s, ...)", endpoint_id, server_id
         )
         return self.get(
-            f"endpoint/{endpoint_id}/server/{str(server_id)}", query_params=query_params
+            f"endpoint/{endpoint_id}/server/{server_id}", query_params=query_params
         )
 
     @utils.doc_api_method(
@@ -634,7 +620,6 @@ class TransferClient(client.BaseClient):
         :param server_data: Fields for the new server, as a server document
         :type server_data: dict
         """
-        endpoint_id = utils.safe_stringify(endpoint_id)
         log.info(f"TransferClient.add_endpoint_server({endpoint_id}, ...)")
         return self.post(f"endpoint/{endpoint_id}/server", data=server_data)
 
@@ -655,15 +640,12 @@ class TransferClient(client.BaseClient):
         :param server_data: Fields on the server to update, as a partial server document
         :type server_data: dict
         """
-        endpoint_id = utils.safe_stringify(endpoint_id)
         log.info(
             "TransferClient.update_endpoint_server(%s, %s, ...)",
             endpoint_id,
             server_id,
         )
-        return self.put(
-            f"endpoint/{endpoint_id}/server/{str(server_id)}", data=server_data
-        )
+        return self.put(f"endpoint/{endpoint_id}/server/{server_id}", data=server_data)
 
     @utils.doc_api_method(
         "Delete endpoint server by ID",
@@ -680,11 +662,10 @@ class TransferClient(client.BaseClient):
         :param server_id: The ID of the server to delete
         :type server_id: str or int
         """
-        endpoint_id = utils.safe_stringify(endpoint_id)
         log.info(
             "TransferClient.delete_endpoint_server(%s, %s)", endpoint_id, server_id
         )
-        return self.delete(f"endpoint/{endpoint_id}/server/{str(server_id)}")
+        return self.delete(f"endpoint/{endpoint_id}/server/{server_id}")
 
     #
     # Roles
@@ -702,7 +683,6 @@ class TransferClient(client.BaseClient):
         :param endpoint_id: The endpoint whose roles are being listed
         :type endpoint_id: str or UUID
         """
-        endpoint_id = utils.safe_stringify(endpoint_id)
         log.info(f"TransferClient.endpoint_role_list({endpoint_id}, ...)")
         return IterableTransferResponse(
             self.get(f"endpoint/{endpoint_id}/role_list", query_params=query_params)
@@ -722,7 +702,6 @@ class TransferClient(client.BaseClient):
         :param role_data: A role document for the new role
         :type role_data: dict
         """
-        endpoint_id = utils.safe_stringify(endpoint_id)
         log.info(f"TransferClient.add_endpoint_role({endpoint_id}, ...)")
         return self.post(f"endpoint/{endpoint_id}/role", data=role_data)
 
@@ -746,7 +725,6 @@ class TransferClient(client.BaseClient):
         :param query_params: Additional passthrough query parameters
         :type query_params: dict, optional
         """
-        endpoint_id = utils.safe_stringify(endpoint_id)
         log.info(f"TransferClient.get_endpoint_role({endpoint_id}, {role_id}, ...)")
         return self.get(
             f"endpoint/{endpoint_id}/role/{role_id}", query_params=query_params
@@ -767,7 +745,6 @@ class TransferClient(client.BaseClient):
         :param role_id: The ID of the role to delete
         :type role_id: str
         """
-        endpoint_id = utils.safe_stringify(endpoint_id)
         log.info(f"TransferClient.delete_endpoint_role({endpoint_id}, {role_id})")
         return self.delete(f"endpoint/{endpoint_id}/role/{role_id}")
 
@@ -789,7 +766,6 @@ class TransferClient(client.BaseClient):
         :param query_params: Additional passthrough query parameters
         :type query_params: dict, optional
         """
-        endpoint_id = utils.safe_stringify(endpoint_id)
         log.info(f"TransferClient.endpoint_acl_list({endpoint_id}, ...)")
         return IterableTransferResponse(
             self.get(f"endpoint/{endpoint_id}/access_list", query_params=query_params)
@@ -815,7 +791,6 @@ class TransferClient(client.BaseClient):
         :param query_params: Additional passthrough query parameters
         :type query_params: dict, optional
         """
-        endpoint_id = utils.safe_stringify(endpoint_id)
         log.info(
             "TransferClient.get_endpoint_acl_rule(%s, %s, ...)", endpoint_id, rule_id
         )
@@ -851,7 +826,6 @@ class TransferClient(client.BaseClient):
         Note that if this rule is being created on a shared endpoint
         the "path" field is relative to the "host_path" of the shared endpoint.
         """
-        endpoint_id = utils.safe_stringify(endpoint_id)
         log.info(f"TransferClient.add_endpoint_acl_rule({endpoint_id}, ...)")
         return self.post(f"endpoint/{endpoint_id}/access", data=rule_data)
 
@@ -869,7 +843,6 @@ class TransferClient(client.BaseClient):
         :param rule_data: A partial ``access`` document containing fields to update
         :type rule_data: dict
         """
-        endpoint_id = utils.safe_stringify(endpoint_id)
         log.info(
             "TransferClient.update_endpoint_acl_rule(%s, %s, ...)",
             endpoint_id,
@@ -889,7 +862,6 @@ class TransferClient(client.BaseClient):
         :param rule_id: The ID of the access rule to remove
         :type rule_id: str
         """
-        endpoint_id = utils.safe_stringify(endpoint_id)
         log.info(
             "TransferClient.delete_endpoint_acl_rule(%s, %s)", endpoint_id, rule_id
         )
@@ -945,7 +917,6 @@ class TransferClient(client.BaseClient):
         :param query_params: Additional passthrough query parameters
         :type query_params: dict, optional
         """
-        bookmark_id = utils.safe_stringify(bookmark_id)
         log.info(f"TransferClient.get_bookmark({bookmark_id})")
         return self.get(f"bookmark/{bookmark_id}", query_params=query_params)
 
@@ -963,7 +934,6 @@ class TransferClient(client.BaseClient):
         :param bookmark_data: A partial bookmark document with fields to update
         :type bookmark_data: dict
         """
-        bookmark_id = utils.safe_stringify(bookmark_id)
         log.info(f"TransferClient.update_bookmark({bookmark_id})")
         return self.put(f"bookmark/{bookmark_id}", data=bookmark_data)
 
@@ -977,7 +947,6 @@ class TransferClient(client.BaseClient):
         :param bookmark_id: The ID of the bookmark to delete
         :type bookmark_id: str or UUID
         """
-        bookmark_id = utils.safe_stringify(bookmark_id)
         log.info(f"TransferClient.delete_bookmark({bookmark_id})")
         return self.delete(f"bookmark/{bookmark_id}")
 
@@ -1037,8 +1006,6 @@ class TransferClient(client.BaseClient):
         >>> ):
         >>>     print(entry["name DESC"], entry["type"])
         """
-        endpoint_id = utils.safe_stringify(endpoint_id)
-
         if query_params is None:
             query_params = {}
         if path is not None:
@@ -1081,7 +1048,6 @@ class TransferClient(client.BaseClient):
         >>> tc = globus_sdk.TransferClient(...)
         >>> tc.operation_mkdir(ep_id, path="/~/newdir/")
         """
-        endpoint_id = utils.safe_stringify(endpoint_id)
         log.info(
             "TransferClient.operation_mkdir({}, {}, {})".format(
                 endpoint_id, path, query_params
@@ -1121,7 +1087,6 @@ class TransferClient(client.BaseClient):
         >>> tc.operation_rename(ep_id, oldpath="/~/file1.txt",
         >>>                     newpath="/~/project1data.txt")
         """
-        endpoint_id = utils.safe_stringify(endpoint_id)
         log.info(
             "TransferClient.operation_rename({}, {}, {}, {})".format(
                 endpoint_id, oldpath, newpath, query_params
@@ -1161,7 +1126,6 @@ class TransferClient(client.BaseClient):
         >>> tc.operation_symlink(ep_id, symlink_target="/~/file1.txt",
         >>>                      path="/~/link-to-file1.txt")
         """
-        endpoint_id = utils.safe_stringify(endpoint_id)
         log.info(
             "TransferClient.operation_symlink({}, {}, {}, {})".format(
                 endpoint_id, symlink_target, path, query_params
@@ -1361,7 +1325,6 @@ class TransferClient(client.BaseClient):
         >>>     print("Event on Task({}) at {}:\n{}".format(
         >>>         task_id, event["time"], event["description"])
         """
-        task_id = utils.safe_stringify(task_id)
         log.info(f"TransferClient.task_event_list({task_id}, ...)")
         if query_params is None:
             query_params = {}
@@ -1385,7 +1348,6 @@ class TransferClient(client.BaseClient):
         :param query_params: Additional passthrough query parameters
         :type query_params: dict, optional
         """
-        task_id = utils.safe_stringify(task_id)
         log.info(f"TransferClient.get_task({task_id}, ...)")
         return self.get(f"task/{task_id}", query_params=query_params)
 
@@ -1410,7 +1372,6 @@ class TransferClient(client.BaseClient):
         :param query_params: Additional passthrough query parameters
         :type query_params: dict, optional
         """
-        task_id = utils.safe_stringify(task_id)
         log.info(f"TransferClient.update_task({task_id}, ...)")
         return self.put(f"task/{task_id}", data=data, query_params=query_params)
 
@@ -1424,7 +1385,6 @@ class TransferClient(client.BaseClient):
         :param task_id: The ID of the task to cancel
         :type task_id: str or UUID
         """
-        task_id = utils.safe_stringify(task_id)
         log.info(f"TransferClient.cancel_task({task_id})")
         return self.post(f"task/{task_id}/cancel")
 
@@ -1473,11 +1433,8 @@ class TransferClient(client.BaseClient):
         >>>     print(".", end="")
         >>> print("\n{0} completed!".format(task_id))
         """
-        task_id = utils.safe_stringify(task_id)
         log.info(
-            "TransferClient.task_wait({}, {}, {})".format(
-                task_id, timeout, polling_interval
-            )
+            "TransferClient.task_wait(%s, %s, %s)", task_id, timeout, polling_interval
         )
 
         # check valid args
@@ -1545,7 +1502,6 @@ class TransferClient(client.BaseClient):
         :param query_params: Additional passthrough query parameters
         :type query_params: dict, optional
         """
-        task_id = utils.safe_stringify(task_id)
         log.info(f"TransferClient.task_pause_info({task_id}, ...)")
         return self.get(f"task/{task_id}/pause_info", query_params=query_params)
 
@@ -1583,7 +1539,6 @@ class TransferClient(client.BaseClient):
         >>>     print("{} -> {}".format(
         >>>         info["source_path"], info["destination_path"]))
         """
-        task_id = utils.safe_stringify(task_id)
         log.info(f"TransferClient.task_successful_transfers({task_id}, ...)")
         return IterableTransferResponse(
             self.get(f"task/{task_id}/successful_transfers", query_params=query_params)
@@ -1617,7 +1572,6 @@ class TransferClient(client.BaseClient):
         >>>     print("{} -> {}".format(
         >>>         info["error_code"], info["source_path"]))
         """
-        task_id = utils.safe_stringify(task_id)
         log.info("TransferClient.task_skipped_errors(%s, ...)", task_id)
         return IterableTransferResponse(
             self.get(f"task/{task_id}/skipped_errors", query_params=query_params)
@@ -1664,7 +1618,6 @@ class TransferClient(client.BaseClient):
         :param query_params: Additional passthrough query parameters
         :type query_params: dict, optional
         """
-        endpoint_id = utils.safe_stringify(endpoint_id)
         log.info(f"TransferClient.endpoint_manager_hosted_endpoint_list({endpoint_id})")
         return IterableTransferResponse(
             self.get(
@@ -1690,7 +1643,6 @@ class TransferClient(client.BaseClient):
         :param query_params: Additional passthrough query parameters
         :type query_params: dict, optional
         """
-        endpoint_id = utils.safe_stringify(endpoint_id)
         log.info(f"TransferClient.endpoint_manager_get_endpoint({endpoint_id})")
         return self.get(
             f"endpoint_manager/endpoint/{endpoint_id}", query_params=query_params
@@ -1713,7 +1665,6 @@ class TransferClient(client.BaseClient):
         :param query_params: Additional passthrough query parameters
         :type query_params: dict, optional
         """
-        endpoint_id = utils.safe_stringify(endpoint_id)
         log.info(
             f"TransferClient.endpoint_manager_endpoint_acl_list({endpoint_id}, ...)"
         )
@@ -1845,16 +1796,16 @@ class TransferClient(client.BaseClient):
             else:
                 query_params["filter_status"] = ",".join(filter_status)
         if filter_task_id is not None:
-            if isinstance(filter_task_id, (uuid.UUID, str, bytes)):
-                query_params["filter_task_id"] = utils.safe_stringify(filter_task_id)
+            if isinstance(filter_task_id, (uuid.UUID, str)):
+                query_params["filter_task_id"] = str(filter_task_id)
             else:
                 query_params["filter_task_id"] = ",".join(
-                    [utils.safe_stringify(tid) for tid in filter_task_id]
+                    [str(tid) for tid in filter_task_id]
                 )
         if filter_owner_id is not None:
-            query_params["filter_owner_id"] = utils.safe_stringify(filter_owner_id)
+            query_params["filter_owner_id"] = str(filter_owner_id)
         if filter_endpoint is not None:
-            query_params["filter_endpoint"] = utils.safe_stringify(filter_endpoint)
+            query_params["filter_endpoint"] = str(filter_endpoint)
         if filter_is_paused is not None:
             query_params["filter_is_paused"] = filter_is_paused
         if filter_completion_time is not None:
@@ -1889,7 +1840,6 @@ class TransferClient(client.BaseClient):
         :param query_params: Additional passthrough query parameters
         :type query_params: dict, optional
         """
-        task_id = utils.safe_stringify(task_id)
         log.info(f"TransferClient.endpoint_manager_get_task({task_id}, ...)")
         return self.get(f"endpoint_manager/task/{task_id}", query_params=query_params)
 
@@ -1932,7 +1882,6 @@ class TransferClient(client.BaseClient):
         :param query_params: Additional passthrough query parameters
         :type query_params: dict, optional
         """
-        task_id = utils.safe_stringify(task_id)
         log.info(f"TransferClient.endpoint_manager_task_event_list({task_id}, ...)")
         if query_params is None:
             query_params = {}
@@ -1966,7 +1915,6 @@ class TransferClient(client.BaseClient):
         :param query_params: Additional passthrough query parameters
         :type query_params: dict, optional
         """
-        task_id = utils.safe_stringify(task_id)
         log.info(f"TransferClient.endpoint_manager_task_pause_info({task_id}, ...)")
         return self.get(
             f"endpoint_manager/task/{task_id}/pause_info", query_params=query_params
@@ -1990,7 +1938,6 @@ class TransferClient(client.BaseClient):
         :param query_params: Additional passthrough query parameters
         :type query_params: dict, optional
         """
-        task_id = utils.safe_stringify(task_id)
         log.info(
             "TransferClient.endpoint_manager_task_successful_transfers(%s, ...)",
             task_id,
@@ -2019,7 +1966,6 @@ class TransferClient(client.BaseClient):
         :param query_params: Additional passthrough query parameters
         :type query_params: dict, optional
         """
-        task_id = utils.safe_stringify(task_id)
         log.info(f"TransferClient.endpoint_manager_task_skipped_errors({task_id}, ...)")
         return IterableTransferResponse(
             self.get(
@@ -2051,7 +1997,7 @@ class TransferClient(client.BaseClient):
         :param query_params: Additional passthrough query parameters
         :type query_params: dict, optional
         """
-        str_task_ids = [utils.safe_stringify(i) for i in task_ids]
+        str_task_ids = [str(i) for i in task_ids]
         log.info(
             f"TransferClient.endpoint_manager_cancel_tasks({str_task_ids}, {message})"
         )
@@ -2081,7 +2027,6 @@ class TransferClient(client.BaseClient):
         :param query_params: Additional passthrough query parameters
         :type query_params: dict, optional
         """
-        admin_cancel_id = utils.safe_stringify(admin_cancel_id)
         log.info(f"TransferClient.endpoint_manager_cancel_status({admin_cancel_id})")
         return self.get(
             f"endpoint_manager/admin_cancel/{admin_cancel_id}",
@@ -2112,7 +2057,7 @@ class TransferClient(client.BaseClient):
         :param query_params: Additional passthrough query parameters
         :type query_params: dict, optional
         """
-        str_task_ids = [utils.safe_stringify(i) for i in task_ids]
+        str_task_ids = [str(i) for i in task_ids]
         log.info(
             f"TransferClient.endpoint_manager_pause_tasks({str_task_ids}, {message})"
         )
@@ -2142,7 +2087,7 @@ class TransferClient(client.BaseClient):
         :param query_params: Additional passthrough query parameters
         :type query_params: dict, optional
         """
-        str_task_ids = [utils.safe_stringify(i) for i in task_ids]
+        str_task_ids = [str(i) for i in task_ids]
         log.info(f"TransferClient.endpoint_manager_resume_tasks({str_task_ids})")
         data = {"task_id_list": str_task_ids}
         return self.post(
@@ -2179,7 +2124,7 @@ class TransferClient(client.BaseClient):
         if query_params is None:
             query_params = {}
         if filter_endpoint is not None:
-            query_params["filter_endpoint"] = utils.safe_stringify(filter_endpoint)
+            query_params["filter_endpoint"] = str(filter_endpoint)
         return IterableTransferResponse(
             self.get("endpoint_manager/pause_rule_list", query_params=query_params)
         )
@@ -2232,7 +2177,6 @@ class TransferClient(client.BaseClient):
         :param query_params: Additional passthrough query parameters
         :type query_params: dict, optional
         """
-        pause_rule_id = utils.safe_stringify(pause_rule_id)
         log.info(f"TransferClient.endpoint_manager_get_pause_rule({pause_rule_id})")
         return self.get(
             f"endpoint_manager/pause_rule/{pause_rule_id}", query_params=query_params
@@ -2266,7 +2210,6 @@ class TransferClient(client.BaseClient):
         >>> }
         >>> update_result = tc.endpoint_manager_update_pause_rule(ep_data)
         """
-        pause_rule_id = utils.safe_stringify(pause_rule_id)
         log.info(f"TransferClient.endpoint_manager_update_pause_rule({pause_rule_id})")
         return self.put(f"endpoint_manager/pause_rule/{pause_rule_id}", data=data)
 
@@ -2288,7 +2231,6 @@ class TransferClient(client.BaseClient):
         :param query_params: Additional passthrough query parameters
         :type query_params: dict, optional
         """
-        pause_rule_id = utils.safe_stringify(pause_rule_id)
         log.info(f"TransferClient.endpoint_manager_delete_pause_rule({pause_rule_id})")
         return self.delete(
             f"endpoint_manager/pause_rule/{pause_rule_id}", query_params=query_params

--- a/src/globus_sdk/services/transfer/data/transfer_data.py
+++ b/src/globus_sdk/services/transfer/data/transfer_data.py
@@ -3,6 +3,7 @@ import logging
 from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 from globus_sdk import utils
+from globus_sdk.types import UUIDLike
 
 if TYPE_CHECKING:
     import globus_sdk
@@ -29,15 +30,15 @@ class TransferData(utils.PayloadWrapper):
         to submit the transfer.
     :type transfer_client: :class:`TransferClient <globus_sdk.TransferClient>`
     :param source_endpoint: The endpoint ID of the source endpoint
-    :type source_endpoint: str
+    :type source_endpoint: str or UUID
     :param destination_endpoint: The endpoint ID of the destination endpoint
-    :type destination_endpoint: str
+    :type destination_endpoint: str or UUID
     :param label: A string label for the Task
     :type label: str, optional
     :param submission_id: A submission ID value fetched via :meth:`get_submission_id \
         <globus_sdk.TransferClient.get_submission_id>`. Defaults to using
         ``transfer_client.get_submission_id``
-    :type submission_id: str, optional
+    :type submission_id: str or UUID, optional
     :param sync_level: The method used to compare items between the source and
         destination. One of  ``"exists"``, ``"size"``, ``"mtime"``, or ``"checksum"``
         See the section below on sync-level for an explanation of values.
@@ -137,11 +138,11 @@ class TransferData(utils.PayloadWrapper):
     def __init__(
         self,
         transfer_client: "globus_sdk.TransferClient",
-        source_endpoint: str,
-        destination_endpoint: str,
+        source_endpoint: UUIDLike,
+        destination_endpoint: UUIDLike,
         *,
         label: Optional[str] = None,
-        submission_id: Optional[str] = None,
+        submission_id: Optional[UUIDLike] = None,
         sync_level: Optional[str] = None,
         verify_checksum: bool = False,
         preserve_timestamp: bool = False,
@@ -154,15 +155,13 @@ class TransferData(utils.PayloadWrapper):
         additional_fields: Optional[Dict[str, Any]] = None,
     ) -> None:
         super().__init__()
-        source_endpoint = utils.safe_stringify(source_endpoint)
-        destination_endpoint = utils.safe_stringify(destination_endpoint)
         log.info("Creating a new TransferData object")
         self["DATA_TYPE"] = "transfer"
         self["submission_id"] = (
             submission_id or transfer_client.get_submission_id()["value"]
         )
-        self["source_endpoint"] = source_endpoint
-        self["destination_endpoint"] = destination_endpoint
+        self["source_endpoint"] = str(source_endpoint)
+        self["destination_endpoint"] = str(destination_endpoint)
         self["verify_checksum"] = verify_checksum
         self["preserve_timestamp"] = preserve_timestamp
         self["encrypt_data"] = encrypt_data
@@ -242,8 +241,6 @@ class TransferData(utils.PayloadWrapper):
             external_checksum is given.
         :type checksum_algorithm: str, optional
         """
-        source_path = utils.safe_stringify(source_path)
-        destination_path = utils.safe_stringify(destination_path)
         item_data = {
             "DATA_TYPE": "transfer_item",
             "source_path": source_path,
@@ -278,8 +275,6 @@ class TransferData(utils.PayloadWrapper):
         :param destination_path: Path to which the source symlink will be transferred
         :type destination_path: str
         """
-        source_path = utils.safe_stringify(source_path)
-        destination_path = utils.safe_stringify(destination_path)
         item_data = {
             "DATA_TYPE": "transfer_symlink_item",
             "source_path": source_path,

--- a/src/globus_sdk/types.py
+++ b/src/globus_sdk/types.py
@@ -3,5 +3,5 @@ import uuid
 from typing import Union
 
 IntLike = Union[int, str]
-UUIDLike = Union[uuid.UUID, str, bytes]
+UUIDLike = Union[uuid.UUID, str]
 DateLike = Union[str, datetime.datetime]

--- a/src/globus_sdk/utils.py
+++ b/src/globus_sdk/utils.py
@@ -5,8 +5,6 @@ from base64 import b64encode
 from enum import Enum
 from typing import Any, Callable, Generator, Iterable, Optional, TypeVar, Union
 
-from .types import IntLike, UUIDLike
-
 T = TypeVar("T")
 
 
@@ -61,36 +59,22 @@ def doc_api_method(
     return decorate
 
 
-def safe_stringify(value: Union[IntLike, UUIDLike]) -> str:
-    """
-    Converts incoming value to a unicode string. Convert bytes by decoding,
-    anything else has __str__ called.
-    Strings are checked to avoid duplications
-    """
-    if isinstance(value, str):
-        return value
-    if isinstance(value, bytes):
-        return value.decode("utf-8")
-    return str(value)
-
-
 def safe_strseq_iter(value: Iterable) -> Generator[str, None, None]:
     """
     Given an Iterable (typically of strings), produce an iterator over it of strings.
     This is a passthrough with two caveats:
     - if the value is a solitary string, yield only that value
-    - any value in the iterable which is not a string will be passed through
-      safe_stringify
+    - str value in the iterable which is not a string
 
     This helps handle cases where a string is passed to a function expecting an iterable
     of strings, as well as cases where an iterable of UUID objects is accepted for a
     list of IDs, or something similar.
     """
-    if isinstance(value, (str, bytes)):
-        yield safe_stringify(value)
+    if isinstance(value, str):
+        yield value
     else:
         for x in value:
-            yield safe_stringify(x)
+            yield str(x)
 
 
 def render_enums_for_api(value: Any) -> Any:

--- a/tests/functional/transfer/test_task_submit.py
+++ b/tests/functional/transfer/test_task_submit.py
@@ -101,7 +101,7 @@ def test_transfer_submit_success(client, transfer_data):
     assert tdata["custom_param"] == "foo"
     assert tdata["sync_level"] == 0
 
-    tdata.add_item(b"/path/to/foo", "/path/to/bar")
+    tdata.add_item("/path/to/foo", "/path/to/bar")
     tdata.add_symlink_item("linkfoo", "linkbar")
 
     res = client.submit_transfer(tdata)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -38,24 +38,6 @@ def test_slash_join(a, b):
     assert utils.slash_join(a, b) == "a/b"
 
 
-class testObject:
-    """test obj for safe_stringify testing"""
-
-    def __str__(self):
-        return "1"
-
-
-@pytest.mark.parametrize("value", ["1", b"1", 1, testObject()])
-def test_safe_stringify(value):
-    """
-    safe_stringifies strings, bytes, an int, an object
-    and confirms safe_stringify returns unicode string for all inputs
-    """
-    safe_value = utils.safe_stringify(value)
-    assert safe_value == "1"
-    assert type(safe_value) == str
-
-
 def test_payload_wrapper_methods():
     # just make sure that PayloadWrapper acts like a dict...
     data = utils.PayloadWrapper()


### PR DESCRIPTION
This is basically our last chance to change this for 3.0 . I think dropping `bytes` support makes things a little bit simpler in a lot of places, and is therefore worth it.
`safe_stringify()` would just become `str()`, so it is completely removed by this change.

---

Removing support for `bytes` as part of a UUIDLike generally makes our internal code simpler. Because `UUID` and `str` can both be used if passed through `str()` and string formatting defaults to using `str()` on elements, in many contexts no conversion is needed now. (A UUID can be used in an f-string and gets formatted correctly.)

There's also some minor cleanup in DeleteData to be more like TransferData.