### PR TITLE
Add __str__ for ScopeBuilder

### DIFF
--- a/changelog.d/20220526_173626_sirosen_scopebuilder_strings.rst
+++ b/changelog.d/20220526_173626_sirosen_scopebuilder_strings.rst
@@ -1,0 +1,2 @@
+* ``ScopeBuilder`` objects now implement ``__str__`` for easy viewing.
+  For example, ``print(globus_sdk.TransferClient.scopes)`` (:pr:`NUMBER`)

--- a/tests/functional/gcs/test_scope_helpers.py
+++ b/tests/functional/gcs/test_scope_helpers.py
@@ -16,5 +16,18 @@ def test_manage_collections_scope_helper(client):
 def test_data_access_scope_helper(client):
     sb = client.get_gcs_collection_scopes(zero_id)
     assert sb.data_access == f"https://auth.globus.org/scopes/{zero_id_s}/data_access"
+    assert sb.https == f"https://auth.globus.org/scopes/{zero_id_s}/https"
     # manage_collections is separated from collection scopes
     assert not hasattr(sb, "manage_collections")
+
+
+def test_str_contains_scope_properties(client):
+    ep_sb = client.get_gcs_endpoint_scopes(zero_id)
+
+    assert "manage_collections" in str(ep_sb)
+    assert ep_sb.manage_collections in str(ep_sb)
+
+    collection_sb = client.get_gcs_collection_scopes(zero_id)
+
+    assert "data_access" in str(collection_sb)
+    assert collection_sb.data_access in str(collection_sb)

--- a/tests/unit/test_scopes.py
+++ b/tests/unit/test_scopes.py
@@ -32,6 +32,16 @@ def test_known_url_scopes():
     )
 
 
+def test_scopebuilder_str():
+    sb = ScopeBuilder(str(uuid.UUID(int=0)), known_scopes="foo", known_url_scopes="bar")
+    rs, foo_scope, bar_scope = sb.resource_server, sb.foo, sb.bar
+
+    stringified = str(sb)
+    assert rs in stringified
+    assert foo_scope in stringified
+    assert bar_scope in stringified
+
+
 def test_mutable_scope_str_and_repr_simple():
     s = MutableScope("simple")
     assert str(s) == "simple"


### PR DESCRIPTION
These objects are fiddly to inspect. Make it nicer to do so with a friendly `__str__` method.

I also slipped in a check for the new `https` property-scope.