### PR TITLE
add user credential methods to GCSClient

### DIFF
--- a/changelog.d/20220615_134057_aaschaer_user_credential.rst
+++ b/changelog.d/20220615_134057_aaschaer_user_credential.rst
@@ -1,0 +1,18 @@
+..
+.. A new scriv changelog fragment
+..
+.. Add one or more items to the list below describing the change in clear, concise terms.
+..
+.. Leave the ":pr:`...`" text alone. When you open a pull request, GitHub Actions will
+.. automatically replace it when the PR is merged.
+..
+
+* Add User Credential methods to GCSClient (:pr:`NUMBER`)
+    * get_user_credential_list
+    * get_user_credential
+    * create_user_credential
+    * update_user_credential
+    * delete_user_credential
+
+* Add connector_id_to_name helper to GCSClient to resolve GCS Connector UUIDs
+  to human readable Connector display names (:pr:`NUMBER`)

--- a/src/globus_sdk/_testing/data/globus_connect_server/create_user_credential.py
+++ b/src/globus_sdk/_testing/data/globus_connect_server/create_user_credential.py
@@ -1,0 +1,35 @@
+from globus_sdk._testing.models import RegisteredResponse, ResponseSet
+
+CREDENTIAL_ID = "af43d884-64a1-4414-897a-680c32374439"
+
+RESPONSES = ResponseSet(
+    metadata={"id": CREDENTIAL_ID},
+    default=RegisteredResponse(
+        service="gcs",
+        path="/user_credentials",
+        method="POST",
+        json={
+            "DATA_TYPE": "result#1.0.0",
+            "code": "success",
+            "data": [
+                {
+                    "DATA_TYPE": "user_credential#1.0.0",
+                    "connector_id": "145812c8-decc-41f1-83cf-bb2a85a2a70b",
+                    "display_name": "updated_posix_credential",
+                    "id": CREDENTIAL_ID,
+                    "identity_id": "948847d4-ffcc-4ae0-ba3a-a4c88d480159",
+                    "invalid": False,
+                    "policies": {"DATA_TYPE": "posix_user_credential_policies#1.0.0"},
+                    "provisioned": False,
+                    "storage_gateway_id": "82247cc9-3208-4d71-bd7f-1b8798c95e6b",
+                    "username": "testuser",
+                },
+            ],
+            "detail": "created",
+            "has_next_page": False,
+            "http_response_code": 201,
+            "message": f"Created User Credential {CREDENTIAL_ID}",
+        },
+        metadata={"id": CREDENTIAL_ID},
+    ),
+)

--- a/src/globus_sdk/_testing/data/globus_connect_server/delete_user_credential.py
+++ b/src/globus_sdk/_testing/data/globus_connect_server/delete_user_credential.py
@@ -1,0 +1,22 @@
+from globus_sdk._testing.models import RegisteredResponse, ResponseSet
+
+CREDENTIAL_ID = "af43d884-64a1-4414-897a-680c32374439"
+
+RESPONSES = ResponseSet(
+    metadata={"id": CREDENTIAL_ID},
+    default=RegisteredResponse(
+        service="gcs",
+        path=f"/user_credentials/{CREDENTIAL_ID}",
+        method="DELETE",
+        json={
+            "DATA_TYPE": "result#1.0.0",
+            "code": "success",
+            "data": [],
+            "detail": "success",
+            "has_next_page": False,
+            "http_response_code": 200,
+            "message": f"Deleted User Credential {CREDENTIAL_ID}",
+        },
+        metadata={"id": CREDENTIAL_ID},
+    ),
+)

--- a/src/globus_sdk/_testing/data/globus_connect_server/get_user_credential.py
+++ b/src/globus_sdk/_testing/data/globus_connect_server/get_user_credential.py
@@ -1,0 +1,34 @@
+from globus_sdk._testing.models import RegisteredResponse, ResponseSet
+
+CREDENTIAL_ID = "af43d884-64a1-4414-897a-680c32374439"
+
+RESPONSES = ResponseSet(
+    metadata={"id": CREDENTIAL_ID},
+    default=RegisteredResponse(
+        service="gcs",
+        path=f"/user_credentials/{CREDENTIAL_ID}",
+        method="GET",
+        json={
+            "DATA_TYPE": "result#1.0.0",
+            "code": "success",
+            "data": [
+                {
+                    "DATA_TYPE": "user_credential#1.0.0",
+                    "connector_id": "145812c8-decc-41f1-83cf-bb2a85a2a70b",
+                    "display_name": "posix_credential",
+                    "id": CREDENTIAL_ID,
+                    "identity_id": "948847d4-ffcc-4ae0-ba3a-a4c88d480159",
+                    "invalid": False,
+                    "policies": {"DATA_TYPE": "posix_user_credential_policies#1.0.0"},
+                    "provisioned": False,
+                    "storage_gateway_id": "82247cc9-3208-4d71-bd7f-1b8798c95e6b",
+                    "username": "testuser",
+                },
+            ],
+            "detail": "success",
+            "has_next_page": False,
+            "http_response_code": 200,
+        },
+        metadata={"id": CREDENTIAL_ID},
+    ),
+)

