### PR TITLE
Add "known_url_scopes" to ScopeBuilder

### DIFF
--- a/changelog.d/20220314_131036_sirosen_known_url_scopes.rst
+++ b/changelog.d/20220314_131036_sirosen_known_url_scopes.rst
@@ -1,0 +1,3 @@
+* ``ScopeBuilder`` objects now support ``known_url_scopes``, and known scope
+  arguments to a ``ScopeBuilder`` may now be of type ``str`` in addition to
+  ``list[str]`` (:pr:`NUMBER`)

--- a/src/globus_sdk/scopes.py
+++ b/src/globus_sdk/scopes.py
@@ -1,4 +1,6 @@
-from typing import List, Optional
+from typing import List, Union
+
+from globus_sdk import utils
 
 
 class ScopeBuilder:
@@ -10,17 +12,36 @@ class ScopeBuilder:
     :type resource_server: str
     :param known_scopes: A list of scope names to pre-populate on this instance. This
         will set attributes on the instance using the URN scope format.
-    :type known_scopes: list, optional
+    :type known_scopes: list of str, optional
+    :param known_url_scopes: A list of scope names to pre-populate on this instance.
+        This will set attributes on the instance using the URL scope format.
+    :type known_url_scopes: list of str, optional
     """
 
     def __init__(
-        self, resource_server: str, *, known_scopes: Optional[List[str]] = None
+        self,
+        resource_server: str,
+        *,
+        known_scopes: Union[List[str], str, None] = None,
+        known_url_scopes: Union[List[str], str, None] = None,
     ) -> None:
         self.resource_server = resource_server
-        self._known_scopes = known_scopes
-        if known_scopes:
-            for scope_name in known_scopes:
+        self._known_scopes = (
+            list(utils.safe_strseq_iter(known_scopes))
+            if known_scopes is not None
+            else []
+        )
+        self._known_url_scopes = (
+            list(utils.safe_strseq_iter(known_url_scopes))
+            if known_url_scopes is not None
+            else []
+        )
+        if self._known_scopes:
+            for scope_name in self._known_scopes:
                 setattr(self, scope_name, self.urn_scope_string(scope_name))
+        if self._known_url_scopes:
+            for scope_name in self._known_url_scopes:
+                setattr(self, scope_name, self.url_scope_string(scope_name))
 
     # custom __getattr__ instructs `mypy` that unknown attributes of a ScopeBuilder are
     # of type `str`, allowing for dynamic attribute names

--- a/tests/unit/test_scopes.py
+++ b/tests/unit/test_scopes.py
@@ -16,3 +16,15 @@ def test_urn_scope_string():
     assert (
         sb.urn_scope_string("scope") == "urn:globus:auth:scope:example.globus.org:scope"
     )
+
+
+def test_known_scopes():
+    sb = ScopeBuilder(str(uuid.UUID(int=0)), known_scopes="foo")
+    assert sb.foo == "urn:globus:auth:scope:00000000-0000-0000-0000-000000000000:foo"
+
+
+def test_known_url_scopes():
+    sb = ScopeBuilder(str(uuid.UUID(int=0)), known_url_scopes="foo")
+    assert sb.foo == (
+        "https://auth.globus.org/scopes/00000000-0000-0000-0000-000000000000/foo"
+    )


### PR DESCRIPTION
Additionally, allow a `str` instead of only `list[str]`.

Initially I only intended to update to add `known_url_scopes`, but I accidentally passed a string in the tests (which failed). Rather than fixing the test, I chose to fix the behavior of ScopeBuilder to allow for a string -- passing a string instead of a string iterable is a rather common error with surprising behavior. (`foo` -> `['f', 'o', 'o']`)