### PR TITLE
Move `get_last_request` helper to `_testing`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,3 +44,4 @@ repos:
         - types-docutils
         - types-jwt
         - types-requests
+        - responses  # signatures for code in `_testing`

--- a/src/globus_sdk/_testing/__init__.py
+++ b/src/globus_sdk/_testing/__init__.py
@@ -1,3 +1,4 @@
+from .helpers import get_last_request
 from .models import RegisteredResponse, ResponseSet
 from .registry import (
     get_response_set,
@@ -7,6 +8,7 @@ from .registry import (
 )
 
 __all__ = (
+    "get_last_request",
     "ResponseSet",
     "RegisteredResponse",
     "load_response_set",

--- a/src/globus_sdk/_testing/helpers.py
+++ b/src/globus_sdk/_testing/helpers.py
@@ -1,0 +1,11 @@
+from typing import Optional
+
+import requests
+import responses
+
+
+def get_last_request() -> Optional[requests.PreparedRequest]:
+    try:
+        return responses.calls[-1].request
+    except IndexError:
+        return None

--- a/tests/common.py
+++ b/tests/common.py
@@ -25,13 +25,6 @@ GO_EP1_SERVER_ID = 207976
 # end constants
 
 
-def get_last_request():
-    try:
-        return responses.calls[-1].request
-    except IndexError:
-        return None
-
-
 def register_api_route(
     service, path, method=responses.GET, adding_headers=None, replace=False, **kwargs
 ):

--- a/tests/functional/auth/test_identity_map.py
+++ b/tests/functional/auth/test_identity_map.py
@@ -2,8 +2,7 @@ import pytest
 import responses
 
 import globus_sdk
-from globus_sdk._testing import load_response
-from tests.common import get_last_request
+from globus_sdk._testing import get_last_request, load_response
 
 IDENTITIES_MULTIPLE_RESPONSE = {
     "identities": [

--- a/tests/functional/auth/test_simple_auth_usage.py
+++ b/tests/functional/auth/test_simple_auth_usage.py
@@ -3,8 +3,7 @@ import uuid
 import pytest
 
 import globus_sdk
-from globus_sdk._testing import load_response
-from tests.common import get_last_request
+from globus_sdk._testing import get_last_request, load_response
 
 
 class StringWrapper:

--- a/tests/functional/gcs/test_collections.py
+++ b/tests/functional/gcs/test_collections.py
@@ -1,7 +1,8 @@
 import pytest
 
 from globus_sdk import GCSAPIError, GuestCollectionDocument, MappedCollectionDocument
-from tests.common import get_last_request, register_api_route_fixture_file
+from globus_sdk._testing import get_last_request
+from tests.common import register_api_route_fixture_file
 
 
 def test_get_collection_list(client):

--- a/tests/functional/gcs/test_roles.py
+++ b/tests/functional/gcs/test_roles.py
@@ -1,7 +1,8 @@
 import json
 
 from globus_sdk import GCSRoleDocument
-from tests.common import get_last_request, register_api_route_fixture_file
+from globus_sdk._testing import get_last_request
+from tests.common import register_api_route_fixture_file
 
 
 def test_get_role_list(client):

--- a/tests/functional/groups/test_groups.py
+++ b/tests/functional/groups/test_groups.py
@@ -9,8 +9,8 @@ from globus_sdk import (
     GroupRequiredSignupFields,
     GroupVisibility,
 )
-from globus_sdk._testing import load_response
-from tests.common import get_last_request, register_api_route_fixture_file
+from globus_sdk._testing import get_last_request, load_response
+from tests.common import register_api_route_fixture_file
 
 
 def test_my_groups_simple(groups_client):

--- a/tests/functional/search/test_search.py
+++ b/tests/functional/search/test_search.py
@@ -6,8 +6,8 @@ import pytest
 import responses
 
 import globus_sdk
-from globus_sdk._testing import load_response
-from tests.common import get_last_request, register_api_route_fixture_file
+from globus_sdk._testing import get_last_request, load_response
+from tests.common import register_api_route_fixture_file
 
 
 @pytest.fixture

--- a/tests/functional/search/test_search_roles.py
+++ b/tests/functional/search/test_search_roles.py
@@ -3,8 +3,7 @@ import json
 import pytest
 
 import globus_sdk
-from globus_sdk._testing import load_response
-from tests.common import get_last_request
+from globus_sdk._testing import get_last_request, load_response
 
 
 @pytest.fixture

--- a/tests/functional/transfer/endpoint_manager/test_task_event_list.py
+++ b/tests/functional/transfer/endpoint_manager/test_task_event_list.py
@@ -2,7 +2,8 @@ import uuid
 
 import pytest
 
-from tests.common import get_last_request, register_api_route
+from globus_sdk._testing import get_last_request
+from tests.common import register_api_route
 
 ZERO_ID = uuid.UUID(int=0)
 

--- a/tests/functional/transfer/endpoint_manager/test_task_list.py
+++ b/tests/functional/transfer/endpoint_manager/test_task_list.py
@@ -3,7 +3,8 @@ import uuid
 
 import pytest
 
-from tests.common import get_last_request, register_api_route
+from globus_sdk._testing import get_last_request
+from tests.common import register_api_route
 
 ZERO_ID = uuid.UUID(int=0)
 

--- a/tests/functional/transfer/test_simple.py
+++ b/tests/functional/transfer/test_simple.py
@@ -5,11 +5,11 @@ import uuid
 import pytest
 
 import globus_sdk
+from globus_sdk._testing import get_last_request
 from tests.common import (
     GO_EP1_ID,
     GO_EP1_SERVER_ID,
     GO_EP2_ID,
-    get_last_request,
     register_api_route_fixture_file,
 )
 

--- a/tests/functional/transfer/test_task_wait.py
+++ b/tests/functional/transfer/test_task_wait.py
@@ -4,7 +4,8 @@ import pytest
 import responses
 
 import globus_sdk
-from tests.common import get_last_request, register_api_route_fixture_file
+from globus_sdk._testing import get_last_request
+from tests.common import register_api_route_fixture_file
 
 TASK1_ID = "b8872740-7edc-11ec-9f33-ed182a728dff"
 

--- a/tests/unit/test_base_client.py
+++ b/tests/unit/test_base_client.py
@@ -7,7 +7,8 @@ import pytest
 
 import globus_sdk
 import globus_sdk.scopes
-from tests.common import get_last_request, register_api_route
+from globus_sdk._testing import get_last_request
+from tests.common import register_api_route
 
 
 @pytest.fixture


### PR DESCRIPTION
For use outside of the SDK testsuite.

From https://github.com/globus/globus-cli/pull/606/files#r824262384