### PR TITLE
Use pylint to enforce greater code quality

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,6 +6,22 @@ on:
   schedule:
     - cron: '0 4 * * 1'
 jobs:
+  lint:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    name: "lint on ${{ matrix.os }} "
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.10"
+      - name: install tox
+        run: python -m pip install -U tox
+      - name: run linting
+        run: make lint
+
   test:
     strategy:
       matrix:
@@ -13,41 +29,58 @@ jobs:
         python-version: ["3.10"]
         include:
           - os: ubuntu-latest
-            python-version: 3.6
+            python-version: "3.6"
           - os: ubuntu-latest
-            python-version: 3.7
+            python-version: "3.7"
           - os: ubuntu-latest
-            python-version: 3.8
+            python-version: "3.8"
           - os: ubuntu-latest
-            python-version: 3.9
-    name: "Python ${{ matrix.python-version }} on ${{ matrix.os }} "
+            python-version: "3.9"
+    name: "test py${{ matrix.python-version }} on ${{ matrix.os }} "
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - name: Setup Python
-        uses: actions/setup-python@v2
+      - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install Requirements
-        run: |
-          python -m pip install -U tox
-      - name: Run Linting
-        # only lint on 3.10 for faster overall runs
-        if: ${{ matrix.python-version == '3.10' }}
-        run: python -m tox -e lint
-      - name: Run Tests
+      - name: install tox
+        run: python -m pip install -U tox
+      - name: run tests
         run: python -m tox -e py,cov-combine,cov-report
-      - name: Mindeps Test
-        # mindeps runs on py36, as "the oldest everything"
-        if: ${{ matrix.python-version == '3.6' && matrix.os == 'ubuntu-latest' }}
-        run: python -m tox -e py-mindeps
-      - name: Ensure docs build
-        # docs are only ever built on a linux 3.10 box (readthedocs)
-        if: ${{ matrix.python-version == '3.10' && matrix.os == 'ubuntu-latest' }}
+
+  test-mindeps:
+    runs-on: ubuntu-latest
+    name: "mindeps"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.6"
+      - name: install tox
+        run: python -m pip install -U tox
+      - name: test
+        run: tox -e py-mindeps
+
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.10"
+      - name: install tox
+        run: python -m pip install -U tox
+      - name: ensure docs build
         run: python -m tox -e docs
-      - name: Check package metadata
-        # only on linux py3.10 for faster runs
-        if: ${{ matrix.python-version == '3.10' && matrix.os == 'ubuntu-latest' }}
-        run: |
-          python -m tox -e twine-check
-          python -m tox -e poetry-check
+
+  test-package-metadata:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.10"
+      - name: install tox
+        run: python -m pip install -U tox
+      - name: check package metadata
+        run: python -m tox -e twine-check,poetry-check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,25 +19,6 @@ repos:
   hooks:
     - id: blacken-docs
       additional_dependencies: ['black==21.12b0']
-- repo: https://github.com/asottile/dead
-  rev: v1.4.0
-  hooks:
-    - id: dead
-      # run `dead` only on specific files, where
-      # (1) `dead` is passing
-      # (2) the structure of the code makes extra unused variable detection
-      #     useful (e.g. subclasses which *must* pass arguments to their
-      #     superclasses or risk silently swallowing/ignoring arguments)
-      # (3) we are prepared to commit to keeping `dead` happy and using
-      #     `# dead: disable` comments as needed
-      args:
-        - "--files"
-        - |
-          (?x)^(
-            src/globus_sdk/services/gcs/data.py|
-            src/globus_sdk/services/transfer/data/delete_data.py|
-            src/globus_sdk/services/transfer/data/transfer_data.py
-          )
 - repo: https://gitlab.com/pycqa/flake8
   rev: 3.9.2
   hooks:

--- a/.pylintrc
+++ b/.pylintrc
@@ -8,7 +8,8 @@ disable =
     import-error,
     protected-access,
     logging-fstring-interpolation,
