### PR TITLE
Implement partial lazy importing in globus-sdk

### DIFF
--- a/changelog.d/20220513_214357_sirosen_half_lazy_imports.rst
+++ b/changelog.d/20220513_214357_sirosen_half_lazy_imports.rst
@@ -1,0 +1,6 @@
+* ``globus_sdk`` now defers many 3rd party imports until they are needed. This
+  may lead to faster import times, but there may be a new delay when libraries
+  are first used. In particular, ``requests`` can be slow to import (~100ms).
+  Applications which are highly sensitive to operation latencies may prefer to
+  ``import requests`` explicitly at some point during application startup to
+  avoid unexpected performance spikes. (:pr:`NUMBER`)

--- a/src/globus_sdk/exc/api.py
+++ b/src/globus_sdk/exc/api.py
@@ -1,10 +1,11 @@
 import logging
-from typing import Any, Dict, List, Mapping, Optional, Union, cast
-
-import requests
+from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Union, cast
 
 from .base import GlobusError
 from .err_info import ErrorInfoContainer
+
+if TYPE_CHECKING:
+    import requests
 
 log = logging.getLogger(__name__)
 
@@ -24,7 +25,7 @@ class GlobusAPIError(GlobusError):
     MESSAGE_FIELDS = ["message", "detail"]
     RECOGNIZED_AUTHZ_SCHEMES = ["bearer", "basic", "globus-goauthtoken"]
 
-    def __init__(self, r: requests.Response, *args: Any, **kwargs: Any):
+    def __init__(self, r: "requests.Response", *args: Any, **kwargs: Any):
         self.http_status = r.status_code
         # defaults, may be rewritten during parsing
         self.code = "Error"

--- a/src/globus_sdk/exc/convert.py
+++ b/src/globus_sdk/exc/convert.py
@@ -1,8 +1,9 @@
-from typing import Any
-
-import requests
+from typing import TYPE_CHECKING, Any
 
 from .base import GlobusError
+
+if TYPE_CHECKING:
+    import requests
 
 # Wrappers around requests exceptions, so the SDK is somewhat independent from details
 # about requests
@@ -34,8 +35,9 @@ class GlobusConnectionError(NetworkError):
     """A connection error occured while making a REST request."""
 
 
-def convert_request_exception(exc: requests.RequestException) -> GlobusError:
+def convert_request_exception(exc: "requests.RequestException") -> GlobusError:
     """Converts incoming requests.Exception to a Globus NetworkError"""
+    import requests
 
     if isinstance(exc, requests.ConnectTimeout):
         return GlobusConnectionTimeoutError("ConnectTimeoutError on request", exc)

--- a/src/globus_sdk/local_endpoint/personal/owner_info.py
+++ b/src/globus_sdk/local_endpoint/personal/owner_info.py
@@ -1,5 +1,4 @@
 import base64
-import shlex
 import uuid
 from typing import Optional, Tuple
 
@@ -63,6 +62,8 @@ class GlobusConnectPersonalOwnerInfo:
     id: Optional[str]
 
     def __init__(self, *, config_dn: str) -> None:
+        import shlex
+
         lineinfo = shlex.split(config_dn)
         if len(lineinfo) != 2:
             raise ValueError("Malformed DN: not right length")

--- a/src/globus_sdk/paging/base.py
+++ b/src/globus_sdk/paging/base.py
@@ -1,6 +1,5 @@
 import abc
 import functools
