### PR TITLE
Omit sphinx extension from coverage reporting

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -15,3 +15,5 @@ exclude_lines =
     if TYPE_CHECKING:
     # skip overloads
     @overload
+
+omit = src/globus_sdk/_sphinxext.py


### PR DESCRIPTION
Counting the internal sphinx extension against our coverage stats for the testsuite is at least arguably inaccurate. Code coverage for the library we ship is a bit different from coverage of the doc tooling.