### PR TITLE
Improve testing subpackage with more responses support and inherited metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,11 @@ TEST_REQUIREMENTS = [
     "pytest<7",
     "coverage<7",
     "pytest-xdist<3",
-    "responses==0.17.0",
+    # 'responses' requirement
+    # on py3.6, use the last version to support 3.6
+    'responses==0.17.0; python_version<"3.7"',
+    # on py3.7+, use the latest version
+    'responses==0.21.0; python_version>="3.7"',
 ]
 DOC_REQUIREMENTS = [
     "sphinx<5",

--- a/src/globus_sdk/_testing/README.rst
+++ b/src/globus_sdk/_testing/README.rst
@@ -15,8 +15,8 @@ Dependencies
 
 This toolchain requires the ``responses`` library.
 
-If you are using ``_testing``, it is recommended that you use the same version of
-``responses`` that the globus-sdk uses. At time of writing, ``responses==0.17.0``.
+``globus_sdk._testing`` is tested to operate with ``responses==0.17.0`` on
+python3.6, and the latest version of ``responses`` on python3.7+ .
 
 Recommended Fixtures
 --------------------

--- a/src/globus_sdk/_testing/data/auth/oauth2_userinfo.py
+++ b/src/globus_sdk/_testing/data/auth/oauth2_userinfo.py
@@ -3,11 +3,11 @@ from globus_sdk._testing.models import RegisteredResponse, ResponseSet
 from ._common import ERROR_ID, UNAUTHORIZED_AUTH_RESPONSE_JSON
 
 RESPONSES = ResponseSet(
+    metadata={"error_id": ERROR_ID},
     unauthorized=RegisteredResponse(
         service="auth",
         path="/v2/oauth2/userinfo",
         status=401,
         json=UNAUTHORIZED_AUTH_RESPONSE_JSON,
-        metadata={"error_id": ERROR_ID},
     ),
 )

--- a/src/globus_sdk/_testing/data/globus_connect_server/create_storage_gateway.py
+++ b/src/globus_sdk/_testing/data/globus_connect_server/create_storage_gateway.py
@@ -1,12 +1,12 @@
 from globus_sdk._testing.models import RegisteredResponse, ResponseSet
 
-_common_meta = {
+metadata = {
     "id": "daa09846-eb92-11e9-b89c-9cb6d0d9fd63",
     "display_name": "example gateway 1",
 }
 
 RESPONSES = ResponseSet(
-    metadata=_common_meta,
+    metadata=metadata,
     default=RegisteredResponse(
         service="gcs",
         method="POST",
@@ -20,8 +20,8 @@ RESPONSES = ResponseSet(
             "data": [
                 {
                     "DATA_TYPE": "storage_gateway#1.0.0",
-                    "id": _common_meta["id"],
-                    "display_name": _common_meta["display_name"],
+                    "id": metadata["id"],
+                    "display_name": metadata["display_name"],
                     "connector_id": "145812c8-decc-41f1-83cf-bb2a85a2a70b",
                     "high_assurance": False,
                     "authentication_assurance_timeout": 15840,
@@ -43,6 +43,5 @@ RESPONSES = ResponseSet(
                 }
             ],
         },
-        metadata=_common_meta,
     ),
 )

--- a/src/globus_sdk/_testing/data/globus_connect_server/create_user_credential.py
+++ b/src/globus_sdk/_testing/data/globus_connect_server/create_user_credential.py
@@ -30,6 +30,5 @@ RESPONSES = ResponseSet(
             "http_response_code": 201,
             "message": f"Created User Credential {CREDENTIAL_ID}",
         },
-        metadata={"id": CREDENTIAL_ID},
     ),
 )

--- a/src/globus_sdk/_testing/data/globus_connect_server/delete_storage_gateway.py
+++ b/src/globus_sdk/_testing/data/globus_connect_server/delete_storage_gateway.py
@@ -1,16 +1,16 @@
 from globus_sdk._testing.models import RegisteredResponse, ResponseSet
 
-_common_meta = {
+metadata = {
     "id": "daa09846-eb92-11e9-b89c-9cb6d0d9fd63",
     "display_name": "example gateway 1",
 }
 
 RESPONSES = ResponseSet(
-    metadata=_common_meta,
+    metadata=metadata,
     default=RegisteredResponse(
         service="gcs",
         method="DELETE",
-        path=f"/storage_gateways/{_common_meta['id']}",
+        path=f"/storage_gateways/{metadata['id']}",
         json={
             "DATA_TYPE": "result#1.0.0",
             "http_response_code": 200,
@@ -19,6 +19,5 @@ RESPONSES = ResponseSet(
             "code": "success",
             "data": [{}],
         },
-        metadata=_common_meta,
     ),
 )

--- a/src/globus_sdk/_testing/data/globus_connect_server/delete_user_credential.py
+++ b/src/globus_sdk/_testing/data/globus_connect_server/delete_user_credential.py
@@ -17,6 +17,5 @@ RESPONSES = ResponseSet(
             "http_response_code": 200,
             "message": f"Deleted User Credential {CREDENTIAL_ID}",
         },
-        metadata={"id": CREDENTIAL_ID},
     ),
 )

--- a/src/globus_sdk/_testing/data/globus_connect_server/get_storage_gateway.py
+++ b/src/globus_sdk/_testing/data/globus_connect_server/get_storage_gateway.py
@@ -1,15 +1,15 @@
 from globus_sdk._testing.models import RegisteredResponse, ResponseSet
 
-_common_meta = {
+metadata = {
     "id": "daa09846-eb92-11e9-b89c-9cb6d0d9fd63",
     "display_name": "example gateway 1",
 }
 
 RESPONSES = ResponseSet(
-    metadata=_common_meta,
+    metadata=metadata,
     default=RegisteredResponse(
         service="gcs",
-        path=f"/storage_gateways/{_common_meta['id']}",
+        path=f"/storage_gateways/{metadata['id']}",
         json={
             "DATA_TYPE": "result#1.0.0",
             "http_response_code": 200,
@@ -19,8 +19,8 @@ RESPONSES = ResponseSet(
             "data": [
                 {
                     "DATA_TYPE": "storage_gateway#1.0.0",
-                    "id": _common_meta["id"],
-                    "display_name": _common_meta["display_name"],
+                    "id": metadata["id"],
+                    "display_name": metadata["display_name"],
                     "connector_id": "145812c8-decc-41f1-83cf-bb2a85a2a70b",
                     "high_assurance": False,
                     "authentication_assurance_timeout": 15840,
@@ -42,6 +42,5 @@ RESPONSES = ResponseSet(
                 }
             ],
         },
-        metadata=_common_meta,
     ),
 )

--- a/src/globus_sdk/_testing/data/globus_connect_server/get_storage_gateway_list.py
+++ b/src/globus_sdk/_testing/data/globus_connect_server/get_storage_gateway_list.py
@@ -60,6 +60,5 @@ RESPONSES = ResponseSet(
                 },
             ],
         },
-        metadata={"ids": GATEWAY_IDS},
     ),
 )

