### PR TITLE
Set a floor for versions of typing_extensions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: install tox
         run: python -m pip install -U tox
       - name: run linting
-        run: tox -e mypy,pylint
+        run: tox -e mypy,pylint,mypy-mindeps
 
   test:
     strategy:

--- a/changelog.d/20220211_202511_sirosen_bound_te.rst
+++ b/changelog.d/20220211_202511_sirosen_bound_te.rst
@@ -1,0 +1,3 @@
+* The ``typing_extensions`` requirement in package metadata now sets a lower
+  bound of ``4.0``, to force upgrades of installations to get a new enough version
+  (:pr:`NUMBER`)

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ setup(
         "cryptography>=3.3.1,!=3.4.0",
         # depend on the latest version of typing-extensions on python versions which do
         # not have all of the typing features we use
-        'typing_extensions;python_version<"3.10"',
+        'typing_extensions>=4.0;python_version<"3.10"',
     ],
     extras_require={"dev": DEV_REQUIREMENTS},
     keywords=["globus"],

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ deps =
     mindeps: requests==2.19.1
     mindeps: pyjwt==2.0.0
     mindeps: cryptography==3.3.1
+    mindeps: typing_extensions==4.0
 commands = coverage run -m pytest {posargs}
 depends =
     py36,py37,py38,py39,py36-mindeps: cov-clean
@@ -41,8 +42,9 @@ deps = pre-commit<3
 skip_install = true
 commands = pre-commit run --all-files
 
-[testenv:mypy]
+[testenv:mypy{,-mindeps}]
 deps = mypy
+       mindeps: typing_extensions==4.0
 commands = mypy src/
 
 [testenv:pylint]


### PR DESCRIPTION
`typing_extensions>=4` is required (where typing_extensions is required).

This is tested in tox both with `mypy-mindeps` and with `py36-mindeps`. The mypy run is only done in GH Actions to reduce the time spent on this when running `make lint`, as it is unlikely to fail.

The `typing` repo has a discussion about capping or not capping the version of `typing_extensions`, but it is not well-resolved. For now, do not apply a cap to the version of `typing_extensions`. We can revisit this if the lack of a cap ever becomes an issue.