### PR TITLE
Fix creating timer job from TransferData

### DIFF
--- a/changelog.d/20220713_115549_rudyardrichter_fix_timer_from_transfer.rst
+++ b/changelog.d/20220713_115549_rudyardrichter_fix_timer_from_transfer.rst
@@ -1,0 +1,1 @@
+* Fix ``TimerJob.from_transfer_data`` for case with TransferData input (:pr:`NUMBER`)

--- a/tests/functional/timer/test_jobs.py
+++ b/tests/functional/timer/test_jobs.py
@@ -33,20 +33,29 @@ def test_get_job(timer_client):
 @pytest.mark.parametrize(
     "interval", [timedelta(days=1), timedelta(minutes=60), 600, None]
 )
-def test_create_job(timer_client, start, interval):
+@pytest.mark.parametrize("convert_to_dict", [True, False])
+def test_create_job(timer_client, start, interval, convert_to_dict):
     meta = load_response(timer_client.create_job).metadata
     transfer_client = TransferClient()
-    transfer_client.get_submission_id = lambda *_0, **_1: {"value": "mock"}
+    transfer_client.get_submission_id = lambda *_0, **_1: {  # type: ignore
+        "value": "mock"
+    }
     transfer_data = TransferData(transfer_client, GO_EP1_ID, GO_EP2_ID)
-    timer_job = TimerJob.from_transfer_data(transfer_data, start, interval)
+    if convert_to_dict:
+        data = dict(transfer_data)
+    else:
+        data = transfer_data
+    timer_job = TimerJob.from_transfer_data(data, start, interval)
     response = timer_client.create_job(timer_job)
     assert response.http_status == 201
     assert response.data["job_id"] == meta["job_id"]
-    timer_job = TimerJob.from_transfer_data(dict(transfer_data), start, interval)
-    response = timer_client.create_job(timer_job)
+    req_body = json.loads(get_last_request().body)  # type: ignore
+    # Check that particular fields do/not exist in the request if we use
+    # `from_transfer_data`
+    assert "source_endpoint_id" in req_body["callback_body"]["body"]
+    assert "DATA" not in req_body["callback_body"]["body"]
     assert response.http_status == 201
     assert response.data["job_id"] == meta["job_id"]
-    req_body = json.loads(get_last_request().body)
     if isinstance(start, datetime):
         assert req_body["start"] == start.isoformat()
     else:


### PR DESCRIPTION
- Fix `TimerJob.from_transfer_data` to correctly translate JSON fields from TransferData to the action provider format
- Improve timer create job test to catch the above issue
