### PR TITLE
Add pagination back to FlowsClient.list_flows

### DIFF
--- a/changelog.d/20221012_190435_sirosen_paginated_flows_list.rst
+++ b/changelog.d/20221012_190435_sirosen_paginated_flows_list.rst
@@ -1,0 +1,1 @@
+* ``FlowsClient.list_flows`` now supports pagination (:pr:`NUMBER`)

--- a/src/globus_sdk/services/flows/client.py
+++ b/src/globus_sdk/services/flows/client.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any, Callable, Dict, List, Optional, TypeVar
 
-from globus_sdk import GlobusHTTPResponse, client, scopes, utils
+from globus_sdk import GlobusHTTPResponse, client, paging, scopes, utils
 from globus_sdk._types import UUIDLike
 from globus_sdk.authorizers import GlobusAuthorizer
 from globus_sdk.scopes import ScopeBuilder
@@ -170,11 +170,13 @@ class FlowsClient(client.BaseClient):
         return self.post("/flows", data=data)
 
     @_flowdoc("List Flows", "Flows/paths/~1flows/get")
+    @paging.has_paginator(paging.MarkerPaginator, items_key="flows")
     def list_flows(
         self,
         *,
         filter_role: Optional[str] = None,
         filter_fulltext: Optional[str] = None,
+        marker: Optional[str] = None,
         query_params: Optional[Dict[str, Any]] = None,
     ) -> IterableFlowsResponse:
         """List deployed Flows
@@ -184,6 +186,8 @@ class FlowsClient(client.BaseClient):
         :type filter_role: str, optional
         :param filter_fulltext: A string to use in a full-text search to filter results
         :type filter_fulltext: str, optional
+        :param marker: A marker for pagination
+        :type marker: str, optional
         :param query_params: Any additional parameters to be passed through
             as query params.
         :type query_params: dict, optional
@@ -207,6 +211,8 @@ class FlowsClient(client.BaseClient):
             query_params["filter_role"] = filter_role
         if filter_fulltext is not None:
             query_params["filter_fulltext"] = filter_fulltext
+        if marker is not None:
+            query_params["marker"] = marker
 
         return IterableFlowsResponse(self.get("/flows", query_params=query_params))
 

--- a/tests/functional/flows/test_list_flows.py
+++ b/tests/functional/flows/test_list_flows.py
@@ -18,7 +18,10 @@ OWNER_ID = "e061df5a-b7b9-4578-a73b-6d4a4edfd66e"
 
 def generate_hello_world_example_flow(n: int) -> Dict[str, Any]:
     flow_id = str(uuid.UUID(int=n))
-    base_time = datetime.datetime.fromisoformat("2021-10-18T19:19:35.967289+00:00")
+    # base_time = datetime.datetime.fromisoformat("2021-10-18T19:19:35.967289+00:00")
+    base_time = datetime.datetime(
+        2021, 10, 18, 19, 19, 35, 967289, tzinfo=datetime.timezone.utc
+    )
     updated_at = created_at = base_time + datetime.timedelta(days=n)
     flow_user_scope = (
         f"https://auth.globus.org/scopes/{flow_id}/"

--- a/tests/functional/flows/test_list_flows.py
+++ b/tests/functional/flows/test_list_flows.py
@@ -1,4 +1,5 @@
 import datetime
+import sys
 import urllib.parse
 import uuid
 from typing import Any, Dict
@@ -18,10 +19,13 @@ OWNER_ID = "e061df5a-b7b9-4578-a73b-6d4a4edfd66e"
 
 def generate_hello_world_example_flow(n: int) -> Dict[str, Any]:
     flow_id = str(uuid.UUID(int=n))
-    # base_time = datetime.datetime.fromisoformat("2021-10-18T19:19:35.967289+00:00")
-    base_time = datetime.datetime(
-        2021, 10, 18, 19, 19, 35, 967289, tzinfo=datetime.timezone.utc
-    )
+    if sys.version_info < (3, 7):
+        # old branch which pyupgrade will remove when we drop py3.6
+        base_time = datetime.datetime(
+            2021, 10, 18, 19, 19, 35, 967289, tzinfo=datetime.timezone.utc
+        )
+    else:
+        base_time = datetime.datetime.fromisoformat("2021-10-18T19:19:35.967289+00:00")
     updated_at = created_at = base_time + datetime.timedelta(days=n)
     flow_user_scope = (
         f"https://auth.globus.org/scopes/{flow_id}/"

--- a/tests/functional/flows/test_list_flows.py
+++ b/tests/functional/flows/test_list_flows.py
@@ -1,8 +1,132 @@
+import datetime
 import urllib.parse
+import uuid
+from typing import Any, Dict
 
 import pytest
+from responses import matchers
 
-from globus_sdk._testing import get_last_request, load_response
+from globus_sdk._testing import (
+    get_last_request,
+    load_response,
+    load_response_set,
+    register_response_set,
+)
+
+OWNER_ID = "e061df5a-b7b9-4578-a73b-6d4a4edfd66e"
+
+
+def generate_hello_world_example_flow(n: int) -> Dict[str, Any]:
+    flow_id = str(uuid.UUID(int=n))
+    base_time = datetime.datetime.fromisoformat("2021-10-18T19:19:35.967289+00:00")
+    updated_at = created_at = base_time + datetime.timedelta(days=n)
+    flow_user_scope = (
+        f"https://auth.globus.org/scopes/{flow_id}/"
+        f"flow_{flow_id.replace('-', '_')}_user"
+    )
+
+    return {
+        "action_url": f"https://flows.automate.globus.org/flows/{flow_id}",
+        "administered_by": [],
+        "api_version": "1.0",
+        "created_at": created_at.isoformat() + "+00:00",
+        "created_by": f"urn:globus:auth:identity:{OWNER_ID}",
+        "definition": {
+            "StartAt": "HelloWorld",
+            "States": {
+                "HelloWorld": {
+                    "ActionScope": (
+                        "https://auth.globus.org/scopes/actions.globus.org/hello_world"
+                    ),
+                    "ActionUrl": "https://actions.globus.org/hello_world",
+                    "End": True,
+                    "Parameters": {"echo_string": "Hello, World."},
+                    "ResultPath": "$.Result",
+                    "Type": "Action",
+                }
+            },
+        },
+        "description": "A simple Flow...",
+        "flow_administrators": [],
+        "flow_owner": f"urn:globus:auth:identity:{OWNER_ID}",
+        "flow_starters": [],
+        "flow_url": f"https://flows.automate.globus.org/flows/{flow_id}",
+        "flow_viewers": [],
+        "globus_auth_scope": flow_user_scope,
+        "globus_auth_username": f"{flow_id}@clients.auth.globus.org",
+        "id": str(flow_id),
+        "input_schema": {
+            "additionalProperties": False,
+            "properties": {
+                "echo_string": {"description": "The string to echo", "type": "string"},
+                "sleep_time": {"type": "integer"},
+            },
+            "required": ["echo_string", "sleep_time"],
+            "type": "object",
+        },
+        "keywords": [],
+        "log_supported": True,
+        "principal_urn": f"urn:globus:auth:identity:{flow_id}",
+        "runnable_by": [],
+        "subtitle": "",
+        "synchronous": False,
+        "title": f"Hello, World (Example {n})",
+        "types": ["Action"],
+        "updated_at": updated_at.isoformat() + "+00:00",
+        "user_role": "flow_viewer",
+        "visible_to": [],
+    }
+
+
+@pytest.fixture(autouse=True, scope="session")
+def setup_paginated_responses() -> None:
+    register_response_set(
+        "list_flows_paginated",
+        {
+            "page0": dict(
+                service="flows",
+                path="/flows",
+                json={
+                    "flows": [generate_hello_world_example_flow(i) for i in range(20)],
+                    "limit": 20,
+                    "has_next_page": True,
+                    "marker": "fake_marker_0",
+                },
+            ),
+            "page1": dict(
+                service="flows",
+                path="/flows",
+                json={
+                    "flows": [
+                        generate_hello_world_example_flow(i) for i in range(20, 40)
+                    ],
+                    "limit": 20,
+                    "has_next_page": True,
+                    "marker": "fake_marker_1",
+                },
+                match=[matchers.query_param_matcher({"marker": "fake_marker_0"})],
+            ),
+            "page2": dict(
+                service="flows",
+                path="/flows",
+                json={
+                    "flows": [
+                        generate_hello_world_example_flow(i) for i in range(40, 60)
+                    ],
+                    "limit": 20,
+                    "has_next_page": False,
+                    "marker": None,
+                },
+                match=[matchers.query_param_matcher({"marker": "fake_marker_1"})],
+            ),
+        },
+        metadata={
+            "owner_id": OWNER_ID,
+            "num_pages": 3,
+            "expect_markers": ["fake_marker_0", "fake_marker_1", None],
+            "total_items": 60,
+        },
+    )
 
 
 @pytest.mark.parametrize("filter_fulltext", [None, "foo"])
@@ -32,3 +156,25 @@ def test_list_flows_simple(flows_client, filter_fulltext, filter_role):
         if v is not None
     }
     assert parsed_qs == expect_query_params
+
+
+@pytest.mark.parametrize("by_pages", [True, False])
+def test_list_flows_paginated(flows_client, by_pages):
+    meta = load_response_set("list_flows_paginated").metadata
+    total_items = meta["total_items"]
+    num_pages = meta["num_pages"]
+    expect_markers = meta["expect_markers"]
+
+    res = flows_client.paginated.list_flows()
+    if by_pages:
+        pages = list(res)
+        assert len(pages) == num_pages
+        for i, page in enumerate(pages):
+            assert page["marker"] == expect_markers[i]
+            if i < num_pages - 1:
+                assert page["has_next_page"] is True
+            else:
+                assert page["has_next_page"] is False
+    else:
+        items = list(res.items())
+        assert len(items) == total_items


### PR DESCRIPTION
The bulk of this change is a response data generator which produces test data. Although it would be nice to put this set of responses into the `_testing` data, it's not 100% clear *where* it should go. For now, this changeset punts on that question and puts the test data into the test module.

Now that Flows is supporting `marker`, the most barebones application of the pagination decorator for marker pagination is sufficient.