### PR TITLE
Add an initial seed codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,11 +9,9 @@
 * @aaschaer @ada-globus @derek-globus @kurtmckee @sirosen
 
 # Flows service
-/src/globus_sdk/services/flows/ @ada-globus @derek-globus @kurtmckee @sirosen
-/src/globus_sdk/_testing/data/flows/ @ada-globus @derek-globus @kurtmckee @sirosen
-/tests/functional/services/flows/ @ada-globus @derek-globus @kurtmckee @sirosen
+**/flows/ @ada-globus @derek-globus @kurtmckee @sirosen
+docs/services/flows.rst @ada-globus @derek-globus @kurtmckee @sirosen
 
 # Timer service
-/src/globus_sdk/services/timer/ @ada-globus @derek-globus @kurtmckee @sirosen
-/src/globus_sdk/_testing/data/timer/ @ada-globus @derek-globus @kurtmckee @sirosen
-/tests/functional/services/timer/ @ada-globus @derek-globus @kurtmckee @sirosen
+**/timer/ @ada-globus @derek-globus @kurtmckee @sirosen
+docs/services/timer.rst @ada-globus @derek-globus @kurtmckee @sirosen

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,19 @@
+#
+# codeowners reference:
+#   https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+#
+# for ease of comparison, usernames are kept alphabetized
+#
+
+# default rule
+* @aaschaer @ada-globus @derek-globus @kurtmckee @sirosen
+
+# Flows service
+/src/globus_sdk/services/flows/ @ada-globus @derek-globus @kurtmckee @sirosen
+/src/globus_sdk/_testing/data/flows/ @ada-globus @derek-globus @kurtmckee @sirosen
+/tests/functional/services/flows/ @ada-globus @derek-globus @kurtmckee @sirosen
+
+# Timer service
+/src/globus_sdk/services/timer/ @ada-globus @derek-globus @kurtmckee @sirosen
+/src/globus_sdk/_testing/data/timer/ @ada-globus @derek-globus @kurtmckee @sirosen
+/tests/functional/services/timer/ @ada-globus @derek-globus @kurtmckee @sirosen


### PR DESCRIPTION
This lists the personnel currently considered responsible for the SDK code. It intentionally does not list all of the impacted stakeholders, and makes no attempt to break down any service responsibilities other than those for flows and timer.

---

Please note that the listed reviewers != the list of personnel in codeowners and that this is intentional.
The order in which names are listed ~reflects who are my bestest friends~ is alphabetical for simpler comparisons and just to set some sort of rule.