-    logging-format-interpolation
+    logging-format-interpolation,
+    fixme,
 
 [VARIABLES]
 ignored-argument-names = args|kwargs

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,14 @@
+[MASTER]
+# for now, disable docparams plugin (enable it later)
+# load-plugins = pylint.extensions.docparams
+
+[MESSAGES CONTROL]
+disable =
+    format,C,R,
+    import-error,
+    protected-access,
+    logging-fstring-interpolation,
+    logging-format-interpolation
+
+[VARIABLES]
+ignored-argument-names = args|kwargs

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,8 +1,33 @@
 [MASTER]
-# for now, disable docparams plugin (enable it later)
-# load-plugins = pylint.extensions.docparams
+load-plugins = pylint.extensions.docparams
 
 [MESSAGES CONTROL]
+# ignore rules as follows:
+#
+# format,C,R
+# formatting and cosmetic rules which are handled by `black`, `isort`, and
+# other tools
+# refactoring rules (e.g. duplicate or similar code) which are very prone to
+# false positives
+#
+# import-error
+# pylint fails to import a module which is used at runtime, these warnings
+# impede simple usage as in `cd globus_sdk; pylint src/`
+#
+# protected-access
+# "disallowed" usage of our own classes and objects gets underfoot
+#
+# logging-*-interpolation
+# objections to log messages doing eager (vs lazy) string formatting
+# this is potentially an area for improvement
+#
+# fixme
+# these comments are often useful; re-enable this to quickly find FIXME and
+# TODO comments
+#
+# missing-raises-doc
+# most SDK methods currently do not document the exceptions which they raise
+# this is an area for improvement
 disable =
     format,C,R,
     import-error,
@@ -10,6 +35,7 @@ disable =
     logging-fstring-interpolation,
     logging-format-interpolation,
     fixme,
