### PR TITLE
Add iter_items to transfer helpers

### DIFF
--- a/changelog.d/20211027_211325_sirosen_transfer_data_iteritems.rst
+++ b/changelog.d/20211027_211325_sirosen_transfer_data_iteritems.rst
@@ -1,0 +1,1 @@
+* Add ``iter_items`` as a method on ``TransferData`` and ``DeleteData`` (:pr:`NUMBER`)

--- a/src/globus_sdk/services/transfer/data/delete_data.py
+++ b/src/globus_sdk/services/transfer/data/delete_data.py
@@ -1,6 +1,6 @@
 import datetime
 import logging
-from typing import TYPE_CHECKING, Any, Dict, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, Iterator, Optional, Union
 
 from globus_sdk import utils
 from globus_sdk.types import UUIDLike
@@ -125,3 +125,11 @@ class DeleteData(utils.PayloadWrapper):
             item_data.update(additional_fields)
         log.debug('DeleteData[{}].add_item: "{}"'.format(self["endpoint"], path))
         self["DATA"].append(item_data)
+
+    def iter_items(self) -> Iterator[Dict[str, Any]]:
+        """
+        An iterator of items created by ``add_item``.
+
+        Each item takes the form of a dictionary.
+        """
+        yield from iter(self["DATA"])

--- a/src/globus_sdk/services/transfer/data/transfer_data.py
+++ b/src/globus_sdk/services/transfer/data/transfer_data.py
@@ -1,6 +1,6 @@
 import datetime
 import logging
-from typing import TYPE_CHECKING, Any, Dict, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, Iterator, Optional, Union
 
 from globus_sdk import utils
 from globus_sdk.types import UUIDLike
@@ -226,7 +226,7 @@ class TransferData(utils.PayloadWrapper):
 
         :param source_path: Path to the source directory or file to be transferred
         :type source_path: str
-        :param destination_path: Path to the source directory or file will be
+        :param destination_path: Path to the destination directory or file will be
             transferred to
         :type destination_path: str
         :param recursive: Set to True if the target at source path is a directory
@@ -289,3 +289,11 @@ class TransferData(utils.PayloadWrapper):
             )
         )
         self["DATA"].append(item_data)
+
+    def iter_items(self) -> Iterator[Dict[str, Any]]:
+        """
+        An iterator of items created by ``add_item``.
+
+        Each item takes the form of a dictionary.
+        """
+        yield from iter(self["DATA"])

--- a/tests/unit/helpers/test_transfer.py
+++ b/tests/unit/helpers/test_transfer.py
@@ -156,3 +156,44 @@ def test_delete_add_item(delete_data):
     data = ddata["DATA"][0]
     assert data["DATA_TYPE"] == "delete_item"
     assert data["path"] == path
+
+
+def test_delete_iter_items(delete_data):
+    ddata = delete_data()
+    # add item
+    ddata.add_item("abc/")
+    ddata.add_item("def/")
+
+    # order preserved, well-formed
+    as_list = list(ddata.iter_items())
+    assert len(as_list) == 2
+
+    def check_item(x, path):
+        assert isinstance(x, dict)
+        assert x.get("DATA_TYPE") == "delete_item"
+        assert x.get("path") == path
+
+    check_item(as_list[0], "abc/")
+    check_item(as_list[1], "def/")
+
+
+def test_transfer_iter_items(transfer_data):
+    tdata = transfer_data()
+    tdata.add_item("source/abc.txt", "dest/abc.txt")
+    tdata.add_item("source/def/", "dest/def/", recursive=True)
+
+    # order preserved, well-formed
+    as_list = list(tdata.iter_items())
+    assert len(as_list) == 2
+
+    def check_item(x, src, dst, params=None):
+        params = params or {}
+        assert isinstance(x, dict)
+        assert x.get("DATA_TYPE") == "transfer_item"
+        assert x.get("source_path") == src
+        assert x.get("destination_path") == dst
+        for k, v in params.items():
+            assert x.get(k) == v
+
+    check_item(as_list[0], "source/abc.txt", "dest/abc.txt")
+    check_item(as_list[1], "source/def/", "dest/def/", {"recursive": True})


### PR DESCRIPTION
TransferData and DeleteData now support `iter_items()` as a method which iterates over the items which have been added to the inner "DATA" arrays.

These are just "nice helpers" for something which can already be done today. However, it's non-obvious to users that once data has been put into a TransferData or DeleteData, it can be read back out. Making it part of the public API contract for these objects makes it clear that this is a supported usage.

The target use-case is submitting a Transfer or Delete task, and then enumerating the files/directories which were transferred or deleted.

---

I also corrected a minor error in a docstring.

NB: this was inspired by a support ticket.