--- a/src/globus_sdk/_testing/data/globus_connect_server/get_user_credential_list.py
+++ b/src/globus_sdk/_testing/data/globus_connect_server/get_user_credential_list.py
@@ -1,0 +1,53 @@
+from globus_sdk._testing.models import RegisteredResponse, ResponseSet
+
+CREDENTIAL_IDS = [
+    "af43d884-64a1-4414-897a-680c32374439",
+    "c96b8f70-1448-46db-89af-292623c93ee4",
+]
+
+RESPONSES = ResponseSet(
+    metadata={"ids": CREDENTIAL_IDS},
+    default=RegisteredResponse(
+        service="gcs",
+        path="/user_credentials",
+        method="GET",
+        json={
+            "DATA_TYPE": "result#1.0.0",
+            "code": "success",
+            "data": [
+                {
+                    "DATA_TYPE": "user_credential#1.0.0",
+                    "connector_id": "145812c8-decc-41f1-83cf-bb2a85a2a70b",
+                    "display_name": "posix_credential",
+                    "id": CREDENTIAL_IDS[0],
+                    "identity_id": "948847d4-ffcc-4ae0-ba3a-a4c88d480159",
+                    "invalid": False,
+                    "policies": {"DATA_TYPE": "posix_user_credential_policies#1.0.0"},
+                    "provisioned": False,
+                    "storage_gateway_id": "82247cc9-3208-4d71-bd7f-1b8798c95e6b",
+                    "username": "testuser",
+                },
+                {
+                    "DATA_TYPE": "user_credential#1.0.0",
+                    "connector_id": "7643e831-5f6c-4b47-a07f-8ee90f401d23",
+                    "display_name": "s3_credential",
+                    "id": CREDENTIAL_IDS[1],
+                    "identity_id": "948847d4-ffcc-4ae0-ba3a-a4c88d480159",
+                    "invalid": False,
+                    "policies": {
+                        "DATA_TYPE": "s3_user_credential_policies#1.0.0",
+                        "s3_key_id": "key_id",
+                        "s3_secret_key": "key_secret",
+                    },
+                    "provisioned": True,
+                    "storage_gateway_id": "99aab7ac-8fde-40e2-b6db-44de8e59597a",
+                    "username": "testuser",
+                },
+            ],
+            "detail": "success",
+            "has_next_page": False,
+            "http_response_code": 200,
+        },
+        metadata={"ids": CREDENTIAL_IDS},
+    ),
+)

--- a/src/globus_sdk/_testing/data/globus_connect_server/update_user_credential.py
+++ b/src/globus_sdk/_testing/data/globus_connect_server/update_user_credential.py
@@ -1,0 +1,35 @@
+from globus_sdk._testing.models import RegisteredResponse, ResponseSet
+
+CREDENTIAL_ID = "af43d884-64a1-4414-897a-680c32374439"
+
+RESPONSES = ResponseSet(
+    metadata={"id": CREDENTIAL_ID},
+    default=RegisteredResponse(
+        service="gcs",
+        path=f"/user_credentials/{CREDENTIAL_ID}",
+        method="PATCH",
+        json={
+            "DATA_TYPE": "result#1.0.0",
+            "code": "success",
+            "data": [
+                {
+                    "DATA_TYPE": "user_credential#1.0.0",
+                    "connector_id": "145812c8-decc-41f1-83cf-bb2a85a2a70b",
+                    "display_name": "updated_posix_credential",
+                    "id": CREDENTIAL_ID,
+                    "identity_id": "948847d4-ffcc-4ae0-ba3a-a4c88d480159",
+                    "invalid": False,
+                    "policies": {"DATA_TYPE": "posix_user_credential_policies#1.0.0"},
+                    "provisioned": False,
+                    "storage_gateway_id": "82247cc9-3208-4d71-bd7f-1b8798c95e6b",
+                    "username": "testuser",
+                },
+            ],
+            "detail": "success",
+            "has_next_page": False,
+            "http_response_code": 200,
+            "message": f"Updated User Credential {CREDENTIAL_ID}",
+        },
+        metadata={"id": CREDENTIAL_ID},
+    ),
+)

