### PR TITLE
Allow use of non-default requests_mock in _testing

### DIFF
--- a/src/globus_sdk/_testing/README.rst
+++ b/src/globus_sdk/_testing/README.rst
@@ -34,6 +34,43 @@ guaranteeing that requests are sent to the production hostnames:
         responses.stop()
         responses.reset()
 
+Methods and Classes
+-------------------
+
+Users of ``globus_sdk._testing`` have the following methods and classes
+available:
+
+``get_last_request``
+    Get the last request which was received, or None if there were no requests.
+
+``ResponseSet``
+    A collection of mock responses, potentially all meant to be activated together
+    (``.activate_all()``), or to be individually selected as options/alternatives
+    (``.activate("case_foo")``).
+
+``RegisteredResponse``
+    A mock response along with descriptive metadata to let a fixture "pass data
+    forward" to the consuming test cases. (e.g. a ``GET Task`` fixture which
+    shares the ``task_id`` it uses with consumers via ``.metadata["task_id"]``)
+
+``load_response_set``
+    Optionally lookup a response set and activate all of its responses. If
+    passed a ``ResponseSet``, activate it, otherwise the first argument is an
+    ID used for lookup.
+
+``load_response``
+    Optionally lookup and activate an individual response. If given a
+    ``RegisteredResponse``, activate it, otherwise the first argument is an ID
+    of a ``ResponseSet`` used for lookup. By default, looks for the response
+    registered under ``case="default"``.
+
+``get_response_set``
+    Lookup a ``ResponseSet`` as in ``load_response_set``, but without
+    activating it.
+
+``register_response_set``
+    Register a new ``ResponseSet`` object.
+
 Usage
 -----
 
@@ -152,7 +189,7 @@ a tetstsuite run (e.g. as an autouse session-level fixture), for reference
 later in the testsuite.
 
 Loading Responses without Registering
--------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Because ``RegisteredResponse`` takes care of resolving ``"auth"`` to the Auth
 URL, ``"transfer"`` to the Transfer URL, and so forth, you might want to use
@@ -191,3 +228,31 @@ Consider the following example of a parametrized test which uses
 In this mode of usage, the response set registry is skipped altogether. It is
 not necessary to name or organize the response fixtures in a way that is usable
 outside of the specific test.
+
+Using non-default responses.RequestsMock objects
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+By default, all methods in ``globus_sdk._testing`` which converse with
+``responses`` use the default mock. This is the behavior offered by
+``responses.add(...)`` and similar methods.
+
+However, you can pass a custom ``RequestsMock`` if so desired to the following
+methods:
+
+* ``get_last_request``
+* ``load_response_set``
+* ``load_response``
+
+as a keyword argument, ``requests_mock``.
+e.g.
+
+
+.. code-block:: python
+
+    from globus_sdk._testing import get_last_request
+    import responses
+
+    custom_mock = responses.RequestsMock(...)
+    ...
+
+    get_last_request(requests_mock=custom_mock)

--- a/src/globus_sdk/_testing/helpers.py
+++ b/src/globus_sdk/_testing/helpers.py
@@ -4,8 +4,11 @@ import requests
 import responses
 
 
-def get_last_request() -> Optional[requests.PreparedRequest]:
+def get_last_request(
+    *, requests_mock: Optional[responses.RequestsMock] = None
+) -> Optional[requests.PreparedRequest]:
+    calls = requests_mock.calls if requests_mock is not None else responses.calls
     try:
-        return cast(requests.PreparedRequest, responses.calls[-1].request)
+        return cast(requests.PreparedRequest, calls[-1].request)
     except IndexError:
         return None

--- a/src/globus_sdk/_testing/models.py
+++ b/src/globus_sdk/_testing/models.py
@@ -59,7 +59,9 @@ class RegisteredResponse:
             return self.parent.metadata
         return {}
 
