### PR TITLE
Move mypy out of pre-commit (tox only)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,16 +35,6 @@ repos:
   hooks:
     - id: pyupgrade
       args: ["--py36-plus"]
-- repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.982
-  hooks:
-    - id: mypy
-      files: ^src/globus_sdk/
-      additional_dependencies:
-        - types-docutils
-        - types-jwt
-        - types-requests
-        - responses  # signatures for code in `_testing`
 
 # custom local hooks
 - repo: local

--- a/setup.py
+++ b/setup.py
@@ -3,19 +3,12 @@ import re
 
 from setuptools import find_packages, setup
 
-MYPY_REQUIREMENTS = [
-    "mypy==0.960",
-    "types-docutils",
-    "types-jwt",
-    "types-requests",
-    "typing-extensions",
-]
 LINT_REQUIREMENTS = [
     "flake8<5",
     "isort<6",
     "black==21.12b0",
     "flake8-bugbear==21.11.29",
-] + MYPY_REQUIREMENTS
+]
 TEST_REQUIREMENTS = [
     "pytest<7",
     "coverage<7",

--- a/tox.ini
+++ b/tox.ini
@@ -42,13 +42,17 @@ deps = pre-commit<3
 skip_install = true
 commands = pre-commit run --all-files
 
-[testenv:mypy{,-mindeps}]
-deps = mindeps: typing_extensions==4.0
-commands = mypy src/ {posargs}
-
-[testenv:mypy-test]
-deps = mypy==0.960
-commands = mypy --show-error-codes --warn-unused-ignores tests/non-pytest/mypy-ignore-tests/
+[testenv:mypy{,-mindeps,-test}]
+deps =
+    mypy==0.982
+    types-docutils
+    types-jwt
+    types-requests
+    typing-extensions>=4.0
+    mindeps: typing_extensions==4.0
+commands =
+    !test: mypy src/ {posargs}
+    test: mypy --show-error-codes --warn-unused-ignores tests/non-pytest/mypy-ignore-tests/
 
 [testenv:test-lazy-imports]
 # these tests are slow and CPU-bound, so they are run with xdist `-n auto` for speed


### PR DESCRIPTION
mypy under pre-commit can cause issues. Firstly, the version of mypy itself, and typestubs, can drift out of sync with the version used by developers outside of pre-commit (e.g. under `tox -e mypy`). Beyond this, there's an issue with mypy behavior in that it requires that all of the dependencies of the package under test be installed. Therefore, there's a need for the pre-commit hook to specify the equivalent of `additional_dependencies: ['-e .']` (which does not work).

mypy under `tox`, by contrast, installs the application or library under test, and therefore can resolve dependencies according to package metadata correctly. The result is that `globus-sdk[dev]` is installed in the environment where `mypy` is running, and the packages are all available without extra or duplicate specification of the dependencies.

In `tox.ini`, `mypy==0.982` (current latest) is now specified, and `mypy` is removed from any of the dependencies specified in the `globus-sdk[dev]` extra. The reason for this change is that `tox` will recreate a virtualenv if the `deps` listed for it are updated, but it will not (under tox v3) transitively resolve dependencies of the locally defined package in order to invalidate "cached" environments. Therefore, with `mypy==...` specified in `tox.ini`, an update to `mypy` will force a `tox -e mypy` run to accurately update mypy for any developer.

In order for `tox.ini` to share a mypy version between `mypy,mypy-mindeps` and `mypy-test`, a slightly clunky usage of tox factors (`test: ...`, `!test: ...`) is needed, but this does more good than harm in that it ensures that the `mypy` version is kept in sync between these targets and only costs us some awkwardness in how commands are specified.

In effect, this change is:
- `pre-commit` will not run `mypy`
- `tox -e mypy` still exists
- `tox -e mypy` has "better cache busting"
- `make lint` still runs `tox -e mypy` as part of its targets
- GitHub Actions CI still runs `tox -e mypy,...`