-import inspect
 import sys
 from typing import (
     Any,
@@ -121,6 +120,8 @@ class Paginator(Iterable[PageT], metaclass=abc.ABCMeta):
         Although the syntax is slightly more verbose, this allows `mypy` and other type
         checkers to more accurately infer the type of the paginator.
         """
+        import inspect
+
         if not inspect.ismethod(method):
             raise TypeError(f"Paginator.wrap can only be used on methods, not {method}")
         if not getattr(method, "_has_paginator", False):

--- a/src/globus_sdk/response.py
+++ b/src/globus_sdk/response.py
@@ -11,11 +11,11 @@ from typing import (
     cast,
 )
 
-from requests import Response
-
 log = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
+    import requests
+
     import globus_sdk
 
 
@@ -40,7 +40,7 @@ class GlobusHTTPResponse:
 
     def __init__(
         self,
-        response: Union[Response, "GlobusHTTPResponse"],
+        response: Union["requests.Response", "GlobusHTTPResponse"],
         client: Optional["globus_sdk.BaseClient"] = None,
     ):
         # init on a GlobusHTTPResponse: we are wrapping this data
@@ -49,7 +49,7 @@ class GlobusHTTPResponse:
             if client is not None:
                 raise ValueError("Redundant client with wrapped response")
             self._wrapped: Optional[GlobusHTTPResponse] = response
-            self._response: Optional[Response] = None
+            self._response: Optional["requests.Response"] = None
             self.client: "globus_sdk.BaseClient" = self._wrapped.client
 
             # copy parsed JSON data off of '_wrapped'
@@ -78,7 +78,7 @@ class GlobusHTTPResponse:
                 self._parsed_json = None
 
     @property
-    def _raw_response(self) -> Response:
+    def _raw_response(self) -> "requests.Response":
         # this is an internal property which traverses any series of wrapped responses
         # until reaching a requests response object
         if self._response is not None:
@@ -187,7 +187,7 @@ class IterableResponse(GlobusHTTPResponse):
 
     def __init__(
         self,
-        response: Union[Response, "GlobusHTTPResponse"],
+        response: Union["requests.Response", "GlobusHTTPResponse"],
         client: Optional["globus_sdk.BaseClient"] = None,
         *,
         iter_key: Optional[str] = None,

--- a/src/globus_sdk/services/auth/client/base.py
+++ b/src/globus_sdk/services/auth/client/base.py
@@ -2,10 +2,18 @@ import collections.abc
 import json
 import logging
 import sys
-from typing import Any, Dict, Iterable, Optional, Type, TypeVar, Union, cast, overload
-
-import jwt
-from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Iterable,
+    Optional,
+    Type,
+    TypeVar,
+    Union,
+    cast,
+    overload,
+)
 
 if sys.version_info >= (3, 8):
     # pylint can't handle quoted annotations yet:
@@ -23,6 +31,9 @@ from globus_sdk.types import IntLike, UUIDLike
 from ..errors import AuthAPIError
 from ..flow_managers import GlobusOAuthFlowManager
 from ..response import GetIdentitiesResponse, OAuthTokenResponse
+
+if TYPE_CHECKING:
+    from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 
 log = logging.getLogger(__name__)
 
@@ -494,7 +505,7 @@ class AuthClient(client.BaseClient):
         openid_configuration: Optional[Union[GlobusHTTPResponse, Dict[str, Any]]],
         *,
         as_pem: "Literal[True]",
-    ) -> RSAPublicKey:
+    ) -> "RSAPublicKey":
         ...
 
     @overload
@@ -513,7 +524,7 @@ class AuthClient(client.BaseClient):
         ] = None,
         *,
         as_pem: bool = False,
-    ) -> Union[RSAPublicKey, Dict[str, Any]]:
+    ) -> Union["RSAPublicKey", Dict[str, Any]]:
         """
         Fetch the Globus Auth JWK.
 
@@ -525,6 +536,8 @@ class AuthClient(client.BaseClient):
         :param as_pem: Decode the JWK to an RSA PEM key, typically for JWT decoding
         :type as_pem: bool
         """
+        import jwt
+
         log.info("Fetching JWK")
         if openid_configuration:
             jwks_uri = openid_configuration["jwks_uri"]
@@ -541,8 +554,8 @@ class AuthClient(client.BaseClient):
             log.debug("JWK as_pem=True requested, decoding...")
             # decode from JWK to an RSA PEM key for JWT decoding
             # cast here because this should never be private key
-            jwk_as_pem: RSAPublicKey = cast(
-                RSAPublicKey,
+            jwk_as_pem: "RSAPublicKey" = cast(
+                "RSAPublicKey",
                 jwt.algorithms.RSAAlgorithm.from_jwk(json.dumps(jwk_data["keys"][0])),
             )
             log.debug("JWK PEM decoding finished successfully")

--- a/src/globus_sdk/services/auth/response/oauth.py
+++ b/src/globus_sdk/services/auth/response/oauth.py
@@ -3,15 +3,14 @@ import logging
 import time
 from typing import TYPE_CHECKING, Any, Dict, Iterator, Optional, Union, cast
 
-import jwt
-from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
-
 from globus_sdk import exc
 from globus_sdk.response import GlobusHTTPResponse
 
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
+    from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
+
     from ..client import AuthClient
 
 
@@ -172,7 +171,7 @@ class OAuthTokenResponse(GlobusHTTPResponse):
         openid_configuration: Optional[
             Union[GlobusHTTPResponse, Dict[str, Any]]
         ] = None,
-        jwk: Optional[RSAPublicKey] = None,
+        jwk: Optional["RSAPublicKey"] = None,
         jwt_params: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
 
@@ -191,6 +190,8 @@ class OAuthTokenResponse(GlobusHTTPResponse):
             step. These are passed verbatim to the jwt library.
         :type jwt_params: dict
         """
+        import jwt
+
         logger.info('Decoding ID Token "%s"', self["id_token"])
         auth_client = cast("AuthClient", self.client)
 
@@ -252,7 +253,7 @@ class OAuthDependentTokenResponse(OAuthTokenResponse):
         openid_configuration: Optional[
             Union[GlobusHTTPResponse, Dict[str, Any]]
         ] = None,
-        jwk: Optional[RSAPublicKey] = None,
+        jwk: Optional["RSAPublicKey"] = None,
         jwt_params: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         # just in case

--- a/src/globus_sdk/services/gcs/errors.py
+++ b/src/globus_sdk/services/gcs/errors.py
@@ -1,8 +1,9 @@
-from typing import Any, Dict, List, Optional, Union
-
-import requests
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from globus_sdk import exc
+
+if TYPE_CHECKING:
+    import requests
 
 
 class GCSAPIError(exc.GlobusAPIError):
@@ -10,7 +11,7 @@ class GCSAPIError(exc.GlobusAPIError):
     Error class for the GCS Manager API client
     """
 
-    def __init__(self, r: requests.Response) -> None:
+    def __init__(self, r: "requests.Response") -> None:
         self.detail_data_type: Optional[str] = None
         self.detail: Union[None, str, Dict[str, Any]] = None
         super().__init__(r)

--- a/src/globus_sdk/services/search/errors.py
+++ b/src/globus_sdk/services/search/errors.py
@@ -1,8 +1,9 @@
-from typing import Any, Dict
-
-import requests
+from typing import TYPE_CHECKING, Any, Dict
 
 from globus_sdk import exc
+
+if TYPE_CHECKING:
+    import requests
 
 
 class SearchAPIError(exc.GlobusAPIError):
@@ -17,7 +18,7 @@ class SearchAPIError(exc.GlobusAPIError):
     # the Search API always and only returns 'message' for string messages
     MESSAGE_FIELDS = ["message"]
 
-    def __init__(self, r: requests.Response) -> None:
+    def __init__(self, r: "requests.Response") -> None:
         self.error_data = None
         super().__init__(r)
 

--- a/src/globus_sdk/services/transfer/errors.py
+++ b/src/globus_sdk/services/transfer/errors.py
@@ -1,8 +1,9 @@
-from typing import Any, Dict, List
-
-import requests
+from typing import TYPE_CHECKING, Any, Dict, List
 
 from globus_sdk import exc
+
+if TYPE_CHECKING:
+    import requests
 
 
 class TransferAPIError(exc.GlobusAPIError):
@@ -14,7 +15,7 @@ class TransferAPIError(exc.GlobusAPIError):
                       provided when contacting support@globus.org.
     """
 
-    def __init__(self, r: requests.Response) -> None:
+    def __init__(self, r: "requests.Response") -> None:
         self.request_id = None
         super().__init__(r)
 

--- a/src/globus_sdk/tokenstorage/sqlite_adapter.py
+++ b/src/globus_sdk/tokenstorage/sqlite_adapter.py
@@ -1,10 +1,12 @@
 import json
-import sqlite3
-from typing import Any, Dict, Iterator, Mapping, Optional, Set
+from typing import TYPE_CHECKING, Any, Dict, Iterator, Mapping, Optional, Set
 
 from globus_sdk.services.auth import OAuthTokenResponse
 from globus_sdk.tokenstorage.base import FileAdapter
 from globus_sdk.version import __version__
+
+if TYPE_CHECKING:
+    import sqlite3
 
 
 class SQLiteAdapter(FileAdapter):
@@ -39,7 +41,9 @@ class SQLiteAdapter(FileAdapter):
     def _is_memory_db(self) -> bool:
         return self.dbname == ":memory:"
 
-    def _init_and_connect(self) -> sqlite3.Connection:
+    def _init_and_connect(self) -> "sqlite3.Connection":
+        import sqlite3
+
         init_tables = self._is_memory_db() or not self.file_exists()
         if init_tables and not self._is_memory_db():  # real file needs to be created
             with self.user_only_umask():

--- a/src/globus_sdk/transport/encoders.py
+++ b/src/globus_sdk/transport/encoders.py
@@ -1,6 +1,7 @@
-from typing import Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
-import requests
+if TYPE_CHECKING:
+    import requests
 
 
 class RequestEncoder:
@@ -18,7 +19,9 @@ class RequestEncoder:
         params: Optional[Dict[str, Any]],
         data: Any,
         headers: Dict[str, str],
-    ) -> requests.Request:
+    ) -> "requests.Request":
+        import requests
+
         if not isinstance(data, (str, bytes)):
             raise TypeError(
                 "Cannot encode non-text in a text request. "
@@ -41,7 +44,9 @@ class JSONRequestEncoder(RequestEncoder):
         params: Optional[Dict[str, Any]],
         data: Any,
         headers: Dict[str, str],
-    ) -> requests.Request:
+    ) -> "requests.Request":
+        import requests
+
         if data is not None:
             headers = {"Content-Type": "application/json", **headers}
         return requests.Request(method, url, json=data, params=params, headers=headers)
