### PR TITLE
Add Transfer notification options to helpers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,14 @@ repos:
       #     superclasses or risk silently swallowing/ignoring arguments)
       # (3) we are prepared to commit to keeping `dead` happy and using
       #     `# dead: disable` comments as needed
-      args: ["--files", "src/globus_sdk/services/gcs/data.py"]
+      args:
+        - "--files"
+        - |
+          (?x)^(
+            src/globus_sdk/services/gcs/data.py|
+            src/globus_sdk/services/transfer/data/delete_data.py|
+            src/globus_sdk/services/transfer/data/transfer_data.py
+          )
 - repo: https://gitlab.com/pycqa/flake8
   rev: 3.9.2
   hooks:

--- a/changelog.d/20220110_210459_sirosen_add_notification_opts.rst
+++ b/changelog.d/20220110_210459_sirosen_add_notification_opts.rst
@@ -1,0 +1,4 @@
+* The ``TransferData`` and ``DeleteData`` helper objects now accept the
+  following parameters: ``notify_on_succeeded``, ``notify_on_failed``, and
+  ``notify_on_inactive``. All three are boolean parameters with a default
+  of ``True``. (:pr:`NUMBER`)

--- a/src/globus_sdk/services/transfer/data/delete_data.py
+++ b/src/globus_sdk/services/transfer/data/delete_data.py
@@ -47,6 +47,18 @@ class DeleteData(utils.PayloadWrapper):
         timestamps include ``2017-10-12 09:30Z``, ``2017-10-12 12:33:54+00:00``, and
         ``2017-10-12``
     :type deadline: str or datetime, optional
+    :param notify_on_succeeded: Send a notification email when the delete task
+        completes with a status of SUCCEEDED.
+        [default: ``True``]
+    :type notify_on_succeeded: bool, optional
+    :param notify_on_failed: Send a notification email when the delete task completes
+        with a status of FAILED.
+        [default: ``True``]
+    :type notify_on_failed: bool, optional
+    :param notify_on_inactive: Send a notification email when the delete task changes
+        status to INACTIVE. e.g. From credentials expiring.
+        [default: ``True``]
+    :type notify_on_inactive: bool, optional
     :param additional_fields: additional fields to be added to the delete
         document. Mostly intended for internal use
     :type additional_fields: dict, optional
@@ -78,6 +90,9 @@ class DeleteData(utils.PayloadWrapper):
         submission_id: Optional[UUIDLike] = None,
         recursive: bool = False,
         deadline: Optional[Union[str, datetime.datetime]] = None,
+        notify_on_succeeded: bool = True,
+        notify_on_failed: bool = True,
+        notify_on_inactive: bool = True,
         additional_fields: Optional[Dict[str, Any]] = None,
     ) -> None:
         super().__init__()
@@ -89,6 +104,9 @@ class DeleteData(utils.PayloadWrapper):
         )
         self["endpoint"] = str(endpoint)
         self["recursive"] = recursive
+        self["notify_on_succeeded"] = notify_on_succeeded
+        self["notify_on_failed"] = notify_on_failed
+        self["notify_on_inactive"] = notify_on_inactive
 
         if label is not None:
             self["label"] = label
@@ -109,7 +127,7 @@ class DeleteData(utils.PayloadWrapper):
                     "in via additional_fields)"
                 )
 
