### PR TITLE
Update dev dependencies, including mypy and docs tools

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,7 +36,7 @@ jobs:
         if: ${{ matrix.python-version == '3.10' }}
         run: python -m tox -e lint
       - name: Run Tests
-        run: python -m tox -e py -- --cov-report="term-missing:skip-covered"
+        run: python -m tox -e py,cov-combine,cov-report
       - name: Mindeps Test
         # mindeps runs on py36, as "the oldest everything"
         if: ${{ matrix.python-version == '3.6' && matrix.os == 'ubuntu-latest' }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks.git
-  rev: v4.0.1
+  rev: v4.1.0
   hooks:
     - id: check-merge-conflict
     - id: trailing-whitespace
 - repo: https://github.com/sirosen/check-jsonschema
-  rev: 0.9.0
+  rev: 0.9.1
   hooks:
     - id: check-github-workflows
     - id: check-readthedocs
@@ -43,12 +43,12 @@ repos:
     - id: isort
       name: "Sort python imports"
 - repo: https://github.com/asottile/pyupgrade
-  rev: v2.29.1
+  rev: v2.31.0
   hooks:
     - id: pyupgrade
       args: ["--py36-plus"]
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.910-1
+  rev: v0.931
   hooks:
     - id: mypy
       files: ^src/globus_sdk/

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import re
 from setuptools import find_packages, setup
 
 MYPY_REQUIREMENTS = [
-    "mypy==0.910",
+    "mypy==0.931",
     "types-docutils",
     "types-jwt",
     "types-requests",

--- a/setup.py
+++ b/setup.py
@@ -18,14 +18,14 @@ LINT_REQUIREMENTS = [
 ] + MYPY_REQUIREMENTS
 TEST_REQUIREMENTS = [
     "pytest<7",
-    "pytest-cov<3",
+    "coverage<7",
     "pytest-xdist<3",
     "responses==0.16.0",
 ]
 DOC_REQUIREMENTS = [
     "sphinx<5",
-    "sphinx-issues<2",
-    "furo==2021.11.23",
+    "sphinx-issues<3",
+    "furo==2022.1.2",
 ]
 DEV_REQUIREMENTS = TEST_REQUIREMENTS + LINT_REQUIREMENTS + DOC_REQUIREMENTS
 

--- a/src/globus_sdk/config/environments.py
+++ b/src/globus_sdk/config/environments.py
@@ -30,7 +30,7 @@ class EnvConfig:
     #
     # and retrieve it with get_config_by_name("beta")
     def __init_subclass__(cls, **kwargs: Any):
-        super().__init_subclass__(**kwargs)  # type: ignore
+        super().__init_subclass__(**kwargs)
         cls._registry[cls.envname] = cls
 
     @classmethod

--- a/src/globus_sdk/tokenstorage/sqlite_adapter.py
+++ b/src/globus_sdk/tokenstorage/sqlite_adapter.py
@@ -1,6 +1,6 @@
 import json
 import sqlite3
-from typing import Any, Dict, Mapping, Optional, cast
+from typing import Any, Dict, Mapping, Optional
 
 from globus_sdk.services.auth import OAuthTokenResponse
 from globus_sdk.tokenstorage.base import FileAdapter
@@ -132,7 +132,7 @@ CREATE TABLE sdk_storage_adapter_internal (
             (self.namespace, config_name),
         ).rowcount
         self._connection.commit()
-        return cast(bool, rowcount != 0)
+        return rowcount != 0
 
     def store(self, token_response: OAuthTokenResponse) -> None:
         """
@@ -214,4 +214,4 @@ CREATE TABLE sdk_storage_adapter_internal (
             (self.namespace, resource_server),
         ).rowcount
         self._connection.commit()
-        return cast(bool, rowcount != 0)
+        return rowcount != 0

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist =
     cov-clean
+    cov-combine
     cov-report
     py{310,39,38,37,36}
     py36-mindeps
@@ -14,15 +15,21 @@ deps =
     mindeps: requests==2.19.1
     mindeps: pyjwt==2.0.0
     mindeps: cryptography==3.3.1
-commands = pytest --cov=src --cov-append --cov-report= {posargs}
+commands = coverage run -m pytest {posargs}
 depends =
-    {py36,py37,py38,py39,py36-mindeps}: cov-clean
-    cov-report: py36,py37,py38,py39,py36-mindeps
+    py36,py37,py38,py39,py36-mindeps: cov-clean
+    cov-combine: py36,py37,py38,py39,py36-mindeps
+    cov-report: cov-combine
 
 [testenv:cov-clean]
 deps = coverage
 skip_install = true
 commands = coverage erase
+
+[testenv:cov-combine]
+deps = coverage
+skip_install = true
+commands = coverage combine
 
 [testenv:cov-report]
 deps = coverage


### PR DESCRIPTION
Most things are current. I think I recently updated things.

Update to mypy==0.930 and handle new warnings (unused ignore, unnecessary casts).

This also switches from `pytest-cov` to `coverage`, which is just to simplify the number of tools on which we need to check for updates. Even though `coverage` is a second-order dependency today, it makes a lot of sense to get rid of `pytest-cov` and just cut out the middleman.