### PR TITLE
Update workflows to handle new CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: install tox
         run: python -m pip install -U tox
       - name: run linting
-        run: make lint
+        run: tox -e mypy,pylint
 
   test:
     strategy:
@@ -59,18 +59,6 @@ jobs:
         run: python -m pip install -U tox
       - name: test
         run: tox -e py-mindeps
-
-  docs:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: "3.10"
-      - name: install tox
-        run: python -m pip install -U tox
-      - name: ensure docs build
-        run: python -m tox -e docs
 
   test-package-metadata:
     runs-on: ubuntu-latest

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -4,7 +4,11 @@ on:
 
 jobs:
   check_has_news_in_changelog_dir:
-    if: ${{ ! contains(github.event.pull_request.labels.*.name, 'no-news-is-good-news') }}
+    if: |
+      ! (
+        contains(github.event.pull_request.labels.*.name, 'no-news-is-good-news') ||
+        github.event.pull_request.title == '[pre-commit.ci] pre-commit autoupdate'
+      )
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This PR will help us see the new CI systems in action.

---

- the 'lint' build in GH Actions is now 'mypy,pylint', drop pre-commit because we now have pre-commit.ci
- the 'docs' build is now redundant with RTD PR builds
- the changelog workflow needs to allow pre-commit.ci autoupdate PRs