### PR TITLE
add entity type to get endpoint _testing data

### DIFF
--- a/src/globus_sdk/_testing/data/transfer/get_endpoint.py
+++ b/src/globus_sdk/_testing/data/transfer/get_endpoint.py
@@ -9,6 +9,7 @@ ENDPOINT_DOC = {
     "organization": "My Org",
     "username": "auser",
     "description": "Example gridftp endpoint.",
+    "entity_type": "GCSv4_host",
     "public": False,
     "french_english_bilingual": False,
     "is_globus_connect": False,


### PR DESCRIPTION
Doing CLI work for https://app.shortcut.com/globus/story/19989/use-entity-type-when-determining-endpointish-type and some tests will depend on `entity_type` being set here.

Can just modify the fixtures CLI side if needed, but this seems like a particularly good field to add to _testing data anyways