### PR TITLE
update type of scopes for ClientCredentialsAuthorizer

### DIFF
--- a/changelog.d/20211201_145304_aaschaer_scopes_type.rst
+++ b/changelog.d/20211201_145304_aaschaer_scopes_type.rst
@@ -1,0 +1,1 @@
+* ClientCredentialsAuthorizer now accepts Union[str, Iterable[str]] as the type for scopes

--- a/changelog.d/20211201_145304_aaschaer_scopes_type.rst
+++ b/changelog.d/20211201_145304_aaschaer_scopes_type.rst
@@ -1,1 +1,1 @@
-* ClientCredentialsAuthorizer now accepts Union[str, Iterable[str]] as the type for scopes
+* ClientCredentialsAuthorizer now accepts Union[str, Iterable[str]] as the type for scopes (:pr:`NUMBER`)

--- a/changelog.d/20211201_145304_aaschaer_scopes_type.rst
+++ b/changelog.d/20211201_145304_aaschaer_scopes_type.rst
@@ -1,1 +1,2 @@
-* ClientCredentialsAuthorizer now accepts Union[str, Iterable[str]] as the type for scopes (:pr:`NUMBER`)
+* ClientCredentialsAuthorizer now accepts ``Union[str, Iterable[str]]``
+  as the type for scopes (:pr:`NUMBER`)

--- a/src/globus_sdk/authorizers/client_credentials.py
+++ b/src/globus_sdk/authorizers/client_credentials.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict, Iterable, Optional, Union
 
 from globus_sdk.services.auth import ConfidentialAppAuthClient, OAuthTokenResponse
 
@@ -36,7 +36,7 @@ class ClientCredentialsAuthorizer(RenewingAuthorizer):
         access tokens that will be used for the Authorization header. These scopes must
         all be for the same resource server, or else the token response will have
         multiple access tokens.
-    :type scopes: str
+    :type scopes: str, or iterable of str
     :param access_token: Initial Access Token to use, only used if ``expires_at`` is
         also set. Must be requested with the same set of scopes passed to this
         authorizer.
@@ -58,7 +58,7 @@ class ClientCredentialsAuthorizer(RenewingAuthorizer):
     def __init__(
         self,
         confidential_client: ConfidentialAppAuthClient,
-        scopes: str,
+        scopes: Union[str, Iterable[str]],
         *,
         access_token: Optional[str] = None,
         expires_at: Optional[int] = None,


### PR DESCRIPTION
Ran into this while linting client credentials work for the CLI.

The `ClientCredentialsAuthorizer` was being too strict in the allowed types for `scopes` since they are just being passed to `oauth2_client_credentials_tokens` which accepts `Optional[Union[str, Iterable[str]]]`