--- a/src/globus_sdk/services/gcs/__init__.py
+++ b/src/globus_sdk/services/gcs/__init__.py
@@ -19,6 +19,7 @@ from .data import (
     S3StoragePolicies,
     StorageGatewayDocument,
     StorageGatewayPolicies,
+    UserCredentialDocument,
 )
 from .errors import GCSAPIError
 from .response import IterableGCSResponse, UnpackingGCSResponse
@@ -47,4 +48,5 @@ __all__ = (
     "GCSAPIError",
     "IterableGCSResponse",
     "UnpackingGCSResponse",
+    "UserCredentialDocument",
 )

--- a/src/globus_sdk/services/gcs/client.py
+++ b/src/globus_sdk/services/gcs/client.py
@@ -5,7 +5,12 @@ from globus_sdk import client, paging, response, scopes, utils
 from globus_sdk._types import UUIDLike
 from globus_sdk.authorizers import GlobusAuthorizer
 
-from .data import CollectionDocument, GCSRoleDocument, StorageGatewayDocument
+from .data import (
+    CollectionDocument,
+    GCSRoleDocument,
+    StorageGatewayDocument,
+    UserCredentialDocument,
+)
 from .errors import GCSAPIError
 from .response import IterableGCSResponse, UnpackingGCSResponse
 
@@ -96,6 +101,27 @@ class GCSClient(client.BaseClient):
         more information.
         """
         return scopes.GCSCollectionScopeBuilder(str(collection_id))
+
+    @staticmethod
+    def connector_id_to_name(connector_id: UUIDLike) -> str:
+        """
+        Helper that converts a given connector_id into a human readable
+        connector name string.
+        """
+        connector_dict = {
+            "7c100eae-40fe-11e9-95a3-9cb6d0d9fd63": "Box",
+            "1b6374b0-f6a4-4cf7-a26f-f262d9c6ca72": "Ceph",
+            "56366b96-ac98-11e9-abac-9cb6d0d9fd63": "Google Cloud Storage",
+            "976cf0cf-78c3-4aab-82d2-7c16adbcc281": "Google Drive",
+            "145812c8-decc-41f1-83cf-bb2a85a2a70b": "POSIX",
+            "7643e831-5f6c-4b47-a07f-8ee90f401d23": "S3",
+            "7e3f3f5e-350c-4717-891a-2f451c24b0d4": "SpectraLogic BlackPearl",
+        }
+
+        if str(connector_id) in connector_dict:
+            return connector_dict[str(connector_id)]
+        else:
+            return "Unknown Connector"
 
     #
     # collection methods
@@ -418,7 +444,7 @@ class GCSClient(client.BaseClient):
         POST /roles
 
         :param data: Data in the format of a Role document, it is recommended
-            to use the `RoleDocumment` class to construct this data.
+            to use the `GCSRoleDocumment` class to construct this data.
         :type data: dict
         :param query_params: Additional passthrough query parameters
         :type query_params: dict, optional
@@ -461,4 +487,110 @@ class GCSClient(client.BaseClient):
         :type query_params: dict, optional
         """
         path = f"/roles/{role_id}"
