### PR TITLE
Make Paginator a Generic type over PageT

### DIFF
--- a/changelog.d/20211115_204209_sirosen_generic_paginator.rst
+++ b/changelog.d/20211115_204209_sirosen_generic_paginator.rst
@@ -1,0 +1,3 @@
+* `Paginator` objects are now generics over a type var for their page type. The
+  page type is bounded by `GlobusHTTPResponse`, and most type-checker behaviors
+  will remain unchanged (:pr:`NUMBER`)

--- a/src/globus_sdk/paging/base.py
+++ b/src/globus_sdk/paging/base.py
@@ -1,10 +1,12 @@
 import abc
-from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional
+from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional, TypeVar
 
 from globus_sdk.response import GlobusHTTPResponse
 
+PageT = TypeVar("PageT", bound=GlobusHTTPResponse)
 
-class Paginator(Iterable[GlobusHTTPResponse], metaclass=abc.ABCMeta):
+
+class Paginator(Iterable[PageT], metaclass=abc.ABCMeta):
     """
     Base class for all paginators.
     This guarantees is that they have generator methods named ``pages`` and ``items``.
@@ -32,18 +34,21 @@ class Paginator(Iterable[GlobusHTTPResponse], metaclass=abc.ABCMeta):
         *,
         items_key: Optional[str] = None,
         client_args: List[Any],
-        client_kwargs: Dict[str, Any]
+        client_kwargs: Dict[str, Any],
+        # the Base paginator must accept arbitrary additional kwargs to indicate that
+        # its child classes could define and use additional kwargs
+        **kwargs: Any,
     ):
         self.method = method
         self.items_key = items_key
         self.client_args = client_args
         self.client_kwargs = client_kwargs
 
-    def __iter__(self) -> Iterator[GlobusHTTPResponse]:
+    def __iter__(self) -> Iterator[PageT]:
         yield from self.pages()
 
     @abc.abstractmethod
-    def pages(self) -> Iterator[GlobusHTTPResponse]:
+    def pages(self) -> Iterator[PageT]:
         """``pages()`` yields GlobusHTTPResponse objects, each one representing a page
         of results."""
 

--- a/src/globus_sdk/paging/last_key.py
+++ b/src/globus_sdk/paging/last_key.py
@@ -1,11 +1,9 @@
 from typing import Any, Callable, Dict, Iterator, List, Optional
 
-from globus_sdk.response import GlobusHTTPResponse
-
-from .base import Paginator
+from .base import PageT, Paginator
 
 
-class LastKeyPaginator(Paginator):
+class LastKeyPaginator(Paginator[PageT]):
     def __init__(
         self,
         method: Callable[..., Any],
@@ -22,7 +20,7 @@ class LastKeyPaginator(Paginator):
         )
         self.last_key: Optional[str] = None
 
-    def pages(self) -> Iterator[GlobusHTTPResponse]:
+    def pages(self) -> Iterator[PageT]:
         has_next_page = True
         while has_next_page:
             if self.last_key:

--- a/src/globus_sdk/paging/limit_offset.py
+++ b/src/globus_sdk/paging/limit_offset.py
@@ -1,11 +1,9 @@
 from typing import Any, Callable, Dict, Iterator, List, Optional
 
-from globus_sdk.response import GlobusHTTPResponse
-
-from .base import Paginator
+from .base import PageT, Paginator
 
 
-class _LimitOffsetBasedPaginator(Paginator):
+class _LimitOffsetBasedPaginator(Paginator[PageT]):
     def __init__(
         self,
         method: Callable[..., Any],
@@ -44,8 +42,8 @@ class _LimitOffsetBasedPaginator(Paginator):
         )
 
 
-class HasNextPaginator(_LimitOffsetBasedPaginator):
-    def pages(self) -> Iterator[GlobusHTTPResponse]:
+class HasNextPaginator(_LimitOffsetBasedPaginator[PageT]):
+    def pages(self) -> Iterator[PageT]:
         has_next_page = True
         while has_next_page:
             self._update_limit()
@@ -56,8 +54,8 @@ class HasNextPaginator(_LimitOffsetBasedPaginator):
             has_next_page = current_page["has_next_page"]
 
 
-class LimitOffsetTotalPaginator(_LimitOffsetBasedPaginator):
-    def pages(self) -> Iterator[GlobusHTTPResponse]:
+class LimitOffsetTotalPaginator(_LimitOffsetBasedPaginator[PageT]):
+    def pages(self) -> Iterator[PageT]:
         has_next_page = True
         while has_next_page:
             self._update_limit()

--- a/src/globus_sdk/paging/marker.py
+++ b/src/globus_sdk/paging/marker.py
@@ -1,11 +1,9 @@
 from typing import Any, Callable, Dict, Iterator, List, Optional
 
-from globus_sdk.response import GlobusHTTPResponse
-
-from .base import Paginator
+from .base import PageT, Paginator
 
 
-class MarkerPaginator(Paginator):
+class MarkerPaginator(Paginator[PageT]):
     """
     A paginator which uses `has_next_page` and `marker` from payloads, sets the `marker`
     query param to page.
@@ -29,7 +27,7 @@ class MarkerPaginator(Paginator):
         )
         self.marker: Optional[str] = None
 
-    def pages(self) -> Iterator[GlobusHTTPResponse]:
+    def pages(self) -> Iterator[PageT]:
         has_next_page = True
         while has_next_page:
             if self.marker:

