### PR TITLE
Add ArrayResponse and use it for GroupsClient.get_my_groups

### DIFF
--- a/changelog.d/20220601_171843_sirosen_add_array_response.rst
+++ b/changelog.d/20220601_171843_sirosen_add_array_response.rst
@@ -5,13 +5,10 @@
     ``[]``, ``0``, or other falsey-types. Previously,
     ``__bool__`` was not defined, meaning it was always ``True``
 
-  * Response objects now define ``__len__`` as ``len(data)``. As a special
-    case, if there is no JSON data, ``len(response)`` is always 0
-
   * ``globus_sdk.response.ArrayResponse`` is a new class which describes
     responses which are expected to hold a top-level array. It satisfies the
-    sequence protocol, allowing indexing with integers and slices, and
-    iteration over the array data
+    sequence protocol, allowing indexing with integers and slices, iteration
+    over the array data, and length checking with ``len(response)``
 
   * ``globus_sdk.GroupsClient.get_my_groups`` returns an ``ArrayResponse``,
     meaning the response data can now be iterated and otherwise used

--- a/changelog.d/20220601_171843_sirosen_add_array_response.rst
+++ b/changelog.d/20220601_171843_sirosen_add_array_response.rst
@@ -1,0 +1,17 @@
+* Improve handling of array-style API responses (:pr:`NUMBER`)
+
+  * Response objects now define ``__bool__`` as ``bool(data)``. This
+    means that ``bool(response)`` could be ``False`` if the data is ``{}``,
+    ``[]``, ``0``, or other falsey-types. Previously,
+    ``__bool__`` was not defined, meaning it was always ``True``
+
+  * Response objects now define ``__len__`` as ``len(data)``. As a special
+    case, if there is no JSON data, ``len(response)`` is always 0
+
+  * ``globus_sdk.response.ArrayResponse`` is a new class which describes
+    responses which are expected to hold a top-level array. It satisfies the
+    sequence protocol, allowing indexing with integers and slices, and
+    iteration over the array data
+
+  * ``globus_sdk.GroupsClient.get_my_groups`` returns an ``ArrayResponse``,
+    meaning the response data can now be iterated and otherwise used

--- a/src/globus_sdk/response.py
+++ b/src/globus_sdk/response.py
@@ -1,3 +1,4 @@
+import collections.abc
 import json
 import logging
 from typing import (
@@ -185,14 +186,6 @@ class GlobusHTTPResponse:
         """
         return bool(self.data)
 
-    def __len__(self) -> int:
-        """
-        ``len(response)`` is an alias for ``len(response.data)``
-        """
-        if self.data is None:
-            return 0
-        return len(self.data)
-
 
 class IterableResponse(GlobusHTTPResponse):
     """This response class adds an __iter__ method on an 'iter_key' variable.
@@ -227,3 +220,13 @@ class ArrayResponse(GlobusHTTPResponse):
 
     def __iter__(self) -> Iterator[Any]:
         return iter(cast(List[Any], self.data))
+
+    def __len__(self) -> int:
+        """
+        ``len(response)`` is an alias for ``len(response.data)``
+        """
+        if not isinstance(self.data, collections.abc.Sequence):
+            raise TypeError(
+                f"Cannot take len() on data when type is '{type(self.data).__name__}'"
+            )
+        return len(self.data)

--- a/src/globus_sdk/response.py
+++ b/src/globus_sdk/response.py
@@ -5,6 +5,7 @@ from typing import (
     Any,
     ClassVar,
     Iterator,
+    List,
     Mapping,
     Optional,
     Union,
@@ -31,7 +32,8 @@ class GlobusHTTPResponse:
     ``GlobusHTTPResponse`` object implements the immutable mapping protocol for
     dict-style access. This is just an alias for access to the underlying data.
 
-    If ``data`` is not a dictionary, item access will raise ``TypeError``.
+    If the response data is not a dictionary or list, item access will raise
+    ``TypeError``.
 
     >>> print("Response ID": r["id"]) # alias for r.data["id"]
 
@@ -148,7 +150,7 @@ class GlobusHTTPResponse:
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.text})"
 
