### PR TITLE
Allow IdentityMap to consume a cache on init

### DIFF
--- a/changelog.d/20211220_175329_sirosen_add_identity_map_custom_cache.rst
+++ b/changelog.d/20211220_175329_sirosen_add_identity_map_custom_cache.rst
@@ -1,0 +1,4 @@
+* ``globus_sdk.IdentityMap`` can now take a cache as an input. This allows
+  multiple ``IdentityMap`` instances to share the same storage cache. Any
+  mutable mapping type is valid, so the cache can be backed by a database or
+  other storage (:pr:`NUMBER`)

--- a/src/globus_sdk/_testing/data/auth/get_identities.py
+++ b/src/globus_sdk/_testing/data/auth/get_identities.py
@@ -43,6 +43,16 @@ RESPONSES = ResponseSet(
             ],
         },
     ),
+    sirosen=RegisteredResponse(
+        service="auth",
+        path="/v2/api/identities",
+        json={"identities": [_sirosen_at_globus_data]},
+        metadata={
+            "id": _sirosen_at_globus_data["id"],
+            "username": _sirosen_at_globus_data["username"],
+            "org": _sirosen_at_globus_data["organization"],
+        },
+    ),
     unauthorized=RegisteredResponse(
         service="auth",
         path="/v2/api/identities",

--- a/src/globus_sdk/services/auth/identity_map.py
+++ b/src/globus_sdk/services/auth/identity_map.py
@@ -164,7 +164,12 @@ class IdentityMap:
             self.unresolved_usernames if key_is_username else self.unresolved_ids
         )
 
+        # start the batch with the key being looked up, and if it is in the unresolved
+        # list remove it
         batch = {key}
+        if key in set_to_use:
+            set_to_use.remove(key)
+
         # until we've exhausted the set or filled the batch, keep trying to add
         while set_to_use and len(batch) < self.id_batch_size:
             value = set_to_use.pop()

--- a/tests/functional/auth/test_identity_map.py
+++ b/tests/functional/auth/test_identity_map.py
@@ -2,7 +2,8 @@ import pytest
 import responses
 
 import globus_sdk
