### PR TITLE
Update tox.ini and handle fallout

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,10 +1,19 @@
 [run]
 parallel = True
-include = src/*
+source = globus_sdk
+# omit must be specified in a way which matches the
+# tox environment installations, so lead with `**`
 omit =
-    src/globus_sdk/_sphinxext.py
-    src/globus_sdk/_testing/*
-    src/globus_sdk/_generate_init.py
+    **/globus_sdk/_sphinxext.py
+    **/globus_sdk/_testing/*
+    **/globus_sdk/_generate_init.py
+
+[paths]
+# path remapping specifies that any installation of
+# the SDK into a tox environment should be treated equivalently to src/
+source =
+    src/globus_sdk/
+    .tox/**/site-packages/globus_sdk/
 
 [report]
 show_missing = True

--- a/.coveragerc
+++ b/.coveragerc
@@ -9,11 +9,11 @@ omit =
     **/globus_sdk/_generate_init.py
 
 [paths]
-# path remapping specifies that any installation of
-# the SDK into a tox environment should be treated equivalently to src/
+# path remapping specifies that any installation of a package in a
+# site-packages directory (e.g. in tox) should be treated equivalently to src/
 source =
-    src/globus_sdk/
-    .tox/**/site-packages/globus_sdk/
+    src/
+    */site-packages/
 
 [report]
 show_missing = True

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,7 +52,7 @@ jobs:
       - name: install tox
         run: python -m pip install -U tox
       - name: run tests
-        run: python -m tox -e py,cov-combine,cov-report
+        run: python -m tox -e py,coverage_report
 
   test-lazy-imports:
     runs-on: ubuntu-latest

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ TEST_REQUIREMENTS = [
     # on py3.6, use the last version to support 3.6
     'responses==0.17.0; python_version<"3.7"',
     # on py3.7+, use the latest version
-    'responses==0.21.0; python_version>="3.7"',
+    'responses==0.22.0; python_version>="3.7"',
 ]
 DOC_REQUIREMENTS = [
     "sphinx<5",

--- a/src/globus_sdk/_testing/helpers.py
+++ b/src/globus_sdk/_testing/helpers.py
@@ -9,6 +9,7 @@ def get_last_request(
 ) -> t.Optional[requests.PreparedRequest]:
     calls = requests_mock.calls if requests_mock is not None else responses.calls
     try:
-        return t.cast(requests.PreparedRequest, calls[-1].request)
+        last_call = t.cast(responses.Call, calls[-1])
     except IndexError:
         return None
+    return t.cast(requests.PreparedRequest, last_call.request)

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,8 @@ envlist =
     py36-mindeps
     coverage_report
 skip_missing_interpreters = true
-minversion = 4.0.0
+# TODO: set a minversion after we drop support for python3.6
+# minversion = 4.0.0
 
 [testenv]
 # build a wheel, not a tarball, and use a common env to do it (so that the wheel is shared)

--- a/tox.ini
+++ b/tox.ini
@@ -1,40 +1,40 @@
 [tox]
 envlist =
-    cov-clean
-    cov-combine
-    cov-report
+    lint
+    mypy
+    test-lazy-imports
+    coverage_clean
     py{311,310,39,38,37,36}
     py36-mindeps
+    coverage_report
 skip_missing_interpreters = true
-minversion = 3.0.0
+minversion = 4.0.0
 
 [testenv]
-usedevelop = true
+# build a wheel, not a tarball, and use a common env to do it (so that the wheel is shared)
+package = wheel
+wheel_build_env = build_wheel
+
 extras = dev
 deps =
     mindeps: requests==2.19.1
     mindeps: pyjwt==2.0.0
     mindeps: cryptography==3.3.1
     mindeps: typing_extensions==4.0
-commands = coverage run -m pytest {posargs}
+commands = coverage run --source globus_sdk -m pytest {posargs}
 depends =
-    py36,py37,py38,py39,py36-mindeps: cov-clean
-    cov-combine: py36,py37,py38,py39,py36-mindeps
-    cov-report: cov-combine
+    py{36,37,38,39,310,311,36-mindeps}: coverage_clean
+    coverage_report: py{36,37,38,39,310,311,36-mindeps}
 
-[testenv:cov-clean]
+[testenv:coverage_clean]
 deps = coverage
 skip_install = true
 commands = coverage erase
 
-[testenv:cov-combine]
+[testenv:coverage_report]
 deps = coverage
 skip_install = true
-commands = coverage combine
-
-[testenv:cov-report]
-deps = coverage
-skip_install = true
+commands_pre = -coverage combine
 commands = coverage report --skip-covered
 
 [testenv:lint]
@@ -44,7 +44,7 @@ commands = pre-commit run --all-files
 
 [testenv:mypy{,-mindeps,-test}]
 deps =
-    mypy==0.982
+    mypy==0.991
     types-docutils
     types-jwt
     types-requests

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ deps =
     mindeps: pyjwt==2.0.0
     mindeps: cryptography==3.3.1
     mindeps: typing_extensions==4.0
-commands = coverage run --source globus_sdk -m pytest {posargs}
+commands = coverage run -m pytest {posargs}
 depends =
     py{36,37,38,39,310,311,36-mindeps}: coverage_clean
     coverage_report: py{36,37,38,39,310,311,36-mindeps}


### PR DESCRIPTION
Refactor the tox config to achieve the following:
- a wheel is built in a shared build_wheel environment for faster overall builds
- `usedevelop=true` is no longer used
- cov-clean is renamed 'coverage_clean'
- cov-cobmine, cov-report are combined into 'coverage_report'
- default tox envs now include `lint` and `mypy`
- update `mypy` in tox.ini to v0.991
- cleanup the 'depends' lists' and add test-lazy-imports to the default envlist

Effects from these changes are handled thusly:
- `responses` must also be updated to the latest (0.22.0) to fix an issue on newer `mypy` versions
- .coveragerc needs adjustment to work when `usedevelop` is not in use, normalizing '.tox/*' installs of globus_sdk to be treated identically to the src/ tree