### PR TITLE
Stricter type annotations

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,7 @@ ignore = W503,W504
 
 [mypy]
 disallow_untyped_defs = true
+disallow_any_generics = true
 ignore_missing_imports = true
 warn_unreachable = true
 warn_unused_ignores = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,15 +14,10 @@ ignore = W503,W504
 
 
 [mypy]
-disallow_untyped_defs = true
-disallow_any_generics = true
+strict = true
 ignore_missing_imports = true
 warn_unreachable = true
-warn_unused_ignores = true
-warn_redundant_casts = true
-warn_return_any = true
 warn_no_return = true
-no_implicit_optional = true
 
 
 [tool:pytest]

--- a/src/globus_sdk/authorizers/client_credentials.py
+++ b/src/globus_sdk/authorizers/client_credentials.py
@@ -62,7 +62,7 @@ class ClientCredentialsAuthorizer(RenewingAuthorizer):
         *,
         access_token: Optional[str] = None,
         expires_at: Optional[int] = None,
-        on_refresh: Optional[Callable] = None,
+        on_refresh: Optional[Callable[[OAuthTokenResponse], Any]] = None,
     ):
         log.info(
             "Setting up ClientCredentialsAuthorizer with confidential_client="

--- a/src/globus_sdk/authorizers/refresh_token.py
+++ b/src/globus_sdk/authorizers/refresh_token.py
@@ -57,7 +57,7 @@ class RefreshTokenAuthorizer(RenewingAuthorizer):
         *,
         access_token: Optional[str] = None,
         expires_at: Optional[int] = None,
-        on_refresh: Optional[Callable] = None,
+        on_refresh: Optional[Callable[[OAuthTokenResponse], Any]] = None,
     ):
         log.info(
             "Setting up RefreshTokenAuthorizer with auth_client="

--- a/src/globus_sdk/authorizers/renewing.py
+++ b/src/globus_sdk/authorizers/renewing.py
@@ -50,7 +50,7 @@ class RenewingAuthorizer(GlobusAuthorizer, metaclass=abc.ABCMeta):
         self,
         access_token: Optional[str] = None,
         expires_at: Optional[int] = None,
-        on_refresh: Optional[Callable] = None,
+        on_refresh: Optional[Callable[[OAuthTokenResponse], Any]] = None,
     ):
         self._access_token = None
         self._access_token_hash = None

--- a/src/globus_sdk/client.py
+++ b/src/globus_sdk/client.py
@@ -38,7 +38,7 @@ class BaseClient:
     error_class: Type[exc.GlobusAPIError] = exc.GlobusAPIError
 
     #: the type of Transport which will be used, defaults to ``RequestsTransport``
-    transport_class: Type = RequestsTransport
+    transport_class: Type[RequestsTransport] = RequestsTransport
 
     #: the scopes for this client may be present as a ``ScopeBuilder``
     scopes: Optional[ScopeBuilder] = None
@@ -50,7 +50,7 @@ class BaseClient:
         base_url: Optional[str] = None,
         authorizer: Optional[GlobusAuthorizer] = None,
         app_name: Optional[str] = None,
-        transport_params: Optional[Dict] = None,
+        transport_params: Optional[Dict[str, Any]] = None,
     ):
         # explicitly check the `service_name` to ensure that it was set
         #
@@ -122,7 +122,7 @@ class BaseClient:
         path: str,
         *,
         query_params: Optional[Dict[str, Any]] = None,
-        headers: Optional[Dict] = None,
+        headers: Optional[Dict[str, str]] = None,
     ) -> GlobusHTTPResponse:
         """
         Make a GET request to the specified path.
@@ -140,8 +140,8 @@ class BaseClient:
         path: str,
         *,
         query_params: Optional[Dict[str, Any]] = None,
-        data: Union[None, Dict, utils.PayloadWrapper] = None,
-        headers: Optional[Dict] = None,
+        data: Union[None, Dict[str, Any], utils.PayloadWrapper] = None,
+        headers: Optional[Dict[str, str]] = None,
         encoding: Optional[str] = None,
     ) -> GlobusHTTPResponse:
         """
@@ -167,7 +167,7 @@ class BaseClient:
         path: str,
         *,
         query_params: Optional[Dict[str, Any]] = None,