-    def __getitem__(self, key: str) -> Any:
+    def __getitem__(self, key: Union[str, int, slice]) -> Any:
         # force evaluation of the data property outside of the upcoming
         # try-catch so that we don't accidentally catch TypeErrors thrown
         # during the getter function itself
@@ -177,6 +179,20 @@ class GlobusHTTPResponse:
             return False
         return item in self.data
 
+    def __bool__(self) -> bool:
+        """
+        ``bool(response)`` is an alias for ``bool(response.data)``
+        """
+        return bool(self.data)
+
+    def __len__(self) -> int:
+        """
+        ``len(response)`` is an alias for ``len(response.data)``
+        """
+        if self.data is None:
+            return 0
+        return len(self.data)
+
 
 class IterableResponse(GlobusHTTPResponse):
     """This response class adds an __iter__ method on an 'iter_key' variable.
@@ -203,3 +219,11 @@ class IterableResponse(GlobusHTTPResponse):
 
     def __iter__(self) -> Iterator[Mapping[Any, Any]]:
         return iter(cast(Mapping[Any, Any], self)[self.iter_key])
+
+
+class ArrayResponse(GlobusHTTPResponse):
+    """This response class adds an ``__iter__`` method which assumes that the top-level
+    data of the response is a JSON array."""
+
+    def __iter__(self) -> Iterator[Any]:
+        return iter(cast(List[Any], self.data))

--- a/src/globus_sdk/services/groups/client.py
+++ b/src/globus_sdk/services/groups/client.py
@@ -46,14 +46,16 @@ class GroupsClient(client.BaseClient):
     )
     def get_my_groups(
         self, *, query_params: Optional[Dict[str, Any]] = None
-    ) -> response.GlobusHTTPResponse:
+    ) -> response.ArrayResponse:
         """
         Return a list of groups your identity belongs to.
 
         :param query_params: Additional passthrough query parameters
         :type query_params: dict, optional
         """
-        return self.get("/groups/my_groups", query_params=query_params)
+        return response.ArrayResponse(
+            self.get("/groups/my_groups", query_params=query_params)
+        )
 
     @_groupdoc("Get Group", "get_group_v2_groups__group_id__get")
     def get_group(

--- a/tests/functional/groups/test_groups.py
+++ b/tests/functional/groups/test_groups.py
@@ -10,6 +10,7 @@ from globus_sdk import (
     GroupVisibility,
 )
 from globus_sdk._testing import get_last_request, load_response
+from globus_sdk.response import ArrayResponse
 from tests.common import register_api_route_fixture_file
 
 
@@ -19,9 +20,9 @@ def test_my_groups_simple(groups_client):
     res = groups_client.get_my_groups()
     assert res.http_status == 200
 
-    data = res.data
-    assert isinstance(data, list)
-    assert set(meta["group_names"]) == {g["name"] for g in data}
+    assert isinstance(res, ArrayResponse)
+    assert isinstance(res.data, list)
+    assert set(meta["group_names"]) == {g["name"] for g in res}
 
 
 def test_get_group(groups_client):

--- a/tests/unit/responses/test_response.py
+++ b/tests/unit/responses/test_response.py
@@ -107,6 +107,21 @@ def test_str(dict_response, list_response):
     assert "nonexistent" not in str(list_response.r)
 
 
+def test_text_response_repr_and_str_contain_raw_data():
+    expect_text = """pu-erh is a distinctive aged tea primarily produced in Yunnan
+
+    depending on the tea used and how it is aged, it can be bright, floral, and fruity
+    or it can take on mushroomy, fermented, and malty notes
+    """
+    raw = _response(
+        expect_text, encoding="utf-8", headers={"Content-Type": "text/plain"}
+    )
+    res = GlobusHTTPResponse(raw, client=mock.Mock())
+
+    assert expect_text in repr(res)
+    assert expect_text in str(res)
+
+
 def test_getitem(dict_response, list_response):
     """
     Confirms that values can be accessed from the GlobusResponse
@@ -121,7 +136,7 @@ def test_getitem(dict_response, list_response):
     assert list_response.r[:-1] == list_response.data[:-1]
 
 