--- a/src/globus_sdk/_testing/data/globus_connect_server/get_user_credential.py
+++ b/src/globus_sdk/_testing/data/globus_connect_server/get_user_credential.py
@@ -29,6 +29,5 @@ RESPONSES = ResponseSet(
             "has_next_page": False,
             "http_response_code": 200,
         },
-        metadata={"id": CREDENTIAL_ID},
     ),
 )

--- a/src/globus_sdk/_testing/data/globus_connect_server/update_storage_gateway.py
+++ b/src/globus_sdk/_testing/data/globus_connect_server/update_storage_gateway.py
@@ -1,16 +1,16 @@
 from globus_sdk._testing.models import RegisteredResponse, ResponseSet
 
-_common_meta = {
+metadata = {
     "id": "daa09846-eb92-11e9-b89c-9cb6d0d9fd63",
     "display_name": "example gateway 1",
 }
 
 RESPONSES = ResponseSet(
-    metadata=_common_meta,
+    metadata=metadata,
     default=RegisteredResponse(
         service="gcs",
         method="PATCH",
-        path=f"/storage_gateways/{_common_meta['id']}",
+        path=f"/storage_gateways/{metadata['id']}",
         json={
             "DATA_TYPE": "result#1.0.0",
             "http_response_code": 200,
@@ -20,8 +20,8 @@ RESPONSES = ResponseSet(
             "data": [
                 {
                     "DATA_TYPE": "storage_gateway#1.0.0",
-                    "id": _common_meta["id"],
-                    "display_name": _common_meta["display_name"],
+                    "id": metadata["id"],
+                    "display_name": metadata["display_name"],
                     "connector_id": "145812c8-decc-41f1-83cf-bb2a85a2a70b",
                     "require_high_assurance": False,
                     "high_assurance": False,
@@ -43,6 +43,5 @@ RESPONSES = ResponseSet(
                 }
             ],
         },
-        metadata=_common_meta,
     ),
 )

--- a/src/globus_sdk/_testing/data/globus_connect_server/update_user_credential.py
+++ b/src/globus_sdk/_testing/data/globus_connect_server/update_user_credential.py
@@ -30,6 +30,5 @@ RESPONSES = ResponseSet(
             "http_response_code": 200,
             "message": f"Updated User Credential {CREDENTIAL_ID}",
         },
-        metadata={"id": CREDENTIAL_ID},
     ),
 )

--- a/src/globus_sdk/_testing/data/groups/delete_group.py
+++ b/src/globus_sdk/_testing/data/groups/delete_group.py
@@ -9,6 +9,5 @@ RESPONSES = ResponseSet(
         path=f"/groups/{GROUP_ID}",
         method="DELETE",
         json=BASE_GROUP_DOC,
-        metadata={"group_id": GROUP_ID},
     ),
 )

