### PR TITLE
Update TransferData and DeleteData to allow no `submission_id`, then fit this with TimerJob.from_transfer_data

### DIFF
--- a/changelog.d/20220815_171620_sirosen_update_transfer_data.rst
+++ b/changelog.d/20220815_171620_sirosen_update_transfer_data.rst
@@ -1,0 +1,12 @@
+* Adjust behaviors of ``TransferData`` and ``TimerJob`` to make
+  ``TimerJob.from_transfer_data`` work (:pr:`NUMBER`)
+** ``TransferData`` avoids passing ``null`` for several values when they are
+   omitted, ranging from optional parameters to ``add_item`` to
+   ``skip_activation_check``
+** ``TransferData`` and ``DeleteData`` now support usage in which the
+    ``transfer_client`` parameters is ``None``. In these cases, if
+    ``submission_id`` is omitted, it will be omitted from the document,
+    allowing the creation of a partial task submsision document with no
+    ``submission_id``
+** ``TimerJob.from_transfer_data`` will now raise a ``ValueError`` if the input
+   document contains ``submission_id`` or ``skip_activation_check``

--- a/changelog.d/20220815_171620_sirosen_update_transfer_data.rst
+++ b/changelog.d/20220815_171620_sirosen_update_transfer_data.rst
@@ -1,5 +1,6 @@
 * Adjust behaviors of ``TransferData`` and ``TimerJob`` to make
-  ``TimerJob.from_transfer_data`` work (:pr:`NUMBER`)
+  ``TimerJob.from_transfer_data`` work and to defer requesting the
+  ``submission_id`` until the task submission call (:pr:`NUMBER`)
 ** ``TransferData`` avoids passing ``null`` for several values when they are
    omitted, ranging from optional parameters to ``add_item`` to
    ``skip_activation_check``
@@ -10,3 +11,28 @@
     ``submission_id``
 ** ``TimerJob.from_transfer_data`` will now raise a ``ValueError`` if the input
    document contains ``submission_id`` or ``skip_activation_check``
+** ``TransferClient.submit_transfer`` and ``TransferClient.submit_delete`` now
+   check to see if the data being sent contains a ``submission_id``. If it does
+   not, ``get_submission_id`` is called automatically and set as the
+   ``submission_id`` on the payload. The new ``submission_id`` is set on the
+   object passed to these methods, meaning that these methods are now
+   side-effecting.
+
+The newly recommended usage for ``TransferData`` and ``DeleteData`` is to pass
+the endpoints as named parameters:
+
+.. code-block:: python
+
+    # -- for TransferData --
+    # old usage
+    transfer_client = TransferClient()
+    transfer_data = TransferData(transfer_client, ep1, ep2)
+    # new (recommended) usage
+    transfer_data = TransferData(source_endpoint=ep1, destination_endpoint=ep2)
+
+    # -- for DeleteData --
+    # old usage
+    transfer_client = TransferClient()
+    delete_data = TransferData(transfer_client, ep)
+    # new (recommended) usage
+    delete_data = DeleteData(endpoint=ep)

--- a/src/globus_sdk/services/timer/data.py
+++ b/src/globus_sdk/services/timer/data.py
@@ -1,9 +1,12 @@
 import datetime
+import logging
 from typing import Any, Dict, Optional, Union
 
 from globus_sdk.config import get_service_url
 from globus_sdk.services.transfer import TransferData
 from globus_sdk.utils import PayloadWrapper, slash_join
+
+log = logging.getLogger(__name__)
 
 
 class TimerJob(PayloadWrapper):
@@ -122,6 +125,9 @@ class TimerJob(PayloadWrapper):
         """
         transfer_action_url = slash_join(
             get_service_url("actions", environment=environment), "transfer/transfer/run"
+        )
+        log.info(
+            "Creating TimerJob from TransferData, action_url=%s", transfer_action_url
         )
         for key in ("submission_id", "skip_activation_check"):
             if key in transfer_data:

--- a/src/globus_sdk/services/timer/data.py
+++ b/src/globus_sdk/services/timer/data.py
@@ -123,6 +123,11 @@ class TimerJob(PayloadWrapper):
         transfer_action_url = slash_join(
             get_service_url("actions", environment=environment), "transfer/transfer/run"
         )
+        for key in ("submission_id", "skip_activation_check"):
+            if key in transfer_data:
+                raise ValueError(
+                    f"cannot create TimerJob from TransferData which has {key} set"
+                )
         # dict will either convert a `TransferData` object or leave us with a dict here
         callback_body = {"body": dict(transfer_data)}
         return cls(

--- a/src/globus_sdk/services/transfer/client.py
+++ b/src/globus_sdk/services/transfer/client.py
@@ -1220,9 +1220,8 @@ class TransferClient(client.BaseClient):
         :meth:`submit_delete <.submit_delete>` methods.
 
         Most users will not need to call this method directly, as the
-        convenience classes :class:`TransferData <globus_sdk.TransferData>`
-        and :class:`DeleteData <globus_sdk.DeleteData>` will call it
-        automatically if they are not passed a ``submission_id`` explicitly.
+        methods :meth:`~submit_transfer` and :meth:`~submit_delete` will call it
+        automatically if the data does not contain a ``submission_id``.
         """
         log.info(f"TransferClient.get_submission_id({query_params})")
         return self.get("submission_id", query_params=query_params)
