### PR TITLE
Add ignore_missing, interpret_globs to DeleteData

### DIFF
--- a/changelog.d/20221108_171745_sirosen_add_missing_delete_data_args.rst
+++ b/changelog.d/20221108_171745_sirosen_add_missing_delete_data_args.rst
@@ -1,0 +1,1 @@
+* Add support for ``interpret_globs`` and ``ignore_missing`` to ``DeleteData`` (:pr:`NUMBER`)

--- a/src/globus_sdk/services/transfer/data/delete_data.py
+++ b/src/globus_sdk/services/transfer/data/delete_data.py
@@ -41,6 +41,13 @@ class DeleteData(utils.PayloadWrapper):
     :param recursive: Recursively delete subdirectories on the target endpoint
       [default: ``False``]
     :type recursive: bool
+    :param ignore_missing: Ignore nonexistent files and directories instead of treating
+        them as errors. [default: ``False``]
+    :type ignore_missing: bool
+    :param interpret_globs: Enable expansion of ``\*?[]`` characters in the last
+        component of paths, unless they are escaped with a preceding backslash, ``\\``
+        [default: ``False``]
+    :type interpret_globs: bool
     :param deadline: An ISO-8601 timestamp (as a string) or a datetime object which
         defines a deadline for the deletion. At the deadline, even if the data deletion
         is not complete, the job will be canceled. We recommend ensuring that the
@@ -93,6 +100,8 @@ class DeleteData(utils.PayloadWrapper):
         label: t.Optional[str] = None,
         submission_id: t.Optional[UUIDLike] = None,
         recursive: bool = False,
+        ignore_missing: bool = False,
+        interpret_globs: bool = False,
         deadline: t.Optional[t.Union[str, datetime.datetime]] = None,
         skip_activation_check: t.Optional[bool] = None,
         notify_on_succeeded: bool = True,
@@ -121,6 +130,8 @@ class DeleteData(utils.PayloadWrapper):
         )
         self._set_optbools(
             recursive=recursive,
+            ignore_missing=ignore_missing,
+            interpret_globs=interpret_globs,
             skip_activation_check=skip_activation_check,
             notify_on_succeeded=notify_on_succeeded,
             notify_on_failed=notify_on_failed,

--- a/tests/unit/helpers/test_transfer.py
+++ b/tests/unit/helpers/test_transfer.py
@@ -149,7 +149,7 @@ def test_transfer_add_symlink_item():
     assert data["destination_path"] == dest_path
 
 
-def test_delete_init():
+def test_delete_init_with_client():
     """
     Verifies DeleteData field initialization
     """
@@ -163,31 +163,43 @@ def test_delete_init():
     assert len(ddata["DATA"]) == 0
 
 
-def test_delete_init_w_params():
-    tc = TransferClient()
-    load_response(tc.get_submission_id)
-    label = "label"
+@pytest.mark.parametrize(
+    "add_kwargs",
+    (
+        {"recursive": True},
+        {"ignore_missing": True},
+        {"interpret_globs": True},
+        {"label": "somelabel"},
+    ),
+)
+def test_delete_init_with_supported_parameters(add_kwargs):
+    ddata = DeleteData(endpoint=GO_EP1_ID, **add_kwargs)
+    for k, v in add_kwargs.items():
+        assert ddata[k] == v
+
+
+def test_delete_init_with_additional_fields():
     params = {"param1": "value1", "param2": "value2"}
-    ddata = DeleteData(
-        tc, GO_EP1_ID, label=label, recursive=True, additional_fields=params
-    )
-    assert ddata["label"] == label
-    assert ddata["recursive"]
-    for par in params:
-        assert ddata[par] == params[par]
+    ddata = DeleteData(endpoint=GO_EP1_ID, additional_fields=params)
+    assert ddata["param1"] == "value1"
+    assert ddata["param2"] == "value2"
 
 
-def test_delete_init_no_client():
-    ddata1 = DeleteData(None, GO_EP1_ID)
-    ddata2 = DeleteData(endpoint=GO_EP1_ID)
-    ddata3 = DeleteData(endpoint=GO_EP1_ID, transfer_client=None)
-
-    for ddata in (ddata1, ddata2, ddata3):
-        assert ddata["DATA_TYPE"] == "delete"
-        assert ddata["endpoint"] == GO_EP1_ID
-        assert "submission_id" not in ddata
-        assert "DATA" in ddata
-        assert len(ddata["DATA"]) == 0
+@pytest.mark.parametrize(
+    "args, kwargs",
+    (
+        ((None, GO_EP1_ID), {}),
+        ((), {"endpoint": GO_EP1_ID}),
+        ((), {"endpoint": GO_EP1_ID, "transfer_client": None}),
+    ),
+)
+def test_delete_init_no_client(args, kwargs):
+    ddata = DeleteData(*args, **kwargs)
+    assert ddata["DATA_TYPE"] == "delete"
+    assert ddata["endpoint"] == GO_EP1_ID
+    assert "submission_id" not in ddata
+    assert "DATA" in ddata
+    assert len(ddata["DATA"]) == 0
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
I discovered this in the course of other work.

These bool parameters were missing from the initializer. Add them with defaults of False (matching the service default behavior).