+    missing-raises-doc,
 
 [VARIABLES]
 ignored-argument-names = args|kwargs

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SDK_VERSION=$(shell grep '^__version__' src/globus_sdk/version.py | cut -d '"' -
 # these are just tox invocations wrapped nicely for convenience
 .PHONY: lint test docs
 lint:
-	tox -e lint,mypy
+	tox -e lint,mypy,pylint
 test:
 	tox
 docs:

--- a/changelog.d/20220111_201918_sirosen_support_pylint.rst
+++ b/changelog.d/20220111_201918_sirosen_support_pylint.rst
@@ -1,0 +1,11 @@
+* Several minor bugs have been found and fixed (:pr:`NUMBER`)
+** Exceptions raised in the SDK always use ``raise ... from`` syntax where
+   appropriate. This corrects exception chaining in the local endpoint and
+   several response objects.
+** The encoding of files opened by the SDK is now always ``UTF-8``
+** ``TransferData`` will now reject unsupported ``sync_level`` values with a
+   ``ValueError`` on initialization, rather than erroring at submission time.
+   The ``sync_level`` has also had its type annotation fixed to allow for
+   ``int`` values.
+** Several instances of undocumented parameters have been discovered, and these
+   are now rectified.

--- a/src/globus_sdk/authorizers/renewing.py
+++ b/src/globus_sdk/authorizers/renewing.py
@@ -101,7 +101,6 @@ class RenewingAuthorizer(GlobusAuthorizer, metaclass=abc.ABCMeta):
         Using whatever method the specific authorizer implementing this class
         does, get a new token response.
         """
-        pass
 
     @abc.abstractmethod
     def _extract_token_data(self, res: OAuthTokenResponse) -> Dict[str, Any]:

--- a/src/globus_sdk/client.py
+++ b/src/globus_sdk/client.py
@@ -265,6 +265,9 @@ class BaseClient:
 
         :return: :class:`GlobusHTTPResponse \
         <globus_sdk.response.GlobusHTTPResponse>` object
+
+        :raises GlobusAPIError: a `GlobusAPIError` will be raised if the response to the
+            request is received and has a status code in the 4xx or 5xx categories
         """
         # prepare data...
         # copy headers if present

--- a/src/globus_sdk/config/env_vars.py
+++ b/src/globus_sdk/config/env_vars.py
@@ -68,7 +68,7 @@ def _load_var(
     return value
 
 
-def _bool_cast(value: Any, default: Any) -> bool:
+def _bool_cast(value: Any, default: Any) -> bool:  # pylint: disable=unused-argument
     if isinstance(value, bool):
         return value
     elif not isinstance(value, str):

--- a/src/globus_sdk/config/environments.py
+++ b/src/globus_sdk/config/environments.py
@@ -48,8 +48,8 @@ class EnvConfig:
         return f"https://{service}.api.{cls.domain}/"
 
     @classmethod
-    def get_by_name(cls, envname: str) -> Optional[Type["EnvConfig"]]:
-        return cls._registry.get(envname)
+    def get_by_name(cls, env: str) -> Optional[Type["EnvConfig"]]:
+        return cls._registry.get(env)
 
 
 def get_service_url(service: str, environment: Optional[str] = None) -> str:

--- a/src/globus_sdk/exc/api.py
+++ b/src/globus_sdk/exc/api.py
@@ -24,7 +24,7 @@ class GlobusAPIError(GlobusError):
     MESSAGE_FIELDS = ["message", "detail"]
     RECOGNIZED_AUTHZ_SCHEMES = ["bearer", "basic", "globus-goauthtoken"]
 
-    def __init__(self, r: requests.Response, *args: Any, **kw: Any):
+    def __init__(self, r: requests.Response, *args: Any, **kwargs: Any):
         self.http_status = r.status_code
         # defaults, may be rewritten during parsing
         self.code = "Error"

--- a/src/globus_sdk/exc/convert.py
+++ b/src/globus_sdk/exc/convert.py
@@ -16,7 +16,7 @@ class NetworkError(GlobusError):
     to explain potentially confusing or inconsistent exceptions passed to us
     """
 
-    def __init__(self, msg: str, exc: Exception, *args: Any, **kw: Any):
+    def __init__(self, msg: str, exc: Exception, *args: Any, **kwargs: Any):
         super().__init__(msg)
         self.underlying_exception = exc
 

--- a/src/globus_sdk/local_endpoint/personal/endpoint.py
+++ b/src/globus_sdk/local_endpoint/personal/endpoint.py
@@ -188,7 +188,7 @@ class LocalGlobusConnectPersonal:
         if self._endpoint_id is None:
             fname = os.path.join(self._local_data_dir, "client-id.txt")
             try:
-                with open(fname) as fp:
+                with open(fname, encoding="utf-8") as fp:
                     self._endpoint_id = fp.read().strip()
             except OSError as e:
                 # no such file or directory gets ignored, everything else reraise

--- a/src/globus_sdk/local_endpoint/personal/owner_info.py
+++ b/src/globus_sdk/local_endpoint/personal/owner_info.py
@@ -92,7 +92,7 @@ class GlobusConnectPersonalOwnerInfo:
     # private methods for SDK usage only
     @classmethod
     def _from_file(cls, filename: str) -> "GlobusConnectPersonalOwnerInfo":
-        with open(filename) as fp:
+        with open(filename, encoding="utf-8") as fp:
             for line in fp:
                 if line.startswith(cls._GRIDMAP_DN_START):
                     return cls(config_dn=line.strip())

--- a/src/globus_sdk/local_endpoint/personal/owner_info.py
+++ b/src/globus_sdk/local_endpoint/personal/owner_info.py
@@ -24,8 +24,8 @@ def _b32decode(v: str) -> str:
     try:
         return str(uuid.UUID(bytes=base64.b32decode(v)))
     # if it fails, then it can't be a b32-encoded identity
-    except ValueError:
-        raise _B32DecodeError("decode and load as UUID failed")
+    except ValueError as err:
+        raise _B32DecodeError("decode and load as UUID failed") from err
 
 
 def _parse_dn_username(s: str) -> Tuple[str, bool]:

--- a/src/globus_sdk/paging/limit_offset.py
+++ b/src/globus_sdk/paging/limit_offset.py
@@ -3,7 +3,7 @@ from typing import Any, Callable, Dict, Iterator, List, Optional
 from .base import PageT, Paginator
 
 
-class _LimitOffsetBasedPaginator(Paginator[PageT]):
+class _LimitOffsetBasedPaginator(Paginator[PageT]):  # pylint: disable=abstract-method
     def __init__(
         self,
         method: Callable[..., Any],

--- a/src/globus_sdk/response.py
+++ b/src/globus_sdk/response.py
@@ -144,7 +144,7 @@ class GlobusHTTPResponse:
         data = self.data
         try:
             return data[key]
-        except TypeError:
+        except TypeError as err:
             log.error(
                 f"Can't index into responses with underlying data of type {type(data)}"
             )
@@ -154,7 +154,9 @@ class GlobusHTTPResponse:
             #
             # "type" is ambiguous, but we don't know if it's the fault of the
             # class at large, or just a particular call's `data` property
-            raise ValueError("This type of response data does not support indexing.")
+            raise ValueError(
+                "This type of response data does not support indexing."
+            ) from err
 
     def __contains__(self, item: Any) -> bool:
         """

--- a/src/globus_sdk/services/auth/client/base.py
+++ b/src/globus_sdk/services/auth/client/base.py
@@ -119,6 +119,9 @@ class AuthClient(client.BaseClient):
         :param provision: Create identities if they do not exist, allowing clients to
             get username-to-identity mappings prior to the identity being used
         :type provision: bool
+        :param query_params: Any additional parameters to be passed through
+            as query params.
+        :type query_params: dict, optional
 
         **Examples**
 
@@ -434,6 +437,11 @@ class AuthClient(client.BaseClient):
             requires a specialize response class to handle the dramatically different
             format of the Dependent Token Grant response
         :type response_class: class, optional
+        :param form_data: The main body of the request
+        :type form_data: dict or `utils.PayloadWrapper`
+        :param body_params: Any additional parameters to be passed through
+            as body parameters.
+        :type body_params: dict, optional
         :rtype: ``response_class``
         """
         log.info("Fetching new token from Globus Auth")

--- a/src/globus_sdk/services/auth/response.py
+++ b/src/globus_sdk/services/auth/response.py
@@ -67,13 +67,13 @@ class _ByScopesGetter:
             try:
                 rs_names.add(self.scope_map[scope]["resource_server"])
                 toks.append(self.scope_map[scope])
-            except KeyError:
+            except KeyError as err:
                 raise KeyError(
                     (
                         'Scope specifier "{}" contains scope "{}" '
                         "which was not found"
                     ).format(scopename, scope)
-                )
+                ) from err
         # if there isn't exactly 1 token, it's an error
         if len(rs_names) != 1:
             raise KeyError(

--- a/src/globus_sdk/services/gcs/data.py
+++ b/src/globus_sdk/services/gcs/data.py
@@ -441,12 +441,3 @@ class GuestCollectionDocument(CollectionDocument):
             user_credential_id=user_credential_id,
         )
         self._ensure_datatype()
-
-
-# an __all__ declaration ensures that `dead` passes on this module, which is quite
-# useful
-__all__ = (
-    "CollectionDocument",
-    "MappedCollectionDocument",
-    "GuestCollectionDocument",
-)

--- a/src/globus_sdk/services/search/data.py
+++ b/src/globus_sdk/services/search/data.py
@@ -61,6 +61,7 @@ class SearchQuery(utils.PayloadWrapper):
         name: str,
         field_name: str,
         *,
+        # pylint: disable=redefined-builtin
         type: str = "terms",
         size: Optional[int] = None,
         date_interval: Optional[str] = None,
@@ -89,6 +90,7 @@ class SearchQuery(utils.PayloadWrapper):
         field_name: str,
         values: List[str],
         *,
+        # pylint: disable=redefined-builtin
         type: str = "match_all",
         additional_fields: Optional[Dict[str, Any]] = None,
     ) -> "SearchQuery":

--- a/src/globus_sdk/services/transfer/client.py
+++ b/src/globus_sdk/services/transfer/client.py
@@ -433,6 +433,8 @@ class TransferClient(client.BaseClient):
             fetched from :meth:`~endpoint_get_activation_requirements`. Only the fields
             for the activation type being used need to be filled in.
         :type requirements_data: dict
+        :param requirements_data: An optional body for the request
+        :type requirements_data: dict, optional
         :param query_params: Any additional parameters will be passed through
             as query params.
         :type query_params: dict, optional
@@ -543,9 +545,9 @@ class TransferClient(client.BaseClient):
         :type max_results: int, optional
         :param next_token: token used for paging
         :type next_token: str, optional
-        :param query_params: Any additional parameters will be passed through
+        :param query_params: Any additional parameters to be passed through
             as query params.
-        :type query_param: dict, optional
+        :type query_params: dict, optional
 
         Get a list of all shared endpoints on a given host endpoint.
         """
@@ -606,6 +608,9 @@ class TransferClient(client.BaseClient):
 
         :param endpoint_id: The endpoint whose servers are being listed
         :type endpoint_id: str or UUID
+        :param query_params: Any additional parameters to be passed through
+            as query params.
+        :type query_params: dict, optional
         """
         log.info(f"TransferClient.endpoint_server_list({endpoint_id}, ...)")
         return IterableTransferResponse(
@@ -715,6 +720,9 @@ class TransferClient(client.BaseClient):
 
         :param endpoint_id: The endpoint whose roles are being listed
         :type endpoint_id: str or UUID
+        :param query_params: Any additional parameters to be passed through
+            as query params.
+        :type query_params: dict, optional
         """
         log.info(f"TransferClient.endpoint_role_list({endpoint_id}, ...)")
         return IterableTransferResponse(

--- a/src/globus_sdk/services/transfer/client.py
+++ b/src/globus_sdk/services/transfer/client.py
@@ -998,6 +998,7 @@ class TransferClient(client.BaseClient):
         show_hidden: Optional[bool] = None,
         orderby: Optional[Union[str, List[str]]] = None,
         # note: filter is a soft keyword in python, so using this name is okay
+        # pylint: disable=redefined-builtin
         filter: Union[str, TransferFilterDict, None] = None,
         query_params: Optional[Dict[str, Any]] = None,
     ) -> IterableTransferResponse:
@@ -1296,6 +1297,7 @@ class TransferClient(client.BaseClient):
         *,
         limit: Optional[int] = None,
         offset: Optional[int] = None,
+        # pylint: disable=redefined-builtin
         filter: Union[str, TransferFilterDict, None] = None,
         query_params: Optional[Dict[str, Any]] = None,
     ) -> IterableTransferResponse:

--- a/src/globus_sdk/services/transfer/data/delete_data.py
+++ b/src/globus_sdk/services/transfer/data/delete_data.py
@@ -127,7 +127,7 @@ class DeleteData(utils.PayloadWrapper):
                     "in via additional_fields)"
                 )
 