+        return self.delete(path, query_params=query_params)
+
+    @_gcsdoc("Get User Credential list", "openapi_User_Credentials/#getUserCredentials")
+    def get_user_credential_list(
+        self,
+        storage_gateway: Optional[UUIDLike] = None,
+        query_params: Optional[Dict[str, Any]] = None,
+    ) -> IterableGCSResponse:
+        """
+        GET /user_credentials
+
+        :param storage_gateway: UUID of a storage gateway to limit results to
+        :type storage_gateway
+        :param query_params: Additional passthrough query parameters
+        :type query_params: dict, optional
+        """
+        if query_params is None:
+            query_params = {}
+        if storage_gateway is not None:
+            query_params["storage_gateway"] = storage_gateway
+
+        path = "/user_credentials"
+        return IterableGCSResponse(self.get(path, query_params=query_params))
+
+    @_gcsdoc("Create a User Credential", "openapi_User_Credentials/#postUserCredential")
+    def create_user_credential(
+        self,
+        data: Union[Dict[str, Any], UserCredentialDocument],
+        query_params: Optional[Dict[str, Any]] = None,
+    ) -> UnpackingGCSResponse:
+        """
+        POST /user_credentials
+
+        :param data: Data in the format of a UserCredential document, it is
+            recommended to use the `UserCredential` class to construct this
+        :type data: dict
+        :param query_params: Additional passthrough query parameters
+        :type query_params: dict, optional
+        """
+        path = "/user_credentials"
+        return UnpackingGCSResponse(
+            self.post(path, data=data, query_params=query_params),
+            "user_credential",
+        )
+
+    @_gcsdoc("Get a User Credential", "openapi_User_Credentials/#getUserCredential")
+    def get_user_credential(
+        self,
+        user_credential_id: UUIDLike,
+        query_params: Optional[Dict[str, Any]] = None,
+    ) -> UnpackingGCSResponse:
+        """
+        GET /user_credentials/{user_credential_id}
+
+        :param user_credential_id: UUID for the UserCredential to be gotten
+        :type user_credential_id: str or UUID
+        :param query_params: Additional passthrough query parameters
+        :type query_params: dict, optional
+        """
+        path = f"/user_credentials/{user_credential_id}"
+        return UnpackingGCSResponse(
+            self.get(path, query_params=query_params), "user_credential"
+        )
+
+    @_gcsdoc(
+        "Update a User Credential", "openapi_User_Credentials/#patchUserCredential"
+    )
+    def update_user_credential(
+        self,
+        user_credential_id: UUIDLike,
+        data: Union[Dict[str, Any], UserCredentialDocument],
+        query_params: Optional[Dict[str, Any]] = None,
+    ) -> UnpackingGCSResponse:
+        """
+        PATCH /user_credentials/{user_credential_id}
+
+        :param user_credential_id: UUID for the UserCredential to be updated
+        :type user_credential_id: str or UUID
+        :param data: Data in the format of a UserCredential document, it is
+            recommended to use the `UserCredential` class to construct this
+        :type data: dict
+        :param query_params: Additional passthrough query parameters
+        :type query_params: dict, optional
+        """
+        path = f"/user_credentials/{user_credential_id}"
+        return UnpackingGCSResponse(
+            self.patch(path, data=data, query_params=query_params), "user_credential"
+        )
+
+    @_gcsdoc(
+        "Delete a User Credential", "openapi_User_Credentials/#deleteUserCredential"
+    )
+    def delete_user_credential(
+        self,
+        user_credential_id: UUIDLike,
+        query_params: Optional[Dict[str, Any]] = None,
+    ) -> response.GlobusHTTPResponse:
+        """
+        DELETE /user_credentials/{user_credential_id}
+
+        :param user_credential_id: UUID for the UserCredential to be deleted
+        :type user_credential_id: str or UUID
+        :param query_params: Additional passthrough query parameters
+        :type query_params: dict, optional
+        """
+        path = f"/user_credentials/{user_credential_id}"
         return self.delete(path, query_params=query_params)

--- a/src/globus_sdk/services/gcs/data/__init__.py
+++ b/src/globus_sdk/services/gcs/data/__init__.py
@@ -21,6 +21,7 @@ from .storage_gateway import (
     StorageGatewayDocument,
     StorageGatewayPolicies,
 )