-        headers: Optional[Dict] = None,
+        headers: Optional[Dict[str, str]] = None,
     ) -> GlobusHTTPResponse:
         """
         Make a DELETE request to the specified path.
@@ -185,8 +185,8 @@ class BaseClient:
         path: str,
         *,
         query_params: Optional[Dict[str, Any]] = None,
-        data: Union[None, Dict, utils.PayloadWrapper] = None,
-        headers: Optional[Dict] = None,
+        data: Union[None, Dict[str, Any], utils.PayloadWrapper] = None,
+        headers: Optional[Dict[str, str]] = None,
         encoding: Optional[str] = None,
     ) -> GlobusHTTPResponse:
         """
@@ -212,8 +212,8 @@ class BaseClient:
         path: str,
         *,
         query_params: Optional[Dict[str, Any]] = None,
-        data: Union[None, Dict, utils.PayloadWrapper] = None,
-        headers: Optional[Dict] = None,
+        data: Union[None, Dict[str, Any], utils.PayloadWrapper] = None,
+        headers: Optional[Dict[str, str]] = None,
         encoding: Optional[str] = None,
     ) -> GlobusHTTPResponse:
         """
@@ -240,8 +240,8 @@ class BaseClient:
         path: str,
         *,
         query_params: Optional[Dict[str, Any]] = None,
-        data: Union[None, Dict, utils.PayloadWrapper] = None,
-        headers: Optional[Dict] = None,
+        data: Union[None, Dict[str, Any], utils.PayloadWrapper] = None,
+        headers: Optional[Dict[str, str]] = None,
         encoding: Optional[str] = None,
     ) -> GlobusHTTPResponse:
         """

