### PR TITLE
Add paginated `post_search` and `scroll` to SearchClient, plus role methods

### DIFF
--- a/changelog.d/20220125_220544_sirosen_search_client_updates.rst
+++ b/changelog.d/20220125_220544_sirosen_search_client_updates.rst
@@ -1,0 +1,1 @@
+* Support pagination on ``SearchClient.post_search`` (:pr:`NUMBER`)

--- a/changelog.d/20220125_232653_sirosen_search_client_updates.rst
+++ b/changelog.d/20220125_232653_sirosen_search_client_updates.rst
@@ -1,0 +1,4 @@
+* Add support for scroll queries to ``SearchClient``. ``SearchClient.scroll``
+  and ``SearchClient.paginated.scroll`` are now available as methods, and a new
+  helper class, ``SearchScrollQuery``, can be used to easily construct
+  scrolling queries. (:pr:`NUMBER`)

--- a/changelog.d/20220126_221236_sirosen_search_client_updates.rst
+++ b/changelog.d/20220126_221236_sirosen_search_client_updates.rst
@@ -1,0 +1,2 @@
+* Add methods to ``SearchClient`` for managing index roles. ``create_role``,
+  ``delete_role``, and ``get_role_list`` (:pr:`NUMBER`)

--- a/docs/services/search.rst
+++ b/docs/services/search.rst
@@ -1,6 +1,3 @@
-.. module:: globus_sdk.search
-
-
 Globus Search
 =============
 
@@ -13,7 +10,19 @@ Globus Search
 Helper Objects
 --------------
 
+Note that you should not use ``SearchQueryBase`` directly, and it is not
+importable from the top level of the SDK. It is included in documentation
+only to document the methods it provides to its subclasses.
+
+.. autoclass:: globus_sdk.services.search.data.SearchQueryBase
+   :members:
+   :show-inheritance:
+
 .. autoclass:: globus_sdk.SearchQuery
+   :members:
+   :show-inheritance:
+
+.. autoclass:: globus_sdk.SearchScrollQuery
    :members:
    :show-inheritance:
 

--- a/src/globus_sdk/__init__.py
+++ b/src/globus_sdk/__init__.py
@@ -46,7 +46,12 @@ from .services.groups import (
     GroupsManager,
     GroupVisibility,
 )
