### PR TITLE
Allow scope names to be different from their value

### DIFF
--- a/changelog.d/20221103_144520_derek_fix_specific_flow_scope_string.rst
+++ b/changelog.d/20221103_144520_derek_fix_specific_flow_scope_string.rst
@@ -1,0 +1,3 @@
+
+* Scope Names (used to set ``ScopeBuilder`` attributes) can be set explicitly
+* Fixed SpecificFlowClient scope string

--- a/changelog.d/20221103_144520_derek_fix_specific_flow_scope_string.rst
+++ b/changelog.d/20221103_144520_derek_fix_specific_flow_scope_string.rst
@@ -1,3 +1,4 @@
 
-* Scope Names (used to set ``ScopeBuilder`` attributes) can be set explicitly
-* Fixed SpecificFlowClient scope string
+* Scope Names can be set explicitly in a ``ScopeBuilder`` (:pr:`NUMBER`)
+* Introduced ``ScopeBuilder.scope_names`` property (:pr:`NUMBER`)
+* Fixed SpecificFlowClient scope string (:pr:`NUMBER`)

--- a/src/globus_sdk/_sphinxext.py
+++ b/src/globus_sdk/_sphinxext.py
@@ -117,14 +117,11 @@ class ListKnownScopes(AddContentDirective):
         sb_name = self.arguments[0]
         sb_basename = sb_name.split(".")[-1]
 
-        add_scopes = []
         example_scope = None
         for arg in self.arguments[1:]:
-            if arg.startswith("add_scopes="):
-                add_scopes = [x for x in arg.split("=")[1].split(",")]
             if arg.startswith("example_scope="):
                 example_scope = arg.split("=")[1]
-        known_scopes = add_scopes + _extract_known_scopes(sb_name)
+        known_scopes = _extract_known_scopes(sb_name)
         if example_scope is None:
             example_scope = known_scopes[0]
 

--- a/src/globus_sdk/_sphinxext.py
+++ b/src/globus_sdk/_sphinxext.py
@@ -13,7 +13,7 @@ from sphinx.util.nodes import nested_parse_with_titles
 
 def _extract_known_scopes(scope_builder_name):
     sb = locate(scope_builder_name)
-    return sb._known_scopes
+    return sb.scope_names
 
 
 def _classname2methods(classname, include_methods):

--- a/src/globus_sdk/scopes.py
+++ b/src/globus_sdk/scopes.py
@@ -147,7 +147,7 @@ class ScopeBuilder:
         None => {}
         "my-str" => {"my-str": "my-str"}
         ["my-list"] => {"my-list": "my-list"}
-        ("my-tuple-key": "my-tuple-val") => {"my-tuple-key": "my-tuple-val"}
+        ("my-tuple-key", "my-tuple-val") => {"my-tuple-key": "my-tuple-val"}
         """
         if items is None:
             return {}
@@ -316,7 +316,6 @@ AuthScopes = _AuthScopesBuilder(
 """Globus Auth scopes.
 
 .. listknownscopes:: globus_sdk.scopes.AuthScopes
-    add_scopes=openid,email,profile
     example_scope=view_identity_set
 """
 

--- a/src/globus_sdk/scopes.py
+++ b/src/globus_sdk/scopes.py
@@ -147,7 +147,7 @@ class ScopeBuilder:
         None => {}
         "my-str" => {"my-str": "my-str"}
         ["my-list"] => {"my-list": "my-list"}
-        {"my-dict-key": "my-dict-val"} => {"my-dict-key": "my-dict-val"}
+        ("my-tuple-key": "my-tuple-val") => {"my-tuple-key": "my-tuple-val"}
         """
         if items is None:
             return {}

--- a/src/globus_sdk/services/flows/client.py
+++ b/src/globus_sdk/services/flows/client.py
@@ -201,7 +201,8 @@ class FlowsClient(client.BaseClient):
         marker: t.Optional[str] = None,
         query_params: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> IterableFlowsResponse:
-        """List deployed Flows
+        """
+        List deployed Flows
 
         :param filter_role: A role name specifying the minimum permissions required for
             a Flow to be included in the response.
@@ -232,7 +233,8 @@ class FlowsClient(client.BaseClient):
 
         Values for ``orderby`` consist of a field name, a space, and an
         ordering mode -- ``ASC`` for "ascending" and ``DESC`` for "descending".
-        Supported field names are
+
+        Supported field names are:
           - ``id``
           - ``scope_string``
           - ``flow_owners``

--- a/src/globus_sdk/services/flows/client.py
+++ b/src/globus_sdk/services/flows/client.py
@@ -312,9 +312,10 @@ class SpecificFlowClient(client.BaseClient):
             transport_params=transport_params,
         )
         self._flow_id = flow_id