--- a/src/globus_sdk/config/env_vars.py
+++ b/src/globus_sdk/config/env_vars.py
@@ -21,7 +21,7 @@ def _load_var(
     varname: str,
     default: Any,
     explicit_value: Optional[Any] = None,
-    cast: Optional[Callable] = None,
+    cast: Optional[Callable[[Any, Any], Any]] = None,
 ) -> Any:
     # use the explicit value if given and non-None, otherwise, do an env lookup
     value = (

--- a/src/globus_sdk/exc/api.py
+++ b/src/globus_sdk/exc/api.py
@@ -160,7 +160,7 @@ class GlobusAPIError(GlobusError):
             json_data = json_data["errors"][0]
         self._load_from_json(json_data)
 
-    def _load_from_json(self, data: dict) -> None:
+    def _load_from_json(self, data: Dict[str, Any]) -> None:
         # rewrite 'code' if present and correct type
         if isinstance(data.get("code"), str):
             self.code = data["code"]

--- a/src/globus_sdk/paging/base.py
+++ b/src/globus_sdk/paging/base.py
@@ -28,7 +28,7 @@ class Paginator(Iterable[GlobusHTTPResponse], metaclass=abc.ABCMeta):
 
     def __init__(
         self,
-        method: Callable,
+        method: Callable[..., Any],
         *,
         items_key: Optional[str] = None,
         client_args: List[Any],
@@ -47,7 +47,7 @@ class Paginator(Iterable[GlobusHTTPResponse], metaclass=abc.ABCMeta):
         """``pages()`` yields GlobusHTTPResponse objects, each one representing a page
         of results."""
 
-    def items(self) -> Iterator:
+    def items(self) -> Iterator[Any]:
         """
         ``items()`` of a paginator is a generator which yields each item in each page of
         results.

--- a/src/globus_sdk/paging/last_key.py
+++ b/src/globus_sdk/paging/last_key.py
@@ -8,7 +8,7 @@ from .base import Paginator
 class LastKeyPaginator(Paginator):
     def __init__(
         self,
-        method: Callable,
+        method: Callable[..., Any],
         *,
         items_key: Optional[str] = None,
         client_args: List[Any],

--- a/src/globus_sdk/paging/limit_offset.py
+++ b/src/globus_sdk/paging/limit_offset.py
@@ -8,10 +8,10 @@ from .base import Paginator
 class _LimitOffsetBasedPaginator(Paginator):
     def __init__(
         self,
-        method: Callable,
+        method: Callable[..., Any],
         *,
         items_key: Optional[str] = None,
-        get_page_size: Callable[[dict], int],
+        get_page_size: Callable[[Dict[str, Any]], int],
         max_total_results: int,
         page_size: int,
         client_args: List[Any],
@@ -36,7 +36,7 @@ class _LimitOffsetBasedPaginator(Paginator):
             self.limit = self.max_total_results - self.offset
         self.client_kwargs["limit"] = self.limit
 
-    def _update_and_check_offset(self, current_page: dict) -> bool:
+    def _update_and_check_offset(self, current_page: Dict[str, Any]) -> bool:
         self.offset += self.get_page_size(current_page)
         self.client_kwargs["offset"] = self.offset
         return (

--- a/src/globus_sdk/paging/marker.py
+++ b/src/globus_sdk/paging/marker.py
@@ -15,7 +15,7 @@ class MarkerPaginator(Paginator):
 
     def __init__(
         self,
-        method: Callable,
+        method: Callable[..., Any],
         *,
         items_key: Optional[str] = None,
         client_args: List[Any],

--- a/src/globus_sdk/paging/next_token.py
+++ b/src/globus_sdk/paging/next_token.py
@@ -16,7 +16,7 @@ class NextTokenPaginator(Paginator):
 
     def __init__(
         self,
-        method: Callable,
+        method: Callable[..., Any],
         *,
         items_key: Optional[str] = None,
         client_args: List[Any],

--- a/src/globus_sdk/paging/table.py
+++ b/src/globus_sdk/paging/table.py
@@ -3,7 +3,7 @@ from typing import Any, Callable, Dict, Optional, Type, TypeVar, cast
 
 from .base import Paginator
 
-C = TypeVar("C", bound=Callable)
+C = TypeVar("C", bound=Callable[..., Any])
 
 
 # stub for mypy
@@ -91,7 +91,7 @@ class PaginatorTable:
         # return paginators
         self._bindings: Dict[str, Callable[..., Paginator]] = {}
 
-    def _add_binding(self, methodname: str, bound_method: Callable) -> None:
+    def _add_binding(self, methodname: str, bound_method: Callable[..., Any]) -> None:
         paginator_class = bound_method._paginator_class  # type: ignore
         paginator_params = bound_method._paginator_params  # type: ignore
         paginator_items_key = bound_method._paginator_items_key  # type: ignore
@@ -108,7 +108,7 @@ class PaginatorTable:
 
         self._bindings[methodname] = paginated_method
 
-    def __getattr__(self, attrname: str) -> Callable:
+    def __getattr__(self, attrname: str) -> Callable[..., Paginator]:
         if attrname not in self._bindings:
             # this could raise AttributeError -- in which case, let it!
             method = getattr(self._client, attrname)

--- a/src/globus_sdk/response.py
+++ b/src/globus_sdk/response.py
@@ -167,5 +167,5 @@ class IterableResponse(GlobusHTTPResponse):
         self.iter_key = iter_key
         super().__init__(response, client)
 
-    def __iter__(self) -> Iterator[Mapping]:
-        return iter(cast(Mapping, self)[self.iter_key])
+    def __iter__(self) -> Iterator[Mapping[Any, Any]]:
+        return iter(cast(Mapping[Any, Any], self)[self.iter_key])

--- a/src/globus_sdk/services/auth/client/base.py
+++ b/src/globus_sdk/services/auth/client/base.py
@@ -370,14 +370,14 @@ class AuthClient(client.BaseClient):
 
     @overload
     def oauth2_token(
-        self, form_data: Union[dict, utils.PayloadWrapper]
+        self, form_data: Union[Dict[str, Any], utils.PayloadWrapper]
     ) -> OAuthTokenResponse:
         ...
 
     @overload
     def oauth2_token(
         self,
-        form_data: Union[dict, utils.PayloadWrapper],
+        form_data: Union[Dict[str, Any], utils.PayloadWrapper],
         *,
         body_params: Optional[Dict[str, Any]],
     ) -> OAuthTokenResponse:
@@ -385,14 +385,17 @@ class AuthClient(client.BaseClient):
 
     @overload
     def oauth2_token(
-        self, form_data: Union[dict, utils.PayloadWrapper], *, response_class: Type[RT]
+        self,
+        form_data: Union[Dict[str, Any], utils.PayloadWrapper],
+        *,
+        response_class: Type[RT],
     ) -> RT:
         ...
 
     @overload
     def oauth2_token(
         self,
-        form_data: Union[dict, utils.PayloadWrapper],
+        form_data: Union[Dict[str, Any], utils.PayloadWrapper],
         *,
         body_params: Optional[Dict[str, Any]],
         response_class: Type[RT],
@@ -401,7 +404,7 @@ class AuthClient(client.BaseClient):
 
     def oauth2_token(
         self,
-        form_data: Union[dict, utils.PayloadWrapper],
+        form_data: Union[Dict[str, Any], utils.PayloadWrapper],
         *,
         body_params: Optional[Dict[str, Any]] = None,
         response_class: Union[Type[OAuthTokenResponse], Type[RT]] = OAuthTokenResponse,
@@ -483,7 +486,7 @@ class AuthClient(client.BaseClient):
         openid_configuration: Optional[Union[GlobusHTTPResponse, Dict[str, Any]]],
         *,
         as_pem: "Literal[False]",
-    ) -> dict:
+    ) -> Dict[str, Any]:
         ...
 
     def get_jwk(
@@ -493,7 +496,7 @@ class AuthClient(client.BaseClient):
         ] = None,
         *,
         as_pem: bool = False,
-    ) -> Union[RSAPublicKey, dict]:
+    ) -> Union[RSAPublicKey, Dict[str, Any]]:
         """
         Fetch the Globus Auth JWK.
 

--- a/src/globus_sdk/services/auth/client/confidential_client.py
+++ b/src/globus_sdk/services/auth/client/confidential_client.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Iterable, Optional, Union
+from typing import Any, Dict, Iterable, Optional, Union
 
 from globus_sdk import exc, utils
 from globus_sdk.authorizers import BasicAuthorizer
@@ -136,7 +136,7 @@ class ConfidentialAppAuthClient(AuthClient):
         return self.current_oauth2_flow_manager
 
     def oauth2_get_dependent_tokens(
-        self, token: str, *, additional_params: Optional[dict] = None
+        self, token: str, *, additional_params: Optional[Dict[str, Any]] = None
     ) -> OAuthDependentTokenResponse:
         """
         Does a `Dependent Token Grant

--- a/src/globus_sdk/services/auth/identity_map.py
+++ b/src/globus_sdk/services/auth/identity_map.py
@@ -143,7 +143,7 @@ class IdentityMap:
         )
 
         # the cache is a dict mapping IDs and Usernames
-        self._cache: Dict[str, dict] = {}
+        self._cache: Dict[str, Dict[str, Any]] = {}
 
     def _fetch_batch_including(self, key: str) -> None:
         """

--- a/src/globus_sdk/services/auth/response.py
+++ b/src/globus_sdk/services/auth/response.py
@@ -49,7 +49,7 @@ class _ByScopesGetter:
     def __str__(self) -> str:
         return json.dumps(self.scope_map)
 
-    def __iter__(self) -> Iterator:
+    def __iter__(self) -> Iterator[str]:
         """iteration gets you every individual scope"""
         return iter(self.scope_map.keys())
 
@@ -133,7 +133,7 @@ class OAuthTokenResponse(GlobusHTTPResponse):
         )
 
     @property
-    def by_resource_server(self) -> Dict[str, dict]:
+    def by_resource_server(self) -> Dict[str, Dict[str, Any]]:
         """
         Representation of the token response in a ``dict`` indexed by resource
         server.
@@ -173,7 +173,7 @@ class OAuthTokenResponse(GlobusHTTPResponse):
             Union[GlobusHTTPResponse, Dict[str, Any]]
         ] = None,
         jwk: Optional[RSAPublicKey] = None,
-        jwt_params: Optional[Dict] = None,
+        jwt_params: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
 
         """
@@ -253,7 +253,7 @@ class OAuthDependentTokenResponse(OAuthTokenResponse):
             Union[GlobusHTTPResponse, Dict[str, Any]]
         ] = None,
         jwk: Optional[RSAPublicKey] = None,
