### PR TITLE
Update to responses==0.17.0 and fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ TEST_REQUIREMENTS = [
     "pytest<7",
     "coverage<7",
     "pytest-xdist<3",
-    "responses==0.16.0",
+    "responses==0.17.0",
 ]
 DOC_REQUIREMENTS = [
     "sphinx<5",

--- a/src/globus_sdk/_testing/models.py
+++ b/src/globus_sdk/_testing/models.py
@@ -48,7 +48,7 @@ class RegisteredResponse:
     def add(self) -> "RegisteredResponse":
         kwargs: Dict[str, Any] = {
             "headers": self.headers,
-            "match_querystring": False,
+            "match_querystring": None,
             **self.kwargs,
         }
         if self.json is not None:

--- a/tests/common.py
+++ b/tests/common.py
@@ -33,13 +33,7 @@ def get_last_request():
 
 
 def register_api_route(
-    service,
-    path,
-    method=responses.GET,
-    adding_headers=None,
-    replace=False,
-    match_querystring=False,
-    **kwargs
+    service, path, method=responses.GET, adding_headers=None, replace=False, **kwargs
 ):
     """
     Handy wrapper for adding URIs to the response mock state.
@@ -62,19 +56,11 @@ def register_api_route(
 
     if replace:
         responses.replace(
-            method,
-            full_url,
-            headers=adding_headers,
-            match_querystring=match_querystring,
-            **kwargs
+            method, full_url, headers=adding_headers, match_querystring=None, **kwargs
         )
     else:
         responses.add(
-            method,
-            full_url,
-            headers=adding_headers,
-            match_querystring=match_querystring,
-            **kwargs
+            method, full_url, headers=adding_headers, match_querystring=None, **kwargs
         )
 
 


### PR DESCRIPTION
This is the final `responses` version with py3.6 support, so we can't upgrade past this until we're ready to begin dropping 3.6.
Updating means that test tools need to set `match_querystring=None` to avoid a deprecation warning. This should ensure that any consumers of `_testing` are not impacted with deprecation warnings (so long as they keep to this same version of `responses`.

---

I thought we were already on this version, so there was a bit of a mixup on this. The `_testing` doc said to use this version, but then the SDK was _not_ using it. That's how it was possible to have the `_testing` code in a state which generated deprecation warnings without catching it immediately.