@@ -1240,6 +1239,12 @@ class TransferClient(client.BaseClient):
             various options. See :class:`TransferData <globus_sdk.TransferData>` for
             details
         :type data: dict or TransferData
+
+        Submit a Transfer Task.
+
+        If no ``submission_id`` is included in the payload, one will be requested and
+        used automatically. The data passed to this method will be modified to include
+        the ``submission_id``.
 
         **Examples**
 
@@ -1259,6 +1264,9 @@ class TransferClient(client.BaseClient):
         a :class:`TransferData <globus_sdk.TransferData>` object.
         """
         log.info("TransferClient.submit_transfer(...)")
+        if "submission_id" not in data:
+            log.debug("submit_transfer autofetching submission_id")
+            data["submission_id"] = self.get_submission_id()["value"]
         return self.post("/transfer", data=data)
 
     @utils.doc_api_method(
@@ -1275,6 +1283,12 @@ class TransferClient(client.BaseClient):
             details
         :type data: dict or DeleteData
 
+        Submit a Delete Task.
+
+        If no ``submission_id`` is included in the payload, one will be requested and
+        used automatically. The data passed to this method will be modified to include
+        the ``submission_id``.
+
         **Examples**
 
         >>> tc = globus_sdk.TransferClient(...)
@@ -1288,6 +1302,9 @@ class TransferClient(client.BaseClient):
         a :class:`DeleteData <globus_sdk.DeleteData>` object.
         """
         log.info("TransferClient.submit_delete(...)")
+        if "submission_id" not in data:
+            log.debug("submit_delete autofetching submission_id")
+            data["submission_id"] = self.get_submission_id()["value"]
         return self.post("/delete", data=data)
 
     #

--- a/src/globus_sdk/services/transfer/data/delete_data.py
+++ b/src/globus_sdk/services/transfer/data/delete_data.py
@@ -2,7 +2,7 @@ import datetime
 import logging
 from typing import TYPE_CHECKING, Any, Dict, Iterator, Optional, Union
 
-from globus_sdk import utils
+from globus_sdk import exc, utils
 from globus_sdk._types import UUIDLike
 
 if TYPE_CHECKING:
@@ -87,8 +87,8 @@ class DeleteData(utils.PayloadWrapper):
 
     def __init__(
         self,
-        transfer_client: Optional["globus_sdk.TransferClient"],
-        endpoint: UUIDLike,
+        transfer_client: Optional["globus_sdk.TransferClient"] = None,
+        endpoint: Optional[UUIDLike] = None,
         *,
         label: Optional[str] = None,
         submission_id: Optional[UUIDLike] = None,
@@ -101,6 +101,11 @@ class DeleteData(utils.PayloadWrapper):
         additional_fields: Optional[Dict[str, Any]] = None,
     ) -> None:
         super().__init__()
