### PR TITLE
Add experimental mypy plugin

### DIFF
--- a/changelog.d/20211108_210542_sirosen_experimental_mypy_plugin.rst
+++ b/changelog.d/20211108_210542_sirosen_experimental_mypy_plugin.rst
@@ -1,0 +1,4 @@
+* A new experimental `mypy` plugin is now provided by the SDK under the name
+  `globus_sdk._mypy_ext`. This plugin is able to recognize and rewrite the
+  types on paginated methods like `TransferClient.paginated.endpoint_search` in
+  order to correctly specify the types of paginated method arguments (:pr:`NUMBER`)

--- a/src/globus_sdk/_mypy_ext.py
+++ b/src/globus_sdk/_mypy_ext.py
@@ -1,0 +1,92 @@
+"""
+Experimental: a mypy plugin for special types within the Globus SDK
+"""
+
+import typing as t
+
+from mypy.nodes import MDEF, TypeInfo
+from mypy.plugin import AttributeContext, Plugin
+from mypy.types import (
+    AnyType,
+    CallableType,
+    Instance,
+    ProperType,
+    Type,
+    TypeOfAny,
+    get_proper_type,
+)
+
+PAGINATOR_NAME = "globus_sdk.paging.base.Paginator"
+PAGINATOR_TABLE_NAME = "globus_sdk.paging.table.PaginatorTable"
+
+
+class GlobusSDKPlugin(Plugin):
+    def _get_paginator_type(self) -> ProperType:
+        symbol = self.lookup_fully_qualified(PAGINATOR_NAME)
+        if symbol and isinstance(symbol.node, TypeInfo):
+            return Instance(symbol.node, [])
+        return AnyType(TypeOfAny.special_form)
+
+    def _get_attribute_type(
+        self, typ: ProperType, attr_name: str
+    ) -> t.Optional[ProperType]:
+        symbol = self.lookup_fully_qualified(f"{typ}.{attr_name}")
+        if not symbol:
+            return None
+        if symbol.kind != MDEF:
+            return None
+        # use type-ignore comments to avoid the runtime overhead of the no-op
+        # `cast` function call
+        node = symbol.node
+        if node is not None:
+            return node.type  # type: ignore
+
+        return None
+
+    def _paginated_method_callback(
+        self, attr_name: str
+    ) -> t.Callable[[AttributeContext], Type]:
+        def callback(ctx: AttributeContext) -> Type:
+            # do not modify the type if the object type is not generic
+            if not isinstance(ctx.type, Instance):
+                return ctx.default_attr_type
+            if len(ctx.type.args) != 1:
+                return ctx.default_attr_type
+            # do not modify the type when operating on non-callable data
+            if not isinstance(ctx.default_attr_type, CallableType):
+                return ctx.default_attr_type
+
+            # resolve the client class under which this paginator table was parametrized
+            client_class_type = get_proper_type(ctx.type.args[0])
+
+            # now resolve the attribute name against that client class, and if it is not
+            # of an expected type (i.e. a callable itself), return the original type
+            attr_type = self._get_attribute_type(client_class_type, attr_name)
+            if attr_type is None or not isinstance(attr_type, CallableType):
+                return ctx.default_attr_type
+
+            # modify the callable type to be a paginated variant
+            return attr_type.copy_modified(
+                # prepend 'paginated.' to the name
+                name=f"paginated.{attr_type.name}",
+                # trim the 'self' argument from the arg list
+                arg_types=attr_type.arg_types[1:],
+                arg_kinds=attr_type.arg_kinds[1:],
+                arg_names=attr_type.arg_names[1:],
+                # return type is a paginator
+                ret_type=self._get_paginator_type(),
+            )
+
+        return callback
+
+    def get_attribute_hook(
+        self, fullname: str
+    ) -> t.Optional[t.Callable[[AttributeContext], Type]]:
+        if fullname.startswith(PAGINATOR_TABLE_NAME):
+            attr_name = fullname.split(".")[-1]
+            return self._paginated_method_callback(attr_name)
+        return None
+
+
+def plugin(version: str) -> t.Type[Plugin]:
+    return GlobusSDKPlugin

--- a/src/globus_sdk/paging/table.py
+++ b/src/globus_sdk/paging/table.py
@@ -1,9 +1,23 @@
 import functools
