### PR TITLE
Custom TransferResponseTransport that does not retry ExternalErrors

### DIFF
--- a/changelog.d/20220222_110056_aaschaer_transfer_transport.rst
+++ b/changelog.d/20220222_110056_aaschaer_transfer_transport.rst
@@ -1,0 +1,10 @@
+..
+.. A new scriv changelog fragment
+..
+.. Add one or more items to the list below describing the change in clear, concise terms.
+..
+.. Leave the ":pr:`...`" text alone. When you open a pull request, GitHub Actions will
+.. automatically replace it when the PR is merged.
+..
+
+* Add TransferRequestsTransport class that does not retry ExternalErrors. This fixes cases in which the TransferClient incorrectly retried requests (:pr:`NUMBER`)

--- a/src/globus_sdk/services/transfer/client.py
+++ b/src/globus_sdk/services/transfer/client.py
@@ -1,7 +1,7 @@
 import logging
 import time
 import uuid
-from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Type, Union
 
 from globus_sdk import client, exc, paging, response, utils
 from globus_sdk.scopes import TransferScopes
@@ -10,6 +10,7 @@ from globus_sdk.types import DateLike, IntLike, UUIDLike
 from .data import DeleteData, TransferData
 from .errors import TransferAPIError
 from .response import ActivationRequirementsResponse, IterableTransferResponse
+from .transport import TransferRequestsTransport
 
 log = logging.getLogger(__name__)
 
@@ -97,6 +98,7 @@ class TransferClient(client.BaseClient):
     """
     service_name = "transfer"
     base_path = "/v0.10/"
+    transport_class: Type[TransferRequestsTransport] = TransferRequestsTransport
     error_class = TransferAPIError
     scopes = TransferScopes
 

--- a/src/globus_sdk/services/transfer/transport.py
+++ b/src/globus_sdk/services/transfer/transport.py
@@ -1,0 +1,25 @@
+"""
+Custom Transport class for the TransferClient that overrides
+default_check_transient_error
+"""
+from globus_sdk.transport import RequestsTransport, RetryCheckResult, RetryContext
+
+
+class TransferRequestsTransport(RequestsTransport):
+    def default_check_transient_error(self, ctx: RetryContext) -> RetryCheckResult:
+        """
+        check for transient error status codes which could be resolved by
+        retrying the request. Does not retry ExternalErrors as those are
+        unlikely to actually be transient.
+        """
+        if ctx.response is not None and (
+            ctx.response.status_code in self.TRANSIENT_ERROR_STATUS_CODES
+        ):
+            try:
+                code = ctx.response.json()["code"]
+            except (ValueError, KeyError):
+                code = ""
+            if "ExternalError" not in code:
+                return RetryCheckResult.do_retry
+
+        return RetryCheckResult.no_decision

--- a/tests/unit/test_transfer_transport.py
+++ b/tests/unit/test_transfer_transport.py
@@ -1,0 +1,39 @@
+from unittest import mock
+
+from globus_sdk.services.transfer.transport import TransferRequestsTransport
+from globus_sdk.transport import RetryCheckRunner, RetryContext
+
+
+def test_transfer_does_not_retry_external():
+    transport = TransferRequestsTransport()
+    checker = RetryCheckRunner(transport.retry_checks)
+
+    body = {
+        "HTTP status": "502",
+        "code": "ExternalError.DirListingFailed.GCDisconnected",
+        "error_name": "Transfer API Error",
+        "message": "The GCP endpoint is not currently connected to Globus",
+        "request_id": "rhvcR0aHX",
+    }
+
+    dummy_response = mock.Mock()
+    dummy_response.json = lambda: body
+    dummy_response.status_code = 502
+    ctx = RetryContext(1, response=dummy_response)
+
+    assert checker.should_retry(ctx) is False
+
+
+def test_transfer_retries_others():
+    transport = TransferRequestsTransport()
+    checker = RetryCheckRunner(transport.retry_checks)
+
+    def _raise_value_error():
+        raise ValueError()
+
+    dummy_response = mock.Mock()
+    dummy_response.json = _raise_value_error
+    dummy_response.status_code = 502
+    ctx = RetryContext(1, response=dummy_response)
+
+    assert checker.should_retry(ctx) is True


### PR DESCRIPTION
For https://app.shortcut.com/globus/story/12770/fix-how-retries-are-done-in-the-sdk-on-transfer-502s-to-not-retry-externalerrors

I went with a custom class that inherits from RequestsTransport, seems to apply pretty cleanly.

Hacked this into my local CLI to do a bit of live API testing and all seemed well.