+        # this must be checked explicitly to handle the fact that `transfer_client` is
+        # the first arg
+        if endpoint is None:
+            raise exc.GlobusSDKUsageError("endpoint is required")
+
         self["DATA_TYPE"] = "delete"
         self["DATA"] = []
         self._set_optstrs(

--- a/src/globus_sdk/services/transfer/data/delete_data.py
+++ b/src/globus_sdk/services/transfer/data/delete_data.py
@@ -28,14 +28,15 @@ class DeleteData(utils.PayloadWrapper):
     :param transfer_client: A ``TransferClient`` instance which will be used to get a
         submission ID if one is not supplied. Should be the same instance that is used
         to submit the deletion.
-    :type transfer_client: :class:`TransferClient <globus_sdk.TransferClient>`
+    :type transfer_client: :class:`TransferClient <globus_sdk.TransferClient>` or None
     :param endpoint: The endpoint ID which is targeted by this deletion Task
     :type endpoint: str or UUID
     :param label: A string label for the Task
     :type label: str, optional
     :param submission_id: A submission ID value fetched via
         :meth:`get_submission_id <globus_sdk.TransferClient.get_submission_id>`.
-        Defaults to using ``transfer_client.get_submission_id``
+        Defaults to using ``transfer_client.get_submission_id`` if a ``transfer_client``
+        is provided
     :type submission_id: str or UUID, optional
     :param recursive: Recursively delete subdirectories on the target endpoint
       [default: ``False``]
@@ -86,14 +87,14 @@ class DeleteData(utils.PayloadWrapper):
 
     def __init__(
         self,
-        transfer_client: "globus_sdk.TransferClient",
+        transfer_client: Optional["globus_sdk.TransferClient"],
         endpoint: UUIDLike,
         *,
         label: Optional[str] = None,
         submission_id: Optional[UUIDLike] = None,
         recursive: bool = False,
         deadline: Optional[Union[str, datetime.datetime]] = None,
-        skip_activation_check: bool = False,
+        skip_activation_check: Optional[bool] = None,
         notify_on_succeeded: bool = True,
         notify_on_failed: bool = True,
         notify_on_inactive: bool = True,
@@ -101,25 +102,25 @@ class DeleteData(utils.PayloadWrapper):
     ) -> None:
         super().__init__()
         self["DATA_TYPE"] = "delete"
-        self["submission_id"] = (
-            str(submission_id)
-            if submission_id is not None
-            else transfer_client.get_submission_id()["value"]
-        )
-        self["endpoint"] = str(endpoint)
-        self["recursive"] = recursive
-        self["skip_activation_check"] = skip_activation_check
-        self["notify_on_succeeded"] = notify_on_succeeded
-        self["notify_on_failed"] = notify_on_failed
-        self["notify_on_inactive"] = notify_on_inactive
-
-        if label is not None:
-            self["label"] = label
-
-        if deadline is not None:
-            self["deadline"] = str(deadline)
-
         self["DATA"] = []
+        self._set_optstrs(
+            endpoint=endpoint,
+            label=label,
+            submission_id=submission_id
+            or (
+                transfer_client.get_submission_id()["value"]
+                if transfer_client
+                else None
+            ),
+            deadline=deadline,
+        )
+        self._set_optbools(
+            recursive=recursive,
+            skip_activation_check=skip_activation_check,
+            notify_on_succeeded=notify_on_succeeded,
+            notify_on_failed=notify_on_failed,
+            notify_on_inactive=notify_on_inactive,
+        )
 
         for k, v in self.items():
             log.info("DeleteData.%s = %s", k, v)

--- a/src/globus_sdk/services/transfer/data/transfer_data.py
+++ b/src/globus_sdk/services/transfer/data/transfer_data.py
@@ -8,7 +8,7 @@ if sys.version_info >= (3, 8):
 else:
     from typing_extensions import Literal
 
-from globus_sdk import utils
+from globus_sdk import exc, utils
 from globus_sdk._types import UUIDLike
 
 if TYPE_CHECKING:
@@ -179,9 +179,9 @@ class TransferData(utils.PayloadWrapper):
 
     def __init__(
         self,
-        transfer_client: Optional["globus_sdk.TransferClient"],
-        source_endpoint: UUIDLike,
-        destination_endpoint: UUIDLike,
+        transfer_client: Optional["globus_sdk.TransferClient"] = None,
+        source_endpoint: Optional[UUIDLike] = None,
+        destination_endpoint: Optional[UUIDLike] = None,
         *,
         label: Optional[str] = None,
         submission_id: Optional[UUIDLike] = None,
@@ -193,7 +193,7 @@ class TransferData(utils.PayloadWrapper):
         skip_activation_check: Optional[bool] = None,
         skip_source_errors: bool = False,
         fail_on_quota_errors: bool = False,
-        recursive_symlinks: str = "ignore",
+        recursive_symlinks: Optional[str] = None,
         delete_destination_extra: bool = False,
         notify_on_succeeded: bool = True,
         notify_on_failed: bool = True,
@@ -201,6 +201,13 @@ class TransferData(utils.PayloadWrapper):
         additional_fields: Optional[Dict[str, Any]] = None,
     ) -> None:
         super().__init__()
+        # these must be checked explicitly to handle the fact that `transfer_client` is
+        # the first arg
+        if source_endpoint is None:
+            raise exc.GlobusSDKUsageError("source_endpoint is required")
+        if destination_endpoint is None:
+            raise exc.GlobusSDKUsageError("destination_endpoint is required")
+
         log.info("Creating a new TransferData object")
         self["DATA_TYPE"] = "transfer"
         self["DATA"] = []

--- a/src/globus_sdk/services/transfer/data/transfer_data.py
+++ b/src/globus_sdk/services/transfer/data/transfer_data.py
@@ -15,6 +15,27 @@ if TYPE_CHECKING:
     import globus_sdk
 
 log = logging.getLogger(__name__)
+_StrSyncLevel = Literal["exists", "size", "mtime", "checksum"]
+_sync_level_dict: Dict[_StrSyncLevel, int] = {
+    "exists": 0,
+    "size": 1,
+    "mtime": 2,
+    "checksum": 3,
+}
+
+
+def _parse_sync_level(sync_level: Union[_StrSyncLevel, int]) -> int:
+    """
+    Map sync_level strings to known int values
+
+    Important: if more levels are added in the future you can always pass as an int
+    """
+    if isinstance(sync_level, str):
+        try:
+            sync_level = _sync_level_dict[sync_level]
+        except KeyError as err:
+            raise ValueError(f"Unrecognized sync_level {sync_level}") from err
+    return sync_level
 
 
 class TransferData(utils.PayloadWrapper):
@@ -34,7 +55,7 @@ class TransferData(utils.PayloadWrapper):
     :param transfer_client: A ``TransferClient`` instance which will be used to get a
         submission ID if one is not supplied. Should be the same instance that is used
         to submit the transfer.
-    :type transfer_client: :class:`TransferClient <globus_sdk.TransferClient>`
+    :type transfer_client: :class:`TransferClient <globus_sdk.TransferClient>` or None
     :param source_endpoint: The endpoint ID of the source endpoint
     :type source_endpoint: str or UUID
     :param destination_endpoint: The endpoint ID of the destination endpoint
@@ -158,20 +179,18 @@ class TransferData(utils.PayloadWrapper):
 
     def __init__(
         self,
-        transfer_client: "globus_sdk.TransferClient",
+        transfer_client: Optional["globus_sdk.TransferClient"],
         source_endpoint: UUIDLike,
         destination_endpoint: UUIDLike,
         *,
         label: Optional[str] = None,
         submission_id: Optional[UUIDLike] = None,
-        sync_level: Union[
-            Literal["exists", "size", "mtime", "checksum"], int, None
-        ] = None,
+        sync_level: Union[_StrSyncLevel, int, None] = None,
         verify_checksum: bool = False,
         preserve_timestamp: bool = False,
         encrypt_data: bool = False,
-        deadline: Optional[Union[datetime.datetime, str]] = None,
-        skip_activation_check: bool = False,
+        deadline: Union[datetime.datetime, str, None] = None,
+        skip_activation_check: Optional[bool] = None,
         skip_source_errors: bool = False,
         fail_on_quota_errors: bool = False,
         recursive_symlinks: str = "ignore",
@@ -184,42 +203,33 @@ class TransferData(utils.PayloadWrapper):
         super().__init__()
         log.info("Creating a new TransferData object")
         self["DATA_TYPE"] = "transfer"
-        self["submission_id"] = (
-            submission_id or transfer_client.get_submission_id()["value"]
-        )
-        self["source_endpoint"] = str(source_endpoint)
-        self["destination_endpoint"] = str(destination_endpoint)
-        self["verify_checksum"] = verify_checksum
-        self["preserve_timestamp"] = preserve_timestamp
-        self["encrypt_data"] = encrypt_data
-        self["recursive_symlinks"] = recursive_symlinks
-        self["skip_activation_check"] = skip_activation_check
-        self["skip_source_errors"] = skip_source_errors
-        self["fail_on_quota_errors"] = fail_on_quota_errors
-        self["delete_destination_extra"] = delete_destination_extra
-        self["notify_on_succeeded"] = notify_on_succeeded
-        self["notify_on_failed"] = notify_on_failed
-        self["notify_on_inactive"] = notify_on_inactive
-        if label is not None:
-            self["label"] = label
-        if deadline is not None:
-            self["deadline"] = str(deadline)
-
-        # map the sync_level (if it's a nice string) to one of the known int
-        # values
-        # you can get away with specifying an invalid sync level -- the API
-        # will just reject you with an error. This is kind of important: if
-        # more levels are added in the future you can pass as an int
-        if sync_level is not None:
-            if isinstance(sync_level, str):
-                sync_dict = {"exists": 0, "size": 1, "mtime": 2, "checksum": 3}
-                try:
-                    sync_level = sync_dict[sync_level]
-                except KeyError as err:
-                    raise ValueError(f"Unrecognized sync_level {sync_level}") from err
-            self["sync_level"] = sync_level
-
         self["DATA"] = []
+        self._set_optstrs(
+            source_endpoint=source_endpoint,
+            destination_endpoint=destination_endpoint,
+            label=label,
+            submission_id=submission_id
+            or (
+                transfer_client.get_submission_id()["value"]
+                if transfer_client
+                else None
+            ),
+            recursive_symlinks=recursive_symlinks,
+            deadline=deadline,
+        )
+        self._set_optbools(
+            verify_checksum=verify_checksum,
+            preserve_timestamp=preserve_timestamp,
+            encrypt_data=encrypt_data,
+            skip_activation_check=skip_activation_check,
+            skip_source_errors=skip_source_errors,
+            fail_on_quota_errors=fail_on_quota_errors,
+            delete_destination_extra=delete_destination_extra,
+            notify_on_succeeded=notify_on_succeeded,
+            notify_on_failed=notify_on_failed,
+            notify_on_inactive=notify_on_inactive,
+        )
+        self._set_value("sync_level", sync_level, callback=_parse_sync_level)
 
         for k, v in self.items():
             log.info("TransferData.%s = %s", k, v)
@@ -282,9 +292,11 @@ class TransferData(utils.PayloadWrapper):
             "source_path": source_path,
             "destination_path": destination_path,
             "recursive": recursive,
-            "external_checksum": external_checksum,
-            "checksum_algorithm": checksum_algorithm,
         }
+        if external_checksum is not None:
+            item_data["external_checksum"] = external_checksum
+        if checksum_algorithm is not None:
+            item_data["checksum_algorithm"] = checksum_algorithm
         if additional_fields is not None:
             item_data.update(additional_fields)
 

--- a/tests/functional/timer/test_jobs.py
+++ b/tests/functional/timer/test_jobs.py
@@ -35,7 +35,9 @@ def test_get_job(timer_client):
 )
 def test_create_job(timer_client, start, interval):
     meta = load_response(timer_client.create_job).metadata
