### PR TITLE
Allow API consumers to specify connection params

### DIFF
--- a/changelog.d/20220922_151311_kevin_sqlite_adapter_connection_params.rst
+++ b/changelog.d/20220922_151311_kevin_sqlite_adapter_connection_params.rst
@@ -1,0 +1,1 @@
+* Add ``connect_params`` passthrough dictionary to ``SQLiteAdapter``, enabling fine-tuning of DB connection parameters (:pr:`NUMBER`)

--- a/tests/unit/test_tokenstorage.py
+++ b/tests/unit/test_tokenstorage.py
@@ -31,6 +31,13 @@ VALUES (?, ?, ?)""",
         adapter.get_token_data("foo_rs")
 
 
+def test_sqliteadapter_passes_connect_params():
+    with pytest.raises(TypeError):
+        SQLiteAdapter(":memory:", connect_params={"invalid_kwarg": True})
+
+    SQLiteAdapter(":memory:", connect_params={"timeout": 10})
+
+
 def test_simplejson_reading_bad_data(tmp_path):
     # non-dict data at root
     foo_file = tmp_path / "foo.json"


### PR DESCRIPTION
There's no SDK-specific need to protect the connection parameters to the DB; enable motivated coders to fine-tune the connection.