### PR TITLE
Publish `get_service_url`, add `get_webapp_url`

### DIFF
--- a/changelog.d/20211117_174041_rudyardrichter_config_get_app_url.rst
+++ b/changelog.d/20211117_174041_rudyardrichter_config_get_app_url.rst
@@ -1,0 +1,10 @@
+..
+.. A new scriv changelog fragment
+..
+.. Add one or more items to the list below describing the change in clear, concise terms.
+..
+.. Leave the ":pr:`...`" text alone. When you open a pull request, GitHub Actions will
+.. automatically replace it when the PR is merged.
+..
+
+* Tweak `get_service_url` to be able to return correct webapp URLs (:pr:`NUMBER`)

--- a/changelog.d/20211117_174041_rudyardrichter_config_get_app_url.rst
+++ b/changelog.d/20211117_174041_rudyardrichter_config_get_app_url.rst
@@ -7,4 +7,7 @@
 .. automatically replace it when the PR is merged.
 ..
 
-* Tweak `get_service_url` to be able to return correct webapp URLs (:pr:`NUMBER`)
+* Document ``globus_sdk.config.get_service_url`` and ``globus_sdk.config.get_webapp_url``
+  (:pr:`NUMBER`)
+    * Internally, these are updated to be able to default to the ``GLOBUS_SDK_ENVIRONMENT`` setting,
+      so specifying an environment is no longer required

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -42,3 +42,18 @@ verification turned on.
     ``TRANSFER``, etc). For example, set
     ``GLOBUS_SDK_SERVICE_URL_TRANSFER="https://proxy-device.example.org/"`` to direct
     the SDK to use a custom URL when contacting the Globus Transfer service.
+
+Config-Related Functions
+------------------------
+
+There are two functions available to translate the configuration described above into the URLs to use for accessing Globus services.
+
+To return specifically the URL for the Globus Web App in a given environment:
+
+.. autofunction:: globus_sdk.config.get_webapp_url
+
+To return the URL for any other service in a given environment:
+
+.. autofunction:: globus_sdk.config.get_service_url
+
+Note that *no other imports* from ``globus_sdk.config`` are considered public.

