### PR TITLE
Fix to be py3.10 compatible

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.9"]
+        python-version: ["3.10"]
         include:
           - os: ubuntu-latest
             python-version: 3.6
@@ -18,6 +18,8 @@ jobs:
             python-version: 3.7
           - os: ubuntu-latest
             python-version: 3.8
+          - os: ubuntu-latest
+            python-version: 3.9
     name: "Python ${{ matrix.python-version }} on ${{ matrix.os }} "
     runs-on: ${{ matrix.os }}
     steps:
@@ -30,8 +32,8 @@ jobs:
         run: |
           python -m pip install -U tox
       - name: Run Linting
-        # only lint on 3.9 for faster overall runs
-        if: ${{ matrix.python-version == '3.9' }}
+        # only lint on 3.10 for faster overall runs
+        if: ${{ matrix.python-version == '3.10' }}
         run: python -m tox -e lint
       - name: Run Tests
         run: python -m tox -e py -- --cov-report="term-missing:skip-covered"
@@ -40,12 +42,12 @@ jobs:
         if: ${{ matrix.python-version == '3.6' && matrix.os == 'ubuntu-latest' }}
         run: python -m tox -e py-mindeps
       - name: Ensure docs build
-        # docs are only ever built on a linux 3.9 box (readthedocs)
-        if: ${{ matrix.python-version == '3.9' && matrix.os == 'ubuntu-latest' }}
+        # docs are only ever built on a linux 3.10 box (readthedocs)
+        if: ${{ matrix.python-version == '3.10' && matrix.os == 'ubuntu-latest' }}
         run: python -m tox -e docs
       - name: Check package metadata
-        # only on linux py3.9 for faster runs
-        if: ${{ matrix.python-version == '3.9' && matrix.os == 'ubuntu-latest' }}
+        # only on linux py3.10 for faster runs
+        if: ${{ matrix.python-version == '3.10' && matrix.os == 'ubuntu-latest' }}
         run: |
           python -m tox -e twine-check
           python -m tox -e poetry-check

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,7 @@ sphinx:
   configuration: docs/conf.py
 formats: all
 python:
-  version: 3.8
+  version: "3.10"
   install:
     - method: pip
       path: .

--- a/changelog.d/20211210_202544_sirosen_py310_compat.rst
+++ b/changelog.d/20211210_202544_sirosen_py310_compat.rst
@@ -1,0 +1,1 @@
+* Update to avoid deprecation warnings on py3.10 (:pr:`NUMBER`)

--- a/setup.py
+++ b/setup.py
@@ -89,5 +89,6 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
 )

--- a/src/globus_sdk/config/env_vars.py
+++ b/src/globus_sdk/config/env_vars.py
@@ -6,7 +6,6 @@ This does not include service URL env vars (see environments.py for loading of t
 """
 import logging
 import os
-from distutils.util import strtobool
 from typing import Any, Callable, Optional, cast
 
 log = logging.getLogger(__name__)
@@ -15,6 +14,16 @@ log = logging.getLogger(__name__)
 ENVNAME_VAR = "GLOBUS_SDK_ENVIRONMENT"
 HTTP_TIMEOUT_VAR = "GLOBUS_SDK_HTTP_TIMEOUT"
 SSL_VERIFY_VAR = "GLOBUS_SDK_VERIFY_SSL"
+
+
+def _str2bool(val: str) -> bool:
+    val = val.lower()
+    if val in ("y", "yes", "t", "true", "on", "1"):
+        return True
+    elif val in ("n", "no", "f", "false", "off", "0"):
+        return False
+    else:
+        raise ValueError(f"invalid truth value: {val}")
 
 
 def _load_var(
@@ -42,7 +51,9 @@ def _load_var(
 def _bool_cast(value: Any, default: Any) -> bool:
     if isinstance(value, bool):
         return value
-    return strtobool(value.lower())
+    elif not isinstance(value, str):
+        raise ValueError(f"cannot cast value {value} of type {type(value)} to bool")
+    return _str2bool(value)
 
 
 def _optfloat_cast(value: Any, default: Any) -> Optional[float]:

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist =
     cov-clean
     cov-report
-    py{39,38,37,36}
+    py{310,39,38,37,36}
     py36-mindeps
 skip_missing_interpreters = true
 minversion = 3.0.0
@@ -43,9 +43,9 @@ deps = pyright
 commands = pyright src/ {posargs}
 
 [testenv:docs]
-# force use of py39 for doc builds so that we get the same behaviors as the
+# force use of py310 for doc builds so that we get the same behaviors as the
 # readthedocs doc build
-basepython = python3.9
+basepython = python3.10
 extras = dev
 whitelist_externals = rm
 changedir = docs/


### PR DESCRIPTION
Replace `distutils.util.strtobool` with a dedicated function so that we don't get deprecation warnings on py310.

Add py3.10 to the build matrix (tox and github actions).

Update RTD to use py3.10

Add 3.10 to classifiers.

@kurtmckee, as the original reporter of this issue, would you be willing to take a quick look at this?
I'm inclined to do a release with it as soon as it merges since it will cause downstream failures for anyone trying to use `filterwarnings=error` in a py3.10 build.