-        jwt_params: Optional[Dict] = None,
+        jwt_params: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         # just in case
         raise NotImplementedError(

--- a/src/globus_sdk/services/gcs/client.py
+++ b/src/globus_sdk/services/gcs/client.py
@@ -9,7 +9,7 @@ from .data import CollectionDocument
 from .errors import GCSAPIError
 from .response import IterableGCSResponse, UnpackingGCSResponse
 
-C = TypeVar("C", bound=Callable)
+C = TypeVar("C", bound=Callable[..., Any])
 
 
 def _gcsdoc(message: str, link: str) -> Callable[[C], C]:
@@ -51,7 +51,7 @@ class GCSClient(client.BaseClient):
         environment: Optional[str] = None,
         authorizer: Optional[GlobusAuthorizer] = None,
         app_name: Optional[str] = None,
-        transport_params: Optional[Dict] = None,
+        transport_params: Optional[Dict[str, Any]] = None,
     ):
         # check if the provided address was a DNS name or an HTTPS URL
         # if it was a URL, do not modify, but if it's a DNS name format it accordingly

--- a/src/globus_sdk/services/gcs/data.py
+++ b/src/globus_sdk/services/gcs/data.py
@@ -191,7 +191,7 @@ class CollectionDocument(utils.PayloadWrapper, abc.ABC):
             self["DATA_TYPE"] = f"collection#{self._deduce_datatype_version()}"
 
     def _set_value(
-        self, key: str, val: Any, callback: Optional[Callable] = None
+        self, key: str, val: Any, callback: Optional[Callable[[Any], Any]] = None
     ) -> None:
         if val is not None:
             self[key] = callback(val) if callback else val
