### PR TITLE
Add a minimal FlowsClient supporting list_flows

### DIFF
--- a/changelog.d/20220819_191430_sirosen_initial_flows_client.rst
+++ b/changelog.d/20220819_191430_sirosen_initial_flows_client.rst
@@ -1,0 +1,7 @@
+* Add an initial Globus Flows client class, ``globus_sdk.FlowsClient`` (:pr:`NUMBER`)
+** ``globus_sdk.FlowsAPIError`` is the error class for this client
+** ``FlowsClient.list_flows`` is implemented as a method for listing deployed
+   flows, with some of the filtering parameters of this API supported as
+   keyword arguments
+** The scopes for the Globus Flows API can be accessed via
+   ``globus_sdk.scopes.FlowsScopes`` or ``globus_sdk.FlowsClient.scopes``

--- a/docs/services/flows.rst
+++ b/docs/services/flows.rst
@@ -1,0 +1,20 @@
+Globus Flows
+=============
+
+.. currentmodule:: globus_sdk
+
+.. autoclass:: FlowsClient
+   :members:
+   :member-order: bysource
+   :show-inheritance:
+   :exclude-members: error_class
+
+Client Errors
+-------------
+
+When an error occurs, a :class:`FlowsClient` will raise a `FlowsAPIError`.
+
+.. autoclass:: FlowsAPIError
+   :members:
+   :show-inheritance:
+

--- a/docs/services/index.rst
+++ b/docs/services/index.rst
@@ -41,6 +41,7 @@ very simply::
     :maxdepth: 1
 
     auth
+    flows
     groups
     search
     timer

--- a/src/globus_sdk/__init__.py
+++ b/src/globus_sdk/__init__.py
@@ -79,6 +79,10 @@ _LAZY_IMPORT_TABLE = {
         "HPSSStoragePolicies",
         "UserCredentialDocument",
     },