-    transfer_data = TransferData(None, GO_EP1_ID, GO_EP2_ID)
+    transfer_data = TransferData(
+        source_endpoint=GO_EP1_ID, destination_endpoint=GO_EP2_ID
+    )
     timer_job = TimerJob.from_transfer_data(transfer_data, start, interval)
     response = timer_client.create_job(timer_job)
     assert response.http_status == 201

--- a/tests/functional/timer/test_jobs.py
+++ b/tests/functional/timer/test_jobs.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 
 import pytest
 
-from globus_sdk import TimerClient, TimerJob, TransferClient, TransferData
+from globus_sdk import TimerClient, TimerJob, TransferData
 from globus_sdk._testing import get_last_request, load_response
 from globus_sdk.config import get_service_url
 from globus_sdk.utils import slash_join
@@ -35,9 +35,7 @@ def test_get_job(timer_client):
 )
 def test_create_job(timer_client, start, interval):
     meta = load_response(timer_client.create_job).metadata
-    transfer_client = TransferClient()
-    load_response(transfer_client.get_submission_id)
-    transfer_data = TransferData(transfer_client, GO_EP1_ID, GO_EP2_ID)
+    transfer_data = TransferData(None, GO_EP1_ID, GO_EP2_ID)
     timer_job = TimerJob.from_transfer_data(transfer_data, start, interval)
     response = timer_client.create_job(timer_job)
     assert response.http_status == 201

