### PR TITLE
Improve str(OAuthTokenResponse)

### DIFF
--- a/changelog.d/20221103_153003_sirosen_update_oauth_token_response_str.rst
+++ b/changelog.d/20221103_153003_sirosen_update_oauth_token_response_str.rst
@@ -1,0 +1,1 @@
+* Improve the ``__str__`` implementation for ``OAuthTokenResponse`` (:pr:`NUMBER`)

--- a/src/globus_sdk/services/auth/response/oauth.py
+++ b/src/globus_sdk/services/auth/response/oauth.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import textwrap
 import time
 import typing as t
 
@@ -225,9 +226,16 @@ class OAuthTokenResponse(GlobusHTTPResponse):
         return decoded
 
     def __str__(self) -> str:
-        # Make printing responses more convenient by only showing the
-        # (typically important) token info
-        return json.dumps(self.by_resource_server, indent=2)
+        by_rs = json.dumps(self.by_resource_server, indent=2, separators=(",", ": "))
+        id_token_to_print = t.cast(t.Optional[str], self.get("id_token"))
+        if id_token_to_print is not None:
+            id_token_to_print = id_token_to_print[:10] + "... (truncated)"
+        return (
+            f"{self.__class__.__name__}:\n"
+            + f"  id_token: {id_token_to_print}\n"
+            + "  by_resource_server:\n"
+            + textwrap.indent(by_rs, "    ")
+        )
 
 
 class OAuthDependentTokenResponse(OAuthTokenResponse):

--- a/tests/unit/responses/test_oauth_token_response.py
+++ b/tests/unit/responses/test_oauth_token_response.py
@@ -69,3 +69,14 @@ def test_by_scopes_lookups_fancy(oauth_token_response):
     assert (
         by_scopes["scope2:1 scope2 scope2:0"]["resource_server"] == "resource_server_2"
     )
+
+
+def test_stringify(oauth_token_response):
+    data = str(oauth_token_response)
+    # it starts the right way
+    assert data.startswith("OAuthTokenResponse:\n")
+    # it contains the id_token, but heavily truncated and annotated as such
+    assert "  id_token: id_token_v... (truncated)\n" in data
+    # it contains the by_resource_server mapping (but we won't assert anything about
+    # that data other than that it starts with a '{')
+    assert "  by_resource_server:\n    {" in data


### PR DESCRIPTION
This makes the str() of an oauth response object more verbose, clarifying that `by_resource_server` is a field (not the set of top-level keys) and including mention of `id_token`. The output is also now more YAML-like, and not just an undecorated JSON dump.

In practice, the `id_token` can be very long, so this implementation truncates it to the first 10 chars and notes it as `... (truncated)`.

No other fields are added to the stringifier as of yet.

resolves #639

---

Example output (with tokens redacted):
```
OAuthTokenResponse:
  id_token: eyJhbGciOi... (truncated)
  by_resource_server:
    {
      "auth.globus.org": {
        "scope": "openid email profile",
        "access_token": "REDACTED",
        "refresh_token": null,
        "token_type": "Bearer",
        "expires_at_seconds": 1667661839,
        "resource_server": "auth.globus.org"
      },
      "transfer.api.globus.org": {
        "scope": "urn:globus:auth:scope:transfer.api.globus.org:all",
        "access_token": "REDACTED",
        "refresh_token": null,
        "token_type": "Bearer",
        "expires_at_seconds": 1667661839,
        "resource_server": "transfer.api.globus.org"
      }
    }
```