### PR TITLE
Add skip_activation_check and add_filter_rule

### DIFF
--- a/changelog.d/20220527_224150_sirosen_add_missing_transfer_opts.rst
+++ b/changelog.d/20220527_224150_sirosen_add_missing_transfer_opts.rst
@@ -1,0 +1,8 @@
+* Several improvements to Transfer helper objects (:pr:`NUMBER`)
+
+  * Add ``TransferData.add_filter_rule`` for adding filter rules (exclude
+    rules) to transfers
+  * Add ``skip_activation_check`` as an argument to ``DeleteData`` and
+    ``TransferData``
+  * The ``sync_level`` argument to ``TransferData`` is now annotated more
+    accurately to reject bad strings

--- a/src/globus_sdk/services/transfer/data/delete_data.py
+++ b/src/globus_sdk/services/transfer/data/delete_data.py
@@ -47,6 +47,9 @@ class DeleteData(utils.PayloadWrapper):
         timestamps include ``2017-10-12 09:30Z``, ``2017-10-12 12:33:54+00:00``, and
         ``2017-10-12``
     :type deadline: str or datetime, optional
+    :param skip_activation_check: When true, allow submission even if the endpoint
+        isn't currently activated
+    :type skip_activation_check: bool, optional
     :param notify_on_succeeded: Send a notification email when the delete task
         completes with a status of SUCCEEDED.
         [default: ``True``]
@@ -90,6 +93,7 @@ class DeleteData(utils.PayloadWrapper):
         submission_id: Optional[UUIDLike] = None,
         recursive: bool = False,
         deadline: Optional[Union[str, datetime.datetime]] = None,
+        skip_activation_check: bool = False,
         notify_on_succeeded: bool = True,
         notify_on_failed: bool = True,
         notify_on_inactive: bool = True,
@@ -104,6 +108,7 @@ class DeleteData(utils.PayloadWrapper):
         )
         self["endpoint"] = str(endpoint)
         self["recursive"] = recursive
+        self["skip_activation_check"] = skip_activation_check
         self["notify_on_succeeded"] = notify_on_succeeded
         self["notify_on_failed"] = notify_on_failed
         self["notify_on_inactive"] = notify_on_inactive

--- a/src/globus_sdk/services/transfer/data/transfer_data.py
+++ b/src/globus_sdk/services/transfer/data/transfer_data.py
@@ -1,6 +1,12 @@
 import datetime
 import logging
+import sys
 from typing import TYPE_CHECKING, Any, Dict, Iterator, Optional, Union
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 from globus_sdk import utils
 from globus_sdk.types import UUIDLike
@@ -70,6 +76,9 @@ class TransferData(utils.PayloadWrapper):
         ``"copy"`` follows symlinks on the source, failing if the link is invalid.
         [default: ``"ignore"``]
     :type recursive_symlinks: str
+    :param skip_activation_check: When true, allow submission even if the endpoints
+        aren't currently activated
+    :type skip_activation_check: bool, optional
     :param skip_source_errors: When true, source permission denied and file
         not found errors from the source endpoint will cause the offending
         path to be skipped.
@@ -155,11 +164,14 @@ class TransferData(utils.PayloadWrapper):
         *,
         label: Optional[str] = None,
         submission_id: Optional[UUIDLike] = None,
-        sync_level: Union[str, int, None] = None,
+        sync_level: Union[
+            Literal["exists", "size", "mtime", "checksum"], int, None
+        ] = None,
         verify_checksum: bool = False,
         preserve_timestamp: bool = False,
         encrypt_data: bool = False,
         deadline: Optional[Union[datetime.datetime, str]] = None,
+        skip_activation_check: bool = False,
         skip_source_errors: bool = False,
         fail_on_quota_errors: bool = False,
         recursive_symlinks: str = "ignore",
@@ -181,6 +193,7 @@ class TransferData(utils.PayloadWrapper):
         self["preserve_timestamp"] = preserve_timestamp
         self["encrypt_data"] = encrypt_data
         self["recursive_symlinks"] = recursive_symlinks
+        self["skip_activation_check"] = skip_activation_check
         self["skip_source_errors"] = skip_source_errors
         self["fail_on_quota_errors"] = fail_on_quota_errors
         self["delete_destination_extra"] = delete_destination_extra
@@ -312,6 +325,56 @@ class TransferData(utils.PayloadWrapper):
             )
         )
         self["DATA"].append(item_data)
