### PR TITLE
Add a complete example with tokenstorage

### DIFF
--- a/docs/examples/group_listing.rst
+++ b/docs/examples/group_listing.rst
@@ -55,3 +55,84 @@ For simplicity, the script will prompt for login on each use.
                 ]
             )
         )
+
+
+.. _example_group_listing_with_token_storage:
+
+Group Listing With Token Storage
+--------------------------------
+
+``globus_sdk.tokenstorage`` provides tools for managing refresh tokens. The
+following example script shows how you might use this to provide a complete
+script which lists the current user's groups using refresh tokens.
+
+
+.. code-block:: python
+
+    import os
+
+    from globus_sdk import GroupsClient, NativeAppAuthClient, RefreshTokenAuthorizer
+    from globus_sdk.tokenstorage import SimpleJSONFileAdapter
+
+    CLIENT_ID = "61338d24-54d5-408f-a10d-66c06b59f6d2"
+    AUTH_CLIENT = NativeAppAuthClient(CLIENT_ID)
+    MY_FILE_ADAPTER = SimpleJSONFileAdapter(
+        os.path.expanduser("~/.list-my-globus-groups-tokens.json")
+    )
+
+
+    def do_login_flow():
+        AUTH_CLIENT.oauth2_start_flow(
+            requested_scopes=GroupsClient.scopes.view_my_groups_and_memberships,
+            refresh_tokens=True,
+        )
+        authorize_url = AUTH_CLIENT.oauth2_get_authorize_url()
+        print(f"Please go to this URL and login:\n\n{authorize_url}\n")
+        auth_code = input("Please enter the code here: ").strip()
+        tokens = AUTH_CLIENT.oauth2_exchange_code_for_tokens(auth_code)
+        return tokens
+
+
+    if not MY_FILE_ADAPTER.file_exists():
+        # do a login flow, getting back initial tokens
+        response = do_login_flow()
+        # now store the tokens and pull out the Groups tokens
+        MY_FILE_ADAPTER.store(response)
+        tokens = response.by_resource_server[GroupsClient.resource_server]
+    else:
+        # otherwise, we already did login; load the tokens from that file
+        tokens = MY_FILE_ADAPTER.get_token_data(GroupsClient.resource_server)
+
+    # construct the RefreshTokenAuthorizer which writes back to storage on refresh
+    authorizer = RefreshTokenAuthorizer(
+        tokens["refresh_token"],
+        AUTH_CLIENT,
+        access_token=tokens["access_token"],
+        expires_at=tokens["expires_at_seconds"],
+        on_refresh=MY_FILE_ADAPTER.on_refresh,
+    )
+    # use that authorizer to authorize the activity of the groups client
+    groups_client = GroupsClient(authorizer=authorizer)
+
+    # print out in CSV format
+    # note that 'name' could have a comma in it, so this is slightly unsafe
+    print("ID,Name,Type,Session Enforcement,Roles")
+    for group in groups_client.get_my_groups():
+        # parse the group to get data for output
+        if group.get("enforce_session"):
+            session_enforcement = "strict"
+        else:
+            session_enforcement = "not strict"
+        roles = ",".join({m["role"] for m in group["my_memberships"]})
+
+        print(
+            ",".join(
+                [
+                    group["id"],
+                    group["name"],
+                    group["group_type"],
+                    session_enforcement,
+                    roles,
+                ]
+            )
+        )

--- a/docs/tokenstorage.rst
+++ b/docs/tokenstorage.rst
@@ -53,7 +53,7 @@ For example:
         tokens["refresh_token"],
         auth_client,
         access_token=tokens["access_token"],
-        expires_at=tokens["access_token_expires"],
+        expires_at=tokens["expires_at_seconds"],
         on_refresh=my_file_adapter.on_refresh,
     )
 
@@ -62,12 +62,20 @@ For example:
         auth_client,
         ["urn:globus:auth:transfer.api.globus.org:all"],
         access_token=tokens["access_token"],
-        expires_at=tokens["access_token_expires"],
+        expires_at=tokens["expires_at_seconds"],
         on_refresh=my_file_adapter.on_refresh,
     )
 
     # and then use the authorizer on a client!
     tc = globus_sdk.TransferClient(authorizer=authorizer)
+
+
+Complete Example Usage
+~~~~~~~~~~~~~~~~~~~~~~
+
+The :ref:`Group Listing With Token Storage Script <example_group_listing_with_token_storage>`
+provides complete and runnable example which leverages ``tokenstorage``.
+
 
 Adapter Types
 -------------


### PR DESCRIPTION
This is a near-duplicate of the group listing example script, but it stores the user's creds using tokenstorage in a JSON file in their homedir.

Add the example, and also cross-link it from the tokenstorage docs.

Fix some minor errors in the existing tokenstorage example (wrong key for "expires_at_seconds").