### PR TITLE
Specify CI build matrix more simply

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,6 +5,7 @@ on:
   # build weekly at 4:00 AM UTC
   schedule:
     - cron: '0 4 * * 1'
+
 jobs:
   lint:
     strategy:
@@ -25,17 +26,15 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.10"]
+        os: [ubuntu-latest]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        # we do not want a large number of windows and macos builds, so
+        # enumerate them explicitly
         include:
-          - os: ubuntu-latest
-            python-version: "3.6"
-          - os: ubuntu-latest
-            python-version: "3.7"
-          - os: ubuntu-latest
-            python-version: "3.8"
-          - os: ubuntu-latest
-            python-version: "3.9"
+          - os: windows-latest
+            python-version: "3.10"
+          - os: macos-latest
+            python-version: "3.10"
     name: "test py${{ matrix.python-version }} on ${{ matrix.os }} "
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Rather than taking all platforms and one python version as the default part of the matrix, make it 'ubuntu' and all python versions. This ends up being shorter and more readable.

No change in the versions and platforms tested.

---

This is not a very significant change. I'm just trying to make the build here look the same as the globus-cli one.