@@ -200,7 +200,7 @@ class CollectionDocument(utils.PayloadWrapper, abc.ABC):
         for k, v in kwargs.items():
             self._set_value(k, v, callback=str)
 
-    def _set_optstrlists(self, **kwargs: Optional[Iterable]) -> None:
+    def _set_optstrlists(self, **kwargs: Optional[Iterable[Any]]) -> None:
         for k, v in kwargs.items():
             self._set_value(k, v, callback=lambda x: list(utils.safe_strseq_iter(x)))
 

--- a/src/globus_sdk/services/gcs/errors.py
+++ b/src/globus_sdk/services/gcs/errors.py
@@ -29,5 +29,5 @@ class GCSAPIError(exc.GlobusAPIError):
         # detail can be a full document, so fetch, then look for a DATA_TYPE
         # and expose it as a top-level attribute for easy access
         self.detail = data.get("detail")
-        if self.detail and "DATA_TYPE" in self.detail:
+        if isinstance(self.detail, dict) and "DATA_TYPE" in self.detail:
             self.detail_data_type = self.detail["DATA_TYPE"]

--- a/src/globus_sdk/services/gcs/errors.py
+++ b/src/globus_sdk/services/gcs/errors.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 import requests
 
@@ -12,7 +12,7 @@ class GCSAPIError(exc.GlobusAPIError):
 
     def __init__(self, r: requests.Response) -> None:
         self.detail_data_type: Optional[str] = None
-        self.detail: Union[None, str, dict] = None
+        self.detail: Union[None, str, Dict[str, Any]] = None
         super().__init__(r)
 
     def _get_args(self) -> List[Any]:
@@ -24,7 +24,7 @@ class GCSAPIError(exc.GlobusAPIError):
             args.append(self.detail)
         return args
 
-    def _load_from_json(self, data: dict) -> None:
+    def _load_from_json(self, data: Dict[str, Any]) -> None:
         super()._load_from_json(data)
         # detail can be a full document, so fetch, then look for a DATA_TYPE
         # and expose it as a top-level attribute for easy access

--- a/src/globus_sdk/services/gcs/response.py
+++ b/src/globus_sdk/services/gcs/response.py
@@ -1,5 +1,5 @@
 import re
-from typing import Any, Callable, Optional, Union
+from typing import Any, Callable, Dict, Optional, Union
 
 from globus_sdk.response import GlobusHTTPResponse, IterableResponse
 
@@ -36,11 +36,11 @@ class UnpackingGCSResponse(GlobusHTTPResponse):
     :type match: str or callable
     """
 
-    def _default_unpacking_match(self, spec: str) -> Callable[[dict], bool]:
+    def _default_unpacking_match(self, spec: str) -> Callable[[Dict[str, Any]], bool]:
         if not re.fullmatch(r"\w+", spec):
             raise ValueError("Invalid UnpackingGCSResponse specification.")
 
-        def match_func(data: dict) -> bool:
+        def match_func(data: Dict[str, Any]) -> bool:
             if not ("DATA_TYPE" in data and isinstance(data["DATA_TYPE"], str)):
                 return False
             if "#" not in data["DATA_TYPE"]:
@@ -53,7 +53,7 @@ class UnpackingGCSResponse(GlobusHTTPResponse):
     def __init__(
         self,
         response: GlobusHTTPResponse,
-        match: Union[str, Callable[[dict], bool]],
+        match: Union[str, Callable[[Dict[str, Any]], bool]],
     ):
         super().__init__(response)
 
@@ -62,7 +62,7 @@ class UnpackingGCSResponse(GlobusHTTPResponse):
         else:
             self._match_func = self._default_unpacking_match(match)
 
-        self._unpacked_data: Optional[dict] = None
+        self._unpacked_data: Optional[Dict[str, Any]] = None
         self._did_unpack = False
 
     @property
@@ -73,7 +73,7 @@ class UnpackingGCSResponse(GlobusHTTPResponse):
         """
         return self._parsed_json
 
