### PR TITLE
Fix annotations to allow data:str

### DIFF
--- a/changelog.d/20220408_044943_sirosen_allow_str_data.rst
+++ b/changelog.d/20220408_044943_sirosen_allow_str_data.rst
@@ -1,0 +1,2 @@
+* Fix annotations to allow request data to be a string. This is
+  supported at runtime but was missing from annotations. (:pr:`NUMBER`)

--- a/src/globus_sdk/client.py
+++ b/src/globus_sdk/client.py
@@ -11,6 +11,8 @@ from globus_sdk.transport import RequestsTransport
 
 log = logging.getLogger(__name__)
 
+DataParamType = Union[None, str, Dict[str, Any], utils.PayloadWrapper]
+
 
 class BaseClient:
     r"""
@@ -137,7 +139,7 @@ class BaseClient:
         path: str,
         *,
         query_params: Optional[Dict[str, Any]] = None,
-        data: Union[None, Dict[str, Any], utils.PayloadWrapper] = None,
+        data: DataParamType = None,
         headers: Optional[Dict[str, str]] = None,
         encoding: Optional[str] = None,
     ) -> GlobusHTTPResponse:
@@ -182,7 +184,7 @@ class BaseClient:
         path: str,
         *,
         query_params: Optional[Dict[str, Any]] = None,
-        data: Union[None, Dict[str, Any], utils.PayloadWrapper] = None,
+        data: DataParamType = None,
         headers: Optional[Dict[str, str]] = None,
         encoding: Optional[str] = None,
     ) -> GlobusHTTPResponse:
@@ -209,7 +211,7 @@ class BaseClient:
         path: str,
         *,
         query_params: Optional[Dict[str, Any]] = None,
-        data: Union[None, Dict[str, Any], utils.PayloadWrapper] = None,
+        data: DataParamType = None,
         headers: Optional[Dict[str, str]] = None,
         encoding: Optional[str] = None,
     ) -> GlobusHTTPResponse:
@@ -237,7 +239,7 @@ class BaseClient:
         path: str,
         *,
         query_params: Optional[Dict[str, Any]] = None,
-        data: Union[None, Dict[str, Any], utils.PayloadWrapper] = None,
+        data: DataParamType = None,
         headers: Optional[Dict[str, str]] = None,
         encoding: Optional[str] = None,
     ) -> GlobusHTTPResponse:

--- a/src/globus_sdk/transport/requests.py
+++ b/src/globus_sdk/transport/requests.py
@@ -268,7 +268,7 @@ class RequestsTransport:
         method: str,
         url: str,
         query_params: Optional[Dict[str, Any]] = None,
-        data: Optional[Dict[str, Any]] = None,
+        data: Union[Dict[str, Any], str, None] = None,
         headers: Optional[Dict[str, str]] = None,
         encoding: Optional[str] = None,
         authorizer: Optional[GlobusAuthorizer] = None,

--- a/tests/non-pytest/mypy-ignore-tests/base_client_usage.py
+++ b/tests/non-pytest/mypy-ignore-tests/base_client_usage.py
@@ -10,3 +10,8 @@ i: int = globus_sdk.BaseClient.resource_server  # type: ignore [assignment]
 c = globus_sdk.BaseClient()
 s = c.resource_server
 i = c.resource_server  # type: ignore [assignment]
+
+# check that data:list warns, but other types are okay
+r = c.request("POST", "/foo", data="bar")
+r = c.request("POST", "/foo", data={})
+r = c.request("POST", "/foo", data=list())  # type: ignore [arg-type]


### PR DESCRIPTION
I found this annotation bug while working on https://github.com/globus/globus-cli/pull/626