### PR TITLE
Add a method for getting a Paginator which preserves argument types

### DIFF
--- a/changelog.d/20220114_171240_sirosen_typed_paginator.rst
+++ b/changelog.d/20220114_171240_sirosen_typed_paginator.rst
@@ -1,0 +1,4 @@
+* Add ``Paginator.wrap`` as a method for getting a paginated methods. This interface is more
+  verbose than the existing ``paginated`` methods, but correctly preserves type
+  annotations. It is therefore preferable for users who are using ``mypy`` to do
+  type checking. (:pr:`NUMBER`)

--- a/docs/core/paging.rst
+++ b/docs/core/paging.rst
@@ -93,6 +93,45 @@ returns the total number of results for the search as a field on each page.
 Most use-cases can be solved with ``items()``, and ``pages()`` will be
 available to you if or when you need it.
 
+Typed Paginators with Paginator.wrap
+------------------------------------
+
+This is an alternate syntax for getting a paginated call. It is more verbose,
+but preserves type annotation information correctly. It is therefore preferable
+for users who want to type-check their code with ``mypy``.
+
+``Paginator.wrap`` converts any client method into a callable which returns a
+paginator. Its usage is very similar to the ``.paginated`` syntax.
+
+.. code-block:: python
+
+    import globus_sdk
+    from globus_sdk.paging import Paginator
+
+    tc = globus_sdk.TransferClient(...)
+
+    # convert `tc.endpoint_search` into a call returning a paginator
+    paginated_call = Paginator.wrap(tc.endpoint_search)
+
+    # now the result is a paginator and we can use `pages()` or `items()` as
+    # normal
+    for endpoint_info in paginated_call("tutorial").items():
+        print("got endpoint_id:", endpoint_info["id"])
+
+
+However, if using ``mypy`` to run ``reveal_type``, the results of
+``tc.paginated.task_successful_transfers`` and
+``Paginator.wrap(tc.task_successful_transfers)`` are very different:
+
+.. code-block:: python
+
+    # def (task_id: Union[uuid.UUID, builtins.str], *, query_params: Union[builtins.dict[builtins.str, Any], None] =) -> globus_sdk.services.transfer.response.iterable.IterableTransferResponse
+    reveal_type(tc.task_successful_transfers)
+    # def [PageT <: globus_sdk.response.GlobusHTTPResponse] (*Any, **Any) -> globus_sdk.paging.base.Paginator[PageT`-1]
+    reveal_type(tc.paginated.task_successful_transfers)
+    # def (task_id: Union[uuid.UUID, builtins.str], *, query_params: Union[builtins.dict[builtins.str, Any], None] =) -> globus_sdk.paging.base.Paginator[globus_sdk.services.transfer.response.iterable.IterableTransferResponse*]
+    reveal_type(Paginator.wrap(tc.task_successful_transfers))
+
 Paginator Types
 ---------------
 

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,9 @@ setup(
         #   non-breaking for our usages
         # - other packages /consumers can specify stricter bounds if necessary
         "cryptography>=3.3.1,!=3.4.0",
+        # depend on the latest version of typing-extensions on python versions which do
+        # not have all of the typing features we use
+        'typing_extensions;python_version<"3.10"',
     ],
     extras_require={"dev": DEV_REQUIREMENTS},
     keywords=["globus"],

--- a/src/globus_sdk/client.py
+++ b/src/globus_sdk/client.py
@@ -1,21 +1,15 @@
-import inspect
 import logging
 import urllib.parse
-from typing import Any, Callable, Dict, Optional, Type, TypeVar, Union, cast
-
-import typing_extensions as te
+from typing import Any, Dict, Optional, Type, Union
 
 from globus_sdk import config, exc, utils
 from globus_sdk.authorizers import GlobusAuthorizer
-from globus_sdk.paging import Paginator, PaginatorTable
+from globus_sdk.paging import PaginatorTable
 from globus_sdk.response import GlobusHTTPResponse
 from globus_sdk.scopes import ScopeBuilder
 from globus_sdk.transport import RequestsTransport
 
 log = logging.getLogger(__name__)
-
-P = te.ParamSpec("P")
-R = TypeVar("R")
 
 
 class BaseClient:
@@ -48,6 +42,11 @@ class BaseClient:
 
     #: the scopes for this client may be present as a ``ScopeBuilder``
     scopes: Optional[ScopeBuilder] = None
