### PR TITLE
Fix an annotation bug + add mypy test

### DIFF
--- a/changelog.d/20221116_231204_sirosen_bugfix_annotation.rst
+++ b/changelog.d/20221116_231204_sirosen_bugfix_annotation.rst
@@ -1,0 +1,2 @@
+* Fix a bug in the type annotations for transport objects which restricted the
+  size of status code tuples set as classvars (:pr:`NUMBER`)

--- a/src/globus_sdk/transport/requests.py
+++ b/src/globus_sdk/transport/requests.py
@@ -91,11 +91,11 @@ class RequestsTransport:
     DEFAULT_MAX_RETRIES = 5
 
     #: status codes for responses which may have a Retry-After header
-    RETRY_AFTER_STATUS_CODES = (429, 503)
+    RETRY_AFTER_STATUS_CODES: t.Tuple[int, ...] = (429, 503)
     #: status codes for error responses which should generally be retried
-    TRANSIENT_ERROR_STATUS_CODES = (429, 500, 502, 503, 504)
+    TRANSIENT_ERROR_STATUS_CODES: t.Tuple[int, ...] = (429, 500, 502, 503, 504)
     #: status codes indicating that authorization info was missing or expired
-    EXPIRED_AUTHORIZATION_STATUS_CODES = (401,)
+    EXPIRED_AUTHORIZATION_STATUS_CODES: t.Tuple[int, ...] = (401,)
 
     #: the encoders are a mapping of encoding names to encoder objects
     encoders: t.Dict[str, RequestEncoder] = {

--- a/tests/non-pytest/mypy-ignore-tests/custom_transport.py
+++ b/tests/non-pytest/mypy-ignore-tests/custom_transport.py
@@ -1,0 +1,9 @@
+from globus_sdk.transport import RequestsTransport
+
+
+# customize the status code tuples
+# make sure mypy does not reject these changes for updating the tuple sizes
+class CustomRetryStatusTransport(RequestsTransport):
+    RETRY_AFTER_STATUS_CODES = (503,)
+    TRANSIENT_ERROR_STATUS_CODES = (500,)
+    EXPIRED_AUTHORIZATION_STATUS_CODES = (401, 403)


### PR DESCRIPTION
Prior to this change, the tuple sizes were deduced by mypy and treated as constraints. `tuple[int, ...]` allows for any-sized tuples to be used.