### PR TITLE
Add RequestsTransport.tune for temp settings

### DIFF
--- a/changelog.d/20220317_002219_sirosen_temporary_transport_settings.rst
+++ b/changelog.d/20220317_002219_sirosen_temporary_transport_settings.rst
@@ -1,0 +1,2 @@
+* Add the ``RequestsTransport.tune`` contextmanager to the transport layer,
+  allowing the settings on the transport to be set temporarily (:pr:`NUMBER`)

--- a/tests/unit/test_transport.py
+++ b/tests/unit/test_transport.py
@@ -1,0 +1,36 @@
+import pytest
+
+from globus_sdk.transport import RequestsTransport, RetryContext
+from globus_sdk.transport.requests import _exponential_backoff
+
+
+def _linear_backoff(ctx: RetryContext) -> float:
+    if ctx.backoff is not None:
+        return ctx.backoff
+    return 0.5 * (2**ctx.attempt)
+
+
+@pytest.mark.parametrize(
+    "param_name, init_value, tune_value",
+    [
+        ("verify_ssl", True, True),
+        ("verify_ssl", True, False),
+        ("http_timeout", 60, 120),
+        ("retry_backoff", _exponential_backoff, _linear_backoff),
+        ("max_sleep", 10, 10),
+        ("max_sleep", 10, 1),
+        ("max_retries", 0, 5),
+        ("max_retries", 10, 0),
+    ],
+)
+def test_transport_tuning(param_name, init_value, tune_value):
+    init_kwargs = {param_name: init_value}
+    transport = RequestsTransport(**init_kwargs)
+
+    assert getattr(transport, param_name) == init_value
+
+    tune_kwargs = {param_name: tune_value}
+    with transport.tune(**tune_kwargs):
+        assert getattr(transport, param_name) == tune_value
+
+    assert getattr(transport, param_name) == init_value


### PR DESCRIPTION
In order to temporarily set max_retries=0 or any other settings, allow the use of a context manager which "tunes" the transport temporarily. `tune()` takes most of the same arguments as transport init, saves instance variables, sets any non-null arguments as attributes, then resets the instance variables afterwards.

---

This work started from a couple of different people asking me in different contexts how to disable retries temporarily (e.g. for a single request). The immediate/obvious thing was to add an argument `retries: int` and thread it through to allow `client.get(..., retries=0)`. However, (1) this won't play nicely with higher level methods which wrap basic http verb-methods and (2) that only covers one setting and won't extend nicely to a wider variety of attributes.

So I started playing with `contextvars` to see if there was some nice way of setting a broad context manager to tune settings, like
```python
with TransportSettings(max_retries=0):
    client.get("/foo")
```

This worked, but it's blocked on python3.6 being removed (`contextvars` were new in 3.7) and turned out to be way more complicated than I liked.

Taking that same idea and trying to simplify it a bit, I came up with the idea of a context manager method on the transport which sets attributes, yields, and then resets them to their old values afterwards.

```python
client = ...
with client.transport.tune(max_retries=0):
    client.get("/foo")
```

For now, the name I've gone with is `tune()`, but other names like `adjust`, `temporary_settings`, etc. are all valid and can be used instead if we prefer them.

The nice thing about the context manager approach is that it works on non-http-verb methods as well:
```python
tc = TransferClient(...)
with tc.transport.tune(http_timeout=10):
    tc.get_task(task_id)
```