@@ -60,7 +65,9 @@ class FormRequestEncoder(RequestEncoder):
         params: Optional[Dict[str, Any]],
         data: Any,
         headers: Dict[str, str],
-    ) -> requests.Request:
+    ) -> "requests.Request":
+        import requests
+
         if not isinstance(data, dict):
             raise TypeError("FormRequestEncoder cannot encode non-dict data")
         return requests.Request(method, url, data=data, params=params, headers=headers)

--- a/src/globus_sdk/transport/retry.py
+++ b/src/globus_sdk/transport/retry.py
@@ -1,10 +1,11 @@
 import enum
 import logging
-from typing import Any, Callable, Dict, List, Optional, TypeVar, cast
-
-import requests
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, TypeVar, cast
 
 from globus_sdk.authorizers import GlobusAuthorizer
+
+if TYPE_CHECKING:
+    import requests
 
 log = logging.getLogger(__name__)
 
@@ -37,7 +38,7 @@ class RetryContext:
         attempt: int,
         *,
         authorizer: Optional[GlobusAuthorizer] = None,
-        response: Optional[requests.Response] = None,
+        response: Optional["requests.Response"] = None,
         exception: Optional[Exception] = None,
     ):
         # retry attempt number

--- a/src/globus_sdk/utils.py
+++ b/src/globus_sdk/utils.py
@@ -1,9 +1,9 @@
+import base64
 import collections
 import collections.abc
 import hashlib
 import os
 import sys
