### PR TITLE
Add ``orderby`` to params for ``list_flows``

### DIFF
--- a/changelog.d/20221013_144254_sirosen_flows_list_supports_orderby.rst
+++ b/changelog.d/20221013_144254_sirosen_flows_list_supports_orderby.rst
@@ -1,0 +1,1 @@
+* Add support for ``orderby`` to ``FlowsClient.list_flows`` (:pr:`NUMBER`)

--- a/src/globus_sdk/services/flows/client.py
+++ b/src/globus_sdk/services/flows/client.py
@@ -176,6 +176,7 @@ class FlowsClient(client.BaseClient):
         *,
         filter_role: Optional[str] = None,
         filter_fulltext: Optional[str] = None,
+        orderby: Optional[str] = None,
         marker: Optional[str] = None,
         query_params: Optional[Dict[str, Any]] = None,
     ) -> IterableFlowsResponse:
@@ -186,6 +187,8 @@ class FlowsClient(client.BaseClient):
         :type filter_role: str, optional
         :param filter_fulltext: A string to use in a full-text search to filter results
         :type filter_fulltext: str, optional
+        :param orderby: A criterion for ordering flows in the listing
+        :type orderby: str, optional
         :param marker: A marker for pagination
         :type marker: str, optional
         :param query_params: Any additional parameters to be passed through
@@ -203,6 +206,22 @@ class FlowsClient(client.BaseClient):
         For example, if ``flow_starter`` is specified then flows for which the user has
         the ``flow_starter``, ``flow_administrator`` or ``flow_owner`` roles will be
         returned.
+
+        **OrderBy Values**
+
+        Values for ``orderby`` consist of a field name, a space, and an
+        ordering mode -- ``ASC`` for "ascending" and ``DESC`` for "descending".
+        Supported field names are
+          - ``id``
+          - ``scope_string``
+          - ``flow_owners``
+          - ``flow_administrators``
+          - ``title``
+          - ``created_at``
+          - ``updated_at``
+
+        For example, ``orderby="updated_at DESC"`` requests a descending sort on update
+        times, getting the most recently updated flow first.
         """
 
         if query_params is None:
@@ -211,6 +230,8 @@ class FlowsClient(client.BaseClient):
             query_params["filter_role"] = filter_role
         if filter_fulltext is not None:
             query_params["filter_fulltext"] = filter_fulltext
+        if orderby is not None:
+            query_params["orderby"] = orderby
         if marker is not None:
             query_params["marker"] = marker
 

--- a/tests/functional/flows/test_list_flows.py
+++ b/tests/functional/flows/test_list_flows.py
@@ -138,7 +138,8 @@ def setup_paginated_responses() -> None:
 
 @pytest.mark.parametrize("filter_fulltext", [None, "foo"])
 @pytest.mark.parametrize("filter_role", [None, "bar"])
-def test_list_flows_simple(flows_client, filter_fulltext, filter_role):
+@pytest.mark.parametrize("orderby", [None, "created_at ASC"])
+def test_list_flows_simple(flows_client, filter_fulltext, filter_role, orderby):
     meta = load_response(flows_client.list_flows).metadata
 
     add_kwargs = {}
@@ -146,6 +147,8 @@ def test_list_flows_simple(flows_client, filter_fulltext, filter_role):
         add_kwargs["filter_fulltext"] = filter_fulltext
     if filter_role:
         add_kwargs["filter_role"] = filter_role
+    if orderby:
+        add_kwargs["orderby"] = orderby
 
     res = flows_client.list_flows(**add_kwargs)
     assert res.http_status == 200
@@ -159,7 +162,11 @@ def test_list_flows_simple(flows_client, filter_fulltext, filter_role):
     parsed_qs = urllib.parse.parse_qs(urllib.parse.urlparse(req.url).query)
     expect_query_params = {
         k: [v]
-        for k, v in (("filter_fulltext", filter_fulltext), ("filter_role", filter_role))
+        for k, v in (
+            ("filter_fulltext", filter_fulltext),
+            ("filter_role", filter_role),
+            ("orderby", orderby),
+        )
         if v is not None
     }
     assert parsed_qs == expect_query_params


### PR DESCRIPTION
This allows ``orderby="updated_at DESC"`` usage and similar.

---

Missing support for ``orderby`` was noted in `globus-cli`.

I briefly considered using `typing.Literal`, allowing for a tuple input, and even setting a default, i.e.
```python
orderby: None | str | tuple[Literal["updated_at", ...], Literal["ASC", "DESC"]]] = ("updated_at", "DESC"),
```
but this made the change a bit unweildy. I also found it awkward to specify all of the string values as a literal, as in
```python
_KNOWN_ORDERBY_VALUES = Literal["updated_at ASC", "updated_at DESC", ...]
...
orderby: None | _KNOWN_ORDERBY_VALUES
```

So ultimately I stuck with `str | None` as the simplest approach. Fancier forms can be added as future refinements.