-def test_contains(dict_response, list_response):
+def test_contains(dict_response, list_response, text_http_response):
     """
     Confirms that individual values are seen in the GlobusResponse
     """
@@ -132,6 +147,8 @@ def test_contains(dict_response, list_response):
     for item in list_response.data:
         assert item in list_response.r
     assert "nonexistent" not in list_response.r
+
+    assert "foo" not in text_http_response.r
 
 
 def test_bool(dict_response, list_response):
@@ -158,7 +175,7 @@ def test_len(dict_response, list_response):
     assert len(null.r) == 0
 
 
-def test_get(dict_response, list_response):
+def test_get(dict_response, list_response, text_http_response):
     """
     Gets individual values from dict response, confirms results
     Confirms list response correctly fails as non indexable
@@ -168,6 +185,9 @@ def test_get(dict_response, list_response):
 
     with pytest.raises(AttributeError):
         list_response.r.get("value1")
+
+    assert text_http_response.r.get("foo") is None
+    assert text_http_response.r.get("foo", default="bar") == "bar"
 
 
 def test_text(malformed_http_response, text_http_response):

--- a/tests/unit/responses/test_response.py
+++ b/tests/unit/responses/test_response.py
@@ -1,4 +1,5 @@
 import json
+import re
 from collections import namedtuple
 from unittest import mock
 
@@ -163,16 +164,28 @@ def test_bool(dict_response, list_response):
     assert bool(null.r) is False
 
 
-def test_len(dict_response, list_response):
-    assert len(dict_response.r) == len(dict_response.data)
-    assert len(list_response.r) == len(list_response.data)
+def test_len(list_response):
+    array = ArrayResponse(list_response.r)
+    assert len(array) == len(list_response.data)
 
-    empty_dict, empty_list = _mk_json_response({}), _mk_json_response([])
-    assert len(empty_dict.r) == 0
-    assert len(empty_list.r) == 0
+    empty_list = _mk_json_response([])
+    empty_array = ArrayResponse(empty_list.r)
+    assert len(empty_list.data) == 0
+    assert len(empty_array) == 0
 
-    null = _mk_json_response(None)
-    assert len(null.r) == 0
+
+def test_len_bad_data(dict_response):
+    null_array = ArrayResponse(_mk_json_response(None).r)
+    with pytest.raises(
+        TypeError, match=re.escape("Cannot take len() on data when type is 'NoneType'")
+    ):
+        len(null_array)
+
+    dict_array = ArrayResponse(dict_response.r)
+    with pytest.raises(
+        TypeError, match=re.escape("Cannot take len() on data when type is 'dict'")
+    ):
+        len(dict_array)
 
 
 def test_get(dict_response, list_response, text_http_response):


### PR DESCRIPTION
I noticed some code out in the wild doing
```python
res = client.get_my_groups()
return {x["id"] for x in res.data}
```

Naturally, we'd like to be able to write this inline as
```python
return {x["id"] for x in client.get_my_groups()}
```

but the response object is not iterable.

The overall goal of this PR is to enable the above style of usage by adding `response.ArrayResponse` and using that in `GroupsClient.get_my_groups`.  `ArrayResponse` should support `__iter__` and `__getitem__` at least, arguably `__len__` as well.

Along the way, I've checked for dunder methods other than `__iter__` which are missing and which make sense to implement on the ArrayResponse type. Some interesting things:
- `__bool__` is reasonable in the normal cases, and even makes sense on dict data. You could take a very strict line and consider its introduction breaking because previously `bool(response)` was always `True`. I think that's far too strict, and have included `__bool__`
- `__getitem__` needs changes. At first, I thought `ArrayResponse.__getitem__` would be specialized, but the base response class doesn't claim to _not_ handle arrays. So `__getitem__` now accepts `str | int | slice` in its annotation.
- `__len__` looks like it would work on the base response class, but it has some corner-case behaviors which would likely prove confusing. `len(IterableResponse(...))` and `len(response)` when `response.data is None` are two of the more noteworthy. The first commit in this series defined `__len__` on `GlobusHTTPResponse`, but it has been narrowed to only `ArrayResponse`.
- some behaviors of `__contains__`, `get()` and other methods were untested