### PR TITLE
Add GetIdentitiesResponse for iterable responses

### DIFF
--- a/changelog.d/20220210_160456_sirosen_iterable_identities_response.rst
+++ b/changelog.d/20220210_160456_sirosen_iterable_identities_response.rst
@@ -1,0 +1,2 @@
+* The response from ``AuthClient.get_identities`` now supports iteration,
+  returning results from the ``"identities"`` array (:pr:`NUMBER`)

--- a/src/globus_sdk/services/auth/client/base.py
+++ b/src/globus_sdk/services/auth/client/base.py
@@ -22,7 +22,7 @@ from globus_sdk.types import IntLike, UUIDLike
 
 from ..errors import AuthAPIError
 from ..flow_managers import GlobusOAuthFlowManager
-from ..response import OAuthTokenResponse
+from ..response import GetIdentitiesResponse, OAuthTokenResponse
 
 log = logging.getLogger(__name__)
 
@@ -119,13 +119,13 @@ class AuthClient(client.BaseClient):
         >>> # by IDs
         >>> r = ac.get_identities(ids="46bd0f56-e24f-11e5-a510-131bef46955c")
         >>> r.data
-        {u'identities': [{u'email': None,
-           u'id': u'46bd0f56-e24f-11e5-a510-131bef46955c',
-           u'identity_provider': u'7daddf46-70c5-45ee-9f0f-7244fe7c8707',
-           u'name': None,
-           u'organization': None,
-           u'status': u'unused',
-           u'username': u'globus@globus.org'}]}
+        {'identities': [{'email': None,
+           'id': '46bd0f56-e24f-11e5-a510-131bef46955c',
+           'identity_provider': '7daddf46-70c5-45ee-9f0f-7244fe7c8707',
+           'name': None,
+           'organization': None,
+           'status': 'unused',
+           'username': 'globus@globus.org'}]}
         >>> ac.get_identities(
         >>>     ids=",".join(
         >>>         ("46bd0f56-e24f-11e5-a510-131bef46955c",
@@ -147,6 +147,13 @@ class AuthClient(client.BaseClient):
         >>>     ids=["46bd0f56-e24f-11e5-a510-131bef46955c",
         >>>          "168edc3d-c6ba-478c-9cf8-541ff5ebdc1c"])
         ...
+
+        The result itself is iterable, so you can use it like so:
+
+        >>> for identity in ac.get_identities(
+        >>>     usernames=['globus@globus.org', 'auth@globus.org']
+        >>> ):
+        >>>     print(identity["id"])
         """
 
         def _convert_listarg(
@@ -181,7 +188,9 @@ class AuthClient(client.BaseClient):
                 "identities set! Expected to result in errors"
             )
 
-        return self.get("/v2/api/identities", query_params=query_params)
+        return GetIdentitiesResponse(
+            self.get("/v2/api/identities", query_params=query_params)
+        )
 
     def oauth2_get_authorize_url(
         self, *, query_params: Optional[Dict[str, Any]] = None

--- a/src/globus_sdk/services/auth/response/__init__.py
+++ b/src/globus_sdk/services/auth/response/__init__.py
@@ -1,0 +1,8 @@
+from .identities import GetIdentitiesResponse
+from .oauth import OAuthDependentTokenResponse, OAuthTokenResponse
+
+__all__ = (
+    "GetIdentitiesResponse",
+    "OAuthTokenResponse",
+    "OAuthDependentTokenResponse",
+)

--- a/src/globus_sdk/services/auth/response/identities.py
+++ b/src/globus_sdk/services/auth/response/identities.py
@@ -1,0 +1,11 @@
+from globus_sdk.response import IterableResponse
+
+
+class GetIdentitiesResponse(IterableResponse):
+    """
+    Response class specific to the Get Identities API
+
+    Provides iteration on the "identities" array in the response.
+    """
+
+    default_iter_key = "identities"

--- a/src/globus_sdk/services/auth/response/oauth.py
+++ b/src/globus_sdk/services/auth/response/oauth.py
@@ -12,7 +12,7 @@ from globus_sdk.response import GlobusHTTPResponse
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
-    from .client import AuthClient
+    from ..client import AuthClient
 
 
 def _convert_token_info_dict(source_dict: GlobusHTTPResponse) -> Dict[str, Any]:


### PR DESCRIPTION
Allow iteration on the `"identities"` key in a get_identities response.