### PR TITLE
Update to flake8==6.0.0 , and update additional_dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,16 +18,16 @@ repos:
   rev: v1.12.1
   hooks:
     - id: blacken-docs
-      additional_dependencies: ['black==21.12b0']
+      additional_dependencies: ['black==22.10.0']
 - repo: https://github.com/PyCQA/flake8
   rev: 6.0.0
   hooks:
     - id: flake8
       name: "Lint python files"
       additional_dependencies:
-        - 'flake8-bugbear==22.7.1'
+        - 'flake8-bugbear==22.10.27'
         - 'flake8-comprehensions==3.10.1'
-        - 'flake8-typing-as-t==0.0.2'
+        - 'flake8-typing-as-t==0.0.3'
 - repo: https://github.com/PyCQA/isort
   rev: 5.10.1
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,12 +20,13 @@ repos:
     - id: blacken-docs
       additional_dependencies: ['black==21.12b0']
 - repo: https://github.com/PyCQA/flake8
-  rev: 5.0.4
+  rev: 6.0.0
   hooks:
     - id: flake8
       name: "Lint python files"
       additional_dependencies:
         - 'flake8-bugbear==22.7.1'
+        - 'flake8-comprehensions==3.10.1'
         - 'flake8-typing-as-t==0.0.2'
 - repo: https://github.com/PyCQA/isort
   rev: 5.10.1

--- a/src/globus_sdk/_sphinxext.py
+++ b/src/globus_sdk/_sphinxext.py
@@ -91,7 +91,7 @@ class AutoMethodList(AddContentDirective):
         include_methods = []
         for arg in self.arguments[1:]:
             if arg.startswith("include_methods="):
-                include_methods = [x for x in arg.split("=")[1].split(",")]
+                include_methods = arg.split("=")[1].split(",")
 
         yield ""
         yield "**Methods**"

--- a/tests/non-pytest/mypy-ignore-tests/base_client_usage.py
+++ b/tests/non-pytest/mypy-ignore-tests/base_client_usage.py
@@ -14,4 +14,4 @@ i = c.resource_server  # type: ignore [assignment]
 # check that data:list warns, but other types are okay
 r = c.request("POST", "/foo", data="bar")
 r = c.request("POST", "/foo", data={})
-r = c.request("POST", "/foo", data=list())  # type: ignore [arg-type]
+r = c.request("POST", "/foo", data=[])  # type: ignore [arg-type]

--- a/tests/unit/responses/test_response.py
+++ b/tests/unit/responses/test_response.py
@@ -264,7 +264,7 @@ def test_iterable_response_using_iter_key():
 def test_can_iter_array_response(list_response):
     arr = ArrayResponse(list_response.r)
     # sorted/reversed are just example stdlib functions which use iter
-    assert list(sorted(arr)) == list(sorted(list_response.data))
+    assert sorted(arr) == sorted(list_response.data)
     assert list(reversed(arr)) == list(reversed(list_response.data))
 
 


### PR DESCRIPTION
Working through various repos I can update nicely with [`upadup`](https://pypi.org/project/upadup/) now that I have it working for basic purposes; I was also poking at other elements of our linting config.

1. Update to the latest flake8 version (no impact for us)
2. Add `flake8-comprehensions`
3. Apply `upadup`

Regarding (2), I saw this as one of the plugins emulated by `ruff` and therefore took a look at it.
I don't think of myself as being very good about writing comprehensions consistently, so I thought it would possibly even call out something inefficient in a core codepath somewhere. I was a little disappointed that it saw so few things in our codebase, but I guess that's a good thing. 😉 
Even so, `flake8-comprehensions` will help protect against mistakes, and it _did_ find a couple of oddities (in places that don't matter much, but still...). So I kept the addition.

I'm more excited about `upadup`!