-    def _unpack(self) -> Optional[dict]:
+    def _unpack(self) -> Optional[Dict[str, Any]]:
         """
         Unpack the response from the `"data"` array, returning the first match found.
         If no matches are founds, or the data is the wrong shape, return None.

--- a/src/globus_sdk/services/groups/client.py
+++ b/src/globus_sdk/services/groups/client.py
@@ -7,7 +7,7 @@ from globus_sdk.types import UUIDLike
 from .data import BatchMembershipActions, GroupPolicies
 from .errors import GroupsAPIError
 
-C = TypeVar("C", bound=Callable)
+C = TypeVar("C", bound=Callable[..., Any])
 
 
 def _groupdoc(message: str, link: str) -> Callable[[C], C]:

--- a/src/globus_sdk/services/search/errors.py
+++ b/src/globus_sdk/services/search/errors.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 import requests
 
 from globus_sdk import exc
@@ -19,6 +21,6 @@ class SearchAPIError(exc.GlobusAPIError):
         self.error_data = None
         super().__init__(r)
 
-    def _load_from_json(self, data: dict) -> None:
+    def _load_from_json(self, data: Dict[str, Any]) -> None:
         super()._load_from_json(data)
         self.error_data = data.get("error_data")

--- a/src/globus_sdk/services/transfer/client.py
+++ b/src/globus_sdk/services/transfer/client.py
@@ -421,7 +421,7 @@ class TransferClient(client.BaseClient):
         self,
         endpoint_id: UUIDLike,
         *,
-        requirements_data: Optional[dict],
+        requirements_data: Optional[Dict[str, Any]],
         query_params: Optional[Dict[str, Any]] = None,
     ) -> response.GlobusHTTPResponse:
         """

--- a/src/globus_sdk/services/transfer/errors.py
+++ b/src/globus_sdk/services/transfer/errors.py
@@ -1,4 +1,4 @@
-from typing import Any, List
+from typing import Any, Dict, List
 
 import requests
 
@@ -23,6 +23,6 @@ class TransferAPIError(exc.GlobusAPIError):
         args.append(self.request_id)
         return args
 
-    def _load_from_json(self, data: dict) -> None:
+    def _load_from_json(self, data: Dict[str, Any]) -> None:
         super()._load_from_json(data)
         self.request_id = data.get("request_id")

--- a/src/globus_sdk/tokenstorage/base.py
+++ b/src/globus_sdk/tokenstorage/base.py
@@ -1,7 +1,7 @@
 import abc
 import contextlib
 import os
-from typing import Dict, Iterator, Optional
+from typing import Any, Dict, Iterator, Optional
 
 from globus_sdk.services.auth import OAuthTokenResponse
 
@@ -12,7 +12,7 @@ class StorageAdapter(metaclass=abc.ABCMeta):
         pass
 
     @abc.abstractmethod
-    def get_token_data(self, resource_server: str) -> Optional[Dict]:
+    def get_token_data(self, resource_server: str) -> Optional[Dict[str, Any]]:
         """
         Lookup token data for a resource server
 

--- a/src/globus_sdk/tokenstorage/file_adapters.py
+++ b/src/globus_sdk/tokenstorage/file_adapters.py
@@ -1,5 +1,5 @@
 import json
-from typing import Dict, Optional, cast
+from typing import Any, Dict, Optional, cast
 
 from globus_sdk.services.auth import OAuthTokenResponse
 from globus_sdk.tokenstorage.base import FileAdapter
@@ -24,7 +24,7 @@ class SimpleJSONFileAdapter(FileAdapter):
     def __init__(self, filename: str):
         self.filename = filename
 
-    def _raw_load(self) -> Dict:
+    def _raw_load(self) -> Dict[str, Any]:
         """
         Load the file contents as JSON and return the resulting dict
         object. If a dict is not found, raises an error.
@@ -35,7 +35,7 @@ class SimpleJSONFileAdapter(FileAdapter):
             raise ValueError("reading from json file got non-dict data")
         return val
 
-    def _handle_formats(self, read_data: Dict) -> Dict:
+    def _handle_formats(self, read_data: Dict[str, Any]) -> Dict[str, Any]:
         """Handle older data formats supported by globus_sdk.tokenstorage
 
         if the data is not in a known/recognized format, this will error
@@ -55,7 +55,7 @@ class SimpleJSONFileAdapter(FileAdapter):
             )
         return read_data
 
-    def _load(self) -> Dict:
+    def _load(self) -> Dict[str, Any]:
         """
         Load data from the file and ensure that the data is in a modern format which can
         be handled by the rest of the adapter.
