### PR TITLE
Fix bug with str(OAuthDependentTokenResponse)

### DIFF
--- a/changelog.d/20221106_201940_sirosen_fix_dependent_token_str.rst
+++ b/changelog.d/20221106_201940_sirosen_fix_dependent_token_str.rst
@@ -1,0 +1,3 @@
+* When ``GlobusHTTPResponse`` contains a list, calls to ``get()`` will no
+  longer fail with an ``AttributeError`` but will return the default value
+  (``None`` if unspecified) instead (:pr:`NUMBER`)

--- a/src/globus_sdk/response.py
+++ b/src/globus_sdk/response.py
@@ -123,9 +123,9 @@ class GlobusHTTPResponse:
     def get(self, key: str, default: t.Any = None) -> t.Any:
         """
         ``get`` is just an alias for ``data.get(key, default)``, but with the added
-        check that if ``data`` is ``None``, it returns the default.
+        checks that if ``data`` is ``None`` or a list, it returns the default.
         """
-        if self.data is None:
+        if self.data is None or isinstance(self.data, list):
             return default
         # NB: `default` is provided as a positional because the native dict type
         # doesn't recognize a keyword argument `default`

--- a/src/globus_sdk/services/auth/response/oauth.py
+++ b/src/globus_sdk/services/auth/response/oauth.py
@@ -227,9 +227,14 @@ class OAuthTokenResponse(GlobusHTTPResponse):
 
     def __str__(self) -> str:
         by_rs = json.dumps(self.by_resource_server, indent=2, separators=(",", ": "))
-        id_token_to_print = t.cast(t.Optional[str], self.get("id_token"))
-        if id_token_to_print is not None:
-            id_token_to_print = id_token_to_print[:10] + "... (truncated)"
+        # dict case -- typical response
+        if isinstance(self.data, dict):
+            id_token_to_print = t.cast(t.Optional[str], self.get("id_token"))
+            if id_token_to_print is not None:
+                id_token_to_print = id_token_to_print[:10] + "... (truncated)"
+        # other (list) case -- dependent tokens response
+        else:
+            id_token_to_print = None
         return (
             f"{self.__class__.__name__}:\n"
             + f"  id_token: {id_token_to_print}\n"

--- a/src/globus_sdk/services/auth/response/oauth.py
+++ b/src/globus_sdk/services/auth/response/oauth.py
@@ -227,14 +227,9 @@ class OAuthTokenResponse(GlobusHTTPResponse):
 
     def __str__(self) -> str:
         by_rs = json.dumps(self.by_resource_server, indent=2, separators=(",", ": "))
-        # dict case -- typical response
-        if isinstance(self.data, dict):
-            id_token_to_print = t.cast(t.Optional[str], self.get("id_token"))
-            if id_token_to_print is not None:
-                id_token_to_print = id_token_to_print[:10] + "... (truncated)"
-        # other (list) case -- dependent tokens response
-        else:
-            id_token_to_print = None
+        id_token_to_print = t.cast(t.Optional[str], self.get("id_token"))
+        if id_token_to_print is not None:
+            id_token_to_print = id_token_to_print[:10] + "... (truncated)"
         return (
             f"{self.__class__.__name__}:\n"
             + f"  id_token: {id_token_to_print}\n"

--- a/tests/unit/responses/conftest.py
+++ b/tests/unit/responses/conftest.py
@@ -48,5 +48,45 @@ def make_oauth_token_response():
 
 
 @pytest.fixture
+def make_oauth_dependent_token_response():
+    """
+    response with conveniently formatted names to help with iteration in tests
+    """
+
+    def f(client=None):
+        return make_response(
+            response_class=(
+                globus_sdk.services.auth.response.OAuthDependentTokenResponse
+            ),
+            json_body=[
+                {
+                    "access_token": "access_token_4",
+                    "expires_in": 3600,
+                    "refresh_token": "refresh_token_4",
+                    "resource_server": "resource_server_4",
+                    "scope": "scope4",
+                    "token_type": "bearer",
+                },
+                {
+                    "access_token": "access_token_5",
+                    "expires_in": 3600,
+                    "refresh_token": "refresh_token_5",
+                    "resource_server": "resource_server_5",
+                    "scope": "scope5",
+                    "token_type": "bearer",
+                },
+            ],
+            client=client,
+        )
+
+    return f
+
+
+@pytest.fixture
 def oauth_token_response(make_oauth_token_response):
     return make_oauth_token_response()
+
+
+@pytest.fixture
+def oauth_dependent_token_response(make_oauth_dependent_token_response):
+    return make_oauth_dependent_token_response()

--- a/tests/unit/responses/test_oauth_token_response.py
+++ b/tests/unit/responses/test_oauth_token_response.py
@@ -80,3 +80,14 @@ def test_stringify(oauth_token_response):
     # it contains the by_resource_server mapping (but we won't assert anything about
     # that data other than that it starts with a '{')
     assert "  by_resource_server:\n    {" in data
+
+
+def test_stringify_dependent_tokens(oauth_dependent_token_response):
+    data = str(oauth_dependent_token_response)
+    # it starts the right way
+    assert data.startswith("OAuthDependentTokenResponse:\n")
+    # it does not contain the id_token, so this is indicated as None
+    assert "  id_token: None\n" in data
+    # it contains the by_resource_server mapping (but we won't assert anything about
+    # that data other than that it starts with a '{')
+    assert "  by_resource_server:\n    {" in data

--- a/tests/unit/responses/test_response.py
+++ b/tests/unit/responses/test_response.py
@@ -196,8 +196,8 @@ def test_get(dict_response, list_response, text_http_response):
     for item in dict_response.data:
         assert dict_response.r.get(item) == dict_response.data.get(item)
 
-    with pytest.raises(AttributeError):
-        list_response.r.get("value1")
+    assert list_response.r.get("value1") is None
+    assert list_response.r.get("value1", "foo") == "foo"
 
     assert text_http_response.r.get("foo") is None
     assert text_http_response.r.get("foo", default="bar") == "bar"


### PR DESCRIPTION
The stringifier inherited from OAuthTokenResponse assumes that `self.get(...)` is safe, but that's only true when the data is a `dict`, as it normally is.
OAuthDependentTokenResponse has `self.data: list`. Therefore, this needs a check and special handling in the stringifier.

Add a test case which fails without this addition, then make the `get()` call conditional on the type of the underlying data.

Arguably this is a "bad" division of responsibilities (base class knows about its subclasses), but any alternative which solves this generically is more verbose or touches on core codepaths like the central `GlobusHTTPResponse.get` implementation.