### PR TITLE
Minor tweaks to test config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,4 +22,5 @@ release:
 
 .PHONY: clean
 clean:
-	rm -rf dist build *.egg-info .tox
+	rm -rf dist build *.egg-info .tox .venv
+	find . -type d -name '__pycache__' -exec rm -r {} +

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,10 +20,17 @@ warn_no_return = true
 
 
 [tool:pytest]
+testpaths = tests
 norecursedirs = tests/non-pytest
 filterwarnings =
     # warnings are errors, like -Werror
     error
+    # ignore cryptography warnings about end of 3.6 support
+    # we are aware, but we only see this warning because we still support py3.6
+    # DO NOT refer to `cryptography.utils.CryptographyDeprecationWarning` for
+    # this because that would cause failures
+    # see also: https://bugs.python.org/issue22543
+    ignore:Python 3.6 is no longer supported by the Python core team.:
 
 [scriv]
 version = literal: src/globus_sdk/version.py: __version__


### PR DESCRIPTION
- add a `find` to `make clean` so that it scrubs `__pycache__` dirs as well
- set pytest testpaths=... for faster test collection (avoids scanning any other dirs for test modules)
- set a needed ignore for cryptography warnings for py3.6 builds

Regarding the last item, the constraints for handling the ignore are tied up in the way that the `warnings` module is initialized. We cannot give a very precise ignore, so use string-based matching for now. If this turns out to be unstable, we can revisit and potentially disable all warnings for the 3.6 builds via tox factor config.