+        user_scope_value = f"flow_{str(flow_id).replace('-', '_')}_user"
         self.scopes = ScopeBuilder(
             resource_server=str(self._flow_id),
-            known_url_scopes=[f"flow_{flow_id}_user"],
+            known_url_scopes=[("user", user_scope_value)],
         )
 
     @_flowdoc("Run Flow", "~1flows~1{flow_id}~1run/post")

--- a/tests/unit/test_scopes.py
+++ b/tests/unit/test_scopes.py
@@ -42,7 +42,7 @@ def test_scopebuilder_str():
     assert bar_scope in stringified
 
 
-def test_differently_named_scopes_in_scopebuilder():
+def test_uniquely_named_scopes():
     rs = str(uuid.uuid4())
     scope_1 = str(uuid.uuid4())
     scope_2 = str(uuid.uuid4())
@@ -56,6 +56,27 @@ def test_differently_named_scopes_in_scopebuilder():
     assert sb.foo == f"urn:globus:auth:scope:{rs}:foo"
     assert sb.my_url_scope == f"https://auth.globus.org/scopes/{rs}/{scope_2}"
     assert sb.bar == f"https://auth.globus.org/scopes/{rs}/bar"
+
+
+def test_sb_allowed_inputs_types():
+    rs = str(uuid.uuid4())
+    scope_1 = "do_a_thing"
+    scope_1_urn = f"urn:globus:auth:scope:{rs}:{scope_1}"
+
+    none_sb = ScopeBuilder(rs, known_scopes=None)
+    str_sb = ScopeBuilder(rs, known_scopes=scope_1)
+    tuple_sb = ScopeBuilder(rs, known_scopes=("scope_1", scope_1))
+    list_sb = ScopeBuilder(rs, known_scopes=[scope_1, ("scope_1", scope_1)])
+
+    assert none_sb.scope_names == []
+    assert scope_1 in str_sb.scope_names
+    assert str_sb.do_a_thing == scope_1_urn
+    assert "scope_1" in tuple_sb.scope_names
+    assert tuple_sb.scope_1 == scope_1_urn
+    assert scope_1 in list_sb.scope_names
+    assert "scope_1" in list_sb.scope_names
+    assert list_sb.scope_1 == scope_1_urn
+    assert list_sb.do_a_thing == scope_1_urn
 
 
 def test_mutable_scope_str_and_repr_simple():

--- a/tests/unit/test_scopes.py
+++ b/tests/unit/test_scopes.py
@@ -42,6 +42,22 @@ def test_scopebuilder_str():
     assert bar_scope in stringified
 
 
+def test_differently_named_scopes_in_scopebuilder():
+    rs = str(uuid.uuid4())
+    scope_1 = str(uuid.uuid4())
+    scope_2 = str(uuid.uuid4())
+    sb = ScopeBuilder(
+        rs,
+        known_scopes=[("my_urn_scope", scope_1), "foo"],
+        known_url_scopes=[("my_url_scope", scope_2), "bar"],
+    )
+
+    assert sb.my_urn_scope == f"urn:globus:auth:scope:{rs}:{scope_1}"
+    assert sb.foo == f"urn:globus:auth:scope:{rs}:foo"
+    assert sb.my_url_scope == f"https://auth.globus.org/scopes/{rs}/{scope_2}"
+    assert sb.bar == f"https://auth.globus.org/scopes/{rs}/bar"
+
+
 def test_mutable_scope_str_and_repr_simple():
     s = MutableScope("simple")
     assert str(s) == "simple"


### PR DESCRIPTION
* Scope Names can be set explicitly in a `ScopeBuilder`
  *  Idea behind this is that scope values (whether they should or shouldn't be) can have a different human-understandable name than their `scope_value`.
  *  With this change, a ScopeBuilder instantiation can attach a more human understandable `scope_name` to a less human understandable `scope_value` to be formatted into either a urn or url
* Introduced `ScopeBuilder.scope_names` property
  *   Moved _sphinxext.py to use this instead of ScopeBuilder internal properties
* Fixed SpecificFlowClient scope string
  * Proof that this is accurate:
    * The scope string has it's operation string replaced from `-` to `_` [here](https://github.com/globusonline/flows/blob/main/globus/flows/scope_utils.py#L80)
    * An example get flow truncated call
    ```
    % globus-automate flow get f73633d2-9445-4558-8228-977f79d71971
    {
      ...trunc...
      "globus_auth_scope": "https://auth.globus.org/scopes/f73633d2-9445-4558-8228-977f79d71971/flow_f73633d2_9445_4558_8228_977f79d71971_user",
      ...trunc...
    }
    ```

### Testing
* Added unit test for re-named scope strings
* Tested out the new SpecificFlowClient usage manually:
```
SpecificFlowClient("7edaaa8a-72cd-4491-b7bd-b1f6160f44db").scopes.user
'https://auth.globus.org/scopes/7edaaa8a-72cd-4491-b7bd-b1f6160f44db/flow_7edaaa8a_72cd_4491_b7bd_b1f6160f44db_user'
```
^ this scope string is verified accurate above