--- a/src/globus_sdk/_testing/data/groups/get_group.py
+++ b/src/globus_sdk/_testing/data/groups/get_group.py
@@ -8,6 +8,5 @@ RESPONSES = ResponseSet(
         service="groups",
         path=f"/groups/{GROUP_ID}",
         json=BASE_GROUP_DOC,
-        metadata={"group_id": GROUP_ID},
     ),
 )

--- a/src/globus_sdk/_testing/data/groups/get_my_groups.py
+++ b/src/globus_sdk/_testing/data/groups/get_my_groups.py
@@ -164,18 +164,16 @@ member_ids = {
     group["id"]: [m["identity_id"] for m in group["my_memberships"]]
     for group in raw_data
 }
-common_metadata = {
-    "group_ids": group_ids,
-    "group_names": group_names,
-    "member_ids": member_ids,
-}
 
 RESPONSES = ResponseSet(
-    metadata=common_metadata,
+    metadata={
+        "group_ids": group_ids,
+        "group_names": group_names,
+        "member_ids": member_ids,
+    },
     default=RegisteredResponse(
         service="groups",
         path="/groups/my_groups",
         json=raw_data,
-        metadata=common_metadata,
     ),
 )

--- a/src/globus_sdk/_testing/data/search/delete_role.py
+++ b/src/globus_sdk/_testing/data/search/delete_role.py
@@ -22,6 +22,5 @@ RESPONSES = ResponseSet(
             },
             "success": True,
         },
-        metadata={"index_id": INDEX_ID, "identity_id": IDENTITY_ID, "role_id": ROLE_ID},
     ),
 )

--- a/src/globus_sdk/_testing/data/search/get_role_list.py
+++ b/src/globus_sdk/_testing/data/search/get_role_list.py
@@ -33,10 +33,5 @@ RESPONSES = ResponseSet(
                 },
             ]
         },
-        metadata={
-            "index_id": INDEX_ID,
-            "identity_ids": IDENTITY_IDS,
-            "role_ids": ROLE_IDS,
-        },
     ),
 )

--- a/src/globus_sdk/_testing/data/search/post_search.py
+++ b/src/globus_sdk/_testing/data/search/post_search.py
@@ -31,6 +31,5 @@ RESPONSES = ResponseSet(
             "offset": 0,
             "total": 10,
         },
-        metadata={"index_id": INDEX_ID},
     ),
 )

