### PR TITLE
Fix preservation of type info via has_paginator

### DIFF
--- a/changelog.d/20211105_171713_sirosen_type_preserving_has_paginator.rst
+++ b/changelog.d/20211105_171713_sirosen_type_preserving_has_paginator.rst
@@ -1,0 +1,1 @@
+* Fix type annotations on client methods with paginated variants (:pr:`NUMBER`)

--- a/src/globus_sdk/paging/table.py
+++ b/src/globus_sdk/paging/table.py
@@ -1,3 +1,4 @@
+import functools
 from typing import Any, Callable, Dict, Optional, Type, TypeVar, cast
 
 from .base import Paginator
@@ -17,7 +18,7 @@ def has_paginator(
     paginator_class: Type[Paginator],
     items_key: Optional[str] = None,
     **paginator_params: Any,
-) -> Callable[[Callable], Callable]:
+) -> Callable[[C], C]:
     """
     Mark a callable -- typically a client method -- as having pagination parameters.
     Usage:
@@ -95,6 +96,7 @@ class PaginatorTable:
         paginator_params = bound_method._paginator_params  # type: ignore
         paginator_items_key = bound_method._paginator_items_key  # type: ignore
 
+        @functools.wraps(bound_method)
         def paginated_method(*args: Any, **kwargs: Any):  # type: ignore
             return paginator_class(
                 bound_method,

--- a/tests/unit/type_annotations/conftest.py
+++ b/tests/unit/type_annotations/conftest.py
@@ -1,0 +1,40 @@
+import os
+import re
+
+import pytest
+
+# mypy's only python-callable API
+# see:
+# https://mypy.readthedocs.io/en/stable/extending_mypy.html#integrating-mypy-into-another-python-application
+from mypy import api as mypy_api
+
+
+@pytest.fixture
+def _in_tmp_path(tmp_path):
+    cur = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        yield
+    finally:
+        os.chdir(cur)
+
+
+@pytest.fixture
+def run_reveal_type(tmp_path, _in_tmp_path):
+    content_path = tmp_path / "reveal_type_test.py"
+
+    def func(code_snippet, *, preamble="import globus_sdk\n\n"):
+        content_path.write_text(preamble + f"reveal_type({code_snippet})")
+        # note: these invocations are slow, but no significant speed improvement was
+        # offered by running dmypy for this use-case
+        result = mypy_api.run(["reveal_type_test.py"])
+        stdout = result[0]
+        print(result)
+        # mypy reveal_type shows notes like
+        #   note: Revealed type is "Union[builtins.str, None]"
+        # find and extract with a regex
+        match = re.search(r'note: Revealed type is "([^"]+)"', stdout)
+        assert match is not None
+        return match.group(1)
+
+    return func

--- a/tests/unit/type_annotations/test_pagination.py
+++ b/tests/unit/type_annotations/test_pagination.py
@@ -1,0 +1,10 @@
+def test_transfer_task_list(run_reveal_type):
+    # task_list is decorated with documentation and pagination helpers; make sure that
+    # the typing information is preserved
+    got_type = run_reveal_type("globus_sdk.TransferClient.task_list")
+    assert got_type != "def (*Any, **Any) -> Any"
+    # don't check the full type: just make sure it starts with a properly annotated
+    # self-type if this is present, it means that the type information was preserved
+    assert got_type.startswith(
+        "def (self: globus_sdk.services.transfer.client.TransferClient"
+    )


### PR DESCRIPTION
This is a minor bugfix, mostly changing `Callable[[Callable], Callable]` into `Callable[[C], C]` where C is a TypeVar.
However, it also provided a good opportunity to pull in the `run_reveal_type` testing utility I wrote for #489 in a separate PR.

`has_paginator` was meant to preserve type information, but it was not doing so properly.

Because the inner decorator was correctly annotated but the outer layer was not, all functions were being converted to generic Callable types when decorated with this.

Additionally, although some cases for preservation of type information in PaginatorTable are difficult (see GitHub #490), the simple case of runtime typing for paginated methods can be handled easily by using functools.wraps on the generated paginated methods.

It's possible in theory that this is inaccurate in some boundary cases, but it's definitely more accurate than the current type information of a generic callable accepting any arguments.

In order to test this change, a new mypy-testing utility is introduced, `run_reveal_type`, specifically for testing type annotations. It runs mypy's reveal_type() on a string input and reports back the result.