--- a/tests/unit/helpers/test_timer.py
+++ b/tests/unit/helpers/test_timer.py
@@ -1,0 +1,24 @@
+import pytest
+
+from globus_sdk import TimerJob, TransferData
+from tests.common import GO_EP1_ID, GO_EP2_ID
+
+
+def test_timer_from_transfer_data_ok():
+    tdata = TransferData(None, GO_EP1_ID, GO_EP2_ID)
+    job = TimerJob.from_transfer_data(tdata, "2022-01-01T00:00:00Z", 600)
+    assert "callback_body" in job
+    assert "body" in job["callback_body"]
+    assert "source_endpoint" in job["callback_body"]["body"]
+    assert "destination_endpoint" in job["callback_body"]["body"]
+    assert job["callback_body"]["body"]["source_endpoint"] == GO_EP1_ID
+    assert job["callback_body"]["body"]["destination_endpoint"] == GO_EP2_ID
+
+
+@pytest.mark.parametrize(
+    "badkey, value", (("submission_id", "foo"), ("skip_activation_check", True))
+)
+def test_timer_from_transfer_data_rejects_forbidden_keys(badkey, value):
+    tdata = TransferData(None, GO_EP1_ID, GO_EP2_ID, **{badkey: value})
+    with pytest.raises(ValueError):
+        TimerJob.from_transfer_data(tdata, "2022-01-01T00:00:00Z", 600)

--- a/tests/unit/helpers/test_transfer.py
+++ b/tests/unit/helpers/test_transfer.py
@@ -71,8 +71,8 @@ def test_transfer_add_item(transfer_data):
     assert data["source_path"] == source_path
     assert data["destination_path"] == dest_path
     assert not data["recursive"]
-    assert data["external_checksum"] is None
-    assert data["checksum_algorithm"] is None
+    assert "external_checksum" not in data
+    assert "checksum_algorithm" not in data
 
     # add recursive item
     tdata.add_item(source_path, dest_path, recursive=True)
@@ -83,8 +83,8 @@ def test_transfer_add_item(transfer_data):
     assert r_data["source_path"] == source_path
     assert r_data["destination_path"] == dest_path
     assert r_data["recursive"]
-    assert r_data["external_checksum"] is None
-    assert r_data["checksum_algorithm"] is None
+    assert "external_checksum" not in data
+    assert "checksum_algorithm" not in data
 
     # item with checksum
     checksum = "d577273ff885c3f84dadb8578bb41399"
@@ -145,9 +145,9 @@ def test_delete_init(delete_data):
     # init with params
     label = "label"
     params = {"param1": "value1", "param2": "value2"}
-    param_ddata = delete_data(label=label, recursive="True", additional_fields=params)
+    param_ddata = delete_data(label=label, recursive=True, additional_fields=params)
     assert param_ddata["label"] == label
-    assert param_ddata["recursive"] == "True"
+    assert param_ddata["recursive"]
     for par in params:
         assert param_ddata[par] == params[par]
 
@@ -272,20 +272,21 @@ def test_tranfer_sync_levels_result(transfer_data, sync_level, result):
         assert tdata["sync_level"] == result
 
 