+
+    # note the type of 'paginated' on the class to assist mypy
+    # in Paginator.wrap, mypy cannot infer that if X is a BaseClient,
+    # X.paginated is a PaginatorTable
+    paginated: PaginatorTable
 
     def __init__(
         self,
@@ -102,30 +101,6 @@ class BaseClient:
 
         # setup paginated methods
         self.paginated = PaginatorTable(self)
-
-    def typed_paginator(self, method: Callable[P, R]) -> Callable[P, Paginator[R]]:
-        """
-        This is an alternate method for getting a paginator for a paginated method which
-        correctly preserves the type signature of the paginated method.
-
-        It should be used on instances of clients and only passed bound methods of those
-        clients. For example, given usage
-
-            >>> tc = TransferClient()
-            >>> paginator = tc.paginated.endpoint_search(...)
-
-        a typed paginator can be acquired with
-
-            >>> tc = TransferClient()
-            >>> paginator_call = tc.typed_paginator(tc.endpoint_search)
-            >>> paginator = paginator_call(...)
-
-        Although the syntax is slightly more verbose, this allows `mypy` and other type
-        checkers to more accurately infer the type of the paginator.
-        """
-        assert inspect.ismethod(method)
-        assert method.__self__ == self
-        return cast(Callable[P, Paginator[R]], getattr(self.paginated, method.__name__))
 
     @property
     def app_name(self) -> Optional[str]:

--- a/src/globus_sdk/client.py
+++ b/src/globus_sdk/client.py
@@ -43,11 +43,6 @@ class BaseClient:
     #: the scopes for this client may be present as a ``ScopeBuilder``
     scopes: Optional[ScopeBuilder] = None
 
-    # note the type of 'paginated' on the class to assist mypy
-    # in Paginator.wrap, mypy cannot infer that if X is a BaseClient,
-    # X.paginated is a PaginatorTable
-    paginated: PaginatorTable
-
     def __init__(
         self,
         *,

--- a/src/globus_sdk/paging/__init__.py
+++ b/src/globus_sdk/paging/__init__.py
@@ -1,9 +1,9 @@
-from .base import Paginator
+from .base import Paginator, has_paginator
 from .last_key import LastKeyPaginator
 from .limit_offset import HasNextPaginator, LimitOffsetTotalPaginator
 from .marker import MarkerPaginator
 from .next_token import NextTokenPaginator
-from .table import PaginatorTable, has_paginator
+from .table import PaginatorTable
 
 __all__ = (
     "Paginator",

--- a/src/globus_sdk/paging/base.py
+++ b/src/globus_sdk/paging/base.py
@@ -1,6 +1,7 @@
 import abc
 import functools
 import inspect
+import sys
 from typing import (
     Any,
     Callable,
@@ -15,12 +16,15 @@ from typing import (
     cast,
 )
 
-import typing_extensions as te
-
 from globus_sdk.response import GlobusHTTPResponse
 
+if sys.version_info >= (3, 10):
+    from typing import ParamSpec
+else:
+    from typing_extensions import ParamSpec
+
 PageT = TypeVar("PageT", bound=GlobusHTTPResponse)
-P = te.ParamSpec("P")
+P = ParamSpec("P")
 R = TypeVar("R", bound=GlobusHTTPResponse)
 C = TypeVar("C", bound=Callable[..., GlobusHTTPResponse])
 

--- a/src/globus_sdk/services/auth/client/base.py
+++ b/src/globus_sdk/services/auth/client/base.py
@@ -2,27 +2,17 @@ import collections.abc
 import json
 import logging
 import sys
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    Iterable,
-    Optional,
-    Type,
-    TypeVar,
-    Union,
-    cast,
-    overload,
-)
+from typing import Any, Dict, Iterable, Optional, Type, TypeVar, Union, cast, overload
 
 import jwt
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 
-if TYPE_CHECKING:
-    if sys.version_info >= (3, 8):
-        from typing import Literal
-    else:
-        from typing_extensions import Literal
+if sys.version_info >= (3, 8):
+    # pylint can't handle quoted annotations yet:
+    # https://github.com/PyCQA/pylint/issues/3299
+    from typing import Literal  # pylint: disable=unused-import
+else:
+    from typing_extensions import Literal
 
 from globus_sdk import client, exc, utils
 from globus_sdk.authorizers import NullAuthorizer

--- a/tests/functional/transfer/test_paginated.py
+++ b/tests/functional/transfer/test_paginated.py
@@ -3,6 +3,7 @@ import random
 import pytest
 import responses
 
+from globus_sdk.paging import Paginator
 from tests.common import register_api_route
 
 # empty search
@@ -227,7 +228,8 @@ def test_shared_endpoint_list_non_paginated(client):
         assert "id" in item
 
 
-def test_shared_endpoint_list_iter_pages(client):
+@pytest.mark.parametrize("paging_variant", ["attr", "wrap"])
+def test_shared_endpoint_list_iter_pages(client, paging_variant):
     # add each page
     for page in SHARED_ENDPOINT_RESULTS:
         register_api_route(
@@ -235,7 +237,12 @@ def test_shared_endpoint_list_iter_pages(client):
         )
 
     # paginator pages() call gets an iterator of pages
-    paginator = client.paginated.get_shared_endpoint_list("endpoint_id")
+    if paging_variant == "attr":
+        paginator = client.paginated.get_shared_endpoint_list("endpoint_id")
+    elif paging_variant == "wrap":
+        paginator = Paginator.wrap(client.get_shared_endpoint_list)("endpoint_id")
+    else:
+        raise NotImplementedError
     count = 0
     for item in paginator.pages():
         count += 1
@@ -244,7 +251,8 @@ def test_shared_endpoint_list_iter_pages(client):
     assert count == 3
 
 
-def test_shared_endpoint_list_iter_items(client):
+@pytest.mark.parametrize("paging_variant", ["attr", "wrap"])
+def test_shared_endpoint_list_iter_items(client, paging_variant):
     # add each page
     for page in SHARED_ENDPOINT_RESULTS:
         register_api_route(
@@ -252,7 +260,12 @@ def test_shared_endpoint_list_iter_items(client):
         )
 
     # paginator items() call gets an iterator of individual page items
-    paginator = client.paginated.get_shared_endpoint_list("endpoint_id")
+    if paging_variant == "attr":
+        paginator = client.paginated.get_shared_endpoint_list("endpoint_id")
+    elif paging_variant == "wrap":
+        paginator = Paginator.wrap(client.get_shared_endpoint_list)("endpoint_id")
+    else:
+        raise NotImplementedError
     count = 0
     for item in paginator.items():
         count += 1

--- a/tests/unit/type_annotations/test_pagination.py
+++ b/tests/unit/type_annotations/test_pagination.py
@@ -14,12 +14,13 @@ def test_transfer_task_list(run_reveal_type):
 
 
 def test_typed_paginated_transfer_task_list(run_reveal_type):
-    # the typed_paginator variant of a method should preserve the parameters
+    # the Paginator.wrap variant of a method should preserve the parameters
     # (ParamSpec) but have an altered return type
     got_type = run_reveal_type(
-        "tc.typed_paginator(tc.task_list)",
+        "Paginator.wrap(tc.task_list)",
         preamble="""\
 import globus_sdk
+from globus_sdk.paging import Paginator
 
 tc = globus_sdk.TransferClient()
 """,

--- a/tests/unit/type_annotations/test_pagination.py
+++ b/tests/unit/type_annotations/test_pagination.py
@@ -1,3 +1,6 @@
+import re
+
+
 def test_transfer_task_list(run_reveal_type):
     # task_list is decorated with documentation and pagination helpers; make sure that
     # the typing information is preserved
@@ -8,3 +11,25 @@ def test_transfer_task_list(run_reveal_type):
     assert got_type.startswith(
         "def (self: globus_sdk.services.transfer.client.TransferClient"
     )
+
+
+def test_typed_paginated_transfer_task_list(run_reveal_type):
+    # the typed_paginator variant of a method should preserve the parameters
+    # (ParamSpec) but have an altered return type
+    got_type = run_reveal_type(
+        "tc.typed_paginator(tc.task_list)",
+        preamble="""\
+import globus_sdk
+
+tc = globus_sdk.TransferClient()
+""",
+    )
+
+    # this is what we'd see if type information were discarded for any reason...
+    assert got_type != "def (*Any, **Any) -> Any"
+
+    # the start of the parameters for task_list is `*` (no positionals)
+    assert got_type.startswith("def (*, ")
+    # the result type ("right hand side") is a paginator of iterable responses
+    rhs = got_type.split("->")[-1].strip()
+    assert re.search(r"Paginator\[globus_sdk\.([^.]+\.)*IterableTransferResponse", rhs)


### PR DESCRIPTION
In parallel with exploration of a mypy plugin for paginators, we discussed last week the possibility of a Callable interface which could preserve the type information about a paginated method. Because it doesn't rely on `__getattr__` proxying to do the lookup, it can be type-preserving without a plugin.

---

This adds a first draft of 'typed_paginator' as a client method which takes other client methods as inputs.

Unfortunately, because mypy v0.910 does not yet implement support for ParamSpec, this code is not yet usable. `mypy` will error on ParamSpec usage, indicating that it believes that the parameter specification for a Callable must be a list or ellipsis. The implementation appears correct (with the caveat that it uses `assert`s and is minimally tested and documented) using mypy master, v0.920, but this means it is not yet ready for general use.

In order to make things work out better, this makes the paginators generics over their "page type". This allows a paginator over a method returning `IterableTransferResponse` to indicate that it has `pages() -> Iterable[IterableTransferResponse]` correctly.
This change could be separated and merged prior to the rest of this work.

---

When `mypy` releases general support for `ParamSpec`, this can be cleaned up with the following:
- figure out where we need `typing_extensions` (and potentially always install it for simplicity)
- replace those `assert`s with usage errors
- add some `reveal_type` tests
- add docs which instruct users on usage `paginator = tc.typed_paginator(tc.endpoint_search)("foo")`, noting that this is only necessary if you want `mypy` to provide full type information