@@ -101,7 +101,7 @@ class SimpleJSONFileAdapter(FileAdapter):
             with open(self.filename, "w") as f:
                 json.dump(to_write, f)
 
-    def get_by_resource_server(self) -> Dict:
+    def get_by_resource_server(self) -> Dict[str, Any]:
         """
         Read only the by_resource_server formatted data from the file, discarding any
         other keys.
@@ -112,7 +112,7 @@ class SimpleJSONFileAdapter(FileAdapter):
         # TODO: when the Globus SDK drops support for py3.6 and py3.7, we can update
         # `_load` to return a TypedDict which guarantees that `by_rs` is a dict
         # see: https://www.python.org/dev/peps/pep-0589/
-        return cast(dict, self._load()["by_rs"])
+        return cast(Dict[str, Any], self._load()["by_rs"])
 
-    def get_token_data(self, resource_server: str) -> Optional[Dict]:
+    def get_token_data(self, resource_server: str) -> Optional[Dict[str, Any]]:
         return self.get_by_resource_server().get(resource_server)

--- a/src/globus_sdk/tokenstorage/sqlite_adapter.py
+++ b/src/globus_sdk/tokenstorage/sqlite_adapter.py
@@ -80,7 +80,7 @@ CREATE TABLE sdk_storage_adapter_internal (
             conn.commit()
         return conn
 
-    def store_config(self, config_name: str, config_dict: Mapping) -> None:
+    def store_config(self, config_name: str, config_dict: Mapping[str, Any]) -> None:
         """
         :param config_name: A string name for the configuration value
         :param config_dict: A dict of config which will be stored serialized as JSON
@@ -98,7 +98,7 @@ CREATE TABLE sdk_storage_adapter_internal (
         )
         self._connection.commit()
 
-    def read_config(self, config_name: str) -> Optional[Dict]:
+    def read_config(self, config_name: str) -> Optional[Dict[str, Any]]:
         """
         :param config_name: A string name for the configuration value
 

--- a/src/globus_sdk/transport/requests.py
+++ b/src/globus_sdk/transport/requests.py
@@ -146,7 +146,7 @@ class RequestsTransport:
         method: str,
         url: str,
         query_params: Optional[Dict[str, Any]] = None,
-        data: Union[Dict, List, str, None] = None,
+        data: Union[Dict[str, Any], List[Any], str, None] = None,
         headers: Optional[Dict[str, str]] = None,
         encoding: Optional[str] = None,
     ) -> requests.Request:
@@ -192,8 +192,8 @@ class RequestsTransport:
         method: str,
         url: str,
         query_params: Optional[Dict[str, Any]] = None,
-        data: Optional[dict] = None,
-        headers: Optional[dict] = None,
+        data: Optional[Dict[str, Any]] = None,
+        headers: Optional[Dict[str, str]] = None,
         encoding: Optional[str] = None,
         authorizer: Optional[GlobusAuthorizer] = None,
     ) -> requests.Response:

--- a/src/globus_sdk/transport/retry.py
+++ b/src/globus_sdk/transport/retry.py
@@ -1,12 +1,14 @@
 import enum
 import logging
-from typing import Callable, Dict, List, Optional, cast
+from typing import Any, Callable, Dict, List, Optional, TypeVar, cast
 
 import requests
 
 from globus_sdk.authorizers import GlobusAuthorizer
 
 log = logging.getLogger(__name__)
+
+C = TypeVar("C", bound=Callable[..., Any])
 
 
 class RetryContext:
@@ -71,7 +73,7 @@ class _RetryCheckFunc:
     _retry_check_flags: RetryCheckFlags
 
 
-def set_retry_check_flags(flag: RetryCheckFlags) -> Callable[[Callable], Callable]:
+def set_retry_check_flags(flag: RetryCheckFlags) -> Callable[[C], C]:
     """
     A decorator for setting retry check flags on a retry check function.
     Usage:
