### PR TITLE
First version of LocalGlobusConnectServer object

### DIFF
--- a/changelog.d/20221108_234645_sirosen_add_local_gcs.rst
+++ b/changelog.d/20221108_234645_sirosen_add_local_gcs.rst
@@ -1,0 +1,6 @@
+* A new object, ``globus_sdk.LocalGlobusConnectServer`` can be used to inspect
+  the local installation of Globus Connect Server (:pr:`NUMBER`)
+
+  * The object supports properties for ``endpoint_id`` and ``domain_name``
+
+  * This only supports Globus Connect Server version 5

--- a/docs/local_endpoints.rst
+++ b/docs/local_endpoints.rst
@@ -14,8 +14,9 @@ users.
 Globus Connect Server
 ---------------------
 
-There are no SDK methods for accessing an installation of Globus Connect
-Server.
+.. autoclass:: LocalGlobusConnectServer
+   :members:
+   :member-order: bysource
 
 Globus Connect Personal
 -----------------------

--- a/src/globus_sdk/__init__.py
+++ b/src/globus_sdk/__init__.py
@@ -42,6 +42,7 @@ _LAZY_IMPORT_TABLE = {
     "local_endpoint": {
         "GlobusConnectPersonalOwnerInfo",
         "LocalGlobusConnectPersonal",
+        "LocalGlobusConnectServer",
     },
     "response": {
         "GlobusHTTPResponse",
@@ -137,6 +138,7 @@ if t.TYPE_CHECKING or sys.version_info < (3, 7):
     from .exc import NetworkError
     from .local_endpoint import GlobusConnectPersonalOwnerInfo
     from .local_endpoint import LocalGlobusConnectPersonal
+    from .local_endpoint import LocalGlobusConnectServer
     from .response import GlobusHTTPResponse
     from .services.auth import AuthAPIError
     from .services.auth import AuthClient
@@ -276,6 +278,7 @@ __all__ = (
     "IterableFlowsResponse",
     "IterableTransferResponse",
     "LocalGlobusConnectPersonal",
+    "LocalGlobusConnectServer",
     "MappedCollectionDocument",
     "NativeAppAuthClient",
     "NetworkError",

--- a/src/globus_sdk/_generate_init.py
+++ b/src/globus_sdk/_generate_init.py
@@ -65,6 +65,7 @@ _LAZY_IMPORT_TABLE: t.List[t.Tuple[str, t.Tuple[str, ...]]] = [
         (
             "GlobusConnectPersonalOwnerInfo",
             "LocalGlobusConnectPersonal",
+            "LocalGlobusConnectServer",
         ),
     ),
     ("response", ("GlobusHTTPResponse",)),

--- a/src/globus_sdk/local_endpoint/__init__.py
+++ b/src/globus_sdk/local_endpoint/__init__.py
@@ -1,6 +1,8 @@
 from .personal import GlobusConnectPersonalOwnerInfo, LocalGlobusConnectPersonal
+from .server import LocalGlobusConnectServer
 
 __all__ = (
     "GlobusConnectPersonalOwnerInfo",
     "LocalGlobusConnectPersonal",
+    "LocalGlobusConnectServer",
 )

--- a/src/globus_sdk/local_endpoint/server/__init__.py
+++ b/src/globus_sdk/local_endpoint/server/__init__.py
@@ -1,0 +1,3 @@
+from .endpoint import LocalGlobusConnectServer
+
+__all__ = ("LocalGlobusConnectServer",)

--- a/src/globus_sdk/local_endpoint/server/endpoint.py
+++ b/src/globus_sdk/local_endpoint/server/endpoint.py
@@ -37,14 +37,14 @@ class LocalGlobusConnectServer:
         applications using the SDK may not be able to interact with Globus Connect
         Server on the container host.
 
-        :type: dict
+        :type: dict or None
         """
         if self._loaded_info is None:
             if self.info_path.is_file():
                 with open(self.info_path, encoding="utf-8") as fp:
                     try:
                         parsed_data = json.load(fp)
-                    except json.JSONDecodeError:
+                    except (UnicodeDecodeError, json.JSONDecodeError):
                         pass
                     else:
                         if isinstance(parsed_data, dict):
@@ -61,7 +61,7 @@ class LocalGlobusConnectServer:
         The endpoint ID of the local Globus Connect Server endpoint.
         None if the data cannot be loaded or is malformed.
 
-        :type: str
+        :type: str or None
         """
         if self.info_dict is not None:
             epid = self.info_dict.get("endpoint_id")
@@ -75,7 +75,7 @@ class LocalGlobusConnectServer:
         The domain name of the local Globus Connect Server endpoint.
         None if the data cannot be loaded or is malformed.
 
-        :type: str
+        :type: str or None
         """
         if self.info_dict is not None:
             domain = self.info_dict.get("domain_name")

--- a/src/globus_sdk/local_endpoint/server/endpoint.py
+++ b/src/globus_sdk/local_endpoint/server/endpoint.py
@@ -1,0 +1,84 @@
+import json
+import pathlib
+import typing as t
+
+
+class LocalGlobusConnectServer:
+    r"""
+    A LocalGlobusConnectServer object represents the available SDK methods
+    for inspecting and controlling a running Globus Connect Server
+    installation.
+
+    These objects do *not* inherit from BaseClient and do not provide methods
+    for interacting with any Globus Service APIs.
+
+    :param info_path: The path to the info file used to inspect the local system
+    :type info_path: str, optional
+    """
+
+    def __init__(
+        self,
+        *,
+        info_path: t.Union[
+            str, pathlib.Path
+        ] = "/var/lib/globus-connect-server/info.json"
+    ) -> None:
+        self.info_path = pathlib.Path(info_path)
+        self._loaded_info: t.Optional[t.Dict[str, t.Any]] = None
+
+    @property
+    def info_dict(self) -> t.Optional[t.Dict[str, t.Any]]:
+        """
+        The info.json data for the local Globus Connect Server, as a dict.
+
+        If the info.json file is not present or cannot be parsed, the data is None.
+        This indicates that there is no local Globus Connect Server node, or if there is
+        one, it cannot be used or examined by the SDK. For example, containerized
+        applications using the SDK may not be able to interact with Globus Connect
+        Server on the container host.
+
+        :type: dict
+        """
+        if self._loaded_info is None:
+            if self.info_path.is_file():
+                with open(self.info_path, encoding="utf-8") as fp:
+                    try:
+                        parsed_data = json.load(fp)
+                    except json.JSONDecodeError:
+                        pass
+                    else:
+                        if isinstance(parsed_data, dict):
+                            self._loaded_info = t.cast(t.Dict[str, t.Any], parsed_data)
+        return self._loaded_info
+
+    @info_dict.deleter
+    def info_dict(self) -> None:
+        self._loaded_info = None
+
+    @property
+    def endpoint_id(self) -> t.Optional[str]:
+        """
+        The endpoint ID of the local Globus Connect Server endpoint.
+        None if the data cannot be loaded or is malformed.
+
+        :type: str
+        """
+        if self.info_dict is not None:
+            epid = self.info_dict.get("endpoint_id")
+            if isinstance(epid, str):
+                return epid
+        return None
+
+    @property
+    def domain_name(self) -> t.Optional[str]:
+        """
+        The domain name of the local Globus Connect Server endpoint.
+        None if the data cannot be loaded or is malformed.
+
+        :type: str
+        """
+        if self.info_dict is not None:
+            domain = self.info_dict.get("domain_name")
+            if isinstance(domain, str):
+                return domain
+        return None

--- a/tests/functional/local_endpoint/test_server.py
+++ b/tests/functional/local_endpoint/test_server.py
@@ -1,0 +1,78 @@
+from globus_sdk import LocalGlobusConnectServer
+
+
+def test_info_dict_from_nonexistent_file_is_none(tmp_path):
+    info_path = tmp_path / "info.json"
+    gcs = LocalGlobusConnectServer(info_path=info_path)
+    assert gcs.info_dict is None
+
+
+def test_info_dict_from_non_json_file_is_none(tmp_path):
+    info_path = tmp_path / "info.json"
+    info_path.write_text("{")
+    gcs = LocalGlobusConnectServer(info_path=info_path)
+    assert gcs.info_dict is None
+
+
+def test_info_dict_from_non_json_object_file_is_none(tmp_path):
+    info_path = tmp_path / "info.json"
+    info_path.write_text("[]")
+    gcs = LocalGlobusConnectServer(info_path=info_path)
+    assert gcs.info_dict is None
+
+
+def test_info_dict_from_empty_json_file_is_okay_but_has_no_properties(tmp_path):
+    info_path = tmp_path / "info.json"
+    info_path.write_text("{}")
+    gcs = LocalGlobusConnectServer(info_path=info_path)
+    assert gcs.info_dict is not None
+    assert gcs.endpoint_id is None
+    assert gcs.domain_name is None
+
+
+def test_info_dict_can_load_endpoint_id(tmp_path):
+    info_path = tmp_path / "info.json"
+    info_path.write_text('{"endpoint_id": "foo"}')
+    gcs = LocalGlobusConnectServer(info_path=info_path)
+    assert gcs.info_dict is not None
+    assert gcs.endpoint_id == "foo"
+
+
+def test_info_dict_can_load_domain(tmp_path):
+    info_path = tmp_path / "info.json"
+    info_path.write_text('{"domain_name": "foo"}')
+    gcs = LocalGlobusConnectServer(info_path=info_path)
+    assert gcs.info_dict is not None
+    assert gcs.domain_name == "foo"
+
+
+def test_endpoint_id_property_ignores_non_str_value(tmp_path):
+    info_path = tmp_path / "info.json"
+    info_path.write_text('{"endpoint_id": 1}')
+    gcs = LocalGlobusConnectServer(info_path=info_path)
+    assert gcs.info_dict is not None
+    assert gcs.endpoint_id is None
+
+
+def test_domain_name_property_ignores_non_str_value(tmp_path):
+    info_path = tmp_path / "info.json"
+    info_path.write_text('{"domain_name": ["foo"]}')
+    gcs = LocalGlobusConnectServer(info_path=info_path)
+    assert gcs.info_dict is not None
+    assert gcs.domain_name is None
+
+
+def test_info_dict_can_reload_with_deleter(tmp_path):
+    info_path = tmp_path / "info.json"
+    info_path.write_text('{"foo": "bar"}')
+
+    # initial load okay
+    gcs = LocalGlobusConnectServer(info_path=info_path)
+    assert gcs.info_dict == {"foo": "bar"}
+    # update the data on disk
+    info_path.write_text('{"bar": "baz"}')
+    # data unchanged on the instance
+    assert gcs.info_dict == {"foo": "bar"}
+    # clear and reload updates the data
+    del gcs.info_dict
+    assert gcs.info_dict == {"bar": "baz"}

--- a/tests/functional/local_endpoint/test_server.py
+++ b/tests/functional/local_endpoint/test_server.py
@@ -21,6 +21,13 @@ def test_info_dict_from_non_json_object_file_is_none(tmp_path):
     assert gcs.info_dict is None
 
 
+def test_info_dict_from_non_unicode_file_is_none(tmp_path):
+    info_path = tmp_path / "info.json"
+    info_path.write_bytes(b'{"foo":"{' + bytes.fromhex("1BAD DEC0DE") + b'}"}')
+    gcs = LocalGlobusConnectServer(info_path=info_path)
+    assert gcs.info_dict is None
+
+
 def test_info_dict_from_empty_json_file_is_okay_but_has_no_properties(tmp_path):
     info_path = tmp_path / "info.json"
     info_path.write_text("{}")


### PR DESCRIPTION
This adds a start on a local GCS object which looks at the canonical `info.json` file and pulls attributes out of it in a type-safe way.

Primarily in order to support testing, the path to the `info.json` file can be set as an argument to the LocalGlobusConnectServer initializer.