### PR TITLE
Update flake8-typing-as-t, remove TYT03 ignores

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
       name: "Lint python files"
       additional_dependencies:
         - 'flake8-bugbear==22.7.1'
-        - 'flake8-typing-as-t==0.0.1'
+        - 'flake8-typing-as-t==0.0.2'
 - repo: https://github.com/PyCQA/isort
   rev: 5.10.1
   hooks:

--- a/src/globus_sdk/paging/base.py
+++ b/src/globus_sdk/paging/base.py
@@ -7,7 +7,7 @@ import typing as t
 from globus_sdk.response import GlobusHTTPResponse
 
 if sys.version_info >= (3, 10):
-    from typing import ParamSpec  # noqa: TYT03
+    from typing import ParamSpec
 else:
     from typing_extensions import ParamSpec
 

--- a/src/globus_sdk/services/auth/client/base.py
+++ b/src/globus_sdk/services/auth/client/base.py
@@ -10,7 +10,7 @@ from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 if sys.version_info >= (3, 8):
     # pylint can't handle quoted annotations yet:
     # https://github.com/PyCQA/pylint/issues/3299
-    from typing import Literal  # pylint: disable=unused-import  # noqa: TYT03
+    from typing import Literal  # pylint: disable=unused-import
 else:
     from typing_extensions import Literal
 

--- a/src/globus_sdk/services/gcs/data/_common.py
+++ b/src/globus_sdk/services/gcs/data/_common.py
@@ -4,7 +4,7 @@ import typing as t
 if sys.version_info < (3, 8):
     from typing_extensions import Protocol
 else:
-    from typing import Protocol  # noqa: TYT03
+    from typing import Protocol
 
 
 class DocumentWithInducedDatatype(Protocol):

--- a/src/globus_sdk/services/transfer/data/transfer_data.py
+++ b/src/globus_sdk/services/transfer/data/transfer_data.py
@@ -4,7 +4,7 @@ import sys
 import typing as t
 
 if sys.version_info >= (3, 8):
-    from typing import Literal  # noqa: TYT03
+    from typing import Literal
 else:
     from typing_extensions import Literal
 


### PR DESCRIPTION
flake8-typing-as-t now understands version_info inspection, so it is not necessary to ignore conditional 'from typing import ...' usage.