-from .services.search import SearchAPIError, SearchClient, SearchQuery
+from .services.search import (
+    SearchAPIError,
+    SearchClient,
+    SearchQuery,
+    SearchScrollQuery,
+)
 from .services.transfer import (
     DeleteData,
     TransferAPIError,
@@ -86,6 +91,7 @@ __all__ = (
     "DeleteData",
     "SearchClient",
     "SearchQuery",
+    "SearchScrollQuery",
     "GroupsClient",
     "BatchMembershipActions",
     "GroupPolicies",

--- a/src/globus_sdk/services/search/__init__.py
+++ b/src/globus_sdk/services/search/__init__.py
@@ -1,5 +1,5 @@
 from .client import SearchClient
-from .data import SearchQuery
+from .data import SearchQuery, SearchScrollQuery
 from .errors import SearchAPIError
 
-__all__ = ("SearchClient", "SearchQuery", "SearchAPIError")
+__all__ = ("SearchClient", "SearchQuery", "SearchScrollQuery", "SearchAPIError")

--- a/src/globus_sdk/services/search/client.py
+++ b/src/globus_sdk/services/search/client.py
@@ -524,3 +524,94 @@ class SearchClient(client.BaseClient):
         """
         log.info(f"SearchClient.get_task_list({index_id})")
         return self.get(f"/v1/task_list/{index_id}", query_params=query_params)
+
+    #
+    # Role Management
+    #
+
+    @utils.doc_api_method("Create Role", "search/reference/role_create/")
+    def create_role(
+        self,
+        index_id: UUIDLike,
+        data: Dict[str, Any],
+        *,
+        query_params: Optional[Dict[str, Any]] = None,
+    ) -> response.GlobusHTTPResponse:
+        """
+        ``POST /v1/index/<index_id>/role``
+
+        Create a new role on an index. You must already have the ``owner`` or
+        ``admin`` role on an index to create additional roles.
+
+        Roles are specified as a role name (one of ``"owner"``, ``"admin"``, or
+        ``"writer"``) and a `Principal URN
+        <https://docs.globus.org/api/search/overview/#principal_urns>`_.
+
+        :param index_id: The index on which to create the role
+        :type index_id: uuid or str
+        :param data: The partial role document to use for creation
+        :type data: dict
+        :param query_params: Any additional query params to pass
+        :type query_params: dict, optional
+
+        **Examples**
+
+        >>> identity_id = "46bd0f56-e24f-11e5-a510-131bef46955c"
+        >>> sc = globus_sdk.SearchClient(...)
+        >>> sc.create_role(
+        >>>     index_id,
+        >>>     {
+        >>>         "role_name": "writer",
+        >>>         "principal": f"urn:globus:auth:identity:{identity_id}"
+        >>>     }
+        >>> )
+        """
+        log.info("SearchClient.create_role(%s, ...)", index_id)
+        return self.post(
+            f"/v1/index/{index_id}/role", data=data, query_params=query_params
+        )
+
+    @utils.doc_api_method("Get Role List", "search/reference/role_list/")
+    def get_role_list(
+        self, index_id: UUIDLike, *, query_params: Optional[Dict[str, Any]] = None
+    ) -> response.GlobusHTTPResponse:
+        """
+        ``GET /v1/index/<index_id>/role_list``
+
+        List all roles on an index. You must have the ``owner`` or ``admin``
+        role on an index to list roles.
+
+        :param index_id: The index on which to list roles
+        :type index_id: uuid or str
+        :param query_params: Any additional query params to pass
+        :type query_params: dict, optional
+        """
+        log.info("SearchClient.get_role_list(%s)", index_id)
+        return self.get(f"/v1/index/{index_id}/role_list", query_params=query_params)
+
+    @utils.doc_api_method("Role Delete", "search/reference/role_delete/")
+    def delete_role(
+        self,
+        index_id: UUIDLike,
+        role_id: str,
+        *,
+        query_params: Optional[Dict[str, Any]] = None,
+    ) -> response.GlobusHTTPResponse:
+        """
+        ``DELETE /v1/index/<index_id>/role/<role_id>``
+
+        Delete a role from an index. You must have the ``owner`` or ``admin``
+        role on an index to delete roles. You cannot remove the last ``owner`` from an
+        index.
+
+        :param index_id: The index from which to delete a role
+        :type index_id: uuid or str
+        :param role_id: The role to delete
+        :type role_id: str
+        :param query_params: Any additional query params to pass
+        :type query_params: dict, optional
+        """
+        log.info("SearchClient.delete_role(%s, %s)", index_id, role_id)
+        return self.delete(
+            f"/v1/index/{index_id}/role/{role_id}", query_params=query_params
+        )

--- a/src/globus_sdk/services/search/client.py
+++ b/src/globus_sdk/services/search/client.py
@@ -5,7 +5,7 @@ from globus_sdk import client, paging, response, utils
 from globus_sdk.scopes import SearchScopes
 from globus_sdk.types import UUIDLike
 
-from .data import SearchQuery
+from .data import SearchQuery, SearchScrollQuery
 from .errors import SearchAPIError
 
 log = logging.getLogger(__name__)
@@ -164,6 +164,38 @@ class SearchClient(client.BaseClient):
             add_kwargs["offset"] = offset
         if limit is not None:
             add_kwargs["limit"] = limit
+        if add_kwargs:
+            data = {**data, **add_kwargs}
+        return self.post(f"v1/index/{index_id}/search", data=data)
+
+    @utils.doc_api_method("Scroll Query", "search/reference/scroll_query")
+    @paging.has_paginator(paging.MarkerPaginator, items_key="gmeta")
+    def scroll(
+        self,
+        index_id: UUIDLike,
+        data: Union[Dict[str, Any], SearchScrollQuery],
+        *,
+        marker: Optional[str] = None,
+    ) -> response.GlobusHTTPResponse:
+        """
+        ``POST /v1/index/<index_id>/scroll``
+
+        :param index_id: The index on which to search
+        :type index_id: str or UUID
+        :param data: A Search Scroll Query document
+        :type data: dict or SearchScrollQuery
+        :param marker: marker used in paging (overwrites any marker in ``data``)
+        :type marker: str, optional
+
+        **Examples**
+
+        >>> sc = globus_sdk.SearchClient(...)
+        >>> scroll_result = sc.scroll(index_id, {"q": "*"})
+        """
+        log.info(f"SearchClient.scroll({index_id}, ...)")
+        add_kwargs = {}
+        if marker is not None:
+            add_kwargs["marker"] = marker
         if add_kwargs:
             data = {**data, **add_kwargs}
         return self.post(f"v1/index/{index_id}/search", data=data)

--- a/src/globus_sdk/services/search/client.py
+++ b/src/globus_sdk/services/search/client.py
@@ -198,7 +198,7 @@ class SearchClient(client.BaseClient):
             add_kwargs["marker"] = marker
         if add_kwargs:
             data = {**data, **add_kwargs}
-        return self.post(f"v1/index/{index_id}/search", data=data)
+        return self.post(f"v1/index/{index_id}/scroll", data=data)
 
     #
     # Bulk data indexing

--- a/src/globus_sdk/services/search/data.py
+++ b/src/globus_sdk/services/search/data.py
@@ -5,20 +5,52 @@ from globus_sdk import utils
 # workaround for absence of Self type
 # for the workaround and some background, see:
 #   https://github.com/python/mypy/issues/11871
-SearchQueryT = TypeVar("SearchQueryT", bound="_SearchQueryBase")
+SearchQueryT = TypeVar("SearchQueryT", bound="SearchQueryBase")
 
 
 # an internal class for declaring multiple related types with shared methods
-class _SearchQueryBase(utils.PayloadWrapper):
+class SearchQueryBase(utils.PayloadWrapper):
+    """
+    The base class for all Search query helpers.
+
+    Search has multiple types of query documents. Not all of their supported attributes
+    are shared, and they therefore do not inherit from one another.
+    This class implements common methods to all of them.
+
+    Query objects have a chainable API, in which methods return the query object after
+    modification. This allows usage like
+
+    >>> query = ...
+    >>> query = query.set_limit(10).set_advanced(False)
+    """
+
     def set_query(self: SearchQueryT, query: str) -> SearchQueryT:
+        """
+        Set the query string for the query document.
+
+        :param query: the new query string
+        :type query: str
+        """
         self["q"] = query
         return self
 
     def set_limit(self: SearchQueryT, limit: int) -> SearchQueryT:
+        """
+        Set the limit for the query document.
+
+        :param limit: a limit on the number of results returned in a single page
+        :type limit: int
+        """
         self["limit"] = limit
         return self
 
     def set_advanced(self: SearchQueryT, advanced: bool) -> SearchQueryT:
+        """
+        Enable or disable advanced query string processing.
+
+        :param advanced: whether to enable (``True``) or not (``False``)
+        :type advanced: bool
+        """
         self["advanced"] = advanced
         return self
 
@@ -31,6 +63,18 @@ class _SearchQueryBase(utils.PayloadWrapper):
         type: str = "match_all",
         additional_fields: Optional[Dict[str, Any]] = None,
     ) -> SearchQueryT:
+        """
+        Add a filter subdocument to the query.
+
+        :param field_name: the field on which to filter
+        :type field_name: str
+        :param values: the values to use in the filter
+        :type values: list of str
+        :param type: the type of filter to apply, defaults to "match_all"
+        :type type: str
+        :param additional_fields: additional data to include in the filter document
+        :type additional_fields: dict, optional
+        """
         self["filters"] = self.get("filters", [])
         new_filter = {
             "field_name": field_name,
@@ -42,10 +86,23 @@ class _SearchQueryBase(utils.PayloadWrapper):
         return self
 
 
-class SearchQuery(_SearchQueryBase):
+class SearchQuery(SearchQueryBase):
     """
     A specialized dict which has helpers for creating and modifying a Search
     Query document.
+
+    :param q: The query string. Required unless filters are used.
+    :type q: str, optional
+    :param limit: A limit on the number of results returned in a single page
+    :type limit: int
+    :param offset: An offset into the set of all results for the query
+    :type offset: int
+    :param advanced: Whether to enable (``True``) or not to enable (``False``) advanced
+        parsing of query strings. The default of ``False`` is robust and guarantees that
+        the query will not error with "bad query string" errors
+    :type advanced: bool, optional
+    :param additional_fields: additional data to include in the query document
+    :type additional_fields: dict, optional
 
     Example usage:
 
@@ -80,6 +137,12 @@ class SearchQuery(_SearchQueryBase):
             self.update(additional_fields)
 
     def set_offset(self, offset: int) -> "SearchQuery":
+        """
+        Set the offset for the query document.
+
+        :param offset: an offset into the set of all results for the query
+        :type offset: int
+        """
         self["offset"] = offset
         return self
 
@@ -95,6 +158,24 @@ class SearchQuery(_SearchQueryBase):
         histogram_range: Optional[Tuple[Any, Any]] = None,
         additional_fields: Optional[Dict[str, Any]] = None,
     ) -> "SearchQuery":
+        """
+        Add a facet subdocument to the query.
+
+        :param name: the name for the facet in the result
+        :type name: str
+        :param field_name: the field on which to build the facet
+        :type field_name: str
+        :param type: the type of facet to apply, defaults to "terms"
+        :type type: str
+        :param size: the size parameter for the facet
+        :type size: int, optional
+        :param date_interval: the date interval for a date histogram facet
+        :type date_interval: str, optional
+        :param histogram_range: a low and high bound for a numeric histogram facet
+        :type histogram_range: tuple, optional
+        :param additional_fields: additional data to include in the facet document
+        :type additional_fields: dict, optional
+        """
         self["facets"] = self.get("facets", [])
         facet: Dict[str, Any] = {
             "name": name,
@@ -119,6 +200,17 @@ class SearchQuery(_SearchQueryBase):
         *,
         additional_fields: Optional[Dict[str, Any]] = None,
     ) -> "SearchQuery":
+        """
+        Add a boost subdocument to the query.
+
+        :param field_name: the field to boost in result weighting
+        :type field_name: str
+        :param factor: the factor by which to adjust the field weight (where ``1.0`` is
+            the default weight)
+        :type factor: str, int, or float
+        :param additional_fields: additional data to include in the boost document
+        :type additional_fields: dict, optional
+        """
         self["boosts"] = self.get("boosts", [])
         boost = {
             "field_name": field_name,
@@ -135,6 +227,16 @@ class SearchQuery(_SearchQueryBase):
         order: Optional[str] = None,
         additional_fields: Optional[Dict[str, Any]] = None,
     ) -> "SearchQuery":
+        """
+        Add a sort subdocument to the query.
+
+        :param field_name: the field on which to sort
+        :type field_name: str
+        :param order: ascending or descending order, given as ``"asc"`` or ``"desc"``
+        :type order: str, optional
+        :param additional_fields: additional data to include in the sort document
+        :type additional_fields: dict, optional
+        """
         self["sort"] = self.get("sort", [])
         sort = {"field_name": field_name, **(additional_fields or {})}
         if order is not None:
@@ -143,7 +245,31 @@ class SearchQuery(_SearchQueryBase):
         return self
 
 
-class SearchScrollQuery(_SearchQueryBase):
+class SearchScrollQuery(SearchQueryBase):
+    """
+    A scrolling query type, for scrolling the full result set for an index.
+
+    Scroll queries have more limited capabilities than general searches.
+    They cannot boost fields, sort, or apply facets. They can, however, still apply the
+    same filtering mechanisms which are available to normal queries.
+
+    Scrolling also differs in that it supports the use of the ``marker`` field, which is
+    used to paginate results.
+
+    :param q: The query string
+    :type q: str, optional
+    :param limit: A limit on the number of results returned in a single page
+    :type limit: int
+    :param advanced: Whether to enable (``True``) or not to enable (``False``) advanced
+        parsing of query strings. The default of ``False`` is robust and guarantees that
+        the query will not error with "bad query string" errors
+    :type advanced: bool, optional
+    :param marker: the marker value
+    :type marker: str, optional
+    :param additional_fields: additional data to include in the query document
+    :type additional_fields: dict, optional
+    """
+
     def __init__(
         self,
         q: Optional[str] = None,
@@ -158,13 +284,19 @@ class SearchScrollQuery(_SearchQueryBase):
             self["q"] = q
         if limit is not None:
             self["limit"] = limit
-        if marker is not None:
-            self["marker"] = marker
         if advanced is not None:
             self["advanced"] = advanced
+        if marker is not None:
+            self["marker"] = marker
         if additional_fields is not None:
             self.update(additional_fields)
 
     def set_marker(self, marker: str) -> "SearchScrollQuery":
+        """
+        Set the marker on a scroll query.
+
+        :param marker: the marker value
+        :type marker: str
+        """
         self["marker"] = marker
         return self

--- a/tests/functional/search/fixture_data/query_result_foo.json
+++ b/tests/functional/search/fixture_data/query_result_foo.json
@@ -1,0 +1,24 @@
+{
+  "@datatype": "GSearchResult",
+  "@version": "2017-09-01",
+  "count": 1,
+  "gmeta": [
+    {
+      "@datatype": "GMetaResult",
+      "@version": "2019-08-27",
+      "entries": [
+        {
+          "content": {
+            "foo": "bar"
+          },
+          "entry_id": null,
+          "matched_principal_sets": []
+        }
+      ],
+      "subject": "foo-bar"
+    }
+  ],
+  "has_next_page": true,
+  "offset": 0,
+  "total": 10
+}

--- a/tests/functional/search/fixture_data/role_create.json
+++ b/tests/functional/search/fixture_data/role_create.json
@@ -1,0 +1,8 @@
+{
+  "creation_date": "2022-01-26 21:53:06",
+  "id": "MDQ1MzAy",
+  "index_id": "60d1160b-f016-40b0-8545-99619865873d",
+  "principal": "urn:globus:auth:identity:46bd0f56-e24f-11e5-a510-131bef46955c",
+  "principal_type": "identity",
+  "role_name": "writer"
+}

--- a/tests/functional/search/fixture_data/role_delete.json
+++ b/tests/functional/search/fixture_data/role_delete.json
@@ -1,0 +1,11 @@
+{
+  "deleted": {
+    "creation_date": "2022-01-26 21:53:06",
+    "id": "MDQ1MzAy",
+    "index_id": "60d1160b-f016-40b0-8545-99619865873d",
+    "principal": "urn:globus:auth:identity:46bd0f56-e24f-11e5-a510-131bef46955c",
+    "principal_type": "identity",
+    "role_name": "writer"
+  },
+  "success": true
+}

--- a/tests/functional/search/fixture_data/role_list.json
+++ b/tests/functional/search/fixture_data/role_list.json
@@ -1,0 +1,20 @@
+{
+  "role_list": [
+    {
+      "creation_date": "2021-11-09 20:26:45",
+      "id": "MDMwMjM5",
+      "index_id": "60d1160b-f016-40b0-8545-99619865873d",
+      "principal": "urn:globus:auth:identity:ae332d86-d274-11e5-b885-b31714a110e9",
+      "principal_type": "identity",
+      "role_name": "owner"
+    },
+    {
+      "creation_date": "2022-01-24 15:33:41",
+      "id": "MDQ0ODYz",
+      "index_id": "60d1160b-f016-40b0-8545-99619865873d",
+      "principal": "urn:globus:auth:identity:c699d42e-d274-11e5-bf75-1fc5bf53bb24",
+      "principal_type": "identity",
+      "role_name": "writer"
+    }
+  ]
+}

--- a/tests/functional/search/fixture_data/scroll_result_1.json
+++ b/tests/functional/search/fixture_data/scroll_result_1.json
@@ -1,0 +1,22 @@
+{
+  "gmeta": [
+    {
+      "@datatype": "GMetaResult",
+      "@version": "2019-08-27",
+      "entries": [
+        {
+          "content": {
+            "foo": "bar"
+          },
+          "entry_id": null,
+          "matched_principal_sets": []
+        }
+      ],
+      "subject": "foo-bar"
+    }
+  ],
+  "count": 1,
+  "total": 2,
+  "has_next_page": true,
+  "marker": "3d34900e3e4211ebb0a806b2af333354"
+}

--- a/tests/functional/search/fixture_data/scroll_result_2.json
+++ b/tests/functional/search/fixture_data/scroll_result_2.json
@@ -1,0 +1,22 @@
+{
+  "gmeta": [
+    {
+      "@datatype": "GMetaResult",
+      "@version": "2019-08-27",
+      "entries": [
+        {
+          "content": {
+            "foo": "baz"
+          },
+          "entry_id": null,
+          "matched_principal_sets": []
+        }
+      ],
+      "subject": "foo-baz"
+    }
+  ],
+  "count": 1,
+  "total": 2,
+  "has_next_page": false,
+  "marker": null
+}

--- a/tests/functional/search/test_search.py
+++ b/tests/functional/search/test_search.py
@@ -107,7 +107,7 @@ def test_search_post_query_arg_overrides(search_client, query_doc):
         globus_sdk.SearchScrollQuery("foo"),
     ],
 )