--- a/src/globus_sdk/client.py
+++ b/src/globus_sdk/client.py
@@ -81,7 +81,7 @@ class BaseClient:
             raise ValueError("Either service_name or base_url must be set")
 
         self.base_url = utils.slash_join(
-            config.get_service_url(self.environment, self.service_name)
+            config.get_service_url(self.service_name, environment=self.environment)
             if base_url is None
             else base_url,
             self.base_path,

--- a/src/globus_sdk/config/__init__.py
+++ b/src/globus_sdk/config/__init__.py
@@ -1,10 +1,11 @@
 from .env_vars import get_environment_name, get_http_timeout, get_ssl_verify
-from .environments import EnvConfig, get_service_url
+from .environments import EnvConfig, get_service_url, get_webapp_url
 
 __all__ = (
     "EnvConfig",
-    "get_service_url",
     "get_environment_name",
     "get_ssl_verify",
     "get_http_timeout",
+    "get_service_url",
+    "get_webapp_url",
 )

--- a/src/globus_sdk/config/environments.py
+++ b/src/globus_sdk/config/environments.py
@@ -57,10 +57,10 @@ def get_service_url(service: str, environment: Optional[str] = None) -> str:
     Return the base URL for the given service in this environment. For example:
 
     >>> from globus_sdk.config import get_service_url
-    >>> get_service_url("auth", environment="sandbox")
-    'https://auth.sandbox.globuscs.info/'
-    >>> get_service_url("search", environment="test")
-    'https://search.api.test.globuscs.info/'
+    >>> get_service_url("auth", environment="preview")
+    'https://auth.preview.globus.org/'
+    >>> get_service_url("search", environment="production")
+    'https://search.api.globus.org/'
 
     If no ``environment`` is specified, this will use the ``GLOBUS_SDK_ENVIRONMENT``
     environment variable.
@@ -87,8 +87,8 @@ def get_webapp_url(environment: Optional[str] = None) -> str:
     """
     Return the URL to access the Globus web app in the given environment. For example:
 
-    >>> get_webapp_url("sandbox")
-    'https://app.sandbox.globuscs.info/'
+    >>> get_webapp_url("preview")
+    'https://app.preview.globus.org/'
     """
     environment = environment or get_environment_name()
     return get_service_url("app", environment=environment)

--- a/src/globus_sdk/config/environments.py
+++ b/src/globus_sdk/config/environments.py
@@ -2,6 +2,8 @@ import logging
 import os
 from typing import Any, Dict, List, Optional, Type, cast
 
+from .env_vars import get_environment_name
+
 log = logging.getLogger(__name__)
 # the format string for a service URL pulled out of the environment
 # these are handled with uppercased service names, e.g.
@@ -50,8 +52,21 @@ class EnvConfig:
         return cls._registry.get(envname)
 
 
-def get_service_url(environment: str, service: str) -> str:
+def get_service_url(service: str, environment: Optional[str] = None) -> str:
+    """
+    Return the base URL for the given service in this environment. For example:
+
+    >>> from globus_sdk.config import get_service_url
+    >>> get_service_url("auth", environment="sandbox")
+    'https://auth.sandbox.globuscs.info/'
+    >>> get_service_url("search", environment="test")
+    'https://search.api.test.globuscs.info/'
+
+    If no ``environment`` is specified, this will use the ``GLOBUS_SDK_ENVIRONMENT``
+    environment variable.
+    """
     log.debug(f'Service URL Lookup for "{service}" under env "{environment}"')
+    environment = environment or get_environment_name()
     # check for an environment variable of the form
     #   GLOBUS_SDK_SERVICE_URL_*
     # and use it ahead of any env config if set
@@ -66,6 +81,17 @@ def get_service_url(environment: str, service: str) -> str:
     url = conf.get_service_url(service)
     log.debug(f'Service URL Lookup Result: "{service}" is at "{url}"')
     return url
+
+
+def get_webapp_url(environment: Optional[str] = None) -> str:
+    """
+    Return the URL to access the Globus web app in the given environment. For example:
+
+    >>> get_webapp_url("sandbox")
+    'https://app.sandbox.globuscs.info/'
+    """
+    environment = environment or get_environment_name()
+    return get_service_url("app", environment=environment)
 
 
 #

--- a/src/globus_sdk/config/environments.py
+++ b/src/globus_sdk/config/environments.py
@@ -12,7 +12,7 @@ _SERVICE_URL_VAR_FORMAT = "GLOBUS_SDK_SERVICE_URL_{}"
 class EnvConfig:
     envname: str
     domain: str
-    no_dotapi: List[str] = ["auth"]
+    no_dotapi: List[str] = ["app", "auth"]
 
     # this same dict is inherited (and therefore shared!) by all subclasses
     _registry: Dict[str, Type["EnvConfig"]] = {}

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -12,24 +12,24 @@ def test_get_service_url():
     Tests environments, services, and missing values
     """
     assert (
-        globus_sdk.config.get_service_url("production", "auth")
+        globus_sdk.config.get_service_url("auth", environment="production")
         == "https://auth.globus.org/"
     )
     assert (
-        globus_sdk.config.get_service_url("production", "transfer")
+        globus_sdk.config.get_service_url("transfer", environment="production")
         == "https://transfer.api.globus.org/"
     )
     assert (
-        globus_sdk.config.get_service_url("preview", "auth")
+        globus_sdk.config.get_service_url("auth", environment="preview")
         == "https://auth.preview.globus.org/"
     )
     assert (
-        globus_sdk.config.get_service_url("preview", "search")
+        globus_sdk.config.get_service_url("search", environment="preview")
         == "https://search.api.preview.globus.org/"
     )
 
     with pytest.raises(ValueError):
-        globus_sdk.config.get_service_url("nonexistent", "auth")
+        globus_sdk.config.get_service_url("auth", environment="nonexistent")
 
 
 @pytest.mark.parametrize(
@@ -144,11 +144,11 @@ def test_service_url_from_env_var():
         os.environ["GLOBUS_SDK_SERVICE_URL_TRANSFER"] = "https://transfer.example.org/"
         # environment setting gets ignored at this point -- only the override applies
         assert (
-            globus_sdk.config.get_service_url("preview", "transfer")
+            globus_sdk.config.get_service_url("transfer", environment="preview")
             == "https://transfer.example.org/"
         )
         assert (
-            globus_sdk.config.get_service_url("production", "transfer")
+            globus_sdk.config.get_service_url("transfer", environment="production")
             == "https://transfer.example.org/"
         )
         # also try with a made up service
@@ -156,6 +156,17 @@ def test_service_url_from_env_var():
             "GLOBUS_SDK_SERVICE_URL_ION_CANNON"
         ] = "https://ion-cannon.example.org/"
         assert (
-            globus_sdk.config.get_service_url("production", "ion_cannon")
+            globus_sdk.config.get_service_url("ion_cannon", environment="production")
             == "https://ion-cannon.example.org/"
         )
+
+        for env in ["sandbox", "test", "integration"]:
+            os.environ["GLOBUS_SDK_ENVIRONMENT"] = env
+            assert (
+                globus_sdk.config.get_service_url("auth")
+                == f"https://auth.{env}.globuscs.info/"
+            )
+            assert (
+                globus_sdk.config.get_webapp_url()
+                == f"https://app.{env}.globuscs.info/"
+            )


### PR DESCRIPTION
This updates `get_service_url` to default to the environment settings to find the environment for a service, lets `get_service_url` return a sensible URL for the webapp and adds `get_webapp_url` for specifically that purpose.

Before:
```python
>>> from globus_sdk.config import get_service_url
>>> get_service_url("test", "app")
'https://app.api.test.globuscs.info/'
```

After:
```python
>>> from globus_sdk.config import get_service_url, get_webapp_url
>>> get_service_url("app", environment="test")
'https://app.test.globuscs.info/'
```
Or just `export GLOBUS_SDK_ENVIRONMENT=test` and then:
```python
>>> from globus_sdk.config import get_webapp_url
>>> get_webapp_url()
'https://app.test.globuscs.info/'
```