-    def add_item(
+    def add_item(  # dead: disable
         self, path: str, *, additional_fields: Optional[Dict[str, Any]] = None
     ) -> None:
         """
@@ -126,10 +144,15 @@ class DeleteData(utils.PayloadWrapper):
         log.debug('DeleteData[{}].add_item: "{}"'.format(self["endpoint"], path))
         self["DATA"].append(item_data)
 
-    def iter_items(self) -> Iterator[Dict[str, Any]]:
+    def iter_items(self) -> Iterator[Dict[str, Any]]:  # dead: disable
         """
         An iterator of items created by ``add_item``.
 
         Each item takes the form of a dictionary.
         """
         yield from iter(self["DATA"])
+
+
+# an __all__ declaration ensures that `dead` passes on this module, which is quite
+# useful
+__all__ = ("DeleteData",)

--- a/src/globus_sdk/services/transfer/data/transfer_data.py
+++ b/src/globus_sdk/services/transfer/data/transfer_data.py
@@ -83,7 +83,19 @@ class TransferData(utils.PayloadWrapper):
         destination endpoint which don’t exist on the source endpoint or are a
         different type. Only applies for recursive directory transfers.
         [default: ``False``]
-    :param delete_destination_extra: bool, optional
+    :type delete_destination_extra: bool, optional
+    :param notify_on_succeeded: Send a notification email when the transfer completes
+        with a status of SUCCEEDED.
+        [default: ``True``]
+    :type notify_on_succeeded: bool, optional
+    :param notify_on_failed: Send a notification email when the transfer completes
+        with a status of FAILED.
+        [default: ``True``]
+    :type notify_on_failed: bool, optional
+    :param notify_on_inactive: Send a notification email when the transfer changes
+        status to INACTIVE. e.g. From credentials expiring.
+        [default: ``True``]
+    :type notify_on_inactive: bool, optional
     :param additional_fields: additional fields to be added to the transfer
         document. Mostly intended for internal use
     :type additional_fields: dict, optional
@@ -152,6 +164,9 @@ class TransferData(utils.PayloadWrapper):
         fail_on_quota_errors: bool = False,
         recursive_symlinks: str = "ignore",
         delete_destination_extra: bool = False,
+        notify_on_succeeded: bool = True,
+        notify_on_failed: bool = True,
+        notify_on_inactive: bool = True,
         additional_fields: Optional[Dict[str, Any]] = None,
     ) -> None:
         super().__init__()
@@ -169,6 +184,9 @@ class TransferData(utils.PayloadWrapper):
         self["skip_source_errors"] = skip_source_errors
         self["fail_on_quota_errors"] = fail_on_quota_errors
         self["delete_destination_extra"] = delete_destination_extra
+        self["notify_on_succeeded"] = notify_on_succeeded
+        self["notify_on_failed"] = notify_on_failed
+        self["notify_on_inactive"] = notify_on_inactive
         if label is not None:
             self["label"] = label
         if deadline is not None:
@@ -198,7 +216,7 @@ class TransferData(utils.PayloadWrapper):
                     "in via additional_fields)"
                 )
 
-    def add_item(
+    def add_item(  # dead: disable
         self,
         source_path: str,
         destination_path: str,
@@ -240,6 +258,8 @@ class TransferData(utils.PayloadWrapper):
             verify_checksum is True, sync_level is "checksum" or 3, or an
             external_checksum is given.
         :type checksum_algorithm: str, optional
+        :param additional_fields: additional fields to be added to the transfer item
+        :type additional_fields: dict, optional
         """
         item_data = {
             "DATA_TYPE": "transfer_item",
@@ -262,7 +282,9 @@ class TransferData(utils.PayloadWrapper):
         )
         self["DATA"].append(item_data)
 
-    def add_symlink_item(self, source_path: str, destination_path: str) -> None:
+    def add_symlink_item(  # dead: disable
+        self, source_path: str, destination_path: str
+    ) -> None:
         """
         Add a symlink to be transferred as a symlink rather than as the
         target of the symlink.
@@ -290,10 +312,15 @@ class TransferData(utils.PayloadWrapper):
         )
         self["DATA"].append(item_data)
 
-    def iter_items(self) -> Iterator[Dict[str, Any]]:
+    def iter_items(self) -> Iterator[Dict[str, Any]]:  # dead: disable
         """
         An iterator of items created by ``add_item``.
 
         Each item takes the form of a dictionary.
         """
         yield from iter(self["DATA"])
+
+
+# an __all__ declaration ensures that `dead` passes on this module, which is quite
+# useful
+__all__ = ("TransferData",)

--- a/tests/unit/helpers/test_transfer.py
+++ b/tests/unit/helpers/test_transfer.py
@@ -197,3 +197,33 @@ def test_transfer_iter_items(transfer_data):
 
     check_item(as_list[0], "source/abc.txt", "dest/abc.txt")
     check_item(as_list[1], "source/def/", "dest/def/", {"recursive": True})
+
+
+@pytest.mark.parametrize("n_succeeded", [None, True, False])
+@pytest.mark.parametrize("n_failed", [None, True, False])
+@pytest.mark.parametrize("n_inactive", [None, True, False])
+def test_notification_options(
+    transfer_data, delete_data, n_succeeded, n_failed, n_inactive
+):
+    notify_kwargs = {}
+    if n_succeeded is not None:
+        notify_kwargs["notify_on_succeeded"] = n_succeeded
+    if n_failed is not None:
+        notify_kwargs["notify_on_failed"] = n_failed
+    if n_inactive is not None:
+        notify_kwargs["notify_on_inactive"] = n_inactive
+
+    ddata = delete_data(**notify_kwargs)
+    tdata = transfer_data(**notify_kwargs)
+
+    def _default(x):
+        return x if x is not None else True
+
+    expect = {
+        "notify_on_succeeded": _default(n_succeeded),
+        "notify_on_failed": _default(n_failed),
+        "notify_on_inactive": _default(n_inactive),
+    }
+    for k, v in expect.items():
+        assert tdata[k] is v
+        assert ddata[k] is v


### PR DESCRIPTION
Add notify_on_{succeeded,failed,inactive} to keyword opts, with defaults of `True` (equivalent to the API default).

Also fix some minor doc issues in nearby code:
- typo in param type doc for `additional_fields` on TransferData
- missing `additional_fields` from param docs for a TransferData method

Begin running `dead` on `transfer_data.py` and `delete_data.py`, which requires the addition of several `dead: disable` comments.

---

As an aside, I think I would like to make these objects dataclasses when py3.7 is our lowest supported python. We could, at least in theory, have an autogenerated `__init__` method. We'd have to explore it a bit.