### PR TITLE
Add _testing mocks for Transfer submit methods

### DIFF
--- a/src/globus_sdk/_testing/data/transfer/_common.py
+++ b/src/globus_sdk/_testing/data/transfer/_common.py
@@ -1,0 +1,5 @@
+import uuid
+
+SUBMISSION_ID = str(uuid.UUID(int=2020))
+ENDPOINT_ID = str(uuid.UUID(int=1234))
+TASK_ID = str(uuid.UUID(int=1001))

--- a/src/globus_sdk/_testing/data/transfer/create_endpoint.py
+++ b/src/globus_sdk/_testing/data/transfer/create_endpoint.py
@@ -1,8 +1,6 @@
-import uuid
-
 from globus_sdk._testing.models import RegisteredResponse, ResponseSet
 
-ENDPOINT_ID = str(uuid.UUID(int=1234))
+from ._common import ENDPOINT_ID
 
 RESPONSES = ResponseSet(
     metadata={"endpoint_id": ENDPOINT_ID},

--- a/src/globus_sdk/_testing/data/transfer/get_endpoint.py
+++ b/src/globus_sdk/_testing/data/transfer/get_endpoint.py
@@ -1,8 +1,6 @@
-import uuid
-
 from globus_sdk._testing.models import RegisteredResponse, ResponseSet
 
-ENDPOINT_ID = str(uuid.UUID(int=1234))
+from ._common import ENDPOINT_ID
 
 ENDPOINT_DOC = {
     "DATA_TYPE": "endpoint",

--- a/src/globus_sdk/_testing/data/transfer/get_submission_id.py
+++ b/src/globus_sdk/_testing/data/transfer/get_submission_id.py
@@ -1,0 +1,12 @@
+from globus_sdk._testing.models import RegisteredResponse, ResponseSet
+
+from ._common import SUBMISSION_ID
+
+RESPONSES = ResponseSet(
+    metadata={"submission_id": SUBMISSION_ID},
+    default=RegisteredResponse(
+        service="transfer",
+        path="/submission_id",
+        json={"value": SUBMISSION_ID},
+    ),
+)

--- a/src/globus_sdk/_testing/data/transfer/submit_delete.py
+++ b/src/globus_sdk/_testing/data/transfer/submit_delete.py
@@ -1,0 +1,31 @@
+from globus_sdk._testing.models import RegisteredResponse, ResponseSet
+
+from ._common import SUBMISSION_ID, TASK_ID
+
+RESPONSES = ResponseSet(
+    metadata={"submission_id": SUBMISSION_ID, "task_id": TASK_ID},
+    default=RegisteredResponse(
+        service="transfer",
+        method="POST",
+        path="/delete",
+        json={
+            "DATA_TYPE": "delete_result",
+            "code": "Accepted",
+            "message": (
+                "The delete has been accepted and a task has been created "
+                "and queued for execution"
+            ),
+            "request_id": "NS2QXhLZ7",
+            "resource": "/delete",
+            "submission_id": SUBMISSION_ID,
+            "task_id": TASK_ID,
+            "task_link": {
+                "DATA_TYPE": "link",
+                "href": f"task/{TASK_ID}?format=json",
+                "rel": "related",
+                "resource": "task",
+                "title": "related task",
+            },
+        },
+    ),
+)

--- a/src/globus_sdk/_testing/data/transfer/submit_transfer.py
+++ b/src/globus_sdk/_testing/data/transfer/submit_transfer.py
@@ -1,0 +1,46 @@
+from globus_sdk._testing.models import RegisteredResponse, ResponseSet
+
+from ._common import SUBMISSION_ID, TASK_ID
+
+RESPONSES = ResponseSet(
+    metadata={"submission_id": SUBMISSION_ID, "task_id": TASK_ID},
+    default=RegisteredResponse(
+        service="transfer",
+        method="POST",
+        path="/transfer",
+        json={
+            "DATA_TYPE": "transfer_result",
+            "code": "Accepted",
+            "message": (
+                "The transfer has been accepted and a task has been created "
+                "and queued for execution"
+            ),
+            "request_id": "7HgMVYazI",
+            "resource": "/transfer",
+            "submission_id": SUBMISSION_ID,
+            "task_id": TASK_ID,
+            "task_link": {
+                "DATA_TYPE": "link",
+                "href": f"task/{TASK_ID}?format=json",
+                "rel": "related",
+                "resource": "task",
+                "title": "related task",
+            },
+        },
+    ),
+    failure=RegisteredResponse(
+        service="transfer",
+        method="POST",
+        path="/transfer",
+        json={
+            "code": "ClientError.BadRequest.NoTransferItems",
+            "message": "A transfer requires at least one item",
+            "request_id": "oUAA6Sq2P",
+            "resource": "/transfer",
+        },
+        status=400,
+        metadata={
+            "request_id": "oUAA6Sq2P",
+        },
+    ),
+)

--- a/src/globus_sdk/_testing/data/transfer/update_endpoint.py
+++ b/src/globus_sdk/_testing/data/transfer/update_endpoint.py
@@ -1,8 +1,6 @@
-import uuid
-
 from globus_sdk._testing.models import RegisteredResponse, ResponseSet
 
-ENDPOINT_ID = str(uuid.UUID(int=1234))
+from ._common import ENDPOINT_ID
 
 RESPONSES = ResponseSet(
     metadata={"endpoint_id": ENDPOINT_ID},

--- a/tests/functional/timer/test_jobs.py
+++ b/tests/functional/timer/test_jobs.py
@@ -36,7 +36,7 @@ def test_get_job(timer_client):
 def test_create_job(timer_client, start, interval):
     meta = load_response(timer_client.create_job).metadata
     transfer_client = TransferClient()
-    transfer_client.get_submission_id = lambda *_0, **_1: {"value": "mock"}
+    load_response(transfer_client.get_submission_id)
     transfer_data = TransferData(transfer_client, GO_EP1_ID, GO_EP2_ID)
     timer_job = TimerJob.from_transfer_data(transfer_data, start, interval)
     response = timer_client.create_job(timer_job)

--- a/tests/functional/transfer/test_task_submit.py
+++ b/tests/functional/transfer/test_task_submit.py
@@ -4,58 +4,14 @@ Tests for submitting Transfer and Delete tasks
 import pytest
 
 import globus_sdk
-from tests.common import GO_EP1_ID, GO_EP2_ID, register_api_route
-
-TRANSFER_SUBMISSION_NODATA_ERROR = """{
-  "code": "ClientError.BadRequest.NoTransferItems",
-  "message": "A transfer requires at least one item",
-  "request_id": "oUAA6Sq2P",
-  "resource": "/transfer"
-}"""
-
-TRANSFER_SUBMISSION_SUCCESS = """{
-  "DATA_TYPE": "transfer_result",
-  "code": "Accepted",
-  "message": "The transfer has been accepted and a task has been created and queued for execution",
-  "request_id": "7HgMVYazI",
-  "resource": "/transfer",
-  "submission_id": "foosubmitid",
-  "task_id": "f51bdaea-ad78-11e8-823c-0a3b7ca8ce66",
-  "task_link": {
-    "DATA_TYPE": "link",
-    "href": "task/f51bdaea-ad78-11e8-823c-0a3b7ca8ce66?format=json",
-    "rel": "related",
-    "resource": "task",
-    "title": "related task"
-  }
-}"""  # noqa
-
-
-DELETE_SUBMISSION_SUCCESS = """{
-  "DATA_TYPE": "delete_result",
-  "code": "Accepted",
-  "message": "The delete has been accepted and a task has been created and queued for execution",
-  "request_id": "NS2QXhLZ7",
-  "resource": "/delete",
-  "submission_id": "foosubmitid",
-  "task_id": "b5370336-ad79-11e8-823c-0a3b7ca8ce66",
-  "task_link": {
-    "DATA_TYPE": "link",
-    "href": "task/b5370336-ad79-11e8-823c-0a3b7ca8ce66?format=json",
-    "rel": "related",
-    "resource": "task",
-    "title": "related task"
-  }
-}"""  # noqa
+from globus_sdk._testing import load_response
+from tests.common import GO_EP1_ID, GO_EP2_ID
 
 
 @pytest.fixture
-def mock_submission_id():
-    register_api_route("transfer", "/submission_id", body='{"value": "foosubmitid"}')
+def transfer_data(client):
+    load_response(client.get_submission_id)
 
-
-@pytest.fixture
-def transfer_data(client, mock_submission_id):
     def _transfer_data(**kwargs):
         return globus_sdk.TransferData(client, GO_EP1_ID, GO_EP2_ID, **kwargs)
 
@@ -63,7 +19,9 @@ def transfer_data(client, mock_submission_id):
 
 
 @pytest.fixture
-def delete_data(client, mock_submission_id):
+def delete_data(client):
+    load_response(client.get_submission_id)
+
     def _delete_data(**kwargs):
         return globus_sdk.DeleteData(client, GO_EP1_ID, **kwargs)
 
@@ -71,26 +29,18 @@ def delete_data(client, mock_submission_id):
 
 
 def test_transfer_submit_failure(client, transfer_data):
-    register_api_route(
-        "transfer",
-        "/transfer",
-        method="POST",
-        status=400,
-        body=TRANSFER_SUBMISSION_NODATA_ERROR,
-    )
+    meta = load_response(client.submit_transfer, case="failure").metadata
 
     with pytest.raises(globus_sdk.TransferAPIError) as excinfo:
         client.submit_transfer(transfer_data())
 
     assert excinfo.value.http_status == 400
-    assert excinfo.value.request_id == "oUAA6Sq2P"
+    assert excinfo.value.request_id == meta["request_id"]
     assert excinfo.value.code == "ClientError.BadRequest.NoTransferItems"
 
 
 def test_transfer_submit_success(client, transfer_data):
-    register_api_route(
-        "transfer", "/transfer", method="POST", body=TRANSFER_SUBMISSION_SUCCESS
-    )
+    meta = load_response(client.submit_transfer).metadata
 
     tdata = transfer_data(
         label="mytask",
@@ -107,14 +57,12 @@ def test_transfer_submit_success(client, transfer_data):
     res = client.submit_transfer(tdata)
 
     assert res
-    assert res["submission_id"] == "foosubmitid"
-    assert res["task_id"] == "f51bdaea-ad78-11e8-823c-0a3b7ca8ce66"
+    assert res["submission_id"] == meta["submission_id"]
+    assert res["task_id"] == meta["task_id"]
 
 
 def test_delete_submit_success(client, delete_data):
-    register_api_route(
-        "transfer", "/delete", method="POST", body=DELETE_SUBMISSION_SUCCESS
-    )
+    meta = load_response(client.submit_delete).metadata
 
     ddata = delete_data(
         label="mytask", deadline="2018-06-01", additional_fields={"custom_param": "foo"}
@@ -126,5 +74,5 @@ def test_delete_submit_success(client, delete_data):
     res = client.submit_delete(ddata)
 
     assert res
-    assert res["submission_id"] == "foosubmitid"
-    assert res["task_id"] == "b5370336-ad79-11e8-823c-0a3b7ca8ce66"
+    assert res["submission_id"] == meta["submission_id"]
+    assert res["task_id"] == meta["task_id"]

--- a/tests/unit/helpers/test_transfer.py
+++ b/tests/unit/helpers/test_transfer.py
@@ -1,17 +1,14 @@
 import pytest
 
 import globus_sdk
+from globus_sdk._testing import load_response
 from tests.common import GO_EP1_ID, GO_EP2_ID
 
 
 @pytest.fixture
 def client():
-    def _mock_submission_id(*args, **kwargs):
-        return {"value": "fooid"}
-
     tc = globus_sdk.TransferClient()
-    tc.get_submission_id = _mock_submission_id
-
+    load_response(tc.get_submission_id)
     return tc
 
 


### PR DESCRIPTION
These methods now have mocks in _testing:

- get_submission_id
- submit_transfer
- submit_delete

Replace any specialized mocking in the testsuite with these, cleaning up usage. Data for the mocks was pulled from existing tests.

The one which is particularly nice to handle is `get_submission_id`, which is now very tidy to handle in a few places where TransferData and DeleteData are constructed.