### PR TITLE
Add __dir__ to the top-level SDK module

### DIFF
--- a/changelog.d/20220819_190305_sirosen_add_module_dirfunc.rst
+++ b/changelog.d/20220819_190305_sirosen_add_module_dirfunc.rst
@@ -1,0 +1,3 @@
+* Implement ``__dir__`` for the lazy importer in ``globus_sdk``. This
+  enables tab completion in the interpreter and other features with
+  rely upon ``dir(globus_sdk)`` (:pr:`NUMBER`)

--- a/src/globus_sdk/__init__.py
+++ b/src/globus_sdk/__init__.py
@@ -182,10 +182,18 @@ if typing.TYPE_CHECKING or sys.version_info < (3, 7):
 
 else:
     def __dir__() -> typing.List[str]:
-        return [
-            name
-            for modname, items in _LAZY_IMPORT_TABLE.items()
-            for name in items
+        # dir(globus_sdk) should include everything exported in __all__
+        # as well as some explicitly selected attributes from the default dir() output
+        # on a module
+        #
+        # see also:
+        # https://discuss.python.org/t/how-to-properly-extend-standard-dir-search-with-module-level-dir/4202
+        return list(__all__) + [
+            # __all__ itself can be inspected
+            "__all__",
+            # useful to figure out where a package is installed
+            "__file__",
+            "__path__",
         ]
 
     def __getattr__(name: str) -> typing.Any:

--- a/src/globus_sdk/__init__.py
+++ b/src/globus_sdk/__init__.py
@@ -181,6 +181,12 @@ if typing.TYPE_CHECKING or sys.version_info < (3, 7):
     from .services.transfer import TransferData
 
 else:
+    def __dir__() -> typing.List[str]:
+        return [
+            name
+            for modname, items in _LAZY_IMPORT_TABLE.items()
+            for name in items
+        ]
 
     def __getattr__(name: str) -> typing.Any:
         for modname, items in _LAZY_IMPORT_TABLE.items():

--- a/src/globus_sdk/_generate_init.py
+++ b/src/globus_sdk/_generate_init.py
@@ -180,10 +180,18 @@ def _init_pieces() -> Iterator[str]:
     yield """
 else:
     def __dir__() -> typing.List[str]:
-        return [
-            name
-            for modname, items in _LAZY_IMPORT_TABLE.items()
-            for name in items
+        # dir(globus_sdk) should include everything exported in __all__
+        # as well as some explicitly selected attributes from the default dir() output
+        # on a module
+        #
+        # see also:
+        # https://discuss.python.org/t/how-to-properly-extend-standard-dir-search-with-module-level-dir/4202
+        return list(__all__) + [
+            # __all__ itself can be inspected
+            "__all__",
+            # useful to figure out where a package is installed
+            "__file__",
+            "__path__",
         ]
 
     def __getattr__(name: str) -> typing.Any:

--- a/src/globus_sdk/_generate_init.py
+++ b/src/globus_sdk/_generate_init.py
@@ -179,6 +179,12 @@ def _init_pieces() -> Iterator[str]:
     yield from _generate_imports()
     yield """
 else:
+    def __dir__() -> typing.List[str]:
+        return [
+            name
+            for modname, items in _LAZY_IMPORT_TABLE.items()
+            for name in items
+        ]
 
     def __getattr__(name: str) -> typing.Any:
         for modname, items in _LAZY_IMPORT_TABLE.items():

--- a/tests/unit/test_lazy_imports.py
+++ b/tests/unit/test_lazy_imports.py
@@ -5,6 +5,10 @@ import pytest
 import globus_sdk
 
 
+def test_epxlicit_dir_func_works():
+    assert "TransferClient" in dir(globus_sdk)
+
+
 def test_force_eager_imports_can_run():
     # this check will not do much, other than ensuring that this does not crash
     globus_sdk._force_eager_imports()

--- a/tests/unit/test_lazy_imports.py
+++ b/tests/unit/test_lazy_imports.py
@@ -7,6 +7,7 @@ import globus_sdk
 
 def test_epxlicit_dir_func_works():
     assert "TransferClient" in dir(globus_sdk)
+    assert "__all__" in dir(globus_sdk)
 
 
 def test_force_eager_imports_can_run():


### PR DESCRIPTION
Explicit __dir__ is part of the PEP 562 spec which added module-level __getattr__. We were missing this function, which had limited negative impact other than the fact that `globus_sdk.Tr<TAB>` was not handled nicely by an interactive interpreter.

---

I encountered this while working on a distinct PR and finding that tab-complete was missing. A quick investigation revealed the missing function. `dir()` may also be used by pycharm and other IDEs to inspect the package, so it's worth including our implementation.