### PR TITLE
Remap flows resource server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ dist
 globus_sdk.egg-info
 eggs/
 .eggs/
+.idea
 
 # virtualenv
 .venv/

--- a/changelog.d/20220920_132048_derek_remap_flows_resource_server.rst
+++ b/changelog.d/20220920_132048_derek_remap_flows_resource_server.rst
@@ -1,0 +1,1 @@
+* Remapped the flows service resource server from it's uuid to the configured dns (flows.globus.org). (:pr:`NUMBER`)

--- a/src/globus_sdk/scopes.py
+++ b/src/globus_sdk/scopes.py
@@ -299,8 +299,37 @@ AuthScopes = _AuthScopesBuilder(
 """
 
 
-FlowsScopes = ScopeBuilder(
+class _FlowsScopeBuilder(ScopeBuilder):
+    """
+    The Flows Service breaks the scopes/resource server convention:
+      its resource server is a domain name but its scopes are built around the client id
+    Given that there isn't a simple way to support this more generally
+      (and we shouldn't encourage supporting this more generally), this class serves to
+      build out the scopes accurately specifically for Flows
+    """
+
+    def __init__(
+        self,
+        domain_name: str,
+        client_id: str,
+        known_scopes: Union[List[str], str, None] = None,
+        known_url_scopes: Union[List[str], str, None] = None,
+    ) -> None:
+        self._client_id = client_id
+        super().__init__(
+            domain_name, known_scopes=known_scopes, known_url_scopes=known_url_scopes
+        )
+
+    def urn_scope_string(self, scope_name: str) -> str:
+        return f"urn:globus:auth:scope:{self._client_id}:{scope_name}"
+
+    def url_scope_string(self, scope_name: str) -> str:
+        return f"https://auth.globus.org/scopes/{self._client_id}/{scope_name}"
+
+
+FlowsScopes = _FlowsScopeBuilder(
     "flows.globus.org",
+    "eec9b274-0c81-4334-bdc2-54e90e689b9a",
     known_url_scopes=[
         "manage_flows",
         "view_flows",

--- a/src/globus_sdk/scopes.py
+++ b/src/globus_sdk/scopes.py
@@ -300,7 +300,7 @@ AuthScopes = _AuthScopesBuilder(
 
 
 FlowsScopes = ScopeBuilder(
-    "eec9b274-0c81-4334-bdc2-54e90e689b9a",
+    "flows.globus.org",
     known_url_scopes=[
         "manage_flows",
         "view_flows",

--- a/tests/unit/test_scopes.py
+++ b/tests/unit/test_scopes.py
@@ -2,7 +2,7 @@ import uuid
 
 import pytest
 
-from globus_sdk.scopes import MutableScope, ScopeBuilder
+from globus_sdk.scopes import FlowsScopes, MutableScope, ScopeBuilder
 
 
 def test_url_scope_string():
@@ -109,3 +109,11 @@ def test_scopebuilder_make_mutable_produces_same_strings():
     sb = ScopeBuilder(str(uuid.UUID(int=0)), known_scopes="foo", known_url_scopes="bar")
     assert str(sb.make_mutable("foo")) == sb.foo
     assert str(sb.make_mutable("bar")) == sb.bar
+
+
+def test_flows_scopes_creation():
+    assert FlowsScopes.resource_server == "flows.globus.org"
+    assert (
+        FlowsScopes.run
+        == "https://auth.globus.org/scopes/eec9b274-0c81-4334-bdc2-54e90e689b9a/run"
+    )


### PR DESCRIPTION
* Remapped the flows service resource server from it's uuid to the configured dns
   * This change is ultimately to support flows ingress into the broader globus-cli. The flows resource server registered in auth is the dns `flows.globus.org` rather than it's UUID client id `eec9b274-0c81-4334-bdc2-54e90e689b9a`. See the code snippet below for a demonstration of this

**Code Snippet demonstrating scopes-associated resource server name** *(relevent tokens/secrets removed for obvious reasons)*
```
import globus_sdk
...
client = globus_sdk.ConfidentialAppAuthClient(CLIENT_ID, CLIENT_SECRET)
requested_scopes = 'https://auth.globus.org/scopes/eec9b274-0c81-4334-bdc2-54e90e689b9a/view_flows'
client.oauth2_start_flow('https://localhost', requested_scopes=requested_scopes)
client.oauth2_get_authorize_url()
...
token_response = client.oauth2_exchange_code_for_tokens(AUTH_CODE)
token_response.by_resource_server.keys()
> dict_keys(['flows.globus.org'])
```

