### PR TITLE
Expose more details of HTTP requests

### DIFF
--- a/changelog.d/20220415_153608_sirosen_expose_more_http_details.rst
+++ b/changelog.d/20220415_153608_sirosen_expose_more_http_details.rst
@@ -1,0 +1,8 @@
+* Several changes expose more details of HTTP requests (:pr:`NUMBER`)
+  * ``GlobusAPIError`` has a new property ``headers`` which provides the
+    case-insensitive mapping of header values from the response
+  * ``GlobusAPIError`` and ``GlobusHTTPResponse`` now include ``http_reason``,
+    a string property containing the "reason" from the response
+  * ``BaseClient.request`` and ``RequestsTransport.request`` now have options
+    for setting boolean options ``allow_redirects`` and ``stream``, controlling
+    how requests are processed

--- a/src/globus_sdk/client.py
+++ b/src/globus_sdk/client.py
@@ -242,6 +242,8 @@ class BaseClient:
         data: DataParamType = None,
         headers: Optional[Dict[str, str]] = None,
         encoding: Optional[str] = None,
+        allow_redirects: bool = True,
+        stream: bool = False,
     ) -> GlobusHTTPResponse:
         """
         Send an HTTP request
@@ -261,6 +263,12 @@ class BaseClient:
             registered with the transport. By default, strings get "text" behavior and
             all other objects get "json".
         :type encoding: str
+        :param allow_redirects: Follow Location headers on redirect response
+            automatically. Defaults to ``True``
+        :type allow_redirects: bool
+        :param stream: Do not immediately download the response content. Defaults to
+            ``False``
+        :type stream: bool
 
         :return: :class:`GlobusHTTPResponse \
         <globus_sdk.response.GlobusHTTPResponse>` object
@@ -289,6 +297,8 @@ class BaseClient:
             headers=rheaders,
             encoding=encoding,
             authorizer=self.authorizer,
+            allow_redirects=allow_redirects,
+            stream=stream,
         )
         log.debug("request made to URL: %s", r.url)
 

--- a/src/globus_sdk/exc/api.py
+++ b/src/globus_sdk/exc/api.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Dict, List, Optional, Union, cast
+from typing import Any, Dict, List, Mapping, Optional, Union, cast
 
 import requests
 
@@ -34,6 +34,27 @@ class GlobusAPIError(GlobusError):
         self._underlying_response = r
         self._parse_response()
         super().__init__(*self._get_args())
+
+    @property
+    def http_reason(self) -> str:
+        """
+        The HTTP reason string from the response.
+
+        This is the part of the status line after the status code, and typically is a
+        string description of the status. If the status line is
+        ``HTTP/1.1 404 Not Found``, then this is the string ``"Not Found"``.
+        """
+        return self._underlying_response.reason
+
+    @property
+    def headers(self) -> Mapping[str, str]:
+        """
+        The HTTP response headers as a case-insensitive mapping.
+
+        For example, ``headers["Content-Length"]`` and ``headers["content-length"]`` are
+        treated as equivalent.
+        """
+        return self._underlying_response.headers
 
     def _json_content_type(self) -> bool:
         r = self._underlying_response

--- a/src/globus_sdk/response.py
+++ b/src/globus_sdk/response.py
@@ -94,6 +94,17 @@ class GlobusHTTPResponse:
         return self._raw_response.status_code
 
     @property
+    def http_reason(self) -> str:
+        """
+        The HTTP reason string from the response.
+
+        This is the part of the status line after the status code, and typically is a
+        string description of the status. If the status line is
+        ``HTTP/1.1 200 OK``, then this is the string ``"OK"``.
+        """
+        return self._raw_response.reason
+
+    @property
     def headers(self) -> Mapping[str, str]:
         """
         The HTTP response headers as a case-insensitive mapping.

--- a/src/globus_sdk/transport/requests.py
+++ b/src/globus_sdk/transport/requests.py
@@ -272,6 +272,8 @@ class RequestsTransport:
         headers: Optional[Dict[str, str]] = None,
         encoding: Optional[str] = None,
         authorizer: Optional[GlobusAuthorizer] = None,
+        allow_redirects: bool = True,
+        stream: bool = False,
     ) -> requests.Response:
         """
         Send an HTTP request
@@ -294,6 +296,12 @@ class RequestsTransport:
         :param authorizer: The authorizer which is used to get or update authorization
             information for the request
         :type authorizer: GlobusAuthorizer, optional
+        :param allow_redirects: Follow Location headers on redirect response
+            automatically. Defaults to ``True``
+        :type allow_redirects: bool
+        :param stream: Do not immediately download the response content. Defaults to
+            ``False``
+        :type stream: bool
 
         :return: ``requests.Response`` object
         """