-from typing import Any, Callable, Dict, Optional, Type, TypeVar, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    Generic,
+    Optional,
+    Type,
+    TypeVar,
+    cast,
+)
 
 from .base import Paginator
 
+if TYPE_CHECKING:
+    from globus_sdk.client import BaseClient  # noqa: F401
+
 C = TypeVar("C", bound=Callable)
+T = TypeVar("T", bound="BaseClient")
 
 
 # stub for mypy
@@ -58,7 +72,7 @@ def has_paginator(
     return decorate
 
 
-class PaginatorTable:
+class PaginatorTable(Generic[T]):
     """
     A PaginatorTable maps multiple methods of an SDK client to paginated variants.
     Given a method, client.foo annotated with the `has_paginator` decorator, the table
@@ -85,7 +99,7 @@ class PaginatorTable:
     Creation of ``PaginatorTable`` objects is considered a private API.
     """
 
-    def __init__(self, client: Any):
+    def __init__(self, client: T):
         self._client = client
         # _bindings is a lazily loaded table of names -> callables which
         # return paginators

--- a/src/globus_sdk/services/auth/client/base.py
+++ b/src/globus_sdk/services/auth/client/base.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     else:
         from typing_extensions import Literal
 
-from globus_sdk import client, exc, utils
+from globus_sdk import client, exc, paging, utils
 from globus_sdk.authorizers import NullAuthorizer
 from globus_sdk.response import GlobusHTTPResponse
 from globus_sdk.scopes import AuthScopes
@@ -72,6 +72,7 @@ class AuthClient(client.BaseClient):
     .. automethodlist:: globus_sdk.AuthClient
     """
 
+    paginated: paging.PaginatorTable["AuthClient"]
     service_name = "auth"
     error_class = AuthAPIError
     scopes = AuthScopes

--- a/src/globus_sdk/services/gcs/client.py
+++ b/src/globus_sdk/services/gcs/client.py
@@ -1,7 +1,7 @@
 import uuid
 from typing import Any, Callable, Dict, Iterable, Optional, TypeVar, Union
 
-from globus_sdk import client, response, scopes, utils
+from globus_sdk import client, paging, response, scopes, utils
 from globus_sdk.authorizers import GlobusAuthorizer
 from globus_sdk.types import UUIDLike
 
@@ -41,6 +41,7 @@ class GCSClient(client.BaseClient):
     .. automethodlist:: globus_sdk.GCSClient
     """
 
+    paginated: paging.PaginatorTable["GCSClient"]
     service_name = "globus_connect_server"
     error_class = GCSAPIError
 

--- a/src/globus_sdk/services/groups/client.py
+++ b/src/globus_sdk/services/groups/client.py
@@ -1,6 +1,6 @@
 from typing import Any, Callable, Dict, Optional, TypeVar, Union
 
-from globus_sdk import client, response, utils
+from globus_sdk import client, paging, response, utils
 from globus_sdk.scopes import GroupsScopes
 from globus_sdk.types import UUIDLike
 
@@ -35,6 +35,7 @@ class GroupsClient(client.BaseClient):
     .. automethodlist:: globus_sdk.GroupsClient
     """
 
+    paginated: paging.PaginatorTable["GroupsClient"]
     base_path = "/v2/"
     error_class = GroupsAPIError
     service_name = "groups"

--- a/src/globus_sdk/services/search/client.py
+++ b/src/globus_sdk/services/search/client.py
@@ -28,6 +28,7 @@ class SearchClient(client.BaseClient):
 
     .. automethodlist:: globus_sdk.SearchClient
     """
+    paginated: paging.PaginatorTable["SearchClient"]
     error_class = SearchAPIError
     service_name = "search"
     scopes = SearchScopes

--- a/src/globus_sdk/services/transfer/client.py
+++ b/src/globus_sdk/services/transfer/client.py
@@ -95,6 +95,7 @@ class TransferClient(client.BaseClient):
 
     .. automethodlist:: globus_sdk.TransferClient
     """
+    paginated: paging.PaginatorTable["TransferClient"]
     service_name = "transfer"
     base_path = "/v0.10/"
     error_class = TransferAPIError


### PR DESCRIPTION
This is a draft PR, as I haven't discussed this plugin, and the issues I encountered and am working around here, with the mypy maintainers at all. Ideally, I could get a conversation going there to confirm that this is basically the right way to do this.

Their docs recommend contacting them before implementing a plugin.

---

This is meant to address #490 by correcting the type information on paginated methods.

Consider this output:
```
$ cat foo.py
import globus_sdk

tc = globus_sdk.TransferClient()

reveal_type(globus_sdk.TransferClient.endpoint_search)
reveal_type(globus_sdk.TransferClient.paginated.endpoint_search)
reveal_type(tc.endpoint_search)
reveal_type(tc.paginated.endpoint_search)

tc.paginated.endpoint_search(unknown_param="foo")
tc.paginated.endpoint_search("foo", "bar")

tc.paginated.get_shared_endpoint_list()
tc.get_shared_endpoint_list()
$ mypy foo.py
foo.py:5: note: Revealed type is "def (self: globus_sdk.services.transfer.client.TransferClient, filter_fulltext: Union[builtins.str, None] =, *, filter_scope: Union[builtins.str, None] =, filter_owner_id: Union[builtins.str, None] =, filter_host_endpoint: Union[uuid.UUID, builtins.str, None] =, filter_non_functional: Union[builtins.bool, None] =, limit: Union[builtins.int, None] =, offset: Union[builtins.int, None] =, query_params: Union[builtins.dict[builtins.str, Any], None] =) -> globus_sdk.services.transfer.response.iterable.IterableTransferResponse"
foo.py:6: note: Revealed type is "def (filter_fulltext: Union[builtins.str, None] =, *, filter_scope: Union[builtins.str, None] =, filter_owner_id: Union[builtins.str, None] =, filter_host_endpoint: Union[uuid.UUID, builtins.str, None] =, filter_non_functional: Union[builtins.bool, None] =, limit: Union[builtins.int, None] =, offset: Union[builtins.int, None] =, query_params: Union[builtins.dict[builtins.str, Any], None] =) -> globus_sdk.paging.base.Paginator"
foo.py:7: note: Revealed type is "def (filter_fulltext: Union[builtins.str, None] =, *, filter_scope: Union[builtins.str, None] =, filter_owner_id: Union[builtins.str, None] =, filter_host_endpoint: Union[uuid.UUID, builtins.str, None] =, filter_non_functional: Union[builtins.bool, None] =, limit: Union[builtins.int, None] =, offset: Union[builtins.int, None] =, query_params: Union[builtins.dict[builtins.str, Any], None] =) -> globus_sdk.services.transfer.response.iterable.IterableTransferResponse"
foo.py:8: note: Revealed type is "def (filter_fulltext: Union[builtins.str, None] =, *, filter_scope: Union[builtins.str, None] =, filter_owner_id: Union[builtins.str, None] =, filter_host_endpoint: Union[uuid.UUID, builtins.str, None] =, filter_non_functional: Union[builtins.bool, None] =, limit: Union[builtins.int, None] =, offset: Union[builtins.int, None] =, query_params: Union[builtins.dict[builtins.str, Any], None] =) -> globus_sdk.paging.base.Paginator"
foo.py:10: error: Unexpected keyword argument "unknown_param" for "paginated.endpoint_search" of "TransferClient"
foo.py:11: error: Too many positional arguments for "paginated.endpoint_search" of "TransferClient"
foo.py:13: error: Missing positional argument "endpoint_id" in call to "paginated.get_shared_endpoint_list" of "TransferClient"
foo.py:14: error: Missing positional argument "endpoint_id" in call to "get_shared_endpoint_list" of "TransferClient"
Found 4 errors in 1 file (checked 1 source file)
```

You need to enable the plugin by setting `plugins = globus_sdk._mypy_ext` to use this.

---

The plugin API is quite difficult to understand. It's not extensively documented and relies on a number of internal details of `mypy`. It uses `mypy.types` and `mypy.nodes` to inspect and create the objects needed for mypy analysis.
The [sqlalchemy-stubs plugin](https://github.com/dropbox/sqlalchemy-stubs/blob/master/sqlmypy.py) is a very good and extensive example, but the tests from the `mypy` repo for the plugin API are much simpler and more understandable.

There are a few things here which could possibly be optimized. e.g. The hook method for handling an `AttributeContext` is generated (that inner callback method) to act as a closure over the `fullname` which was seen by the plugin. I don't know if this is necessary, but I can't find another way of accessing `fullname` from the hook. It means that a function is generated once per paginated attribute name.