### PR TITLE
Add testing for package metadata

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,3 +39,9 @@ jobs:
         # docs are only ever built on a linux 3.9 box (readthedocs)
         if: ${{ matrix.python-version == '3.9' && matrix.os == 'ubuntu-latest' }}
         run: python -m tox -e docs
+      - name: Check package metadata
+        # only on linux py3.9 for faster runs
+        if: ${{ matrix.python-version == '3.9' && matrix.os == 'ubuntu-latest' }}
+        run: |
+          python -m tox -e twine-check
+          python -m tox -e poetry-check

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ no_implicit_optional = true
 
 
 [tool:pytest]
+norecursedirs = tests/non-pytest
 filterwarnings =
     # warnings are errors, like -Werror
     error

--- a/tests/non-pytest/poetry-lock-test/.gitignore
+++ b/tests/non-pytest/poetry-lock-test/.gitignore
@@ -1,0 +1,1 @@
+poetry.lock

--- a/tests/non-pytest/poetry-lock-test/README
+++ b/tests/non-pytest/poetry-lock-test/README
@@ -1,0 +1,9 @@
+Ensure that `poetry install` of the SDK works correctly.
+
+This means that `poetry` can parse the version specifiers for all dependencies,
+including dev extras, correctly.
+
+Inspired by #474
+( https://github.com/globus/globus-sdk-python/pull/474 )
+
+This can be run via the tox package checks. Try `tox -e poetry-check`

--- a/tests/non-pytest/poetry-lock-test/pyproject.toml
+++ b/tests/non-pytest/poetry-lock-test/pyproject.toml
@@ -1,0 +1,15 @@
+[tool.poetry]
+name = "poetry-install-test"
+version = "0.1.0"
+description = ""
+authors = ["Stephen Rosen <sirosen@globus.org>"]
+
+[tool.poetry.dependencies]
+python = "^3.8"
+globus-sdk = { path = "../../.." }
+
+[tool.poetry.dev-dependencies]
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/tox.ini
+++ b/tox.ini
@@ -37,6 +37,27 @@ changedir = docs/
 commands_pre = rm -rf _build/
 commands = sphinx-build -d _build/doctrees -b dirhtml -W . _build/dirhtml {posargs}
 
+[testenv:twine-check]
+skip_install = true
+deps = twine
+       wheel
+       poetry
+whitelist_externals = rm
+commands_pre = rm -rf dist/
+# check that twine validating package data works
+commands = python setup.py sdist bdist_wheel
+           twine check dist/*
+
+[testenv:poetry-check]
+skip_install = true
+deps = poetry
+# remove the dist dir because it can lead to (confusing) spurious failures
+whitelist_externals = rm
+commands_pre = rm -rf dist/
+# use `poetry lock` to ensure that poetry can parse our dependencies
+changedir = tests/non-pytest/poetry-lock-test
+commands = poetry lock
+
 [testenv:publish-release]
 skip_install = true
 deps = twine
@@ -44,6 +65,5 @@ deps = twine
 # clean the build dir before rebuilding
 whitelist_externals = rm
 commands_pre = rm -rf dist/
-commands =
-    python setup.py sdist bdist_wheel
-    twine upload dist/*
+commands = python setup.py sdist bdist_wheel
+           twine upload dist/*


### PR DESCRIPTION
1. Add a `twine-check` tox env
2. Add a `poetry-check` tox env
3. Run both of these under CI

twine-check runs the `twine check` command after a package build.
poetry-check requires that we define some non-pytest testing data, so an appropriate dir is setup with the test files inside of it. The `poetry-lock-test` contains a pyproject.toml where `poetry lock` should work and point at the current version of the SDK in-tree. If the package metadata is not correct (as it was in #474), the `poetry lock` command will fail.