### PR TITLE
Use HTTP "reason" as failover in exc args

### DIFF
--- a/changelog.d/20220225_211912_sirosen_failover_to_reason.rst
+++ b/changelog.d/20220225_211912_sirosen_failover_to_reason.rst
@@ -1,0 +1,1 @@
+* Use the "reason phrase" as a failover for stringified API errors with no body (:pr:`NUMBER`)

--- a/src/globus_sdk/exc/api.py
+++ b/src/globus_sdk/exc/api.py
@@ -106,7 +106,10 @@ class GlobusAPIError(GlobusError):
             self._get_request_authorization_scheme(),
             self.http_status,
             self.code,
-            self.message,
+            # if the message is "", try using response reason
+            # for details on these, and some examples, see
+            #   https://datatracker.ietf.org/doc/html/rfc7231#section-6.1
+            self.message or self._underlying_response.reason,
         ]
 
     def _parse_response(self) -> None:


### PR DESCRIPTION
When marshalling arguments to pass to `Exception` for an API error, the `message` field is included last. However, in the event of an empty body, there's no use for that field.

HTTP provides for a "reason phrase", e.g. the "Not Found" in "404 Not Found".

With this change, the reason will be used as a failover for the empty message case. No public members of the exception classes are changed -- this is done only to provide slightly better traces when errors are sent back by API Gateway, WAF, and other proxies and devices which might send a useful "reason" but discard or not generate a useful body.

---

This is kind of tricky to test. You can make a dummy webserver and so forth, but I primarily made sure that `reason` will be populated and left it at that.