-from base64 import b64encode
 from enum import Enum
 from typing import (
     TYPE_CHECKING,
@@ -30,11 +30,13 @@ else:
 
 
 def sha256_string(s: str) -> str:
+
     return hashlib.sha256(s.encode("utf-8")).hexdigest()
 
 
 def b64str(s: str) -> str:
-    return b64encode(s.encode("utf-8")).decode("utf-8")
+
+    return base64.b64encode(s.encode("utf-8")).decode("utf-8")
 
 
 def slash_join(a: str, b: Optional[str]) -> str:

--- a/tests/unit/test_imports.py
+++ b/tests/unit/test_imports.py
@@ -34,3 +34,17 @@ def test_import_str(importstring):
     assert status == 0, str(proc.communicate())
     proc.stdout.close()
     proc.stderr.close()
+
+
+def test_requests_is_not_eagerly_imported():
+    execstr = "import sys, globus_sdk; assert 'requests' not in sys.modules"
+    proc = subprocess.Popen(
+        f'{PYTHON_BINARY} -c "{execstr}"',
+        shell=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    status = proc.wait()
+    assert status == 0, str(proc.communicate())
+    proc.stdout.close()
+    proc.stderr.close()


### PR DESCRIPTION
This defers imports of 3rd party packages and some stdlib modules until they are first used. Where necessary, the packages are imported at type checking time.

This means that, for example, applications which do not use `globus_sdk.GlobusConnectPersonalOwnerInfo` do not necessarily end up importing `shlex`. As a result, the startup cost associated with importing that module is not paid. In particular, `requests` is a slow import, and if an application has codepaths which do not send requests at all (e.g. globus-cli with completions) we can save over 100ms by deferring the import.

However, the cost of imports must be paid at some point when these modules and packages are needed. As a result, the changelog calls out `requests` explicitly as an area of interest for "very latency-sensitive" applications.

3rd party packages deferred:
- requests
- jwt
- cryptography

stdlib modules deferred:
- sqlite3
- shlex
- inspect

After some study of the dependencies within the stdlib, no other modules or packages of interest were easily identifiable.

The result is a reduction in the time to `import globus_sdk` of over 100ms.

---

For some related background, see also: #559 

The numbers here are only somewhat less extreme. While that showed an improvement from 220ms to 17ms, this change shows a reduction to 76ms on py3.7