### PR TITLE
Add support for skipping the registry in _testing

### DIFF
--- a/src/globus_sdk/_testing/__init__.py
+++ b/src/globus_sdk/_testing/__init__.py
@@ -1,23 +1,10 @@
-from typing import Any
-
+from .models import RegisteredResponse, ResponseSet
 from .registry import (
-    RegisteredResponse,
-    ResponseSet,
     get_response_set,
+    load_response,
+    load_response_set,
     register_response_set,
 )
-
-
-def load_response_set(set_id: Any) -> ResponseSet:
-    ret = get_response_set(set_id)
-    ret.activate_all()
-    return ret
-
-
-def load_response(set_id: Any, *, case: str = "default") -> RegisteredResponse:
-    rset = get_response_set(set_id)
-    return rset.activate(case)
-
 
 __all__ = (
     "ResponseSet",

--- a/src/globus_sdk/_testing/data/auth/get_identities.py
+++ b/src/globus_sdk/_testing/data/auth/get_identities.py
@@ -1,4 +1,4 @@
-from globus_sdk._testing.registry import RegisteredResponse, ResponseSet
+from globus_sdk._testing.models import RegisteredResponse, ResponseSet
 
 from ._common import ERROR_ID, UNAUTHORIZED_AUTH_RESPONSE_JSON
 

--- a/src/globus_sdk/_testing/data/auth/oauth2_userinfo.py
+++ b/src/globus_sdk/_testing/data/auth/oauth2_userinfo.py
@@ -1,4 +1,4 @@
-from globus_sdk._testing.registry import RegisteredResponse, ResponseSet
+from globus_sdk._testing.models import RegisteredResponse, ResponseSet
 
 from ._common import ERROR_ID, UNAUTHORIZED_AUTH_RESPONSE_JSON
 

--- a/src/globus_sdk/_testing/models.py
+++ b/src/globus_sdk/_testing/models.py
@@ -1,0 +1,106 @@
+from typing import Any, Dict, Iterator, Optional
+
+import responses
+
+from ..utils import slash_join
+
+
+class RegisteredResponse:
+    _url_map = {
+        "auth": "https://auth.globus.org/",
+        "nexus": "https://nexus.api.globusonline.org/",
+        "transfer": "https://transfer.api.globus.org/v0.10",
+        "search": "https://search.api.globus.org/",
+        "gcs": "https://abc.xyz.data.globus.org/api",
+        "groups": "https://groups.api.globus.org/v2/",
+    }
+
+    def __init__(
+        self,
+        *,
+        path: str,
+        service: Optional[str] = None,
+        method: str = responses.GET,
+        headers: Optional[Dict[str, str]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        json: Optional[Dict[str, Any]] = None,
+        body: Optional[str] = None,
+        **kwargs: Any,
+    ) -> None:
+        self.service = service
+        self.path = path
+        if service:
+            self.full_url = slash_join(self._url_map[service], path)
+        else:
+            self.full_url = path
+
+        self.method = method
+        self.json = json
+        self.body = body
+
+        if headers is None:
+            headers = {"Content-Type": "application/json"}
+        self.headers = headers
+
+        self.metadata = metadata or {}
+        self.kwargs = kwargs
+
+    def add(self) -> "RegisteredResponse":
+        kwargs: Dict[str, Any] = {
+            "headers": self.headers,
+            "match_querystring": False,
+            **self.kwargs,
+        }
+        if self.json is not None:
+            kwargs["json"] = self.json
+        if self.body is not None:
+            kwargs["body"] = self.body
+
+        responses.add(self.method, self.full_url, **kwargs)
+        return self
+
+
+class ResponseSet:
+    def __init__(
+        self,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs: RegisteredResponse,
+    ) -> None:
+        self.metadata = metadata
+        self._data: Dict[str, RegisteredResponse] = {**kwargs}
+
+    def register(self, case: str, value: RegisteredResponse) -> None:
+        self._data[case] = value
+
+    def lookup(self, case: str) -> RegisteredResponse:
+        try:
+            return self._data[case]
+        except KeyError as e:
+            raise Exception("did not find a matching registered response") from e
+
+    def __bool__(self) -> bool:
+        return bool(self._data)
+
+    def __iter__(self) -> Iterator[RegisteredResponse]:
+        return iter(self._data.values())
+
+    def activate(self, case: str) -> RegisteredResponse:
+        return self.lookup(case).add()
+
+    def activate_all(self) -> "ResponseSet":
+        for x in self:
+            x.add()
+        return self
+
+    @classmethod
+    def from_dict(
+        cls,
+        data: Dict[str, Dict[str, Any]],
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs: Dict[str, Dict[str, Any]],
+    ) -> "ResponseSet":
+        # constructor which expects native dicts and converts them to RegisteredResponse
+        # objects, then puts them into the ResponseSet
+        return cls(
+            metadata=metadata, **{k: RegisteredResponse(**v) for k, v in data.items()}
+        )

--- a/src/globus_sdk/_testing/registry.py
+++ b/src/globus_sdk/_testing/registry.py
@@ -1,112 +1,9 @@
 import importlib
-from typing import Any, Dict, Iterator, Optional, Union
-
-import responses
+from typing import Any, Dict, Optional, Union
 
 import globus_sdk
 
-from ..utils import slash_join
-
-
-class RegisteredResponse:
-    _url_map = {
-        "auth": "https://auth.globus.org/",
-        "nexus": "https://nexus.api.globusonline.org/",
-        "transfer": "https://transfer.api.globus.org/v0.10",
-        "search": "https://search.api.globus.org/",
-        "gcs": "https://abc.xyz.data.globus.org/api",
-        "groups": "https://groups.api.globus.org/v2/",
-    }
-
-    def __init__(
-        self,
-        *,
-        path: str,
-        service: Optional[str] = None,
-        method: str = responses.GET,
-        headers: Optional[Dict[str, str]] = None,
-        metadata: Optional[Dict[str, Any]] = None,
-        json: Optional[Dict[str, Any]] = None,
-        body: Optional[str] = None,
-        **kwargs: Any,
-    ) -> None:
-        self.service = service
-        self.path = path
-        if service:
-            self.full_url = slash_join(self._url_map[service], path)
-        else:
-            self.full_url = path
-
-        self.method = method
-        self.json = json
-        self.body = body
-
-        if headers is None:
-            headers = {"Content-Type": "application/json"}
-        self.headers = headers
-
-        self.metadata = metadata or {}
-        self.kwargs = kwargs
-
-    def add(self) -> "RegisteredResponse":
-        kwargs: Dict[str, Any] = {
-            "headers": self.headers,
-            "match_querystring": False,
-            **self.kwargs,
-        }
-        if self.json is not None:
-            kwargs["json"] = self.json
-        if self.body is not None:
-            kwargs["body"] = self.body
-
-        responses.add(self.method, self.full_url, **kwargs)
-        return self
-
-
-class ResponseSet:
-    def __init__(
-        self,
-        metadata: Optional[Dict[str, Any]] = None,
-        **kwargs: RegisteredResponse,
-    ) -> None:
-        self.metadata = metadata
-        self._data: Dict[str, RegisteredResponse] = {**kwargs}
-
-    def register(self, case: str, value: RegisteredResponse) -> None:
-        self._data[case] = value
-
-    def lookup(self, case: str) -> RegisteredResponse:
-        try:
-            return self._data[case]
-        except KeyError as e:
-            raise Exception("did not find a matching registered response") from e
-
-    def __bool__(self) -> bool:
-        return bool(self._data)
-
-    def __iter__(self) -> Iterator[RegisteredResponse]:
-        return iter(self._data.values())
-
-    def activate(self, case: str) -> RegisteredResponse:
-        return self.lookup(case).add()
-
-    def activate_all(self) -> None:
-        for x in self:
-            x.add()
-
-    @classmethod
-    def from_dict(
-        cls,
-        data: Dict[str, Dict[str, Any]],
-        metadata: Optional[Dict[str, Any]] = None,
-        **kwargs: Dict[str, Dict[str, Any]],
-    ) -> "ResponseSet":
-        # constructor which expects native dicts and converts them to RegisteredResponse
-        # objects, then puts them into the ResponseSet
-        return cls(
-            metadata=metadata, **{k: RegisteredResponse(**v) for k, v in data.items()}
-        )
-
+from .models import RegisteredResponse, ResponseSet
 
 _RESPONSE_SET_REGISTRY: Dict[Any, ResponseSet] = {}
 
@@ -172,3 +69,18 @@ def get_response_set(set_id: Any) -> ResponseSet:
         raise ValueError(f"no fixtures defined for {module_name}") from e
     assert isinstance(module.RESPONSES, ResponseSet)
     return module.RESPONSES
+
+
+def load_response_set(set_id: Any) -> ResponseSet:
+    if isinstance(set_id, ResponseSet):
+        return set_id.activate_all()
+    ret = get_response_set(set_id)
+    ret.activate_all()
+    return ret
+
+
+def load_response(set_id: Any, *, case: str = "default") -> RegisteredResponse:
+    if isinstance(set_id, RegisteredResponse):
+        return set_id.add()
+    rset = get_response_set(set_id)
+    return rset.activate(case)


### PR DESCRIPTION
`load_response_set` and `load_response` can now take their relevant object types directly. This allows use of the RegisteredResponse interface even under parametrized tests and other scenarios where it's not useful or desirable to register a ResponseSet for multiple tests to use.

Convert the transport retry tests to use this behavior in order to demonstrate. There's also an example in the `_testing` readme.

Also, while doing this, reorganize `_testing` a little. The registry module now contains all of the code for adding to and reading from the registry, and the models have been moved into a dedicated module, separate from the registry. The main goal of this cleanup is to make the registry more readable, as new and more nuanced behaviors are being added here.

---

@rudyardrichter, I thought this change might solve the problem you described running multiple registration calls under a parametrized test by providing a more "direct" outlet for your scenario. I initially imagined that your case would be solved with direct `responses` usage, but it occurs to me that

1. Once you start using `globus_sdk._testing`, you might prefer to use _only_ that, rather than a mix of some tests using `_testing` and some using `responses`
2. We are offering some value by handling "service name" resolution, and that might be desirable even when registering explicit responses

I still think that the original usage we discussed of multiple registrations *should* work -- the registry is just a global dict and all you'd be doing is overwriting values in it -- but we can dig into that specific case more later.