@@ -313,7 +321,11 @@ class RequestsTransport:
             try:
                 log.debug("request about to send")
                 resp = ctx.response = self.session.send(
-                    req.prepare(), timeout=self.http_timeout, verify=self.verify_ssl
+                    req.prepare(),
+                    timeout=self.http_timeout,
+                    verify=self.verify_ssl,
+                    allow_redirects=allow_redirects,
+                    stream=stream,
                 )
             except requests.RequestException as err:
                 log.debug("request hit error (RequestException)")

--- a/tests/functional/base_client/test_advanced_http_options.py
+++ b/tests/functional/base_client/test_advanced_http_options.py
@@ -1,0 +1,48 @@
+from globus_sdk._testing import RegisteredResponse, load_response
+
+
+def test_allow_redirects_false(client):
+    # based on a real response from 'GET https://auth.globus.org/'
+    load_response(
+        RegisteredResponse(
+            path="https://foo.api.globus.org/bar",
+            status=302,
+            headers={
+                "Date": "Fri, 15 Apr 2022 15:35:44 GMT",
+                "Content-Type": "text/html",
+                "Content-Length": "138",
+                "Connection": "keep-alive",
+                "Server": "nginx",
+                "Location": "https://www.globus.org/",
+            },
+            body="""\
+<html>
+<head><title>302 Found</title></head>
+<body>
+<center><h1>302 Found</h1></center>
+<hr><center>nginx</center>
+</body>
+</html>
+""",
+        )
+    )
+    # NOTE: this test isn't very "real" because of where `responses` intercepts the
+    # request/response action
+    # even without `allow_redirects=False`, this test would pass
+    # if we find a better way of testing redirect behavior, consider removing this test
+    res = client.request("GET", "/bar", allow_redirects=False)
+    assert res.http_status == 302
+
+
+def test_stream_true(client):
+    load_response(
+        RegisteredResponse(
+            path="https://foo.api.globus.org/bar",
+            json={"foo": "bar"},
+        )
+    )
+    res = client.request("GET", "/bar", stream=True)
+    assert res.http_status == 200
+    # forcing JSON evaluation still works as expected (this must force the download /
+    # evaluation of content)
+    assert res["foo"] == "bar"


### PR DESCRIPTION
Motivation:
In the `globus api` command, I wanted to disable redirects and found we couldn't. I also wanted verbose mode to reconstruct the response string (as best we can) and was missing several pieces of data. [This commit](https://github.com/globus/globus-cli/pull/626/commits/ea767b3b1fd1d4178077a06ffbbc17376459f200) on the [`globus api` PR](https://github.com/globus/globus-cli/pull/626) shows what is possible with the new options and values.

`stream` is not used anywhere today, but I've added it in case we need it in the future. While looking at docs on `allow_redirects`, I examined the other options of `requests.Session.send` and on prepared request objects. `stream` was the only one that I judged might have some utility.

I did consider exposing the underlying `requests.Response` objects rather than adding the new attributes, but have decided not to do so. Right now, the use of `requests` is encapsulated by the SDK -- the thinking behind that has always been that we could plug-and-play an alternate transport like urllib3 or even (if we can sort out how) aiohttp. It's probably a far-off possibility that we'll do this in the near term, but for now I'm not going to disrupt the status-quo with respect to this. `requests` is "somewhat hidden" and usually shouldn't need to be touched directly.

---

New options:

- allow_redirects: bool on `request` methods
- stream: bool on `request` methods

These are underlying `requests` options which are re-exposed via the SDK methods for raw request sending. Because they are "advanced", they are not also re-exposed on the `get()`, `post()`, etc helper methods.

New properties:

- http_reason on responses and errors
- headers on errors

This lets the caller get more detail about the HTTP interaction in the success and error cases.

Tests exercise the new functionality, with the caveat that `allow_redirects=False` doesn't really do anything when running under `responses`. If we find a better test, there's a comment which will help us know that we can remove the old test.

For the tests, there are some status->reason mappings that "do the normal thing", e.g. `200 -> OK`, but these aren't baked into the SDK anywhere or even into `_testing`.

---

One final, minor note: you may note that `http_reason` is of type `str`, not `str | None`, even though `requests.Response.reason` is given a value of `None` on init. The `reason` will actually always be populated, and it took some digging to find this out. `http.client.HTTPResponse` is used, and the reason string is pulled from the status line of the response.