+from .user_credential import UserCredentialDocument
 
 __all__ = (
     "MappedCollectionDocument",
@@ -42,4 +43,5 @@ __all__ = (
     "ActiveScaleStoragePolicies",
     "IrodsStoragePolicies",
     "HPSSStoragePolicies",
+    "UserCredentialDocument",
 )

--- a/src/globus_sdk/services/gcs/data/user_credential.py
+++ b/src/globus_sdk/services/gcs/data/user_credential.py
@@ -1,0 +1,41 @@
+from typing import Any, Dict, Optional
+
+from globus_sdk import utils
+from globus_sdk._types import UUIDLike
+
+
+class UserCredentialDocument(utils.PayloadWrapper):
+    """
+    Convenience class for constructing a UserCredential document
+    to use as the `data` parameter to `create_user_credential` and
+    `update_user_credential`
+
+    :param DATA_TYPE: Versioned document type.
+    :type DATA_TYPE: str
+
+    """
+
+    def __init__(
+        self,
+        DATA_TYPE: str = "user_credential#1.0.0",
+        identity_id: Optional[UUIDLike] = None,
+        connector_id: Optional[UUIDLike] = None,
+        username: Optional[str] = None,
+        display_name: Optional[str] = None,
+        storage_gateway_id: Optional[UUIDLike] = None,
+        policies: Optional[Dict[str, Any]] = None,
+        additional_fields: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        super().__init__()
+        self._set_optstrs(
+            DATA_TYPE=DATA_TYPE,
+            identity_id=identity_id,
+            connector_id=connector_id,
+            username=username,
+            display_name=display_name,
+            storage_gateway_id=storage_gateway_id,
+            policies=policies,
+            additional_fields=additional_fields,
+        )
+        if additional_fields is not None:
+            self.update(additional_fields)

--- a/tests/functional/gcs/fixture_data/user_credential_list.json
+++ b/tests/functional/gcs/fixture_data/user_credential_list.json
@@ -1,0 +1,23 @@
+{
+  "DATA_TYPE": "result#1.0.0",
+  "code": "success",
+  "data": [
+    {
+      "DATA_TYPE": "user_credential#1.0.0",
+      "connector_id": "145812c8-decc-41f1-83cf-bb2a85a2a70b",
+      "display_name": "aaschaer",
+      "id": "58f2d95a-11ce-512e-b90a-a523ed6c37d4",
+      "identity_id": "6e661986-4d49-4b88-982f-6873f842ca6e",
+      "invalid": false,
+      "policies": {
+        "DATA_TYPE": "posix_user_credential_policies#1.0.0"
+      },
+      "provisioned": false,
+      "storage_gateway_id": "0af12dc0-eb8c-43d9-bf90-50bc5b69879b",
+      "username": "aaschaer"
+    }
+  ],
+  "detail": "success",
+  "has_next_page": false,
+  "http_response_code": 200
+}

--- a/tests/functional/gcs/test_user_credential.py
+++ b/tests/functional/gcs/test_user_credential.py
@@ -1,0 +1,77 @@
+import json
+
+from globus_sdk._testing import get_last_request, load_response
+from globus_sdk.services.gcs import UserCredentialDocument
+
+
+def test_get_user_credential_list(client):
+    metadata = load_response(client.get_user_credential_list).metadata
+    res = client.get_user_credential_list()
+
+    assert len(list(res)) == 2
+    # sanity check some fields
+    assert res["DATA_TYPE"] == "result#1.0.0"
+    for item in res:
+        assert item["DATA_TYPE"] == "user_credential#1.0.0"
+        assert item["id"] in metadata["ids"]
+        assert "identity_id" in item
+        assert "username" in item
+
+
+def test_get_user_credential(client):
+    metadata = load_response(client.get_user_credential).metadata
+    uc_id = metadata["id"]
+    res = client.get_user_credential(uc_id)
+
+    assert res["DATA_TYPE"] == "user_credential#1.0.0"
+    assert res.full_data["DATA_TYPE"] == "result#1.0.0"
+    assert res["id"] == uc_id
+    assert res["display_name"] == "posix_credential"
+    assert client.connector_id_to_name(res["connector_id"]) == "POSIX"
+
+
+def test_create_user_credential(client):
+    metadata = load_response(client.create_user_credential).metadata
+    uc_id = metadata["id"]
+
+    data = UserCredentialDocument(
+        storage_gateway_id="82247cc9-3208-4d71-bd7f-1b8798c95e6b",
+        identity_id="948847d4-ffcc-4ae0-ba3a-a4c88d480159",
+        username="testuser",
+        display_name="posix_credential",
+    )
+
+    res = client.create_user_credential(data)
+    assert res["DATA_TYPE"] == "user_credential#1.0.0"
+    assert res.full_data["DATA_TYPE"] == "result#1.0.0"
+    assert res.full_data["message"] == f"Created User Credential {uc_id}"
+
+    req_body = req_body = json.loads(get_last_request().body)
+    for key, value in req_body.items():
+        assert req_body[key] == value
+
+
+def test_update_user_credential(client):
+    metadata = load_response(client.update_user_credential).metadata
+    uc_id = metadata["id"]
+
+    data = UserCredentialDocument(
+        display_name="updated_posix_credential",
+    )
+
+    res = client.update_user_credential(uc_id, data)
+    assert res["DATA_TYPE"] == "user_credential#1.0.0"
+    assert res.full_data["DATA_TYPE"] == "result#1.0.0"
+    assert res.full_data["message"] == f"Updated User Credential {uc_id}"
+
+    req_body = json.loads(get_last_request().body)
+    assert req_body["display_name"] == "updated_posix_credential"
+
+
+def test_delete_user_credential(client):
+    metadata = load_response(client.delete_user_credential).metadata
+    uc_id = metadata["id"]
+
+    res = client.delete_user_credential(uc_id)
+    assert res["DATA_TYPE"] == "result#1.0.0"
+    assert res["message"] == f"Deleted User Credential {uc_id}"


### PR DESCRIPTION
One notable addition alongside the CRUD operations is the addition of a `connector_id_to_name` helper to the GCSClient, which I added since the UserCredential response document includes a connector_id that is opaque without some kind of lookup table like this. If there is a better place for this to live I'm happy to move it, but I think we need something like this at least to support the CLI.