-def test_skip_activation_check_supported(transfer_data, delete_data):
-    # default, false
-    tdata = transfer_data()
-    ddata = delete_data()
-    for data in [tdata, ddata]:
-        assert "skip_activation_check" in data
-        assert data["skip_activation_check"] is False
-
-    # can set to True
-    tdata = transfer_data(skip_activation_check=True)
-    ddata = delete_data(skip_activation_check=True)
-    for data in [tdata, ddata]:
+@pytest.mark.parametrize("datatype", ("transfer", "delete"))
+@pytest.mark.parametrize("value", (None, True, False))
+def test_skip_activation_check_supported(transfer_data, delete_data, datatype, value):
+    method = transfer_data if datatype == "transfer" else delete_data
+    if value is None:
+        # not present if not provided as a param or provided as explicit None
+        assert "skip_activation_check" not in method()
+    elif value:
+        data = method(skip_activation_check=True)
         assert "skip_activation_check" in data
         assert data["skip_activation_check"] is True
+    else:
+        data = method(skip_activation_check=False)
+        assert "skip_activation_check" in data
+        assert data["skip_activation_check"] is False
 
 
 def test_add_filter_rule(transfer_data):

--- a/tests/unit/helpers/test_transfer.py
+++ b/tests/unit/helpers/test_transfer.py
@@ -1,65 +1,84 @@
 import pytest
 
-import globus_sdk
+from globus_sdk import DeleteData, GlobusSDKUsageError, TransferClient, TransferData
 from globus_sdk._testing import load_response
 from tests.common import GO_EP1_ID, GO_EP2_ID
 
 
-@pytest.fixture
-def client():
-    tc = globus_sdk.TransferClient()
-    load_response(tc.get_submission_id)
-    return tc
-
-
-@pytest.fixture
-def transfer_data(client):
-    def _transfer_data(**kwargs):
-        return globus_sdk.TransferData(client, GO_EP1_ID, GO_EP2_ID, **kwargs)
-
-    return _transfer_data
-
-
-@pytest.fixture
-def delete_data(client):
-    def _delete_data(**kwargs):
-        return globus_sdk.DeleteData(client, GO_EP1_ID, **kwargs)
-
-    return _delete_data
-
-
-def test_tranfer_init(transfer_data):
+def test_tranfer_init_simple():
     """
     Creates TransferData objects with and without parameters,
     Verifies TransferData field initialization
     """
+    tc = TransferClient()
+    meta = load_response(tc.get_submission_id).metadata
     # default init
-    tdata = transfer_data()
+    tdata = TransferData(tc, GO_EP1_ID, GO_EP2_ID)
     assert tdata["DATA_TYPE"] == "transfer"
     assert tdata["source_endpoint"] == GO_EP1_ID
     assert tdata["destination_endpoint"] == GO_EP2_ID
-    assert "submission_id" in tdata
+    assert tdata["submission_id"] == meta["submission_id"]
     assert "DATA" in tdata
     assert len(tdata["DATA"]) == 0
 
+
+def test_tranfer_init_w_params():
+    tc = TransferClient()
+    meta = load_response(tc.get_submission_id).metadata
     # init with params
     label = "label"
     params = {"param1": "value1", "param2": "value2"}
