### PR TITLE
Add `last_key` arg to `endpoint_manager_task_list`

### DIFF
--- a/changelog.d/20221212_152325_ada_sc_20588.rst
+++ b/changelog.d/20221212_152325_ada_sc_20588.rst
@@ -1,0 +1,11 @@
+..
+.. A new scriv changelog fragment
+..
+.. Add one or more items to the list below describing the change in clear, concise terms.
+..
+.. Leave the ":pr:`...`" text alone. When you open a pull request, GitHub Actions will
+.. automatically replace it when the PR is merged.
+..
+
+* Fix a bug where ``TransferClient.endpoint_manager_task_list`` didn't handle
+  the ``last_key`` argument when paginated (:pr:`NUMBER`)

--- a/src/globus_sdk/services/transfer/client.py
+++ b/src/globus_sdk/services/transfer/client.py
@@ -1873,6 +1873,7 @@ class TransferClient(client.BaseClient):
         filter_completion_time: t.Union[None, str, t.Tuple[DateLike, DateLike]] = None,
         filter_min_faults: t.Optional[int] = None,
         filter_local_user: t.Optional[str] = None,
+        last_key: t.Optional[str] = None,
         query_params: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> IterableTransferResponse:
         r"""
@@ -1940,6 +1941,8 @@ class TransferClient(client.BaseClient):
             from the endpoint, and match the values of ``filter_endpoint`` and
             ``filter_local_user`` on the source or on the destination.
         :type filter_local_user: str, optional
+        :param last_key: the last key, for paging
+        :type last_key: str, optional
         :param query_params: Additional passthrough query parameters
         :type query_params: dict, optional
 
@@ -1997,6 +2000,8 @@ class TransferClient(client.BaseClient):
             query_params["filter_min_faults"] = filter_min_faults
         if filter_local_user is not None:
             query_params["filter_local_user"] = filter_local_user
+        if last_key is not None:
+            query_params["last_key"] = last_key
         return IterableTransferResponse(
             self.get("endpoint_manager/task_list", query_params=query_params)
         )

--- a/tests/functional/services/transfer/test_paginated.py
+++ b/tests/functional/services/transfer/test_paginated.py
@@ -84,7 +84,7 @@ def _mk_task_doc(idx):
     }
 
 
-MULTIPAGE_TASK_LIST_RESULTS = [
+MULTIPAGE_OFFSET_TASK_LIST_RESULTS = [
     {
         "DATA_TYPE": "task_list",
         "offset": 0,
@@ -97,6 +97,24 @@ MULTIPAGE_TASK_LIST_RESULTS = [
         "offset": 100,
         "limit": 200,
         "total": 200,
+        "DATA": [_mk_task_doc(x) for x in range(100, 200)],
+    },
+]
+
+
+MULTIPAGE_LASTKEY_TASK_LIST_RESULTS = [
+    {
+        "DATA_TYPE": "task_list",
+        "last_key": "abc",
+        "limit": 100,
+        "has_next_page": True,
+        "DATA": [_mk_task_doc(x) for x in range(100)],
+    },
+    {
+        "DATA_TYPE": "task_list",
+        "last_key": "def",
+        "limit": 100,
+        "has_next_page": False,
         "DATA": [_mk_task_doc(x) for x in range(100, 200)],
     },
 ]
@@ -125,7 +143,8 @@ def test_endpoint_search_one_page(client):
     "api_methodname,paged_data",
     [
         ("endpoint_search", MULTIPAGE_SEARCH_RESULTS),
-        ("task_list", MULTIPAGE_TASK_LIST_RESULTS),
+        ("task_list", MULTIPAGE_OFFSET_TASK_LIST_RESULTS),
+        ("endpoint_manager_task_list", MULTIPAGE_LASTKEY_TASK_LIST_RESULTS),
     ],
 )
 def test_paginated_method_multipage(client, method, api_methodname, paged_data):
@@ -140,6 +159,13 @@ def test_paginated_method_multipage(client, method, api_methodname, paged_data):
         route = "/task_list"
         client_method = client.task_list
         paginated_method = client.paginated.task_list
+        call_args = ()
+        wrapper_type = "task_list"
+        data_type = "task"
+    elif api_methodname == "endpoint_manager_task_list":
+        route = "/endpoint_manager/task_list"
+        client_method = client.endpoint_manager_task_list
+        paginated_method = client.paginated.endpoint_manager_task_list
         call_args = ()
         wrapper_type = "task_list"
         data_type = "task"


### PR DESCRIPTION
Resolves an issue where the TransferClient's `endpoint_manager_task_list` method didn't accept the `last_key` argument sent by the paginator. Addresses an issue first reported in [ticket 359253](https://globusonline.zendesk.com/agent/tickets/359253).

Signed-off-by: Ada Nikolaidis <ada@globus.org>