### PR TITLE
mypy bugfix: allow dynamic ScopeBuilder attrs

### DIFF
--- a/src/globus_sdk/scopes.py
+++ b/src/globus_sdk/scopes.py
@@ -29,8 +29,8 @@ class ScopeBuilder:
     #       from globus_sdk.scopes import TransferScopes
     #       x = TransferScopes.all
     #
-    # the assignment to `x` will fail type checking without this because `all` will be
-    # unknown to `mypy`
+    # without this method, the assignment to `x` would fail type checking
+    # because `all` is unknown to mypy
     #
     # note that the implementation just raises AttributeError; this is okay because
     # __getattr__ is only called as a last resort, when __getattribute__ has failed

--- a/src/globus_sdk/scopes.py
+++ b/src/globus_sdk/scopes.py
@@ -22,6 +22,22 @@ class ScopeBuilder:
             for scope_name in known_scopes:
                 setattr(self, scope_name, self.urn_scope_string(scope_name))
 
+    # custom __getattr__ instructs `mypy` that unknown attributes of a ScopeBuilder are
+    # of type `str`, allowing for dynamic attribute names
+    # to test, try creating a module with
+    #
+    #       from globus_sdk.scopes import TransferScopes
+    #       x = TransferScopes.all
+    #
+    # the assignment to `x` will fail type checking without this because `all` will be
+    # unknown to `mypy`
+    #
+    # note that the implementation just raises AttributeError; this is okay because
+    # __getattr__ is only called as a last resort, when __getattribute__ has failed
+    # normal attribute access will not be disrupted
+    def __getattr__(self, name: str) -> str:
+        raise AttributeError
+
     def urn_scope_string(self, scope_name: str) -> str:
         """
         Return a complete string representing the scope with a given name for this

--- a/src/globus_sdk/services/auth/oauth2_constants.py
+++ b/src/globus_sdk/services/auth/oauth2_constants.py
@@ -6,5 +6,5 @@ DEFAULT_REQUESTED_SCOPES = (
     AuthScopes.openid,
     AuthScopes.profile,
     AuthScopes.email,
-    TransferScopes.all,  # type: ignore[attr-defined]
+    TransferScopes.all,
 )


### PR DESCRIPTION
A custom `__getattr__` implementation tells `mypy` to expect `str` for unknown attributes of a ScopeBuilder object.

This is the approach documented in the mypy cheat sheet [1] as a way of telling mypy the type for "unknown attributes".

[1] https://mypy.readthedocs.io/en/latest/cheat_sheet_py3.html#when-you-re-puzzled-or-when-things-are-complicated

---

I ran `mypy` with this change before and after on the documented usage. Fails before; works after.