### PR TITLE
Fix index id key in doc example

### DIFF
--- a/src/globus_sdk/services/search/client.py
+++ b/src/globus_sdk/services/search/client.py
@@ -47,7 +47,7 @@ class SearchClient(client.BaseClient):
 
         >>> sc = globus_sdk.SearchClient(...)
         >>> index = sc.get_index(index_id)
-        >>> assert index['index_id'] == index_id
+        >>> assert index['id'] == index_id
         >>> print(index["display_name"],
         >>>       "(" + index_id + "):",
         >>>       index["description"])


### PR DESCRIPTION
Minor correction to a documentation example. The key for the index ID is `id` in the response for `get_index`.

Also, those short examples are really useful.
