### PR TITLE
Fix type-preservation for internal decorators

### DIFF
--- a/changelog.d/20211011_210434_sirosen_fix_decorator_types.rst
+++ b/changelog.d/20211011_210434_sirosen_fix_decorator_types.rst
@@ -1,0 +1,11 @@
+..
+.. A new scriv changelog fragment
+..
+.. Add one or more items to the list below describing the change in clear, concise terms.
+..
+.. Leave the ":pr:`...`" text alone. When you open a pull request, GitHub Actions will
+.. automatically replace it when the PR is merged.
+..
+
+* Fix several internal decorators which were destroying type information about
+  decorated functions. Type signatures of many methods are therefore corrected (:pr:`NUMBER`)

--- a/src/globus_sdk/paging/table.py
+++ b/src/globus_sdk/paging/table.py
@@ -1,6 +1,8 @@
-from typing import Any, Callable, Dict, Optional, Type, cast
+from typing import Any, Callable, Dict, Optional, Type, TypeVar, cast
 
 from .base import Paginator
+
+C = TypeVar("C", bound=Callable)
 
 
 # stub for mypy
@@ -31,7 +33,7 @@ def has_paginator(
     >>> paginator = c.paginated.foo()
     """
 
-    def decorate(func: Callable) -> Callable:
+    def decorate(func: C) -> C:
         as_paginated = cast(_PaginatedFunc, func)
         as_paginated._has_paginator = True
         as_paginated._paginator_class = paginator_class

--- a/src/globus_sdk/services/gcs/client.py
+++ b/src/globus_sdk/services/gcs/client.py
@@ -9,15 +9,13 @@ from .data import CollectionDocument
 from .errors import GCSAPIError
 from .response import IterableGCSResponse, UnpackingGCSResponse
 
-RT = TypeVar("RT")
+C = TypeVar("C", bound=Callable)
 
 
-def _gcsdoc(
-    message: str, link: str
-) -> Callable[[Callable[..., RT]], Callable[..., RT]]:
+def _gcsdoc(message: str, link: str) -> Callable[[C], C]:
     # do not use functools.partial because it doesn't preserve type information
     # see: https://github.com/python/mypy/issues/1484
-    def partial(func: Callable) -> Callable:
+    def partial(func: C) -> C:
         return utils.doc_api_method(
             message,
             link,

--- a/src/globus_sdk/services/groups/client.py
+++ b/src/globus_sdk/services/groups/client.py
@@ -7,15 +7,13 @@ from globus_sdk.types import UUIDLike
 from .data import BatchMembershipActions, GroupPolicies
 from .errors import GroupsAPIError
 
-RT = TypeVar("RT")
+C = TypeVar("C", bound=Callable)
 
 
-def _groupdoc(
-    message: str, link: str
-) -> Callable[[Callable[..., RT]], Callable[..., RT]]:
+def _groupdoc(message: str, link: str) -> Callable[[C], C]:
     # do not use functools.partial because it doesn't preserve type information
     # see: https://github.com/python/mypy/issues/1484
-    def partial(func: Callable) -> Callable:
+    def partial(func: C) -> C:
         return utils.doc_api_method(
             message,
             link,

--- a/src/globus_sdk/utils.py
+++ b/src/globus_sdk/utils.py
@@ -5,7 +5,7 @@ from base64 import b64encode
 from enum import Enum
 from typing import Any, Callable, Generator, Iterable, Optional, TypeVar
 
-T = TypeVar("T")
+C = TypeVar("C", bound=Callable)
 
 
 def sha256_string(s: str) -> str:
@@ -41,8 +41,8 @@ def doc_api_method(
     external_format_str: str = (
         "See `{message} <{base_url}/{link}>`_ in the API documentation for details."
     ),
-) -> Callable[[Callable[..., T]], Callable[..., T]]:
-    def decorate(func: Callable[..., T]) -> Callable[..., T]:
+) -> Callable[[C], C]:
+    def decorate(func: C) -> C:
         func.__doc__ = f"""{func.__doc__}
 
         **External Documentation**


### PR DESCRIPTION
Several utility decorators in the SDK were preserving return types, but none of the rest of the type signature for the functions and methods which they decorate.

To resolve, specify them in a more appropriate way that indicates to type-checkers that the type of the original function is being preserved.