### PR TITLE
Update fields to extract AuthAPIError messages

### DIFF
--- a/changelog.d/20220525_183700_sirosen_auth_errmessage_fields.rst
+++ b/changelog.d/20220525_183700_sirosen_auth_errmessage_fields.rst
@@ -1,0 +1,1 @@
+* Update the fields used to extract ``AuthAPIError`` messages (:pr:`NUMBER`)

--- a/src/globus_sdk/services/auth/errors.py
+++ b/src/globus_sdk/services/auth/errors.py
@@ -12,4 +12,4 @@ class AuthAPIError(exc.GlobusAPIError):
     Customizes message parsing to support the field named 'error'.
     """
 
-    MESSAGE_FIELDS = ["message", "detail", "error"]
+    MESSAGE_FIELDS = ["detail", "title"]

--- a/tests/unit/test_exc.py
+++ b/tests/unit/test_exc.py
@@ -61,7 +61,15 @@ def _mk_json_response(data, status):
 
 @pytest.fixture
 def json_response():
-    json_data = {"errors": [{"message": "json error message", "code": "Json Error"}]}
+    json_data = {
+        "errors": [
+            {
+                "message": "json error message",
+                "title": "json error message",
+                "code": "Json Error",
+            }
+        ]
+    }
     return _mk_json_response(json_data, 400)
 
 
@@ -88,7 +96,7 @@ def transfer_response():
 
 @pytest.fixture
 def simple_auth_response():
-    auth_data = {"error": "simple auth error message"}
+    auth_data = {"detail": "simple auth error message"}
     return _mk_json_response(auth_data, 404)
 
 
@@ -98,7 +106,7 @@ def nested_auth_response():
         "errors": [
             {"detail": "nested auth error message", "code": "Auth Error"},
             {
-                "message": "some other error which will not be seen",
+                "title": "some other error which will not be seen",
                 "code": "HiddenError",
             },
         ]


### PR DESCRIPTION
"message" does not appear to match the API -- it is never used. "error" is a copy of "code" in some cases, but it is only used in the
top-level error wrapper (not the nested error doc we extract). "title" *is* actively used as an alternative to "detail" and was not being checked. Add this to the fields.

This can be refined further over time if we see issues with this message parsing.

The change could technically be breaking for code which uses `AuthAPIError.message` to drive logic. e.g.

    try: ...
    except AuthAPIError as e:
        if "foostr" in e.message: ...
        raise

However, we're improving behavior and staying consistent with the spirit of semver. The above kind of logic presumably _should have been_ written as

    try: ...
    except AuthAPIError as e:
        if "foostr" in e.raw_text: ...
        raise