### PR TITLE
Add 'setattr' to the lazy importer

### DIFF
--- a/changelog.d/20220701_151639_sirosen_lazy_import_setattr.rst
+++ b/changelog.d/20220701_151639_sirosen_lazy_import_setattr.rst
@@ -1,0 +1,2 @@
+* Use ``setattr`` in the lazy-importer. This makes attribute access after
+  imports faster by several orders of magnitude. (:pr:`NUMBER`)

--- a/src/globus_sdk/__init__.py
+++ b/src/globus_sdk/__init__.py
@@ -186,7 +186,9 @@ else:
         for modname, items in _LAZY_IMPORT_TABLE.items():
             if name in items:
                 mod = importlib.import_module("." + modname, __name__)
-                return getattr(mod, name)
+                value = getattr(mod, name)
+                setattr(sys.modules[__name__], name, value)
+                return value
 
         raise AttributeError(f"module {__name__} has no attribute {name}")
 

--- a/src/globus_sdk/_generate_init.py
+++ b/src/globus_sdk/_generate_init.py
@@ -184,7 +184,9 @@ else:
         for modname, items in _LAZY_IMPORT_TABLE.items():
             if name in items:
                 mod = importlib.import_module("." + modname, __name__)
-                return getattr(mod, name)
+                value = getattr(mod, name)
+                setattr(sys.modules[__name__], name, value)
+                return value
 
         raise AttributeError(f"module {__name__} has no attribute {name}")
 """


### PR DESCRIPTION
Results in a ~2000x speedup for repeated attribute access on the `globus_sdk` module object.

----

Before:
```
>>> timeit.timeit("globus_sdk.TransferClient", setup="import globus_sdk; globus_sdk.TransferClient")
19.294644853973296
```

After:
```
>>> timeit.timeit("globus_sdk.TransferClient", setup="import globus_sdk; globus_sdk.TransferClient")
0.06822110997745767
```

It may not seem important, but this is a cost paid hundreds or even thousands of times over.
Plus, this impacts `dir(globus_sdk)` -- a detail I intentionally omitted from the changelog because I don't want to accidentally encourage less knowledgeable python users to start poking at `dir()`.