### PR TITLE
Fix remaining type ignore comments in src/ tree

### DIFF
--- a/src/globus_sdk/paging/table.py
+++ b/src/globus_sdk/paging/table.py
@@ -1,6 +1,14 @@
-from typing import Any, Callable, Dict, Optional, Type
+from typing import Any, Callable, Dict, Optional, Type, cast
 
 from .base import Paginator
+
+
+# stub for mypy
+class _PaginatedFunc:
+    _has_paginator: bool
+    _paginator_class: Type[Paginator]
+    _paginator_items_key: Optional[str]
+    _paginator_params: Dict[str, Any]
 
 
 def has_paginator(
@@ -24,10 +32,12 @@ def has_paginator(
     """
 
     def decorate(func: Callable) -> Callable:
-        func._has_paginator = True  # type: ignore
-        func._paginator_class = paginator_class  # type: ignore
-        func._paginator_items_key = items_key  # type: ignore
-        func._paginator_params = paginator_params  # type: ignore
+        as_paginated = cast(_PaginatedFunc, func)
+        as_paginated._has_paginator = True
+        as_paginated._paginator_class = paginator_class
+        as_paginated._paginator_items_key = items_key
+        as_paginated._paginator_params = paginator_params
+
         func.__doc__ = f"""{func.__doc__}
 
         **Paginated Usage**

--- a/src/globus_sdk/services/auth/client/base.py
+++ b/src/globus_sdk/services/auth/client/base.py
@@ -36,7 +36,7 @@ from ..response import OAuthTokenResponse
 
 log = logging.getLogger(__name__)
 
-T = TypeVar("T")
+RT = TypeVar("RT", bound=GlobusHTTPResponse)
 
 
 class AuthClient(client.BaseClient):
@@ -385,8 +385,8 @@ class AuthClient(client.BaseClient):
 
     @overload
     def oauth2_token(
-        self, form_data: Union[dict, utils.PayloadWrapper], *, response_class: Type[T]
-    ) -> T:
+        self, form_data: Union[dict, utils.PayloadWrapper], *, response_class: Type[RT]
+    ) -> RT:
         ...
 
     @overload
@@ -395,8 +395,8 @@ class AuthClient(client.BaseClient):
         form_data: Union[dict, utils.PayloadWrapper],
         *,
         body_params: Optional[Dict[str, Any]],
-        response_class: Type[T],
-    ) -> T:
+        response_class: Type[RT],
+    ) -> RT:
         ...
 
     def oauth2_token(
@@ -404,8 +404,8 @@ class AuthClient(client.BaseClient):
         form_data: Union[dict, utils.PayloadWrapper],
         *,
         body_params: Optional[Dict[str, Any]] = None,
-        response_class: Union[Type[OAuthTokenResponse], Type[T]] = OAuthTokenResponse,
-    ) -> Union[OAuthTokenResponse, T]:
+        response_class: Union[Type[OAuthTokenResponse], Type[RT]] = OAuthTokenResponse,
+    ) -> Union[OAuthTokenResponse, RT]:
         """
         This is the generic form of calling the OAuth2 Token endpoint.
         It takes ``form_data``, a dict which will be encoded in a form POST
@@ -435,7 +435,7 @@ class AuthClient(client.BaseClient):
                 data=data,
                 encoding="form",
             )
-        )  # type: ignore
+        )
 
     @utils.doc_api_method(
         "Userinfo", "auth/reference/#get_or_post_v2_oauth2_userinfo_resource"

--- a/src/globus_sdk/transport/retry.py
+++ b/src/globus_sdk/transport/retry.py
@@ -1,5 +1,5 @@
 import enum
-from typing import Callable, Dict, List, Optional
+from typing import Callable, Dict, List, Optional, cast
 
 import requests
 
@@ -63,6 +63,11 @@ class RetryCheckFlags(enum.Flag):
     RUN_ONCE = enum.auto()
 
 
+# stub for mypy
+class _RetryCheckFunc:
+    _retry_check_flags: RetryCheckFlags
+
+
 def set_retry_check_flags(flag: RetryCheckFlags) -> Callable[[Callable], Callable]:
     """
     A decorator for setting retry check flags on a retry check function.
@@ -73,7 +78,8 @@ def set_retry_check_flags(flag: RetryCheckFlags) -> Callable[[Callable], Callabl
     """
 
     def decorator(func: Callable) -> Callable:
-        func._retry_check_flags = flag  # type: ignore
+        as_check = cast(_RetryCheckFunc, func)
+        as_check._retry_check_flags = flag
         return func
 
     return decorator


### PR DESCRIPTION
Just to follow-up on #472, this "fixes" the remaining usages of `type: ignore` comments.

In the first commit, this is an actual fix: setting the bound on a type var correctly specifies the range of classes which can be passed in to `AuthClient.oauth2_token` as `response_class`. With the bound set, the ignore comment becomes unnecessary.

The other changes are less obviously an improvement. Decorated functions raise warnings about undefined attributes -- and rightly so -- when we decorate to add metadata to them. However, `mypy` is pacified if we first cast to a stub class which defines the desired attributes.
This has three benefits, though they are all marginal:
1. `git grep 'type: ignore' src/` will be empty
2. The assignment statements themselves don't need "annoying"/"ugly" ignore comments
3. We could, if we ever want, cast in other contexts once we test for the presence of these attributes, to have nicer type-checked code at usage sites

(Note: to fully follow through on that last one, we'd probably need to make the stubs callable.)