### PR TITLE
Fix changelog rst bullet point nesting

### DIFF
--- a/changelog.d/20221012_102848_derek_fix_changelog_formatting.rst
+++ b/changelog.d/20221012_102848_derek_fix_changelog_formatting.rst
@@ -1,0 +1,2 @@
+
+* Fixed rst formatting for a few nested bullet points in existing changelog (:pr:`NUMBER`)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,10 +19,11 @@ v3.12.0 (2022-09-21)
 
 * Add Mapped Collection policy helper types for constructing ``policies`` data. (:pr:`607`)
   The following new types are introduced:
-** ``CollectionPolicies`` (the base class for these types)
-** ``POSIXCollectionPolicies``
-** ``POSIXStagingCollectionPolicies``
-** ``GoogleCloudStorageCollectionPolicies``
+
+  * ``CollectionPolicies`` (the base class for these types)
+  * ``POSIXCollectionPolicies``
+  * ``POSIXStagingCollectionPolicies``
+  * ``GoogleCloudStorageCollectionPolicies``
 
 * Fix bug where ``UserCredential`` policies were being converted to a string (:pr:`608`)
 
@@ -36,22 +37,23 @@ v3.11.0 (2022-08-30)
 * Adjust behaviors of ``TransferData`` and ``TimerJob`` to make
   ``TimerJob.from_transfer_data`` work and to defer requesting the
   ``submission_id`` until the task submission call (:pr:`602`)
-** ``TransferData`` avoids passing ``null`` for several values when they are
-   omitted, ranging from optional parameters to ``add_item`` to
-   ``skip_activation_check``
-** ``TransferData`` and ``DeleteData`` now support usage in which the
+
+  * ``TransferData`` avoids passing ``null`` for several values when they are
+    omitted, ranging from optional parameters to ``add_item`` to
+    ``skip_activation_check``
+  * ``TransferData`` and ``DeleteData`` now support usage in which the
     ``transfer_client`` parameters is ``None``. In these cases, if
     ``submission_id`` is omitted, it will be omitted from the document,
     allowing the creation of a partial task submsision document with no
     ``submission_id``
-** ``TimerJob.from_transfer_data`` will now raise a ``ValueError`` if the input
-   document contains ``submission_id`` or ``skip_activation_check``
-** ``TransferClient.submit_transfer`` and ``TransferClient.submit_delete`` now
-   check to see if the data being sent contains a ``submission_id``. If it does
-   not, ``get_submission_id`` is called automatically and set as the
-   ``submission_id`` on the payload. The new ``submission_id`` is set on the
-   object passed to these methods, meaning that these methods are now
-   side-effecting.
+  * ``TimerJob.from_transfer_data`` will now raise a ``ValueError`` if the input
+    document contains ``submission_id`` or ``skip_activation_check``
+  * ``TransferClient.submit_transfer`` and ``TransferClient.submit_delete`` now
+    check to see if the data being sent contains a ``submission_id``. If it does
+    not, ``get_submission_id`` is called automatically and set as the
+    ``submission_id`` on the payload. The new ``submission_id`` is set on the
+    object passed to these methods, meaning that these methods are now
+    side-effecting.
 
 The newly recommended usage for ``TransferData`` and ``DeleteData`` is to pass
 the endpoints as named parameters:
@@ -77,12 +79,13 @@ the endpoints as named parameters:
   rely upon ``dir(globus_sdk)`` (:pr:`603`)
 
 * Add an initial Globus Flows client class, ``globus_sdk.FlowsClient`` (:pr:`604`)
-** ``globus_sdk.FlowsAPIError`` is the error class for this client
-** ``FlowsClient.list_flows`` is implemented as a method for listing deployed
-   flows, with some of the filtering parameters of this API supported as
-   keyword arguments
-** The scopes for the Globus Flows API can be accessed via
-   ``globus_sdk.scopes.FlowsScopes`` or ``globus_sdk.FlowsClient.scopes``
+
+  * ``globus_sdk.FlowsAPIError`` is the error class for this client
+  * ``FlowsClient.list_flows`` is implemented as a method for listing deployed
+    flows, with some of the filtering parameters of this API supported as
+    keyword arguments
+  * The scopes for the Globus Flows API can be accessed via
+    ``globus_sdk.scopes.FlowsScopes`` or ``globus_sdk.FlowsClient.scopes``
 
 .. _changelog-3.10.1:
 
@@ -496,20 +499,20 @@ v3.0.0a3 (2021-06-25)
 
 * Pagination has changed significantly. (:pr:`418`)
 
-** Methods which support pagination like ``TransferClient.endpoint_search`` no
-   longer return an iterable ``PaginatedResource`` type. Instead, these client
-   methods return ``GlobusHTTPResponse`` objects with a single page of results.
+  * Methods which support pagination like ``TransferClient.endpoint_search`` no
+    longer return an iterable ``PaginatedResource`` type. Instead, these client
+    methods return ``GlobusHTTPResponse`` objects with a single page of results.
 
-** Paginated variants of these methods are available by renaming a call from
-   ``client.<method>`` to ``client.paginated.<method>``. So, for example, a
-   ``TransferClient`` now supports ``client.paginated.endpoint_search()``.
-   The arguments to this function are the same as the original method.
+  * Paginated variants of these methods are available by renaming a call from
+    ``client.<method>`` to ``client.paginated.<method>``. So, for example, a
+    ``TransferClient`` now supports ``client.paginated.endpoint_search()``.
+    The arguments to this function are the same as the original method.
 
-** ``client.paginated.<method>`` calls return ``Paginator`` objects, which
-   support two types of iteration: by ``pages()`` and by ``items()``. To
-   replicate the same behavior as SDK v1.x and v2.x ``PaginatedResource``
-   types, use ``items()``, as in
-   ``client.paginated.endpoint_search("query").items()``
+  * ``client.paginated.<method>`` calls return ``Paginator`` objects, which
+    support two types of iteration: by ``pages()`` and by ``items()``. To
+    replicate the same behavior as SDK v1.x and v2.x ``PaginatedResource``
+    types, use ``items()``, as in
+    ``client.paginated.endpoint_search("query").items()``
 
 v3.0.0a2 (2021-06-10)
 ---------------------


### PR DESCRIPTION
Fixed the bullet point nesting for select malformed locations in existing changelog.

`tox -e docs` was outputting the following warning (interpretted by sphinx as an error) for me locally:
```
Warning, treated as error:
<truncated>/changelog.rst:22:Bullet list ends without a blank line; unexpected unindent.
```

The current [public changelog](https://globus-sdk-python.readthedocs.io/en/stable/changelog.html) doesn't render these locations as intended.

**Snapshot of Readthedocs changelog**
![image](https://user-images.githubusercontent.com/113056046/195383627-88e0c135-7caf-49dc-8cbf-1ff9e837cef1.png)

**Snapshot of tox-locally built changelog after this change**
![image](https://user-images.githubusercontent.com/113056046/195384165-cc84df88-7921-45bc-a56b-705abf700899.png)

