### PR TITLE
Update the minimum requests and crypto versions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,6 +35,10 @@ jobs:
         run: python -m tox -e lint
       - name: Run Tests
         run: python -m tox -e py -- --cov-report="term-missing:skip-covered"
+      - name: Mindeps Test
+        # mindeps runs on py36, as "the oldest everything"
+        if: ${{ matrix.python-version == '3.6' && matrix.os == 'ubuntu-latest' }}
+        run: python -m tox -e py-mindeps
       - name: Ensure docs build
         # docs are only ever built on a linux 3.9 box (readthedocs)
         if: ${{ matrix.python-version == '3.9' && matrix.os == 'ubuntu-latest' }}

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,13 @@ setup(
     package_dir={"": "src"},
     package_data={"globus_sdk": ["py.typed"]},
     python_requires=">=3.6",
-    install_requires=["requests>=2.9.2,<3.0.0", "pyjwt[crypto]>=2.0.0,<3.0.0"],
+    install_requires=[
+        "requests>=2.19.1,<3.0.0",
+        "pyjwt[crypto]>=2.0.0,<3.0.0",
+        # cryptography 3.4.0 is known-bugged, see:
+        #   https://github.com/pyca/cryptography/issues/5756
+        "cryptography>=2.0,<3.7,!=3.4.0",
+    ],
     extras_require={"dev": DEV_REQUIREMENTS},
     keywords=["globus"],
     classifiers=[

--- a/src/globus_sdk/services/auth/response.py
+++ b/src/globus_sdk/services/auth/response.py
@@ -4,7 +4,7 @@ import time
 from typing import TYPE_CHECKING, Any, Dict, Iterator, Optional, Union, cast
 
 import jwt
-from cryptography.hazmat.backends.openssl.rsa import RSAPublicKey
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 
 from globus_sdk import exc
 from globus_sdk.response import GlobusHTTPResponse

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,23 @@
 [tox]
-envlist = cov-clean,py{39,38,37,36},cov-report
+envlist =
+    cov-clean
+    cov-report
+    py{39,38,37,36}
+    py36-mindeps
 skip_missing_interpreters = true
+minversion = 3.0.0
 
 [testenv]
 usedevelop = true
 extras = dev
+deps =
+    mindeps: requests==2.19.1
+    mindeps: pyjwt==2.0.0
+    mindeps: cryptography==2.0
 commands = pytest --cov=src --cov-append --cov-report= {posargs}
 depends =
-    {py36,py37,py38,py39}: cov-clean
-    cov-report: py36,py37,py38,py39
+    {py36,py37,py38,py39,py36-mindeps}: cov-clean
+    cov-report: py36,py37,py38,py39,py36-mindeps
 
 [testenv:cov-clean]
 deps = coverage


### PR DESCRIPTION
This sets a lower bound on `cryptography` (missing), and adds a `py36-mindeps` env to tox. Run in this mode, we verify the SDK testsuite against the minimum dependency versions we specify, to ensure compatibility.

resolves #481