### PR TITLE
Expose `headers` from response objects

### DIFF
--- a/changelog.d/20211201_202405_sirosen_propogate_response_properties.rst
+++ b/changelog.d/20211201_202405_sirosen_propogate_response_properties.rst
@@ -1,0 +1,8 @@
+* The implementation of several properties of ``GlobusHTTPResponse`` has
+  changed (:pr:`NUMBER`)
+
+  * Responses have a new property, ``headers``, a case-insensitive
+    dict of headers from the response
+
+  * Responses now implement ``http_status`` and ``content_type`` as
+    properties without setters

--- a/tests/unit/responses/test_response.py
+++ b/tests/unit/responses/test_response.py
@@ -10,7 +10,7 @@ from globus_sdk.response import GlobusHTTPResponse, IterableResponse
 _TestResponse = namedtuple("_TestResponse", ("data", "r"))
 
 
-def _response(data=None, encoding="utf-8", headers=None):
+def _response(data=None, encoding="utf-8", headers=None, status=None):
     r = requests.Response()
 
     is_json = isinstance(data, (dict, list))
@@ -28,6 +28,9 @@ def _response(data=None, encoding="utf-8", headers=None):
         r.headers.update(headers)
     elif is_json:
         r.headers["Content-Type"] = "application/json"
+
+    if status is not None:
+        r.status_code = status
 
     return r
 
@@ -182,3 +185,14 @@ def test_cannot_construct_base_iterable_response():
     r = _response(b"foo: bar, baz: buzz")
     with pytest.raises(TypeError):
         IterableResponse(r, client=mock.Mock())
+
+
+def test_http_status_code_on_response():
+    r1 = _response(status=404)
+    assert r1.status_code == 404
+
+    r2 = GlobusHTTPResponse(r1, client=mock.Mock())  # handle a Response object
+    assert r2.http_status == 404
+
+    r3 = GlobusHTTPResponse(r2)  # wrap another response
+    assert r3.http_status == 404

--- a/tests/unit/responses/test_response.py
+++ b/tests/unit/responses/test_response.py
@@ -196,3 +196,14 @@ def test_http_status_code_on_response():
 
     r3 = GlobusHTTPResponse(r2)  # wrap another response
     assert r3.http_status == 404
+
+
+def test_http_headers_from_response():
+    r1 = _response(headers={"Content-Length": "5"})
+    assert r1.headers["content-length"] == "5"
+
+    r2 = GlobusHTTPResponse(r1, client=mock.Mock())  # handle a Response object
+    assert r2.headers["content-length"] == "5"
+
+    r3 = GlobusHTTPResponse(r2)  # wrap another response
+    assert r3.headers["content-length"] == "5"


### PR DESCRIPTION
`GlobusHTTPResponse.headers` is just a pointer at the `requests.Response.headers` mapping.

To enable this, an internal-only property, `_raw_response` is added which traverses wrapped response objects until it reaches the original response object. We can then use that property to implement `headers` as a property which returns `self._raw_response.headers`. This pattern is also applicable to some existing data -- `http_status` and `content_type` -- so these are changed to be uniform.

This means that `http_status` and `content_type` are now read-only, which is a minor interface change. It is therefore noted explicitly in the changelog.

---

The added test uses http status code to demonstrate that the wrapping preserves properties as intended.