-def test_search_paginated_scroll_qeury(search_client, query_doc):
+def test_search_paginated_scroll_query(search_client, query_doc):
     index_id = str(uuid.uuid1())
     register_api_route_fixture_file(
         "search",

--- a/tests/functional/search/test_search.py
+++ b/tests/functional/search/test_search.py
@@ -111,14 +111,14 @@ def test_search_paginated_scroll_query(search_client, query_doc):
     index_id = str(uuid.uuid1())
     register_api_route_fixture_file(
         "search",
-        f"/v1/index/{index_id}/search",
+        f"/v1/index/{index_id}/scroll",
         "scroll_result_1.json",
         method="POST",
         match=[responses.matchers.json_params_matcher({"q": "foo"})],
     )
     register_api_route_fixture_file(
         "search",
-        f"/v1/index/{index_id}/search",
+        f"/v1/index/{index_id}/scroll",
         "scroll_result_2.json",
         method="POST",
         match=[

--- a/tests/functional/search/test_search.py
+++ b/tests/functional/search/test_search.py
@@ -1,0 +1,99 @@
+import json
+import urllib.parse
+import uuid
+
+import pytest
+
+import globus_sdk
+from tests.common import get_last_request, register_api_route_fixture_file
+
+
+@pytest.fixture
+def search_client(no_retry_transport):
+    class CustomSearchClient(globus_sdk.SearchClient):
+        transport_class = no_retry_transport
+
+    return CustomSearchClient()
+
+
+def test_search_query_simple(search_client):
+    index_id = str(uuid.uuid1())
+    register_api_route_fixture_file(
+        "search", f"/v1/index/{index_id}/search", "query_result_foo.json"
+    )
+
+    res = search_client.search(index_id, q="foo")
+    assert res.http_status == 200
+
+    data = res.data
+    assert isinstance(data, dict)
+    assert data["gmeta"][0]["entries"][0]["content"]["foo"] == "bar"
+
+    req = get_last_request()
+    assert req.body is None
+    parsed_qs = urllib.parse.parse_qs(urllib.parse.urlparse(req.url).query)
+    assert parsed_qs == {
+        "q": ["foo"],
+        "advanced": ["False"],
+        "limit": ["10"],
+        "offset": ["0"],
+    }
+
+
+@pytest.mark.parametrize(
+    "query_doc",
+    [
+        {"q": "foo"},
+        {"q": "foo", "limit": 10},
+        globus_sdk.SearchQuery("foo"),
+    ],
+)
+def test_search_post_query_simple(search_client, query_doc):
+    index_id = str(uuid.uuid1())
+    register_api_route_fixture_file(
+        "search", f"/v1/index/{index_id}/search", "query_result_foo.json", method="POST"
+    )
+
+    res = search_client.post_search(index_id, query_doc)
+    assert res.http_status == 200
+
+    data = res.data
+    assert isinstance(data, dict)
+    assert data["gmeta"][0]["entries"][0]["content"]["foo"] == "bar"
+
+    req = get_last_request()
+    assert req.body is not None
+    req_body = json.loads(req.body)
+    assert req_body == dict(query_doc)
+
+
+@pytest.mark.parametrize(
+    "query_doc",
+    [
+        {"q": "foo", "limit": 10, "offset": 0},
+        globus_sdk.SearchQuery("foo", limit=10, offset=0),
+    ],
+)
+def test_search_post_query_arg_overrides(search_client, query_doc):
+    index_id = str(uuid.uuid1())
+    register_api_route_fixture_file(
+        "search", f"/v1/index/{index_id}/search", "query_result_foo.json", method="POST"
+    )
+
+    res = search_client.post_search(index_id, query_doc, limit=100, offset=150)
+    assert res.http_status == 200
+
+    data = res.data
+    assert isinstance(data, dict)
+    assert data["gmeta"][0]["entries"][0]["content"]["foo"] == "bar"
+
+    req = get_last_request()
+    assert req.body is not None
+    req_body = json.loads(req.body)
+    assert req_body != dict(query_doc)
+    assert req_body["q"] == query_doc["q"]
+    assert req_body["limit"] == 100
+    assert req_body["offset"] == 150
+    # important! these should be unchanged (no side-effects)
+    assert query_doc["limit"] == 10
+    assert query_doc["offset"] == 0

--- a/tests/functional/search/test_search_roles.py
+++ b/tests/functional/search/test_search_roles.py
@@ -1,0 +1,62 @@
+import json
+
+import pytest
+
+import globus_sdk
+from tests.common import get_last_request, register_api_route_fixture_file
+
+ROLE_ID = "MDQ1MzAy"
+INDEX_ID = "60d1160b-f016-40b0-8545-99619865873d"
+
+
+@pytest.fixture
+def search_client(no_retry_transport):
+    class CustomSearchClient(globus_sdk.SearchClient):
+        transport_class = no_retry_transport
+
+    return CustomSearchClient()
+
+
+def test_search_role_create(search_client):
+    register_api_route_fixture_file(
+        "search", f"/v1/index/{INDEX_ID}/role", "role_create.json", method="POST"
+    )
+
+    urn = "urn:globus:auth:identity:46bd0f56-e24f-11e5-a510-131bef46955c"
+    data = {"role_name": "writer", "principal": urn}
+
+    res = search_client.create_role(INDEX_ID, data)
+    assert res.http_status == 200
+    assert res["index_id"] == INDEX_ID
+    assert res["role_name"] == "writer"
+
+    last_req = get_last_request()
+    sent = json.loads(last_req.body)
+    assert sent == data
+
+
+def test_search_role_delete(search_client):
+    register_api_route_fixture_file(
+        "search",
+        f"/v1/index/{INDEX_ID}/role/{ROLE_ID}",
+        "role_delete.json",
+        method="DELETE",
+    )
+
+    res = search_client.delete_role(INDEX_ID, ROLE_ID)
+    assert res.http_status == 200
+    assert res["success"] is True
+    assert res["deleted"]["index_id"] == INDEX_ID
+    assert res["deleted"]["id"] == ROLE_ID
+
+
+def test_search_role_list(search_client):
+    register_api_route_fixture_file(
+        "search", f"/v1/index/{INDEX_ID}/role_list", "role_list.json"
+    )
+
+    res = search_client.get_role_list(INDEX_ID)
+    assert res.http_status == 200
+    role_list = res["role_list"]
+    assert isinstance(role_list, list)
+    assert len(role_list) == 2


### PR DESCRIPTION
The SearchClient gains three new methods here: `paginated.post_search`, `scroll`, and `paginated.scroll`

This also begins the long road towards having more complete test coverage of the SearchClient, its helpers, and methods.
These APIs are slightly different from some of the existing paginated ones, in that their pagination parameters are body params, not query params. However, because the paginator objects "just" pass their relevant arguments through to the client methods (`marker`, `limit`, etc), it is possible to support these only by ensuring that `marker`, `limit`, and `offset` are supported as keyword args.
Some care is taken not to mutate the data which was passed in to these methods, but otherwise the implementation does not require special efforts.

In order to make `scroll` more usable, an additional helper object is added, `SearchScrollQuery`, for this specialized query type.
The newly fleshed out documentation on this and `SearchQuery` should clarify the difference.