-    def add_item(  # dead: disable
+    def add_item(
         self, path: str, *, additional_fields: Optional[Dict[str, Any]] = None
     ) -> None:
         """
@@ -144,15 +144,10 @@ class DeleteData(utils.PayloadWrapper):
         log.debug('DeleteData[{}].add_item: "{}"'.format(self["endpoint"], path))
         self["DATA"].append(item_data)
 
-    def iter_items(self) -> Iterator[Dict[str, Any]]:  # dead: disable
+    def iter_items(self) -> Iterator[Dict[str, Any]]:
         """
         An iterator of items created by ``add_item``.
 
         Each item takes the form of a dictionary.
         """
         yield from iter(self["DATA"])
-
-
-# an __all__ declaration ensures that `dead` passes on this module, which is quite
-# useful
-__all__ = ("DeleteData",)

--- a/src/globus_sdk/services/transfer/data/transfer_data.py
+++ b/src/globus_sdk/services/transfer/data/transfer_data.py
@@ -219,7 +219,7 @@ class TransferData(utils.PayloadWrapper):
                     "in via additional_fields)"
                 )
 
-    def add_item(  # dead: disable
+    def add_item(
         self,
         source_path: str,
         destination_path: str,
@@ -285,9 +285,7 @@ class TransferData(utils.PayloadWrapper):
         )
         self["DATA"].append(item_data)
 
-    def add_symlink_item(  # dead: disable
-        self, source_path: str, destination_path: str
-    ) -> None:
+    def add_symlink_item(self, source_path: str, destination_path: str) -> None:
         """
         Add a symlink to be transferred as a symlink rather than as the
         target of the symlink.
@@ -315,15 +313,10 @@ class TransferData(utils.PayloadWrapper):
         )
         self["DATA"].append(item_data)
 