--- a/src/globus_sdk/_testing/data/search/search.py
+++ b/src/globus_sdk/_testing/data/search/search.py
@@ -30,6 +30,5 @@ RESPONSES = ResponseSet(
             "offset": 0,
             "total": 10,
         },
-        metadata={"index_id": INDEX_ID},
     ),
 )

--- a/src/globus_sdk/_testing/data/timer/delete_job.py
+++ b/src/globus_sdk/_testing/data/timer/delete_job.py
@@ -2,15 +2,12 @@ from globus_sdk._testing.models import RegisteredResponse, ResponseSet
 
 from .get_job import JOB_ID, JOB_JSON
 
-metadata = {"job_id": JOB_ID}
-
 RESPONSES = ResponseSet(
-    metadata=metadata,
+    metadata={"job_id": JOB_ID},
     default=RegisteredResponse(
         service="timer",
         path=f"/jobs/{JOB_ID}",
         method="DELETE",
         json=JOB_JSON,
-        metadata=metadata,
     ),
 )

--- a/src/globus_sdk/_testing/data/timer/get_job.py
+++ b/src/globus_sdk/_testing/data/timer/get_job.py
@@ -117,6 +117,5 @@ RESPONSES = ResponseSet(
         path=f"/jobs/{JOB_ID}",
         method="GET",
         json=JOB_JSON,
-        metadata={"job_id": JOB_ID},
     ),
 )

--- a/src/globus_sdk/_testing/data/timer/list_jobs.py
+++ b/src/globus_sdk/_testing/data/timer/list_jobs.py
@@ -2,15 +2,12 @@ from globus_sdk._testing.models import RegisteredResponse, ResponseSet
 
 from .get_job import JOB_ID, JOB_JSON
 
-metadata = {"job_ids": [JOB_ID]}
-
 RESPONSES = ResponseSet(
-    metadata=metadata,
+    metadata={"job_ids": [JOB_ID]},
     default=RegisteredResponse(
         service="timer",
         path="/jobs/",
         method="GET",
         json={"jobs": [JOB_JSON]},
-        metadata=metadata,
     ),
 )

--- a/src/globus_sdk/_testing/data/timer/update_job.py
+++ b/src/globus_sdk/_testing/data/timer/update_job.py
@@ -6,15 +6,12 @@ UPDATED_NAME = "updated name"
 UPDATED_JSON = dict(JOB_JSON)
 UPDATED_JSON["name"] = UPDATED_NAME  # mypy complains if this is onelinerized
 
-metadata = {"job_id": JOB_ID, "name": UPDATED_NAME}
-
 RESPONSES = ResponseSet(
-    metadata=metadata,
+    metadata={"job_id": JOB_ID, "name": UPDATED_NAME},
     default=RegisteredResponse(
         service="timer",
         path=f"/jobs/{JOB_ID}",
         method="PATCH",
         json=UPDATED_JSON,
-        metadata=metadata,
     ),
 )

--- a/tests/unit/test_paging.py
+++ b/tests/unit/test_paging.py
@@ -3,7 +3,6 @@ from unittest import mock
 
 import pytest
 import requests
-import six
 
 from globus_sdk.paging import HasNextPaginator
 from globus_sdk.response import GlobusHTTPResponse
@@ -35,7 +34,7 @@ class PagingSimulator:
 
         # make the simulated response
         response = requests.Response()
-        response._content = six.b(json.dumps(data))
+        response._content = json.dumps(data).encode()
         response.headers["Content-Type"] = "application/json"
         return IterableTransferResponse(GlobusHTTPResponse(response, mock.Mock()))
 


### PR DESCRIPTION
- Use `responses==0.21.0` (current latest) on py3.7+ and update testing readme to note support
- RegisteredResponse objects inherit `metadata` from the containing ResponseSet where appropriate (unspecified)

I consider more complex behaviors for inheritance, e.g. merging. However, if you can load the response object, you can access `parent`, so `x = load_response(...); x.parent.metadata` is valid as a way of getting at all of the data.

Net-net, the inheritance change lets us cut enough lines that the diff is still negative! 🥳 