### PR TITLE
Support python 3.11

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,14 +31,14 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
         # we do not want a large number of windows and macos builds, so
         # enumerate them explicitly
         include:
           - os: windows-latest
-            python-version: "3.10"
+            python-version: "3.11"
           - os: macos-latest
-            python-version: "3.10"
+            python-version: "3.11"
     name: "test py${{ matrix.python-version }} on ${{ matrix.os }} "
     runs-on: ${{ matrix.os }}
     steps:
@@ -80,7 +80,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: install tox
         run: python -m pip install -U tox
       - name: check package metadata

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,7 +6,7 @@ sphinx:
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.10"
+    python: "3.11"
 
 python:
   install:

--- a/changelog.d/20221027_192405_sirosen_add_3_11.rst
+++ b/changelog.d/20221027_192405_sirosen_add_3_11.rst
@@ -1,0 +1,1 @@
+* Python 3.11 is now officially supported (:pr:`NUMBER`)

--- a/changelog.d/20221027_201213_sirosen_support_py311.rst
+++ b/changelog.d/20221027_201213_sirosen_support_py311.rst
@@ -1,0 +1,2 @@
+* Add a `close()` method to `SQLiteAdapter` which closes the underlying
+  connection (:pr:`NUMBER`)

--- a/setup.py
+++ b/setup.py
@@ -90,5 +90,6 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
 )

--- a/src/globus_sdk/tokenstorage/sqlite_adapter.py
+++ b/src/globus_sdk/tokenstorage/sqlite_adapter.py
@@ -100,6 +100,12 @@ CREATE TABLE sdk_storage_adapter_internal (
             conn.commit()
         return conn
 
+    def close(self) -> None:
+        """
+        Close the underlying database connection.
+        """
+        self._connection.close()
+
     def store_config(
         self, config_name: str, config_dict: t.Mapping[str, t.Any]
     ) -> None:

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist =
     cov-clean
     cov-combine
     cov-report
-    py{310,39,38,37,36}
+    py{311,310,39,38,37,36}
     py36-mindeps
 skip_missing_interpreters = true
 minversion = 3.0.0
@@ -71,9 +71,9 @@ deps = pyright
 commands = pyright src/ {posargs}
 
 [testenv:docs]
-# force use of py310 for doc builds so that we get the same behaviors as the
+# force use of py311 for doc builds so that we get the same behaviors as the
 # readthedocs doc build
-basepython = python3.10
+basepython = python3.11
 extras = dev
 whitelist_externals = rm
 changedir = docs/


### PR DESCRIPTION
In the changelog, this is called out as "official support" since the code all worked on 3.11 prior to this change.

Places touched:
- CI testing job on linux (all pythons)
- CI testing on windows (latest python only)
- CI testing on macos (latest python only)
- readthedocs config
- pypi classifiers
- tox testenvs

CI builds should be examined to see what might fail in particular. Local testing under pyenv+tox works, but it's always possible that something will be different in the CI environment.