@@ -80,7 +82,7 @@ def set_retry_check_flags(flag: RetryCheckFlags) -> Callable[[Callable], Callabl
     >>> def foo(ctx): ...
     """
 
-    def decorator(func: Callable) -> Callable:
+    def decorator(func: C) -> C:
         as_check = cast(_RetryCheckFunc, func)
         as_check._retry_check_flags = flag
         return func
@@ -116,8 +118,8 @@ class RetryCheckRunner:
     # check configs: a list of pairs, (check, flags)
     # a check without flags is assumed to have flags=NONE
     def __init__(self, checks: List[RetryCheck]):
-        self._checks = []
-        self._check_data: Dict[Callable, Dict] = {}
+        self._checks: List[RetryCheck] = []
+        self._check_data: Dict[RetryCheck, Dict[str, Any]] = {}
         for check in checks:
             self._checks.append(check)
             self._check_data[check] = {}

--- a/src/globus_sdk/utils.py
+++ b/src/globus_sdk/utils.py
@@ -6,6 +6,7 @@ import sys
 from base64 import b64encode
 from enum import Enum
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     Generator,
@@ -17,9 +18,14 @@ from typing import (
     cast,
 )
 
-C = TypeVar("C", bound=Callable)
+C = TypeVar("C", bound=Callable[..., Any])
 T = TypeVar("T")
 R = TypeVar("R")
+
+if TYPE_CHECKING:
+    PayloadWrapperBase = collections.UserDict[str, Any]
+else:
+    PayloadWrapperBase = collections.UserDict
 
 
 def sha256_string(s: str) -> str:
@@ -69,7 +75,7 @@ def doc_api_method(
     return decorate
 
 
-def safe_strseq_iter(value: Iterable) -> Generator[str, None, None]:
+def safe_strseq_iter(value: Iterable[Any]) -> Generator[str, None, None]:
     """
     Given an Iterable (typically of strings), produce an iterator over it of strings.
     This is a passthrough with two caveats:
@@ -103,7 +109,7 @@ def render_enums_for_api(value: Any) -> Any:
     return value.value if isinstance(value, Enum) else value
 
 
-class PayloadWrapper(collections.UserDict):
+class PayloadWrapper(PayloadWrapperBase):
     """
     A class for defining helper objects which wrap some kind of "payload" dict.
     Typical for helper objects which formulate a request payload, e.g. as JSON.

--- a/tox.ini
+++ b/tox.ini
@@ -38,6 +38,10 @@ commands = pre-commit run --all-files
 deps = mypy
 commands = mypy src/
 
+[testenv:pyright]
+deps = pyright
+commands = pyright src/ {posargs}
+
 [testenv:docs]
 # force use of py39 for doc builds so that we get the same behaviors as the
 # readthedocs doc build


### PR DESCRIPTION
We've had some issues with the type annotations in the SDK being too loose and losing information. In order to try to protect against this, we now have type annotation tests, but stricter type checker settings could also help protect us.

## mypy --strict

The only unsatisfied part of `mypy --strict` for us was `disallow-any-generics`.

`disallow-any-generics` in mypy prevents the declaration of a decorator like
```python
def mydeco(f: Callable) -> Callable: ...
```
because `Callable` in this case is a generic with implicit `Any` usage.

Setting this would require either
```python
def mydeco(f: Callable[..., Any]) -> Callable[..., Any]: ...
```
or, the ideal,
```python
C = TypeVar("C", bound=Callable[..., Any])  # note: we aren't even allowed bare 'Callable' here
def mydeco(f: C) -> C: ...
```

The flag also prevents use of bare `dict`, `list`, and other types which have corresponding generic variants (and will support class getitem in newer pythons). e.g.
```python
def f(d: dict) -> list: ...
```
must be written
```python
def f(d: Dict[Any, Any]) -> List[Any]: ...
```

When turning this option on, the only oddity that needed resolution was `UserDict` in `PayloadWrapper`. `UserDict` supports `__class_getitem__` under mypy, but not for all runtime python versions we support. This is handled with a very simple conditional definition of `PayloadWrapperBase`.

## pyright

I also investigated `pyright`, in particular for its `--verifytypes` option. It is possible with this PR to run `tox -e pyright -- --verifytypes globus_sdk --ignoreexternal`, but I do not find the results suitable for integration into CI.

I was able to convince the pyright maintainers to allow conditional redefinition of a function with an identical signature, so after their next release we _could_ add `tox -e pyright` to our linting phases. I'm unsure of the wisdom of doing so, so pyright is present in tox.ini but unused for now.

Running `pyright` in its normal mode on our source did uncover one interesting false negative from `mypy`, in which we were subscripting a dict without checking its type.

## Conclusion

The main achievement here is that by setting `disallow-any-generics = true` for mypy, we can turn on mypy `strict = true`. There were no additional changes needed after `disallow-any-generics` in order to turn on strict mode (and remove redundant settings from config).