--- a/src/globus_sdk/paging/next_token.py
+++ b/src/globus_sdk/paging/next_token.py
@@ -1,11 +1,9 @@
 from typing import Any, Callable, Dict, Iterator, List, Optional
 
-from globus_sdk.response import GlobusHTTPResponse
-
-from .base import Paginator
+from .base import PageT, Paginator
 
 
-class NextTokenPaginator(Paginator):
+class NextTokenPaginator(Paginator[PageT]):
     """
     A paginator which uses `next_token` from payloads to set the `next_token`
     query param to page.
@@ -30,7 +28,7 @@ class NextTokenPaginator(Paginator):
         )
         self.next_token: Optional[str] = None
 
-    def pages(self) -> Iterator[GlobusHTTPResponse]:
+    def pages(self) -> Iterator[PageT]:
         has_next_page = True
         while has_next_page:
             if self.next_token:

--- a/src/globus_sdk/paging/table.py
+++ b/src/globus_sdk/paging/table.py
@@ -1,21 +1,23 @@
 import functools
-from typing import Any, Callable, Dict, Optional, Type, TypeVar, cast
+from typing import Any, Callable, Dict, Generic, Optional, Type, TypeVar, cast
 
-from .base import Paginator
+from globus_sdk.response import GlobusHTTPResponse
 
-C = TypeVar("C", bound=Callable[..., Any])
+from .base import PageT, Paginator
+
+C = TypeVar("C", bound=Callable[..., GlobusHTTPResponse])
 
 
 # stub for mypy
-class _PaginatedFunc:
+class _PaginatedFunc(Generic[PageT]):
     _has_paginator: bool
-    _paginator_class: Type[Paginator[Any]]
+    _paginator_class: Type[Paginator[PageT]]
     _paginator_items_key: Optional[str]
     _paginator_params: Dict[str, Any]
 
 
 def has_paginator(
-    paginator_class: Type[Paginator[Any]],
+    paginator_class: Type[Paginator[PageT]],
     items_key: Optional[str] = None,
     **paginator_params: Any,
 ) -> Callable[[C], C]:
@@ -35,7 +37,7 @@ def has_paginator(
     """
 
     def decorate(func: C) -> C:
-        as_paginated = cast(_PaginatedFunc, func)
+        as_paginated = cast(_PaginatedFunc[PageT], func)
         as_paginated._has_paginator = True
         as_paginated._paginator_class = paginator_class
         as_paginated._paginator_items_key = items_key
@@ -89,16 +91,16 @@ class PaginatorTable:
         self._client = client
         # _bindings is a lazily loaded table of names -> callables which
         # return paginators
-        self._bindings: Dict[str, Callable[..., Paginator[Any]]] = {}
+        self._bindings: Dict[str, Callable[..., Paginator[PageT]]] = {}
 
-    def _add_binding(self, methodname: str, bound_method: Callable[..., Any]) -> None:
-        as_paginated = cast(_PaginatedFunc, bound_method)
+    def _add_binding(self, methodname: str, bound_method: Callable[..., PageT]) -> None:
+        as_paginated = cast(_PaginatedFunc[PageT], bound_method)
         paginator_class = as_paginated._paginator_class
         paginator_params = as_paginated._paginator_params
         paginator_items_key = as_paginated._paginator_items_key
 
         @functools.wraps(bound_method)
-        def paginated_method(*args: Any, **kwargs: Any) -> Paginator[Any]:
+        def paginated_method(*args: Any, **kwargs: Any) -> Paginator[PageT]:
             return paginator_class(
                 bound_method,
                 client_args=list(args),
@@ -109,7 +111,7 @@ class PaginatorTable:
 
         self._bindings[methodname] = paginated_method
 
-    def __getattr__(self, attrname: str) -> Callable[..., Paginator[Any]]:
+    def __getattr__(self, attrname: str) -> Callable[..., Paginator[PageT]]:
         if attrname not in self._bindings:
             # this could raise AttributeError -- in which case, let it!
             method = getattr(self._client, attrname)


### PR DESCRIPTION
This work was extracted from #494. I don't think it makes a lot of sense purely on its own because there's no clear motivation. #494 (or something like it) _is_ the motivator. We will want to be able to indicate that a paginated call to Endpoint Search returns a paginator _of `IterableTransferResponse`_ objects. To describe that kind of container-relationship in the types, a Generic is most appropriate.

---

This makes Paginator a generic over PageT, a type var with the type bound of GlobusHTTPResponse. This means that hte iterable elements of a paginator are still expected to be response objects, and they will still type-check as having the necessary methods and attributes of a response. However, this also makes it possible for a paginator to be constructed with PageT bound to a specific value, e.g. `IterableTransferResponse`.

This would mean that the pages of the paginator have a more specific type, and can be expected to respond to those methods.

Under the current implementation of pagination, a lot of type information is being lost. However, if a more type-specific pagination interface is added (PR #494), then the type-preserving paginator will be able to indicate the page type which it is producing.

Because `mypy --strict` disallows implicit `Any` on generics, several locations need to be updated with an explicit type variable for the paginators, usually Any.
One minor change this raised is that it allowed us to turn off a `type: ignore` in the paginator table. The result, however, is that we
must add `**kwargs: Any` to the base paginator class (because subclasses may implement additional keyword args) in order for that method to type-check.