### PR TITLE
Fix a bad ref to `BaseClient`

### DIFF
--- a/src/globus_sdk/services/gcs/client.py
+++ b/src/globus_sdk/services/gcs/client.py
@@ -38,7 +38,8 @@ class GCSClient(client.BaseClient):
     <https://docs.globus.org/globus-connect-server/v5/api/>`_.
 
     Unlike other client types, this must be provided with an address for the GCS
-    Manager. All other arguments are the same as those for `~globus_sdk.BaseClient`.
+    Manager. All other arguments are the same as those for
+    :class:`~globus_sdk.BaseClient`.
 
     :param gcs_address: The FQDN (DNS name) or HTTPS URL for the GCS Manager API.
     :type gcs_address: str


### PR DESCRIPTION
This was rendering as `~globus_sdk.BaseClient` instead of as a link:

https://globus-sdk-python.readthedocs.io/en/stable/services/gcs.html#globus_sdk.GCSClient