-    def add(self) -> "RegisteredResponse":
+    def add(
+        self, *, requests_mock: Optional[responses.RequestsMock] = None
+    ) -> "RegisteredResponse":
         kwargs: Dict[str, Any] = {
             "headers": self.headers,
             "match_querystring": None,
@@ -70,7 +72,10 @@ class RegisteredResponse:
         if self.body is not None:
             kwargs["body"] = self.body
 
-        responses.add(self.method, self.full_url, **kwargs)
+        if requests_mock is None:
+            responses.add(self.method, self.full_url, **kwargs)
+        else:
+            requests_mock.add(self.method, self.full_url, **kwargs)
         return self
 
 
@@ -106,12 +111,16 @@ class ResponseSet:
     def __iter__(self) -> Iterator[RegisteredResponse]:
         return iter(self._data.values())
 
-    def activate(self, case: str) -> RegisteredResponse:
-        return self.lookup(case).add()
+    def activate(
+        self, case: str, *, requests_mock: Optional[responses.RequestsMock] = None
+    ) -> RegisteredResponse:
+        return self.lookup(case).add(requests_mock=requests_mock)
 
-    def activate_all(self) -> "ResponseSet":
+    def activate_all(
+        self, *, requests_mock: Optional[responses.RequestsMock] = None
+    ) -> "ResponseSet":
         for x in self:
-            x.add()
+            x.add(requests_mock=requests_mock)
         return self
 
     @classmethod

--- a/src/globus_sdk/_testing/registry.py
+++ b/src/globus_sdk/_testing/registry.py
@@ -1,6 +1,8 @@
 import importlib
 from typing import Any, Dict, Optional, Union
 
+import responses
+
 import globus_sdk
 
 from .models import RegisteredResponse, ResponseSet
@@ -71,16 +73,23 @@ def get_response_set(set_id: Any) -> ResponseSet:
     return module.RESPONSES
 
 
-def load_response_set(set_id: Any) -> ResponseSet:
+def load_response_set(
+    set_id: Any, *, requests_mock: Optional[responses.RequestsMock] = None
+) -> ResponseSet:
     if isinstance(set_id, ResponseSet):
-        return set_id.activate_all()
+        return set_id.activate_all(requests_mock=requests_mock)
     ret = get_response_set(set_id)
-    ret.activate_all()
+    ret.activate_all(requests_mock=requests_mock)
     return ret
 
 
-def load_response(set_id: Any, *, case: str = "default") -> RegisteredResponse:
+def load_response(
+    set_id: Any,
+    *,
+    case: str = "default",
+    requests_mock: Optional[responses.RequestsMock] = None,
+) -> RegisteredResponse:
     if isinstance(set_id, RegisteredResponse):
-        return set_id.add()
+        return set_id.add(requests_mock=requests_mock)
     rset = get_response_set(set_id)
-    return rset.activate(case)
+    return rset.activate(case, requests_mock=requests_mock)

--- a/tests/functional/_testing/test_non_default_mock.py
+++ b/tests/functional/_testing/test_non_default_mock.py
@@ -1,0 +1,50 @@
+"""
+Test that globus_sdk._testing can accept a non-default requests mock
+"""
+import sys
+
+import pytest
+import requests
+import responses
+
+from globus_sdk import GlobusHTTPResponse, GroupsClient
+from globus_sdk._testing import get_last_request, load_response
+
+
+@pytest.fixture
+def custom_reqests_mock():
+    responses.stop()
+
+    with responses.RequestsMock() as m:
+        yield m
+
+    if sys.version_info < (3, 7):
+        # start the default mock again afterwards, so that test fixture teardown doesn't
+        # double-stop and fail on responses==0.17.0
+        # use an `if version_info` check to allow pyupgrade to remove this automatically
+        # in the future
+        responses.start()
+
+
+def test_get_last_request_on_empty_custom_mock_returns_none(custom_reqests_mock):
+    assert get_last_request(requests_mock=custom_reqests_mock) is None
+
+
+def test_get_last_request_on_custom_mock_populated_via_manual_load(custom_reqests_mock):
+    custom_reqests_mock.add("GET", "https://example.org/", json={"foo": "bar"})
+    r = requests.get("https://example.org/")
+    assert r.json() == {"foo": "bar"}
+
+    req = get_last_request(requests_mock=custom_reqests_mock)
+    assert req is not None
+    assert req.body is None  # "example" assertion about a request
+
+
+def test_register_client_method_and_call_on_custom_mock(custom_reqests_mock):
+    gc = GroupsClient()
+    loaded = load_response(gc.get_group, requests_mock=custom_reqests_mock)
+
+    group_id = loaded.metadata["group_id"]
+    data = gc.get_group(group_id)
+
+    assert isinstance(data, GlobusHTTPResponse)


### PR DESCRIPTION
responses has an interface which allows you to customize the mocking of `requests` with an object. The `_testing` package was all built using the default mocks, which meant that it couldn't accept a `RequestsMock` as an input and gracefully attach to it.
This adds `requests_mock=...` as an argument to all response loading methods.

Also, extend the readme with
- doc on RequestsMock usage
- a short "index" of _testing contents

---

I ran into this as an issue on a project which had a customized RequestsMock for some tests. I was surprised to realize that I couldn't use `_testing` at all.