-    param_tdata = transfer_data(
-        label=label, sync_level="exists", additional_fields=params
+    tdata = TransferData(
+        tc,
+        GO_EP1_ID,
+        GO_EP2_ID,
+        label=label,
+        sync_level="exists",
+        additional_fields=params,
     )
-    assert param_tdata["label"] == label
+    assert tdata["label"] == label
+    assert tdata["submission_id"] == meta["submission_id"]
     # sync_level of "exists" should be converted to 0
-    assert param_tdata["sync_level"] == 0
+    assert tdata["sync_level"] == 0
     for par in params:
-        assert param_tdata[par] == params[par]
+        assert tdata[par] == params[par]
 
 
-def test_transfer_add_item(transfer_data):
+def test_tranfer_init_no_client():
+    tdata1 = TransferData(None, GO_EP1_ID, GO_EP2_ID)
+    tdata2 = TransferData(source_endpoint=GO_EP1_ID, destination_endpoint=GO_EP2_ID)
+    tdata3 = TransferData(
+        source_endpoint=GO_EP1_ID, destination_endpoint=GO_EP2_ID, transfer_client=None
+    )
+    for tdata in (tdata1, tdata2, tdata3):
+        assert tdata["DATA_TYPE"] == "transfer"
+        assert tdata["source_endpoint"] == GO_EP1_ID
+        assert tdata["destination_endpoint"] == GO_EP2_ID
+        assert "submission_id" not in tdata
+        assert "DATA" in tdata
+        assert len(tdata["DATA"]) == 0
+
+
+@pytest.mark.parametrize(
+    "tdata_args",
+    [
+        (),
+        (GO_EP1_ID, GO_EP2_ID),
+        (None, None, None),
+        (None, GO_EP1_ID, None),
+        (None, None, GO_EP2_ID),
+    ],
+)
+def test_tranfer_init_rejects_bad_usage(tdata_args):
+    with pytest.raises(GlobusSDKUsageError):
+        TransferData(*tdata_args)
+
+
+def test_transfer_add_item():
     """
     Adds items to TransferData, verifies results
     """
-    tdata = transfer_data()
+    tdata = TransferData(source_endpoint=GO_EP1_ID, destination_endpoint=GO_EP2_ID)
     # add item
     source_path = "source/path/"
     dest_path = "dest/path/"
@@ -113,11 +132,11 @@ def test_transfer_add_item(transfer_data):
     assert all(fields_data[k] == v for k, v in addfields.items())
 
 
-def test_transfer_add_symlink_item(transfer_data):
+def test_transfer_add_symlink_item():
     """
     Adds a transfer_symlink_item to TransferData, verifies results
     """
-    tdata = transfer_data()
+    tdata = TransferData(source_endpoint=GO_EP1_ID, destination_endpoint=GO_EP2_ID)
     # add item
     source_path = "source/path/"
     dest_path = "dest/path/"
@@ -130,33 +149,60 @@ def test_transfer_add_symlink_item(transfer_data):
     assert data["destination_path"] == dest_path
 
 
-def test_delete_init(delete_data):
+def test_delete_init():
     """
     Verifies DeleteData field initialization
     """
-    # default init
-    default_ddata = delete_data()
-    assert default_ddata["DATA_TYPE"] == "delete"
-    assert default_ddata["endpoint"] == GO_EP1_ID
-    assert "submission_id" in default_ddata
-    assert "DATA" in default_ddata
-    assert len(default_ddata["DATA"]) == 0
+    tc = TransferClient()
+    load_response(tc.get_submission_id)
+    ddata = DeleteData(tc, GO_EP1_ID)
+    assert ddata["DATA_TYPE"] == "delete"
+    assert ddata["endpoint"] == GO_EP1_ID
+    assert "submission_id" in ddata
+    assert "DATA" in ddata
+    assert len(ddata["DATA"]) == 0
 
-    # init with params
+
+def test_delete_init_w_params():
+    tc = TransferClient()
+    load_response(tc.get_submission_id)
     label = "label"
     params = {"param1": "value1", "param2": "value2"}
-    param_ddata = delete_data(label=label, recursive=True, additional_fields=params)
-    assert param_ddata["label"] == label
-    assert param_ddata["recursive"]
+    ddata = DeleteData(
+        tc, GO_EP1_ID, label=label, recursive=True, additional_fields=params
+    )
+    assert ddata["label"] == label
+    assert ddata["recursive"]
     for par in params:
-        assert param_ddata[par] == params[par]
+        assert ddata[par] == params[par]
 
 
-def test_delete_add_item(delete_data):
+def test_delete_init_no_client():
+    ddata1 = DeleteData(None, GO_EP1_ID)
+    ddata2 = DeleteData(endpoint=GO_EP1_ID)
+    ddata3 = DeleteData(endpoint=GO_EP1_ID, transfer_client=None)
+
+    for ddata in (ddata1, ddata2, ddata3):
+        assert ddata["DATA_TYPE"] == "delete"
+        assert ddata["endpoint"] == GO_EP1_ID
+        assert "submission_id" not in ddata
+        assert "DATA" in ddata
+        assert len(ddata["DATA"]) == 0
+
+
+@pytest.mark.parametrize(
+    "ddata_args", [(), (GO_EP1_ID,), (None, None), (GO_EP1_ID, None)]
+)
+def test_delete_init_rejects_bad_usage(ddata_args):
+    with pytest.raises(GlobusSDKUsageError):
+        DeleteData(*ddata_args)
+
+
+def test_delete_add_item():
     """
     Adds items to DeleteData, verifies results
     """
-    ddata = delete_data()
+    ddata = DeleteData(endpoint=GO_EP1_ID)
 
     # add normal item
     path = "source/path/"
@@ -176,8 +222,8 @@ def test_delete_add_item(delete_data):
     assert all(fields_data[k] == v for k, v in addfields.items())
 
 
-def test_delete_iter_items(delete_data):
-    ddata = delete_data()
+def test_delete_iter_items():
+    ddata = DeleteData(endpoint=GO_EP1_ID)
     # add item
     ddata.add_item("abc/")
     ddata.add_item("def/")
@@ -195,8 +241,8 @@ def test_delete_iter_items(delete_data):
     check_item(as_list[1], "def/")
 
 
-def test_transfer_iter_items(transfer_data):
-    tdata = transfer_data()
+def test_transfer_iter_items():
+    tdata = TransferData(source_endpoint=GO_EP1_ID, destination_endpoint=GO_EP2_ID)
     tdata.add_item("source/abc.txt", "dest/abc.txt")
     tdata.add_item("source/def/", "dest/def/", recursive=True)
 
@@ -220,9 +266,7 @@ def test_transfer_iter_items(transfer_data):
 @pytest.mark.parametrize("n_succeeded", [None, True, False])
 @pytest.mark.parametrize("n_failed", [None, True, False])
 @pytest.mark.parametrize("n_inactive", [None, True, False])
-def test_notification_options(
-    transfer_data, delete_data, n_succeeded, n_failed, n_inactive
-):
+def test_notification_options(n_succeeded, n_failed, n_inactive):
     notify_kwargs = {}
     if n_succeeded is not None:
         notify_kwargs["notify_on_succeeded"] = n_succeeded
@@ -231,8 +275,10 @@ def test_notification_options(
     if n_inactive is not None:
         notify_kwargs["notify_on_inactive"] = n_inactive
 
-    ddata = delete_data(**notify_kwargs)
-    tdata = transfer_data(**notify_kwargs)
+    ddata = DeleteData(endpoint=GO_EP1_ID, **notify_kwargs)
+    tdata = TransferData(
+        source_endpoint=GO_EP1_ID, destination_endpoint=GO_EP2_ID, **notify_kwargs
+    )
 
     def _default(x):
         return x if x is not None else True
@@ -263,34 +309,49 @@ def test_notification_options(
         (100, 100),
     ],
 )
-def test_tranfer_sync_levels_result(transfer_data, sync_level, result):
+def test_tranfer_sync_levels_result(sync_level, result):
     if isinstance(result, type) and issubclass(result, Exception):
         with pytest.raises(result):
-            transfer_data(sync_level=sync_level)
+            TransferData(
+                source_endpoint=GO_EP1_ID,
+                destination_endpoint=GO_EP2_ID,
+                sync_level=sync_level,
+            )
     else:
-        tdata = transfer_data(sync_level=sync_level)
+        tdata = TransferData(
+            source_endpoint=GO_EP1_ID,
+            destination_endpoint=GO_EP2_ID,
+            sync_level=sync_level,
+        )
         assert tdata["sync_level"] == result
 
 
 @pytest.mark.parametrize("datatype", ("transfer", "delete"))
 @pytest.mark.parametrize("value", (None, True, False))
-def test_skip_activation_check_supported(transfer_data, delete_data, datatype, value):
-    method = transfer_data if datatype == "transfer" else delete_data
+def test_skip_activation_check_supported(datatype, value):
+    def create(**kwargs):
+        if datatype == "transfer":
+            return TransferData(
+                source_endpoint=GO_EP1_ID, destination_endpoint=GO_EP2_ID, **kwargs
+            )
+        else:
+            return DeleteData(endpoint=GO_EP1_ID, **kwargs)
+
     if value is None:
         # not present if not provided as a param or provided as explicit None
-        assert "skip_activation_check" not in method()
+        assert "skip_activation_check" not in create()
     elif value:
-        data = method(skip_activation_check=True)
+        data = create(skip_activation_check=True)
         assert "skip_activation_check" in data
         assert data["skip_activation_check"] is True
     else:
-        data = method(skip_activation_check=False)
+        data = create(skip_activation_check=False)
         assert "skip_activation_check" in data
         assert data["skip_activation_check"] is False
 
 
-def test_add_filter_rule(transfer_data):
-    tdata = transfer_data()
+def test_add_filter_rule():
+    tdata = TransferData(source_endpoint=GO_EP1_ID, destination_endpoint=GO_EP2_ID)
     assert "filter_rules" not in tdata
 
     tdata.add_filter_rule("*.tgz", type="file")


### PR DESCRIPTION
### Motivation

We want to rework `TransferData` and `DeleteData` to not take a `TransferClient` as a parameter. For the near term, this means "allow `None`" and longer term it means "in SDKv4, remove this parameter".

Additionally, `submission_id` is a mismatch between the Transfer Action Provider[^1] and Transfer Task Submission APIs. The Action Provider is visible via Timer, so it's effectively a mismatch between what `TransferData` provides and what Timer requires.

Additionally, and somewhat relatedly, `TransferData` and `DeleteData` will pass explicit `null` values today (which the Transfer API accepts/ignores), but we'd like to remove this. That makes the documents better match user expectations.

[1]: I'm talking about the upcoming changes to the Transfer AP, not the current behavior.

### Implementation

Several fields in TransferData and DeleteData are good fits for the (relatively new) `_set_optstrs` and `_set_optbools` helpers. `sync_level` is actually a good fit for `_set_value` with a custom callback. Converting to these "automatically" handles removal of null values. This also uniformizes behavior between fields like `label` which had special handling to avoid passing `null` and various other fields.

The switch to allow for a `transfer_client` of `None` is relatively simple, and wraps the `get_submission_id` call with an `if None` check.

With this done, `TimerJob` can start rejecting documents which set `submission_id` or `skip_activation_check`, which are not valid for Transfer Action Provider inputs. I chose `ValueError` for this behavior because it seems the most straightforward approach.

As we have discussed on other occasions, this is "technically backwards incompatible", but I'm advocating for it in the "spirit rather than letter of semver".