### PR TITLE
Add MutableScope type for manipulating scopes

### DIFF
--- a/changelog.d/20220426_121025_sirosen_mutable_scopes.rst
+++ b/changelog.d/20220426_121025_sirosen_mutable_scopes.rst
@@ -1,0 +1,9 @@
+* New tools for working with optional and dependent scope strings (:pr:`NUMBER`)
+
+  * A new class is provided for constructing optional and dependent scope
+    strings, ``MutableScope``. Import as in
+    ``from globus_sdk.scopes import MutableScope``
+
+  * ``ScopeBuilder`` objects provide a method, ``make_mutable``, which converts
+    from a scope name to a ``MutableScope`` object. See documentation on scopes
+    for usage details

--- a/docs/scopes.rst
+++ b/docs/scopes.rst
@@ -76,6 +76,45 @@ To elaborate on the above example:
     # data from the response
     tokendata = token_response.by_resource_server[TransferScopes.resource_server]
 
+MutableScope objects
+--------------------
+
+In order to support optional and dependent scopes, an additional type is
+provided by ``globus_sdk.scopes``: the ``MutableScope`` class.
+
+``MutableScope`` can be constructed directly, from full scope strings, or via a
+``ScopeBuilder``'s ``make_mutable`` method, given a scope's short name.
+
+For example, one can create a ``MutableScope`` from the Groups "all" scope as
+follows:
+
+.. code-block:: python
+
+    from globus_sdk.scopes import GroupsScopes
+
+    scope = GroupsScopes.make_mutable("all")
+
+MutableScopes provide the most value when handling scope dependencies. For
+example, given a Globus Connect Server Mapped Collection, it may be desirable
+to construct a "data_access" scope as an optional dependency for the Transfer
+Scope. To do so, one first creates the mutable scope object, then adds the
+dependency to it:
+
+.. code-block:: python
+
+    from globus_sdk.scopes import GCSCollectionScopeBuilder, TransferScopes
+
+    MAPPED_COLLECTION_ID = "...ID HERE..."
+
+    transfer_scope = TransferScopes.make_mutable("all")
+    transfer_scope.add_dependency(
+        GCSCollectionScopeBuilder(MAPPED_COLLECTION_ID).data_access, optional=True
+    )
+
+``MutableScope``\s can be used in most of the same locations where scope
+strings can be used, but you can also call ``str()`` on them to get a
+stringified representation.
+
 ScopeBuilder Types and Constants
 --------------------------------
 
@@ -88,6 +127,10 @@ ScopeBuilder Types and Constants
     :show-inheritance:
 
 .. autoclass:: globus_sdk.scopes.GCSCollectionScopeBuilder
+    :members:
+    :show-inheritance:
+
+.. autoclass:: globus_sdk.scopes.MutableScope
     :members:
     :show-inheritance:
 

--- a/src/globus_sdk/services/auth/flow_managers/authorization_code.py
+++ b/src/globus_sdk/services/auth/flow_managers/authorization_code.py
@@ -1,8 +1,8 @@
 import logging
 import urllib.parse
-from typing import TYPE_CHECKING, Any, Dict, Iterable, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
-from globus_sdk import utils
+from globus_sdk import scopes, utils
 
 from ..oauth2_constants import DEFAULT_REQUESTED_SCOPES
 from ..response import OAuthTokenResponse
@@ -56,15 +56,15 @@ class GlobusAuthorizationCodeFlowManager(GlobusOAuthFlowManager):
         self,
         auth_client: "globus_sdk.AuthClient",
         redirect_uri: str,
-        requested_scopes: Optional[Union[str, Iterable[str]]] = None,
+        requested_scopes: Optional[scopes._ScopeCollectionType] = None,
         state: str = "_default",
         refresh_tokens: bool = False,
     ):
-        # default to the default requested scopes
-        self.requested_scopes = requested_scopes or DEFAULT_REQUESTED_SCOPES
-        # convert scopes iterable to string immediately on load
-        if not isinstance(self.requested_scopes, str):
-            self.requested_scopes = " ".join(self.requested_scopes)
+        # convert a scope object or iterable to string immediately on load
+        # and default to the default requested scopes
+        self.requested_scopes: str = scopes.MutableScope.scopes2str(
+            requested_scopes or DEFAULT_REQUESTED_SCOPES
+        )
 
         # store the remaining parameters directly, with no transformation
         self.client_id = auth_client.client_id

--- a/tests/unit/authorizers/test_client_credentials_authorizer.py
+++ b/tests/unit/authorizers/test_client_credentials_authorizer.py
@@ -3,6 +3,7 @@ from unittest import mock
 import pytest
 
 from globus_sdk.authorizers import ClientCredentialsAuthorizer
+from globus_sdk.scopes import MutableScope
 
 ACCESS_TOKEN = "access_token_1"
 EXPIRES_AT = -1
@@ -59,3 +60,13 @@ def test_multiple_resource_servers(authorizer, response):
 
     assert "didn't return exactly one token" in str(excinfo.value)
     assert SCOPES in str(excinfo.value)