-from tests.common import get_last_request, register_api_route
+from globus_sdk._testing import load_response
+from tests.common import get_last_request
 
 IDENTITIES_MULTIPLE_RESPONSE = {
     "identities": [
@@ -27,20 +28,6 @@ IDENTITIES_MULTIPLE_RESPONSE = {
     ]
 }
 
-IDENTITIES_SINGLE_RESPONSE = {
-    "identities": [
-        {
-            "email": "sirosen@globus.org",
-            "id": "ae341a98-d274-11e5-b888-dbae3a8ba545",
-            "identity_provider": "927d7238-f917-4eb2-9ace-c523fa9ba34e",
-            "name": "Stephen Rosen",
-            "organization": "Globus Team",
-            "status": "used",
-            "username": "sirosen@globus.org",
-        }
-    ]
-}
-
 
 @pytest.fixture
 def client(no_retry_transport):
@@ -51,19 +38,17 @@ def client(no_retry_transport):
 
 
 def test_identity_map(client):
-    register_api_route("auth", "/v2/api/identities", json=IDENTITIES_SINGLE_RESPONSE)
-    idmap = globus_sdk.IdentityMap(client, ["sirosen@globus.org"])
-    assert idmap["sirosen@globus.org"]["organization"] == "Globus Team"
+    meta = load_response(client.get_identities, case="sirosen").metadata
+    idmap = globus_sdk.IdentityMap(client, [meta["username"]])
+    assert idmap[meta["username"]]["organization"] == meta["org"]
 
     # lookup by ID also works
-    assert (
-        idmap["ae341a98-d274-11e5-b888-dbae3a8ba545"]["organization"] == "Globus Team"
-    )
+    assert idmap[meta["id"]]["organization"] == meta["org"]
 
     # the last (only) API call was the one by username
     last_req = get_last_request()
     assert "ids" not in last_req.params
-    assert last_req.params == {"usernames": "sirosen@globus.org", "provision": "false"}
+    assert last_req.params == {"usernames": meta["username"], "provision": "false"}
 
 
 def test_identity_map_initialization_no_values(client):
@@ -107,19 +92,17 @@ def test_identity_map_add(client):
 
 
 def test_identity_map_add_after_lookup(client):
-    register_api_route("auth", "/v2/api/identities", json=IDENTITIES_SINGLE_RESPONSE)
+    meta = load_response(client.get_identities, case="sirosen").metadata
     idmap = globus_sdk.IdentityMap(client)
-    x = idmap["sirosen@globus.org"]["id"]
+    x = idmap[meta["username"]]["id"]
     # this is the key: adding it will indicate that we've already seen this ID, perhaps
     # "unintuitively", and that's part of the value of `add()` returning a boolean value
     assert idmap.add(x) is False
-    assert idmap[x] == idmap["sirosen@globus.org"]
+    assert idmap[x] == idmap[meta["username"]]
 
 
 def test_identity_map_multiple(client):
-    register_api_route(
-        "auth", ("/v2/api/identities"), json=IDENTITIES_MULTIPLE_RESPONSE
-    )
+    meta = load_response(client.get_identities, case="multiple").metadata
     idmap = globus_sdk.IdentityMap(client, ["sirosen@globus.org", "globus@globus.org"])
     assert idmap["sirosen@globus.org"]["organization"] == "Globus Team"
     assert idmap["globus@globus.org"]["organization"] is None
@@ -128,15 +111,15 @@ def test_identity_map_multiple(client):
     # order doesn't matter, but it should be just these two
     # if IdentityMap doesn't deduplicate correctly, it could send
     # `sirosen@globus.org,globus@globus.org,sirosen@globus.org` on the first lookup
-    assert last_req.params["usernames"] in [
-        "sirosen@globus.org,globus@globus.org",
-        "globus@globus.org,sirosen@globus.org",
+    assert last_req.params["usernames"].split(",") in [
+        meta["usernames"],
+        meta["usernames"][::-1],
     ]
     assert last_req.params["provision"] == "false"
 
 
 def test_identity_map_keyerror(client):
-    register_api_route("auth", "/v2/api/identities", json=IDENTITIES_SINGLE_RESPONSE)
+    load_response(client.get_identities, case="sirosen")
     idmap = globus_sdk.IdentityMap(client)
     # a name which doesn't come back, indicating that it was not found, will KeyError
     with pytest.raises(KeyError):
@@ -147,7 +130,7 @@ def test_identity_map_keyerror(client):
 
 
 def test_identity_map_get_with_default(client):
-    register_api_route("auth", "/v2/api/identities", json=IDENTITIES_SINGLE_RESPONSE)
+    load_response(client.get_identities, case="sirosen")
     magic = object()  # sentinel value
     idmap = globus_sdk.IdentityMap(client)
     # a name which doesn't come back, if looked up with `get()` should return the
@@ -156,30 +139,31 @@ def test_identity_map_get_with_default(client):
 
 
 def test_identity_map_del(client):
-    register_api_route("auth", "/v2/api/identities", json=IDENTITIES_SINGLE_RESPONSE)
+    meta = load_response(client.get_identities).metadata
     idmap = globus_sdk.IdentityMap(client)
-    identity_id = idmap["sirosen@globus.org"]["id"]
+    identity_id = idmap[meta["username"]]["id"]
     del idmap[identity_id]
-    assert idmap.get("sirosen@globus.org")["id"] == identity_id
+    assert idmap.get(meta["username"])["id"] == identity_id
     # we've only made one request so far
     assert len(responses.calls) == 1
     # but a lookup by ID after a del is going to trigger another request because we've
     # invalidated the cached ID data and are asking the IDMap to look it up again
-    assert idmap.get(identity_id)["username"] == "sirosen@globus.org"
+    assert idmap.get(identity_id)["username"] == meta["username"]
     assert len(responses.calls) == 2
 
 
 @pytest.mark.parametrize(
     "lookup1,lookup2",
     [
-        ("sirosen@globus.org", "sirosen@globus.org"),
-        ("sirosen@globus.org", "ae341a98-d274-11e5-b888-dbae3a8ba545"),
-        ("ae341a98-d274-11e5-b888-dbae3a8ba545", "sirosen@globus.org"),
+        ("username", "username"),
+        ("username", "id"),
+        ("id", "username"),
     ],
 )
 @pytest.mark.parametrize("initial_add", [True, False])
 def test_identity_map_shared_cache_match(client, initial_add, lookup1, lookup2):
-    register_api_route("auth", "/v2/api/identities", json=IDENTITIES_SINGLE_RESPONSE)
+    meta = load_response(client.get_identities, case="sirosen").metadata
+    lookup1, lookup2 = meta[lookup1], meta[lookup2]
     cache = {}
     idmap1 = globus_sdk.IdentityMap(client, cache=cache)
     idmap2 = globus_sdk.IdentityMap(client, cache=cache)
@@ -189,10 +173,10 @@ def test_identity_map_shared_cache_match(client, initial_add, lookup1, lookup2):
     # no requests yet...
     assert len(responses.calls) == 0
     # do the first lookup, it should make one request
-    assert idmap1[lookup1]["organization"] == "Globus Team"
+    assert idmap1[lookup1]["organization"] == meta["org"]
     assert len(responses.calls) == 1
     # lookup more values and make sure that "everything matches"
-    assert idmap2[lookup2]["organization"] == "Globus Team"
+    assert idmap2[lookup2]["organization"] == meta["org"]
     assert idmap1[lookup1]["id"] == idmap2[lookup2]["id"]
     assert idmap1[lookup2]["id"] == idmap2[lookup1]["id"]
     # we've only made one request, because the shared cache captured this info on the
@@ -201,17 +185,12 @@ def test_identity_map_shared_cache_match(client, initial_add, lookup1, lookup2):
 
 
 @pytest.mark.parametrize(
-    "lookup1,lookup2",
-    [
-        ("sirosen@globus.org", "globus@globus.org"),
-        (
-            "46bd0f56-e24f-11e5-a510-131bef46955c",
-            "ae341a98-d274-11e5-b888-dbae3a8ba545",
-        ),
-    ],
+    "lookup_style",
+    ["usernames", "ids"],
 )
-def test_identity_map_shared_cache_mismatch(client, lookup1, lookup2):
-    register_api_route("auth", "/v2/api/identities", json=IDENTITIES_MULTIPLE_RESPONSE)
+def test_identity_map_shared_cache_mismatch(client, lookup_style):
+    meta = load_response(client.get_identities, case="multiple").metadata
+    lookup1, lookup2 = meta[lookup_style]
     cache = {}
     idmap1 = globus_sdk.IdentityMap(client, [lookup1, lookup2], cache=cache)
     idmap2 = globus_sdk.IdentityMap(client, cache=cache)
@@ -227,3 +206,18 @@ def test_identity_map_shared_cache_mismatch(client, lookup1, lookup2):
     # we've only made one request, because the shared cache captured this info on the
     # very first call
     assert len(responses.calls) == 1
+
+
+def test_identity_map_prepopulated_cache(client):
+    meta = load_response(client.get_identities).metadata
+
+    # populate the cache, even with nulls it should stop any lookups from happening
+    cache = {meta["id"]: None, meta["username"]: None}
+    idmap = globus_sdk.IdentityMap(client, cache=cache)
+    # no requests yet...
+    assert len(responses.calls) == 0
+    # do the lookups
+    assert idmap[meta["id"]] is None
+    assert idmap[meta["username"]] is None
+    # still no calls made
+    assert len(responses.calls) == 0


### PR DESCRIPTION
This allows multiple IdentityMap instances to share a cache by allowing users to pass a cache to the IdentityMap.

Naive usage still looks identical, with an automatic dict wrapped inside of the map object.

Add more tests to explore this behavior.

---

This isn't really relevant to any work we have in progress. It's an old branch I've had kicking around for a long time, to improve the behavior of IdentityMap. I figured I might as well clean it up and get it merged.