+
+    def add_filter_rule(
+        self,
+        name: str,
+        *,
+        method: Literal["exclude"] = "exclude",
+        type: Optional[  # pylint: disable=redefined-builtin
+            Literal["file", "dir"]
+        ] = None,
+    ) -> None:
+        """
+        Add a filter rule to the transfer document.
+
+        These rules specify which items are or are not included when recursively
+        transferring directories.
+
+        Currently, only ``method="exclude"`` (the default) is supported. This means that
+        items matching the ``name`` field will be excluded from the transfer.
+
+        :param name: A pattern to match against item names. Wildcards are supported, as
+            are character groups: ``*`` matches everything, ``?`` matches any single
+            character, ``[]`` matches any single character within the brackets, and
+            ``[!]`` matches any single character not within the brackets.
+        :type name: str
+        :param method: The method to use for filtering. Only the default, ``"exclude"``
+            is supported.
+        :type method: str, optional
+        :param type: The types of items on which to apply this filter rule. Either
+            ``"file"`` or ``"dir"``. If unspecified, the rule applies to both.
+        :type type: str, optional
+
+        Example Usage:
+
+        >>> tdata = TransferData(...)
+        >>> tdata.add_filter_rule("*.tgz", type="file")
+        >>> tdata.add_filter_rule("*.tar.gz", type="file")
+
+        ``tdata`` now describes a transfer which will skip any gzipped tar files with
+        the extensions `.tgz` or `.tar.gz`
+        """
+        if "filter_rules" not in self:
+            self["filter_rules"] = []
+        rule = {
+            "DATA_TYPE": "filter_rule",
+            "method": method,
+            "name": name,
+        }
+        if type is not None:
+            rule["type"] = type
+        self["filter_rules"].append(rule)
 
     def iter_items(self) -> Iterator[Dict[str, Any]]:
         """

--- a/tests/non-pytest/mypy-ignore-tests/transfer_data.py
+++ b/tests/non-pytest/mypy-ignore-tests/transfer_data.py
@@ -1,0 +1,24 @@
+import uuid
+
+from globus_sdk import TransferClient, TransferData
+
+# simple usage, ok
+tc = TransferClient()
+TransferData(tc, "srcep", "destep")
+
+# can set sync level
+TransferData(tc, "srcep", "destep", sync_level=1)
+TransferData(tc, "srcep", "destep", sync_level="exists")
+# unknown int values are allowed
+TransferData(tc, "srcep", "destep", sync_level=100)
+# unknown str values are rejected (Literal)
+TransferData(tc, "srcep", "destep", sync_level="sizes")  # type: ignore[arg-type]
+
+# TransferData.add_filter_rule
+tdata = TransferData(tc, uuid.UUID(), uuid.UUID())
+tdata.add_filter_rule("*.tgz")
+tdata.add_filter_rule("*.tgz", method="exclude")
+tdata.add_filter_rule("*.tgz", type="file")
+# bad values rejected (Literal)
+tdata.add_filter_rule("*.tgz", type="files")  # type: ignore[arg-type]
+tdata.add_filter_rule("*.tgz", method="include")  # type: ignore[arg-type]

--- a/tests/unit/helpers/test_transfer.py
+++ b/tests/unit/helpers/test_transfer.py
@@ -273,3 +273,40 @@ def test_tranfer_sync_levels_result(transfer_data, sync_level, result):
     else:
         tdata = transfer_data(sync_level=sync_level)
         assert tdata["sync_level"] == result
+
+
+def test_skip_activation_check_supported(transfer_data, delete_data):
+    # default, false
+    tdata = transfer_data()
+    ddata = delete_data()
+    for data in [tdata, ddata]:
+        assert "skip_activation_check" in data
+        assert data["skip_activation_check"] is False
+
+    # can set to True
+    tdata = transfer_data(skip_activation_check=True)
+    ddata = delete_data(skip_activation_check=True)
+    for data in [tdata, ddata]:
+        assert "skip_activation_check" in data
+        assert data["skip_activation_check"] is True
+
+
+def test_add_filter_rule(transfer_data):
+    tdata = transfer_data()
+    assert "filter_rules" not in tdata
+
+    tdata.add_filter_rule("*.tgz", type="file")
+    assert "filter_rules" in tdata
+    assert isinstance(tdata["filter_rules"], list)
+    assert len(tdata["filter_rules"]) == 1
+    assert tdata["filter_rules"][0]["DATA_TYPE"] == "filter_rule"
+    assert tdata["filter_rules"][0]["method"] == "exclude"
+    assert tdata["filter_rules"][0]["name"] == "*.tgz"
+    assert tdata["filter_rules"][0]["type"] == "file"
+
+    tdata.add_filter_rule("tmp")
+    assert len(tdata["filter_rules"]) == 2
+    assert tdata["filter_rules"][1]["DATA_TYPE"] == "filter_rule"
+    assert tdata["filter_rules"][1]["method"] == "exclude"
+    assert tdata["filter_rules"][1]["name"] == "tmp"
+    assert "type" not in tdata["filter_rules"][1]


### PR DESCRIPTION
Add skip_activation_check as a bool arg to both TransferData and DeleteData. `add_filter_rule` is a new method on TransferData for adding exclude filter rules.

Also, start using Literal to type-check `sync_level` string values.

---

Cleaning up old branches, I found this in my local repo. Rebased and improved for our current codebase, I believe this is a set of missing options for these helpers.