+
+
+def test_can_create_authorizer_from_mutable_scopes(client):
+    a1 = ClientCredentialsAuthorizer(client, MutableScope("foo"))
+    assert a1.scopes == "foo"
+
+    a2 = ClientCredentialsAuthorizer(
+        client, [MutableScope("foo"), "bar", MutableScope("baz").add_dependency("buzz")]
+    )
+    assert a2.scopes == "foo bar baz[buzz]"

--- a/tests/unit/test_scopes.py
+++ b/tests/unit/test_scopes.py
@@ -1,6 +1,8 @@
 import uuid
 
-from globus_sdk.scopes import ScopeBuilder
+import pytest
+
+from globus_sdk.scopes import MutableScope, ScopeBuilder
 
 
 def test_url_scope_string():
@@ -28,3 +30,72 @@ def test_known_url_scopes():
     assert sb.foo == (
         "https://auth.globus.org/scopes/00000000-0000-0000-0000-000000000000/foo"
     )
+
+
+def test_mutable_scope_str_and_repr_simple():
+    s = MutableScope("simple")
+    assert str(s) == "simple"
+    assert repr(s) == "MutableScope('simple')"
+
+    s2 = MutableScope("simple", optional=True)
+    assert str(s2) == "*simple"
+    assert repr(s2) == "MutableScope('simple', optional=True)"
+
+
+def test_mutable_scope_str_and_repr_with_dependencies():
+    s = MutableScope("top")
+    s.add_dependency("foo")
+    assert str(s) == "top[foo]"
+    s.add_dependency("bar", optional=True)
+    # NOTE: order is not guaranteed for dict() until python3.7
+    assert str(s) in ("top[foo *bar]", "top[*bar foo]")
+    assert repr(s) in (
+        "MutableScope('top', dependencies={'foo': False, 'bar': True})",
+        "MutableScope('top', dependencies={'bar': True, 'foo': False})",
+    )
+
+    s2 = MutableScope("top", optional=True)
+    s2.add_dependency("foo")
+    assert str(s2) == "*top[foo]"
+    s2.add_dependency("bar", optional=True)
+    # NOTE: order is not guaranteed for dict() until python3.7
+    assert str(s2) in ("*top[foo *bar]", "*top[*bar foo]")
+    assert repr(s2) in (
+        "MutableScope('top', optional=True, dependencies={'foo': False, 'bar': True})",
+        "MutableScope('top', optional=True, dependencies={'bar': True, 'foo': False})",
+    )
+
+
+def test_mutable_scope_str_nested():
+    top = MutableScope("top")
+    mid = MutableScope("mid")
+    bottom = MutableScope("bottom")
+    mid.add_dependency(str(bottom))
+    top.add_dependency(str(mid))
+    assert str(bottom) == "bottom"
+    assert str(mid) == "mid[bottom]"
+    assert str(top) == "top[mid[bottom]]"
+
+
+def test_mutable_scope_collection_to_str():
+    foo = MutableScope("foo")
+    bar = MutableScope("bar")
+    baz = "baz"
+    assert MutableScope.scopes2str(foo) == "foo"
+    assert MutableScope.scopes2str([foo, bar]) == "foo bar"
+    assert MutableScope.scopes2str(baz) == "baz"
+    assert MutableScope.scopes2str([foo, baz]) == "foo baz"
+
+
+def test_mutable_scope_rejects_scope_with_optional_marker():
+    s = MutableScope("top")
+    with pytest.raises(ValueError) as excinfo:
+        s.add_dependency("*subscope")
+
+    assert "add_dependency cannot contain a leading '*'" in str(excinfo.value)
+
+
+def test_scopebuilder_make_mutable_produces_same_strings():
+    sb = ScopeBuilder(str(uuid.UUID(int=0)), known_scopes="foo", known_url_scopes="bar")
+    assert str(sb.make_mutable("foo")) == sb.foo
+    assert str(sb.make_mutable("bar")) == sb.bar


### PR DESCRIPTION
In order to define optional scopes and scoes with dependencies, define a new type, MutableScope, from the scopes module. Anywhere that scope strings are accepted, MutableScopes are now accepted too.

MutableScope.collection2str is a static method attached to the class for converting strings, iterables of strings, and mixed iterables of strings and MutableScopes into the desired (space-separated) string.

Additionally, `ScopeBuilder.make_mutable` is added as a method for ScopeBuilders to create MutableScope objects from their existing scope attributes.

Narrative docs are added and MutableScope is added to the `scopes` module's reference documentation.

---

A brief note on the scope of this feature-set:
I considered allowing `add_dependency(MutableScope(...))` and several other conveniences and variants when I did the first implementation. However, as I worked through various cases, the complexity it introduced seemed greater than the benefit of supporting it. This is therefore fairly "bare bones" and can be expanded in the future. One thing I kept from those efforts is the check for a leading `*` on a scope string. I think it provides some value, given that `foo[**bar]` is not valid, but `foo[bar]` and `foo[*bar]` both are.