### PR TITLE
Fix CI builds for tox v4 and any other changes

### DIFF
--- a/tests/non-pytest/lazy-imports/test_for_import_cycles.py
+++ b/tests/non-pytest/lazy-imports/test_for_import_cycles.py
@@ -18,7 +18,7 @@ import globus_sdk
 
 PYTHON_BINARY = os.environ.get("GLOBUS_TEST_PY", sys.executable)
 
-MODULE_NAMES = frozenset(globus_sdk._LAZY_IMPORT_TABLE.keys())
+MODULE_NAMES = sorted(globus_sdk._LAZY_IMPORT_TABLE.keys())
 
 
 @pytest.mark.parametrize(

--- a/tox.ini
+++ b/tox.ini
@@ -75,7 +75,7 @@ commands = pyright src/ {posargs}
 # readthedocs doc build
 basepython = python3.10
 extras = dev
-whitelist_externals = rm
+allowlist_externals = rm
 changedir = docs/
 # clean the build dir before rebuilding
 commands_pre = rm -rf _build/
@@ -85,7 +85,7 @@ commands = sphinx-build -d _build/doctrees -b dirhtml -W . _build/dirhtml {posar
 skip_install = true
 deps = build
        twine
-whitelist_externals = rm
+allowlist_externals = rm
 commands_pre = rm -rf dist/
 # check that twine validating package data works
 commands = python -m build
@@ -95,7 +95,7 @@ commands = python -m build
 skip_install = true
 deps = poetry
 # remove the dist dir because it can lead to (confusing) spurious failures
-whitelist_externals = rm
+allowlist_externals = rm
 commands_pre = rm -rf dist/
 # use `poetry lock` to ensure that poetry can parse our dependencies
 changedir = tests/non-pytest/poetry-lock-test
@@ -113,7 +113,7 @@ skip_install = true
 deps = build
        twine
 # clean the build dir before rebuilding
-whitelist_externals = rm
+allowlist_externals = rm
 commands_pre = rm -rf dist/
 commands = python -m build
            twine upload dist/*


### PR DESCRIPTION
Update whitelist_externals to allowlist_externals.
In tox version 4, the deprecated config key has been removed.

---

Use a sorted list for lazy import test params.
This fixes an issue on py3.11 in which the order of this frozenset is no longer fixed (it was never guaranteed) and the result is that a distributed test run delivers test parameters in different orders.
pytest-xdist fails if workers see different parameters -- even if it is only order that varies.

---

I am now marking this ready for review.
RTD is still failing because github appears to have some issue with PR head refs. `gh pr checkout 663` doesn't work either.
I'm not sure if this is a global issue or something which has gone wrong with the state of this particular PR.

I advocate for ignoring the failing RTD build for now, until we can get more things cleaned up.