### PR TITLE
Minor doc fixes to handle warnings

### DIFF
--- a/docs/examples/guest_collection_creation.rst
+++ b/docs/examples/guest_collection_creation.rst
@@ -1,7 +1,7 @@
 .. _example_guest_collection_creation:
 
 Guest Collection Creation Script
-----------------------------
+--------------------------------
 
 The following is a script for a Globus client identity to create a GCSv5 guest
 collection on an existing mapped collection that it has a valid mapping for.

--- a/src/globus_sdk/services/gcs/client.py
+++ b/src/globus_sdk/services/gcs/client.py
@@ -498,7 +498,7 @@ class GCSClient(client.BaseClient):
         GET /user_credentials
 
         :param storage_gateway: UUID of a storage gateway to limit results to
-        :type storage_gateway
+        :type storage_gateway: str or UUID, optional
         :param query_params: Additional passthrough query parameters
         :type query_params: dict, optional
         """


### PR DESCRIPTION
Insufficient underline & incomplete param doc.
Discovered with `tox -e docs` which runs with warnings converted to errors.