### PR TITLE
Remove doc references to 'scopes' field in Auth

### DIFF
--- a/docs/examples/client_credentials.rst
+++ b/docs/examples/client_credentials.rst
@@ -24,8 +24,6 @@ To do so, follow the relevant documentation for the
 registration.
 
 During registration, make sure that the "Native App" checkbox is unchecked.
-You will typically want your scopes to be ``openid``, ``profile``, ``email``,
-and ``urn:globus:auth:scope:transfer.api.globus.org:all``.
 
 Once your client is created, expand it on the Projects page and click "Generate
 Secret". Save the secret in a secure location accessible from your code.

--- a/docs/examples/three_legged_oauth.rst
+++ b/docs/examples/three_legged_oauth.rst
@@ -35,9 +35,6 @@ registration.
 Make sure that the "Native App" checkbox is unchecked, and list
 ``http://localhost:5000/login`` in the "Redirect URIs".
 
-Set the Scopes to ``openid``, ``profile``, ``email``,
-``urn:globus:auth:scope:transfer.api.globus.org:all``.
-
 On the projects page, expand the client description and click "Generate
 Secret".
 Save the resulting secret a file named ``example_app.conf``, along with the client ID:


### PR DESCRIPTION
Two of the example docs instruct users following along to set Scopes in Auth to specific strings. However, the field has been removed, so the docs should not include this instruction.