### PR TITLE
Bugfix: remove python_version bound for dev extra

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ MYPY_REQUIREMENTS = [
     "types-docutils",
     "types-jwt",
     "types-requests",
-    "typing-extensions; python_version<'3,8'",
+    "typing-extensions",
 ]
 LINT_REQUIREMENTS = [
     "flake8<4",
@@ -21,7 +21,6 @@ TEST_REQUIREMENTS = [
     "pytest-cov<3",
     "pytest-xdist<3",
     "responses==0.13.3",
-    "typing-extensions; python_version<'3,8'",
 ]
 DOC_REQUIREMENTS = [
     "sphinx<5",


### PR DESCRIPTION
When using `python_version` to bound where `typing-extensions` gets installed, the version string was malformed (comma vs dot). `pip` ignores this, but it's an error for some tools (notably, `poetry`).

Additionally, `mypy` depends on `typing-extensions`. There is therefore no purpose being served by our version dispatch and conditional requirement.

To fix the bug and simplify things, simply remove the `python_version` spec.

---

Note: after this is done, I want to add some kind of check for this if possible, but I'm not sure what tools are at our disposal. `twine check` does _not_ flag this issue. I'll be looking into this.