-    def iter_items(self) -> Iterator[Dict[str, Any]]:  # dead: disable
+    def iter_items(self) -> Iterator[Dict[str, Any]]:
         """
         An iterator of items created by ``add_item``.
 
         Each item takes the form of a dictionary.
         """
         yield from iter(self["DATA"])
-
-
-# an __all__ declaration ensures that `dead` passes on this module, which is quite
-# useful
-__all__ = ("TransferData",)

--- a/src/globus_sdk/services/transfer/data/transfer_data.py
+++ b/src/globus_sdk/services/transfer/data/transfer_data.py
@@ -155,7 +155,7 @@ class TransferData(utils.PayloadWrapper):
         *,
         label: Optional[str] = None,
         submission_id: Optional[UUIDLike] = None,
-        sync_level: Optional[str] = None,
+        sync_level: Union[str, int, None] = None,
         verify_checksum: bool = False,
         preserve_timestamp: bool = False,
         encrypt_data: bool = False,
@@ -196,12 +196,15 @@ class TransferData(utils.PayloadWrapper):
         # values
         # you can get away with specifying an invalid sync level -- the API
         # will just reject you with an error. This is kind of important: if
-        # more levels are added in the future this method doesn't become
-        # garbage overnight
+        # more levels are added in the future you can pass as an int
         if sync_level is not None:
