### PR TITLE
Update check-jsonschema repo url

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
   hooks:
     - id: check-merge-conflict
     - id: trailing-whitespace
-- repo: https://github.com/sirosen/check-jsonschema
+- repo: https://github.com/python-jsonschema/check-jsonschema
   rev: 0.19.2
   hooks:
     - id: check-github-workflows


### PR DESCRIPTION
I'm doing a bit of a sweep to find and eliminate uses of the old URL.
All of github is too broad, but projects at Globus -- especially ones where I'm a primary author! 😬 -- seem like a good place to at least be sure.