### PR TITLE
Ensure test coverage of base64 usages

### DIFF
--- a/src/globus_sdk/authorizers/basic.py
+++ b/src/globus_sdk/authorizers/basic.py
@@ -1,6 +1,6 @@
 import logging
 
-from globus_sdk.utils import safe_b64encode
+from globus_sdk import utils
 
 from .base import StaticGlobusAuthorizer
 
@@ -29,4 +29,4 @@ class BasicAuthorizer(StaticGlobusAuthorizer):
         self.password = password
 
         to_b64 = f"{username}:{password}"
-        self.header_val = f"Basic {safe_b64encode(to_b64)}"
+        self.header_val = f"Basic {utils.b64str(to_b64)}"

--- a/src/globus_sdk/utils.py
+++ b/src/globus_sdk/utils.py
@@ -3,7 +3,7 @@ import collections.abc
 import hashlib
 from base64 import b64encode
 from enum import Enum
-from typing import Any, Callable, Generator, Iterable, Optional, TypeVar, Union
+from typing import Any, Callable, Generator, Iterable, Optional, TypeVar
 
 T = TypeVar("T")
 
@@ -12,12 +12,8 @@ def sha256_string(s: str) -> str:
     return hashlib.sha256(s.encode("utf-8")).hexdigest()
 
 
-def safe_b64encode(s: Union[bytes, str]) -> str:
-    if isinstance(s, str):
-        encoded = b64encode(s.encode("utf-8"))
-    else:
-        encoded = b64encode(s)
-    return encoded.decode("utf-8")
+def b64str(s: str) -> str:
+    return b64encode(s.encode("utf-8")).decode("utf-8")
 
 
 def slash_join(a: str, b: Optional[str]) -> str:

--- a/tests/unit/helpers/test_auth_flow_managers.py
+++ b/tests/unit/helpers/test_auth_flow_managers.py
@@ -1,0 +1,54 @@
+import base64
+import hashlib
+import os
+
+import pytest
+
+from globus_sdk import GlobusSDKUsageError
+from globus_sdk.services.auth.flow_managers.native_app import make_native_app_challenge
+
+
+@pytest.mark.parametrize(
+    "verifier",
+    [
+        "x" * 20,  # too short
+        "x" * 200,  # too long
+        ("x" * 40) + "/" + ("y" * 40),  # includes invalid characters
+    ],
+)
+def test_invalid_native_app_challenge(verifier):
+    with pytest.raises(GlobusSDKUsageError):
+        make_native_app_challenge(verifier)
+
+
+def test_simple_input_native_app_challenge():
+    verifier = "x" * 80
+    challenge = (
+        base64.urlsafe_b64encode(hashlib.sha256(verifier.encode("utf-8")).digest())
+        .rstrip(b"=")
+        .decode("utf-8")
+    )
+    res_verifier, res_challenge = make_native_app_challenge(verifier)
+    assert res_verifier == verifier
+    assert res_challenge == challenge
+
+
+def test_random_native_app_challenge(monkeypatch):
+    b64vals = []
+
+    def mock_urandom(n: int):
+        return b"xyz"
+
+    def mock_b64encode(b: bytes):
+        b64vals.append(b)
+        return b"abc123"
+
+    monkeypatch.setattr(os, "urandom", mock_urandom)
+    monkeypatch.setattr(base64, "urlsafe_b64encode", mock_b64encode)
+
+    verifier, challenge = make_native_app_challenge()
+    assert verifier == "abc123"
+    assert challenge == "abc123"
+
+    assert len(b64vals) == 2
+    assert b64vals == [b"xyz", hashlib.sha256(b"abc123").digest()]

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -3,18 +3,18 @@ import pytest
 from globus_sdk import utils
 
 
-def test_safe_b64encode_non_ascii():
+def test_b64str_non_ascii():
     test_string = "ⓤⓢⓔⓡⓝⓐⓜⓔ"
     expected_b64 = "4pOk4pOi4pOU4pOh4pOd4pOQ4pOc4pOU"
 
-    assert utils.safe_b64encode(test_string) == expected_b64
+    assert utils.b64str(test_string) == expected_b64
 
 
-def test_safe_b64encode_ascii():
+def test_b64str_ascii():
     test_string = "username"
     expected_b64 = "dXNlcm5hbWU="
 
-    assert utils.safe_b64encode(test_string) == expected_b64
+    assert utils.b64str(test_string) == expected_b64
 
 
 def test_sha256string():


### PR DESCRIPTION
`safe_b64encode` is only used on `str` inputs. Remove unused handling for `bytes`.

Add unit tests for code verifier handling in Native App flow manager, which relies on b64 encoding.

This improves test coverage with a couple of checks. The Native App verifier tests may seem a little silly since they're doing basically the same steps as the verifier code itself, but I can't think what other test we could write for this.