-            sync_dict = {"exists": 0, "size": 1, "mtime": 2, "checksum": 3}
-            # TODO: sync_level not allowed to be int?
-            self["sync_level"] = sync_dict.get(sync_level, sync_level)
+            if isinstance(sync_level, str):
+                sync_dict = {"exists": 0, "size": 1, "mtime": 2, "checksum": 3}
+                try:
+                    sync_level = sync_dict[sync_level]
+                except KeyError as err:
+                    raise ValueError(f"Unrecognized sync_level {sync_level}") from err
+            self["sync_level"] = sync_level
 
         self["DATA"] = []
 

--- a/src/globus_sdk/tokenstorage/base.py
+++ b/src/globus_sdk/tokenstorage/base.py
@@ -9,7 +9,9 @@ from globus_sdk.services.auth import OAuthTokenResponse
 class StorageAdapter(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def store(self, token_response: OAuthTokenResponse) -> None:
-        pass
+        """
+        Store an `OAuthTokenResponse` in the underlying storage for this adapter.
+        """
 
     @abc.abstractmethod
     def get_token_data(self, resource_server: str) -> Optional[Dict[str, Any]]:
@@ -20,7 +22,6 @@ class StorageAdapter(metaclass=abc.ABCMeta):
         expiration time, or returns ``None``, indicating that there was no data for that
         resource server.
         """
-        pass
 
     def on_refresh(self, token_response: OAuthTokenResponse) -> None:
         """

--- a/src/globus_sdk/tokenstorage/file_adapters.py
+++ b/src/globus_sdk/tokenstorage/file_adapters.py
@@ -29,7 +29,7 @@ class SimpleJSONFileAdapter(FileAdapter):
         Load the file contents as JSON and return the resulting dict
         object. If a dict is not found, raises an error.
         """
-        with open(self.filename) as f:
+        with open(self.filename, encoding="utf-8") as f:
             val = json.load(f)
         if not isinstance(val, dict):
             raise ValueError("reading from json file got non-dict data")
@@ -98,7 +98,7 @@ class SimpleJSONFileAdapter(FileAdapter):
 
         # deny rwx to Group and World, exec to User
         with self.user_only_umask():
-            with open(self.filename, "w") as f:
+            with open(self.filename, "w", encoding="utf-8") as f:
                 json.dump(to_write, f)
 
     def get_by_resource_server(self) -> Dict[str, Any]:

--- a/src/globus_sdk/transport/requests.py
+++ b/src/globus_sdk/transport/requests.py
@@ -201,7 +201,7 @@ class RequestsTransport:
         Send an HTTP request
 
         :param url: URL for the request
-        :type path: str
+        :type url: str
         :param method: HTTP request method, as an all caps string
         :type method: str
         :param query_params: Parameters to be encoded as a query string
@@ -215,6 +215,9 @@ class RequestsTransport:
             registered with the transport. By default, strings get "text" behavior and
             all other objects get "json".
         :type encoding: str
+        :param authorizer: The authorizer which is used to get or update authorization
+            information for the request
+        :type authorizer: GlobusAuthorizer, optional
 
         :return: ``requests.Response`` object
         """

--- a/src/globus_sdk/utils.py
+++ b/src/globus_sdk/utils.py
@@ -23,6 +23,7 @@ T = TypeVar("T")
 R = TypeVar("R")
 
 if TYPE_CHECKING:
+    # pylint: disable=unsubscriptable-object
     PayloadWrapperBase = collections.UserDict[str, Any]
 else:
     PayloadWrapperBase = collections.UserDict

--- a/tests/unit/helpers/test_transfer.py
+++ b/tests/unit/helpers/test_transfer.py
@@ -227,3 +227,28 @@ def test_notification_options(
     for k, v in expect.items():
         assert tdata[k] is v
         assert ddata[k] is v
+
+
+@pytest.mark.parametrize(
+    "sync_level, result",
+    [
+        ("exists", 0),
+        (0, 0),
+        ("size", 1),
+        (1, 1),
+        ("mtime", 2),
+        (2, 2),
+        ("checksum", 3),
+        (3, 3),
+        ("EXISTS", ValueError),
+        ("hash", ValueError),
+        (100, 100),
+    ],
+)
+def test_tranfer_sync_levels_result(transfer_data, sync_level, result):
+    if isinstance(result, type) and issubclass(result, Exception):
+        with pytest.raises(result):
+            transfer_data(sync_level=sync_level)
+    else:
+        tdata = transfer_data(sync_level=sync_level)
+        assert tdata["sync_level"] == result

--- a/tox.ini
+++ b/tox.ini
@@ -45,6 +45,10 @@ commands = pre-commit run --all-files
 deps = mypy
 commands = mypy src/
 
+[testenv:pylint]
+deps = pylint
+commands = pylint src/
+
 [testenv:pyright]
 deps = pyright
 commands = pyright src/ {posargs}


### PR DESCRIPTION
This changeset introduces `pylint`.

There are a few issues with `pylint`:
1. It has several rules like the refactoring rules which are prone to false positives
2. Some of its rules are simply too strict (e.g. lazy log formatting) and force a lot of change when it is introduced
3. Even with a carefully curated ruleset, like any linter it can show false-positives
4. It's slow! Too slow to run as a pre-commit hook

However, after trying it (again) I find that it discovers several real issues in our code. I'd like us to try to keep `pylint` happy.
In addition to the config and CI changes, there are the following changes to our codebase:

- remove unnecessary `pass` directives
- `sync_level` on `TransferData` now raises a ValueError on unrecognized strings [1]
- when raising a new exception in a handler, always use `raise X from err` syntax (chaining)
- always explicitly use "utf-8" when opening files [2]
- avoid shadowing names from an external scope when entering a narrower scope
- document all function parameters -- undocumented parameters will be caught

[1] was changed in https://github.com/globus/globus-sdk-python/commit/8e5cd819f88db399c096b887665dac150ff65bf3 . The commit message details the full change. This is _technically_ backwards incompatible because the unsupported value is now rejected with a `ValueError` when `TransferData` is constructed, not a `GlobusAPIError` when it is submitted. However, I think we can take the stance that this is a reasonable improvement to a behavior which was not quite right from the start, and therefore is an improvement. Doing this in a minor version still follows the spirit of semver.

[2] https://github.com/globus/globus-sdk-python/commit/a031c3805950e8f40053639d81702d928bcd4930 is a similar case of "spirit of semver, not the letter of it". It is technically possible that someone has written a latin-1 encoded file with non-ascii content via the token storage adapter, and that this will break. However, the chances of this in practice are very slim. Python versions 3.11 or later may actually change to UTF-8 by default anyway, and using the locale-specified encoding is a messy bit of code we'd rather not have in the long term. Similarly, I'm fairly sure that gridmap is ASCII-only. Specifying UTF-8 now simply makes us explicit about our expectations, and is probably what we should do in all cases.

The changelog fragment shows how I would explain this change to users.