### PR TITLE
remove nonexistant monitor_ongoing transfer scope

### DIFF
--- a/changelog.d/20220617_162628_aaschaer_remove_monitor_ongoing.rst
+++ b/changelog.d/20220617_162628_aaschaer_remove_monitor_ongoing.rst
@@ -1,0 +1,10 @@
+..
+.. A new scriv changelog fragment
+..
+.. Add one or more items to the list below describing the change in clear, concise terms.
+..
+.. Leave the ":pr:`...`" text alone. When you open a pull request, GitHub Actions will
+.. automatically replace it when the PR is merged.
+..
+
+* Remove nonexistant monitor_ongoing scope from TransferScopes (:pr:`NUMBER`)

--- a/src/globus_sdk/scopes.py
+++ b/src/globus_sdk/scopes.py
@@ -352,7 +352,6 @@ TransferScopes = ScopeBuilder(
     known_scopes=[
         "all",
         "gcp_install",
-        "monitor_ongoing",
     ],
 )
 """Globus Transfer scopes.


### PR DESCRIPTION
I haven't checked that one cannot actually request this scope, but it is at least completely unused by the Transfer service.