+    "services.flows": {
+        "FlowsClient",
+        "FlowsAPIError",
+    },
     "services.groups": {
         "BatchMembershipActions",
         "GroupMemberVisibility",
@@ -157,6 +161,8 @@ if typing.TYPE_CHECKING or sys.version_info < (3, 7):
     from .services.gcs import IrodsStoragePolicies
     from .services.gcs import HPSSStoragePolicies
     from .services.gcs import UserCredentialDocument
+    from .services.flows import FlowsClient
+    from .services.flows import FlowsAPIError
     from .services.groups import BatchMembershipActions
     from .services.groups import GroupMemberVisibility
     from .services.groups import GroupPolicies
@@ -255,6 +261,8 @@ __all__ = (
     "IrodsStoragePolicies",
     "HPSSStoragePolicies",
     "UserCredentialDocument",
+    "FlowsClient",
+    "FlowsAPIError",
     "BatchMembershipActions",
     "GroupMemberVisibility",
     "GroupPolicies",

--- a/src/globus_sdk/__init__.py
+++ b/src/globus_sdk/__init__.py
@@ -82,6 +82,7 @@ _LAZY_IMPORT_TABLE = {
     "services.flows": {
         "FlowsClient",
         "FlowsAPIError",
+        "IterableFlowsResponse",
     },
     "services.groups": {
         "BatchMembershipActions",
@@ -163,6 +164,7 @@ if typing.TYPE_CHECKING or sys.version_info < (3, 7):
     from .services.gcs import UserCredentialDocument
     from .services.flows import FlowsClient
     from .services.flows import FlowsAPIError
+    from .services.flows import IterableFlowsResponse
     from .services.groups import BatchMembershipActions
     from .services.groups import GroupMemberVisibility
     from .services.groups import GroupPolicies
@@ -263,6 +265,7 @@ __all__ = (
     "UserCredentialDocument",
     "FlowsClient",
     "FlowsAPIError",
+    "IterableFlowsResponse",
     "BatchMembershipActions",
     "GroupMemberVisibility",
     "GroupPolicies",

--- a/src/globus_sdk/_generate_init.py
+++ b/src/globus_sdk/_generate_init.py
@@ -111,6 +111,7 @@ _LAZY_IMPORT_TABLE: List[Tuple[str, Tuple[str, ...]]] = [
         (
             "FlowsClient",
             "FlowsAPIError",
+            "IterableFlowsResponse",
         ),
     ),
     (

--- a/src/globus_sdk/_generate_init.py
+++ b/src/globus_sdk/_generate_init.py
@@ -107,6 +107,13 @@ _LAZY_IMPORT_TABLE: List[Tuple[str, Tuple[str, ...]]] = [
         ),
     ),
     (
+        "services.flows",
+        (
+            "FlowsClient",
+            "FlowsAPIError",
+        ),
+    ),
+    (
         "services.groups",
         (
             "BatchMembershipActions",

--- a/src/globus_sdk/_testing/data/flows/_common.py
+++ b/src/globus_sdk/_testing/data/flows/_common.py
@@ -1,0 +1,99 @@
+TWO_HOP_TRANSFER_FLOW_ID = "24bc4997-b483-4c25-a19c-64b0afc00743"
+TWO_HOP_TRANSFER_FLOW_DEFINITION = {
+    "States": {
+        "Transfer1": {
+            "Next": "Transfer2",
+            "Type": "Action",
+            "Comment": "Initial Transfer from Campus to DMZ",
+            "ActionUrl": "https://actions.globus.org/transfer/transfer",
+            "Parameters": {
+                "transfer_items": [
+                    {
+                        "recursive": True,
+                        "source_path.$": "$.source_path",
+                        "destination_path.$": "$.staging_path",
+                    }
+                ],
+                "source_endpoint_id.$": "$.source_endpoint_id",
+                "destination_endpoint_id.$": "$.staging_endpoint_id",
+            },
+            "ResultPath": "$.Transfer1Result",
+            "ActionScope": (
+                "https://auth.globus.org/scopes/actions.globus.org/transfer/transfer"
+            ),
+        },
+        "Transfer2": {
+            "End": True,
+            "Type": "Action",
+            "Comment": "Transfer from DMZ to dataset repository",
+            "ActionUrl": "https://actions.globus.org/transfer/transfer",
+            "Parameters": {
+                "transfer_items": [
+                    {
+                        "recursive": True,
+                        "source_path.$": "$.staging_path",
+                        "destination_path.$": "$.destination_path",
+                    }
+                ],
+                "source_endpoint_id.$": "$.staging_endpoint_id",
+                "destination_endpoint_id.$": "$.destination_endpoint_id",
+            },
+            "ResultPath": "$.Transfer2Result",
+            "ActionScope": (
+                "https://auth.globus.org/scopes/actions.globus.org/transfer/transfer"
+            ),
+        },
+    },
+    "Comment": "Two step transfer",
+    "StartAt": "Transfer1",
+}
+TWO_HOP_TRANSFER_FLOW_DOC = {
+    "id": TWO_HOP_TRANSFER_FLOW_ID,
+    "definition": TWO_HOP_TRANSFER_FLOW_DEFINITION,
+    "input_schema": {
+        "type": "object",
+        "required": [
+            "source_endpoint_id",
+            "source_path",
+            "staging_endpoint_id",
+            "staging_path",
+            "destination_endpoint_id",
+            "destination_path",
+        ],
+        "properties": {
+            "source_path": {"type": "string"},
+            "staging_path": {"type": "string"},
+            "destination_path": {"type": "string"},
+            "source_endpoint_id": {"type": "string"},
+            "staging_endpoint_id": {"type": "string"},
+            "destination_endpoint_id": {"type": "string"},
+        },
+        "additionalProperties": False,
+    },
+    "globus_auth_scope": "https://auth.globus.org/scopes/"
+    + TWO_HOP_TRANSFER_FLOW_ID
+    + "/flow_24bc4997_b483_4c25_a19c_64b0afc00743_user",
+    "synchronous": False,
+    "log_supported": True,
+    "types": ["Action"],
+    "api_version": "1.0",
+    "title": "Multi Step Transfer",
+    "subtitle": "",
+    "description": "",
+    "keywords": [],
+    "principal_urn": f"urn:globus:auth:identity:{TWO_HOP_TRANSFER_FLOW_ID}",
+    "globus_auth_username": (f"{TWO_HOP_TRANSFER_FLOW_ID}@clients.auth.globus.org"),
+    "created_at": "2020-09-01T17:59:20.711845+00:00",
+    "updated_at": "2020-09-01T17:59:20.711845+00:00",
+    "user_role": "flow_starter",
+    "created_by": "urn:globus:auth:identity:b44bddda-d274-11e5-978a-9f15789a8150",
+    "visible_to": [],
+    "runnable_by": [],
+    "administered_by": [],
+    "action_url": f"https://flows.globus.org/flows/{TWO_HOP_TRANSFER_FLOW_ID}",
+    "flow_url": f"https://flows.globus.org/flows/{TWO_HOP_TRANSFER_FLOW_ID}",
+    "flow_owner": "urn:globus:auth:identity:b44bddda-d274-11e5-978a-9f15789a8150",
+    "flow_viewers": [],
+    "flow_starters": [],
+    "flow_administrators": [],
+}

--- a/src/globus_sdk/_testing/data/flows/list_flows.py
+++ b/src/globus_sdk/_testing/data/flows/list_flows.py
@@ -1,0 +1,17 @@
+from globus_sdk._testing.models import RegisteredResponse, ResponseSet
+
+from ._common import TWO_HOP_TRANSFER_FLOW_DOC, TWO_HOP_TRANSFER_FLOW_ID
+
+RESPONSES = ResponseSet(
+    metadata={"first_flow_id": TWO_HOP_TRANSFER_FLOW_ID},
+    default=RegisteredResponse(
+        service="flows",
+        path="/flows",
+        json={
+            "flows": [TWO_HOP_TRANSFER_FLOW_DOC],
+            "limit": 20,
+            "has_next_page": False,
+            "marker": None,
+        },
+    ),
+)

--- a/src/globus_sdk/_testing/models.py
+++ b/src/globus_sdk/_testing/models.py
@@ -14,6 +14,7 @@ class RegisteredResponse:
         "gcs": "https://abc.xyz.data.globus.org/api",
         "groups": "https://groups.api.globus.org/v2/",
         "timer": "https://timer.automate.globus.org/",
+        "flows": "https://flows.automate.globus.org/",
     }
 
     def __init__(

--- a/src/globus_sdk/config/environments.py
+++ b/src/globus_sdk/config/environments.py
@@ -107,6 +107,7 @@ class ProductionEnvConfig(EnvConfig):
     domain = "globus.org"
     nexus_url = "https://nexus.api.globusonline.org/"
     timer_url = "https://timer.automate.globus.org/"
+    flows_url = "https://flows.automate.globus.org/"
     actions_url = "https://actions.automate.globus.org/"
 
 

--- a/src/globus_sdk/paging/marker.py
+++ b/src/globus_sdk/paging/marker.py
@@ -17,6 +17,7 @@ class MarkerPaginator(Paginator[PageT]):
         *,
         items_key: Optional[str] = None,
         marker_key: str = "marker",
+        marker_param_name: str = "marker",
         client_args: List[Any],
         client_kwargs: Dict[str, Any]
     ):
@@ -28,6 +29,7 @@ class MarkerPaginator(Paginator[PageT]):
         )
         self.marker: Optional[str] = None
         self.marker_key = marker_key
+        self.marker_param_name = marker_param_name
 
     def _check_has_next_page(self, page: Dict[str, Any]) -> bool:
         return bool(page.get("has_next_page", False))
@@ -36,7 +38,7 @@ class MarkerPaginator(Paginator[PageT]):
         has_next_page = True
         while has_next_page:
             if self.marker:
-                self.client_kwargs["marker"] = self.marker
+                self.client_kwargs[self.marker_param_name] = self.marker
             current_page = self.method(*self.client_args, **self.client_kwargs)
             yield current_page
             self.marker = current_page.get(self.marker_key)

--- a/src/globus_sdk/paging/marker.py
+++ b/src/globus_sdk/paging/marker.py
@@ -17,7 +17,6 @@ class MarkerPaginator(Paginator[PageT]):
         *,
         items_key: Optional[str] = None,
         marker_key: str = "marker",
-        marker_param_name: str = "marker",
         client_args: List[Any],
         client_kwargs: Dict[str, Any]
     ):
@@ -29,7 +28,6 @@ class MarkerPaginator(Paginator[PageT]):
         )
         self.marker: Optional[str] = None
         self.marker_key = marker_key
-        self.marker_param_name = marker_param_name
 
     def _check_has_next_page(self, page: Dict[str, Any]) -> bool:
         return bool(page.get("has_next_page", False))
@@ -38,7 +36,7 @@ class MarkerPaginator(Paginator[PageT]):
         has_next_page = True
         while has_next_page:
             if self.marker:
-                self.client_kwargs[self.marker_param_name] = self.marker
+                self.client_kwargs["marker"] = self.marker
             current_page = self.method(*self.client_args, **self.client_kwargs)
             yield current_page
             self.marker = current_page.get(self.marker_key)

--- a/src/globus_sdk/scopes.py
+++ b/src/globus_sdk/scopes.py
@@ -299,6 +299,21 @@ AuthScopes = _AuthScopesBuilder(
 """
 
 
+FlowsScopes = ScopeBuilder(
+    "eec9b274-0c81-4334-bdc2-54e90e689b9a",
+    known_url_scopes=[
+        "manage_flows",
+        "view_flows",
+        "run",
+        "run_status",
+        "run_manage",
+    ],
+)
+"""Globus Flows scopes.
+.. listknownscopes:: globus_sdk.scopes.FlowsScopes
+"""
+
+
 GroupsScopes = ScopeBuilder(
     "groups.api.globus.org",
     known_scopes=[

--- a/src/globus_sdk/services/flows/__init__.py
+++ b/src/globus_sdk/services/flows/__init__.py
@@ -1,7 +1,9 @@
 from .client import FlowsClient
 from .errors import FlowsAPIError
+from .response import IterableFlowsResponse
 
 __all__ = (
     "FlowsAPIError",
     "FlowsClient",
+    "IterableFlowsResponse",
 )

--- a/src/globus_sdk/services/flows/__init__.py
+++ b/src/globus_sdk/services/flows/__init__.py
@@ -1,0 +1,7 @@
+from .client import FlowsClient
+from .errors import FlowsAPIError
+
+__all__ = (
+    "FlowsAPIError",
+    "FlowsClient",
+)

--- a/src/globus_sdk/services/flows/client.py
+++ b/src/globus_sdk/services/flows/client.py
@@ -1,9 +1,10 @@
 import logging
 from typing import Any, Callable, Dict, Optional, TypeVar
 
-from globus_sdk import client, paging, response, scopes, utils
+from globus_sdk import client, paging, scopes, utils
 
 from .errors import FlowsAPIError
+from .response import IterableFlowsResponse
 
 log = logging.getLogger(__name__)
 
@@ -46,7 +47,7 @@ class FlowsClient(client.BaseClient):
         filter_role: Optional[str] = None,
         filter_fulltext: Optional[str] = None,
         query_params: Optional[Dict[str, Any]] = None,
-    ) -> response.GlobusHTTPResponse:
+    ) -> IterableFlowsResponse:
         """List deployed Flows
 
         :param filter_role: A role name specifying the minimum permissions required for
@@ -65,11 +66,11 @@ class FlowsClient(client.BaseClient):
         The valid values for ``role`` are, in order of precedence for ``filter_role``:
           - ``flow_viewer``
           - ``flow_starter``
-          - ``flow_administrators``
+          - ``flow_administrator``
           - ``flow_owner``
 
         For example, if ``flow_starter`` is specified then flows for which the user has
-        the ``flow_starter``, ``flow_administrators`` or ``flow_owner`` roles will be
+        the ``flow_starter``, ``flow_administrator`` or ``flow_owner`` roles will be
         returned.
         """
 
@@ -78,8 +79,8 @@ class FlowsClient(client.BaseClient):
         if filter_role is not None:
             query_params["filter_role"] = filter_role
         if filter_fulltext is not None:
-            query_params["filter_role"] = filter_role
+            query_params["filter_fulltext"] = filter_fulltext
         if pagination_token is not None:
             query_params["pagination_token"] = pagination_token
 
-        return self.get("/flows", query_params=query_params)
+        return IterableFlowsResponse(self.get("/flows", query_params=query_params))

--- a/src/globus_sdk/services/flows/client.py
+++ b/src/globus_sdk/services/flows/client.py
@@ -1,0 +1,85 @@
+import logging
+from typing import Any, Callable, Dict, Optional, TypeVar
+
+from globus_sdk import client, paging, response, scopes, utils
+
+from .errors import FlowsAPIError
+
+log = logging.getLogger(__name__)
+
+C = TypeVar("C", bound=Callable[..., Any])
+
+
+def _flowdoc(message: str, link: str) -> Callable[[C], C]:
+    # do not use functools.partial because it doesn't preserve type information
+    # see: https://github.com/python/mypy/issues/1484
+    def partial(func: C) -> C:
+        return utils.doc_api_method(
+            message,
+            link,
+            external_base_url="https://globusonline.github.io/flows#tag",
+        )(func)
+
+    return partial
+
+
+class FlowsClient(client.BaseClient):
+    r"""
+    Client for the Globus Flows API.
+
+    .. automethodlist:: globus_sdk.FlowsClient
+    """
+    error_class = FlowsAPIError
+    service_name = "flows"
+    scopes = scopes.FlowsScopes
+
+    @_flowdoc("List Flows", "Flows/paths/~1flows/get")
+    @paging.has_paginator(
+        paging.MarkerPaginator,
+        items_key="flows",
+        marker_param_name="pagination_token",
+    )
+    def list_flows(
+        self,
+        *,
+        pagination_token: Optional[str] = None,
+        filter_role: Optional[str] = None,
+        filter_fulltext: Optional[str] = None,
+        query_params: Optional[Dict[str, Any]] = None,
+    ) -> response.GlobusHTTPResponse:
+        """List deployed Flows
+
+        :param filter_role: A role name specifying the minimum permissions required for
+            a Flow to be included in the response.
+        :type filter_role: str, optional
+        :param filter_fulltext: A string to use in a full-text search to filter results
+        :type filter_fulltext: str, optional
+        :param pagination_token: A marker for pagination
+        :type pagination_token: str, optional
+        :param query_params: Any additional parameters to be passed through
+            as query params.
+        :type query_params: dict, optional
+
+        **Role Values**
+
+        The valid values for ``role`` are, in order of precedence for ``filter_role``:
+          - ``flow_viewer``
+          - ``flow_starter``
+          - ``flow_administrators``
+          - ``flow_owner``
+
+        For example, if ``flow_starter`` is specified then flows for which the user has
+        the ``flow_starter``, ``flow_administrators`` or ``flow_owner`` roles will be
+        returned.
+        """
+
+        if query_params is None:
+            query_params = {}
+        if filter_role is not None:
+            query_params["filter_role"] = filter_role
+        if filter_fulltext is not None:
+            query_params["filter_role"] = filter_role
+        if pagination_token is not None:
+            query_params["pagination_token"] = pagination_token
+
+        return self.get("/flows", query_params=query_params)

--- a/src/globus_sdk/services/flows/client.py
+++ b/src/globus_sdk/services/flows/client.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any, Callable, Dict, Optional, TypeVar
 
-from globus_sdk import client, paging, scopes, utils
+from globus_sdk import client, scopes, utils
 
 from .errors import FlowsAPIError
 from .response import IterableFlowsResponse
@@ -35,15 +35,9 @@ class FlowsClient(client.BaseClient):
     scopes = scopes.FlowsScopes
 
     @_flowdoc("List Flows", "Flows/paths/~1flows/get")
-    @paging.has_paginator(
-        paging.MarkerPaginator,
-        items_key="flows",
-        marker_param_name="pagination_token",
-    )
     def list_flows(
         self,
         *,
-        pagination_token: Optional[str] = None,
         filter_role: Optional[str] = None,
         filter_fulltext: Optional[str] = None,
         query_params: Optional[Dict[str, Any]] = None,
@@ -55,8 +49,6 @@ class FlowsClient(client.BaseClient):
         :type filter_role: str, optional
         :param filter_fulltext: A string to use in a full-text search to filter results
         :type filter_fulltext: str, optional
-        :param pagination_token: A marker for pagination
-        :type pagination_token: str, optional
         :param query_params: Any additional parameters to be passed through
             as query params.
         :type query_params: dict, optional
@@ -80,7 +72,5 @@ class FlowsClient(client.BaseClient):
             query_params["filter_role"] = filter_role
         if filter_fulltext is not None:
             query_params["filter_fulltext"] = filter_fulltext
-        if pagination_token is not None:
-            query_params["pagination_token"] = pagination_token
 
         return IterableFlowsResponse(self.get("/flows", query_params=query_params))

--- a/src/globus_sdk/services/flows/errors.py
+++ b/src/globus_sdk/services/flows/errors.py
@@ -1,0 +1,7 @@
+from globus_sdk.exc import GlobusAPIError
+
+
+class FlowsAPIError(GlobusAPIError):
+    """
+    Error class to represent error responses from Flows.
+    """

--- a/src/globus_sdk/services/flows/response.py
+++ b/src/globus_sdk/services/flows/response.py
@@ -1,0 +1,9 @@
+from globus_sdk import response
+
+
+class IterableFlowsResponse(response.IterableResponse):
+    """
+    An iterable response containing a "flows" array.
+    """
+
+    default_iter_key = "flows"

--- a/tests/functional/flows/conftest.py
+++ b/tests/functional/flows/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+
+import globus_sdk
+
+
+@pytest.fixture
+def flows_client(no_retry_transport):
+    class CustomFlowsClient(globus_sdk.FlowsClient):
+        transport_class = no_retry_transport
+
+    return CustomFlowsClient()

--- a/tests/functional/flows/test_list_flows.py
+++ b/tests/functional/flows/test_list_flows.py
@@ -1,9 +1,34 @@
-from globus_sdk._testing import load_response
+import urllib.parse
+
+import pytest
+
+from globus_sdk._testing import get_last_request, load_response
 
 
-def test_list_flows_simple(flows_client):
+@pytest.mark.parametrize("filter_fulltext", [None, "foo"])
+@pytest.mark.parametrize("filter_role", [None, "bar"])
+def test_list_flows_simple(flows_client, filter_fulltext, filter_role):
     meta = load_response(flows_client.list_flows).metadata
 
-    res = flows_client.list_flows()
+    add_kwargs = {}
+    if filter_fulltext:
+        add_kwargs["filter_fulltext"] = filter_fulltext
+    if filter_role:
+        add_kwargs["filter_role"] = filter_role
+
+    res = flows_client.list_flows(**add_kwargs)
     assert res.http_status == 200
+    # dict-like indexing
     assert meta["first_flow_id"] == res["flows"][0]["id"]
+    # list conversion (using __iter__) and indexing
+    assert meta["first_flow_id"] == list(res)[0]["id"]
+
+    req = get_last_request()
+    assert req.body is None
+    parsed_qs = urllib.parse.parse_qs(urllib.parse.urlparse(req.url).query)
+    expect_query_params = {
+        k: [v]
+        for k, v in (("filter_fulltext", filter_fulltext), ("filter_role", filter_role))
+        if v is not None
+    }
+    assert parsed_qs == expect_query_params

--- a/tests/functional/flows/test_list_flows.py
+++ b/tests/functional/flows/test_list_flows.py
@@ -1,0 +1,9 @@
+from globus_sdk._testing import load_response
+
+
+def test_list_flows_simple(flows_client):
+    meta = load_response(flows_client.list_flows).metadata
+
+    res = flows_client.list_flows()
+    assert res.http_status == 200
+    assert meta["first_flow_id"] == res["flows"][0]["id"]


### PR DESCRIPTION
FlowsClient is defined with the attributes and configuration needed to talk to the Globus Flows API. A single paginated method named "list_flows" is supplied, with only some of its (many) parameters provided as keyword arguments.

A data stub in _testing and a single test for the "simple listing case" are included the exercise the code and ensure the resolution of the service URL and other plumbing works as expected.

`_generate_init` is updated with the new module and its attributes.

One notable quirk of this client: the method is paginated, but the pagination parameter is named "pagination_token" rather than the more typical "marker". For this reason, the parameter name is now configurable when instantiating a MarkerPaginator. The paginated usage is not tested as of yet.