### PR TITLE
Fix doc warnings which error locally

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,6 +2,7 @@ version: 2
 
 sphinx:
   configuration: docs/conf.py
+  fail_on_warning: true
 
 build:
   os: ubuntu-20.04

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,7 +7,9 @@ sphinx:
 build:
   os: ubuntu-20.04
   tools:
-    python: "3.11"
+    # NOTE: make sure this matches the basepython in tox.ini for 'docs'
+    # TODO: update to py311 as soon as RTD stops using 3.11.0b3 instead of 3.11.0
+    python: "3.10"
 
 python:
   install:

--- a/src/globus_sdk/services/flows/client.py
+++ b/src/globus_sdk/services/flows/client.py
@@ -219,6 +219,7 @@ class FlowsClient(client.BaseClient):
         **Role Values**
 
         The valid values for ``role`` are, in order of precedence for ``filter_role``:
+
           - ``flow_viewer``
           - ``flow_starter``
           - ``flow_administrator``
@@ -233,6 +234,7 @@ class FlowsClient(client.BaseClient):
         Values for ``orderby`` consist of a field name, a space, and an
         ordering mode -- ``ASC`` for "ascending" and ``DESC`` for "descending".
         Supported field names are
+
           - ``id``
           - ``scope_string``
           - ``flow_owners``

--- a/tox.ini
+++ b/tox.ini
@@ -71,9 +71,9 @@ deps = pyright
 commands = pyright src/ {posargs}
 
 [testenv:docs]
-# force use of py311 for doc builds so that we get the same behaviors as the
+# force use of py310 for doc builds so that we get the same behaviors as the
 # readthedocs doc build
-basepython = python3.11
+basepython = python3.10
 extras = dev
 whitelist_externals = rm
 changedir = docs/


### PR DESCRIPTION
And also set `fail_on_warning: true` so that the CI run of sphinx (done by readthedocs) will match local runs of sphinx (done by `tox -e docs`)

The warnings came from missing whitespace before lists.

---

This impacts #641 and #642. The latter is where I discovered this. In the former, I'd like to suggest a change which requires that we fix this in order to be able to run `tox -e docs` to test the change locally.