### PR TITLE
Move _testing docs to internal part of docs/ dir

### DIFF
--- a/docs/testing/getting_started.rst
+++ b/docs/testing/getting_started.rst
@@ -1,14 +1,12 @@
-Welcome to ``globus_sdk._testing``
-==================================
-
 .. warning::
 
-    Use at your own risk! This subpackage is highly experimental. It may
-    feature breaking changes to the data and the interfaces without prior
-    notice.
+    This component is an *alpha*. Interfaces may change outside of the
+    normal semver policy.
 
-This is an experimental internal module offered by the Globus SDK to share
-API fixtures for use with the ``responses`` library.
+Getting Started with _testing
+=============================
+
+:ref:`Back to _testing root <testing_root>`.
 
 Dependencies
 ------------
@@ -33,48 +31,6 @@ guaranteeing that requests are sent to the production hostnames:
         yield
         responses.stop()
         responses.reset()
-
-Methods and Classes
--------------------
-
-Users of ``globus_sdk._testing`` have the following methods and classes
-available:
-
-``get_last_request``
-    Get the last request which was received, or None if there were no requests.
-
-``ResponseSet``
-    A collection of mock responses, potentially all meant to be activated together
-    (``.activate_all()``), or to be individually selected as options/alternatives
-    (``.activate("case_foo")``).
-
-``RegisteredResponse``
-    A mock response along with descriptive metadata to let a fixture "pass data
-    forward" to the consuming test cases. (e.g. a ``GET Task`` fixture which
-    shares the ``task_id`` it uses with consumers via ``.metadata["task_id"]``)
-
-``ResponseList``
-    A series of mock responses which *must* be activated together in a single
-    step. This can be stored in a ``ResponseSet`` as a case, describing a set
-    of responses registered to a specific name.
-
-``load_response_set``
-    Optionally lookup a response set and activate all of its responses. If
-    passed a ``ResponseSet``, activate it, otherwise the first argument is an
-    ID used for lookup.
-
-``load_response``
-    Optionally lookup and activate an individual response. If given a
-    ``RegisteredResponse``, activate it, otherwise the first argument is an ID
-    of a ``ResponseSet`` used for lookup. By default, looks for the response
-    registered under ``case="default"``.
-
-``get_response_set``
-    Lookup a ``ResponseSet`` as in ``load_response_set``, but without
-    activating it.
-
-``register_response_set``
-    Register a new ``ResponseSet`` object.
 
 Usage
 -----

--- a/docs/testing/index.rst
+++ b/docs/testing/index.rst
@@ -1,0 +1,23 @@
+:orphan:
+
+.. warning::
+
+    This component is an *alpha*. Interfaces may change outside of the
+    normal semver policy.
+
+.. _testing_root:
+
+Globus SDK _testing (alpha)
+===========================
+
+.. warning::
+
+    The exact data and payloads provided via ``_testing`` are a best
+    approximation of API responses. They may change in any SDK release to be
+    more accurate.
+
+.. toctree::
+    :caption: Contents
+
+    getting_started
+    reference

--- a/docs/testing/reference.rst
+++ b/docs/testing/reference.rst
@@ -1,0 +1,39 @@
+.. warning::
+
+    This component is an *alpha*. Interfaces may change outside of the
+    normal semver policy.
+
+_testing Reference
+==================
+
+:ref:`Back to _testing root <testing_root>`.
+
+.. module:: globus_sdk._testing
+
+Functions
+---------
+
+.. autofunction:: get_last_request
+
+.. autofunction:: register_response_set
+
+.. autofunction:: get_response_set
+
+.. autofunction:: load_response_set
+
+.. autofunction:: load_response
+
+Classes
+-------
+
+.. autoclass:: RegisteredResponse
+    :members:
+    :member-order: bysource
+
+.. autoclass:: ResponseList
+    :members:
+    :member-order: bysource
+
+.. autoclass:: ResponseSet
+    :members:
+    :member-order: bysource

--- a/src/globus_sdk/_testing/helpers.py
+++ b/src/globus_sdk/_testing/helpers.py
@@ -7,6 +7,12 @@ import responses
 def get_last_request(
     *, requests_mock: t.Optional[responses.RequestsMock] = None
 ) -> t.Optional[requests.PreparedRequest]:
+    """
+    Get the last request which was received, or None if there were no requests.
+
+    :param requests_mock: A non-default ``RequestsMock`` object to use.
+    :type requests_mock: responses.RequestsMock
+    """
     calls = requests_mock.calls if requests_mock is not None else responses.calls
     try:
         last_call = t.cast(responses.Call, calls[-1])

--- a/src/globus_sdk/_testing/models.py
+++ b/src/globus_sdk/_testing/models.py
@@ -6,6 +6,12 @@ from ..utils import slash_join
 
 
 class RegisteredResponse:
+    """
+    A mock response along with descriptive metadata to let a fixture "pass data
+    forward" to the consuming test cases. (e.g. a ``GET Task`` fixture which
+    shares the ``task_id`` it uses with consumers via ``.metadata["task_id"]``)
+    """
+
     _url_map = {
         "auth": "https://auth.globus.org/",
         "nexus": "https://nexus.api.globusonline.org/",
@@ -84,6 +90,9 @@ class ResponseList:
     """
     A series of unnamed responses, meant to be used and referred to as a single case
     within a ResponseSet.
+
+    This can be stored in a ``ResponseSet`` as a case, describing a series
+    of responses registered to a specific name (e.g. to describe a paginated API).
     """
 
     def __init__(
@@ -115,9 +124,12 @@ class ResponseList:
 
 class ResponseSet:
     """
-    A collection of responses. On init, this implicitly sets the parent of
-    any response objects to this response set. On register() it does not do
-    so automatically.
+    A collection of mock responses, potentially all meant to be activated together
+    (``.activate_all()``), or to be individually selected as options/alternatives
+    (``.activate("case_foo")``).
+
+    On init, this implicitly sets the parent of any response objects to this response
+    set. On register() it does not do so automatically.
     """
 
     def __init__(

--- a/src/globus_sdk/_testing/registry.py
+++ b/src/globus_sdk/_testing/registry.py
@@ -15,6 +15,19 @@ def register_response_set(
     rset: t.Union[ResponseSet, t.Dict[str, t.Dict[str, t.Any]]],
     metadata: t.Optional[t.Dict[str, t.Any]] = None,
 ) -> ResponseSet:
+    """
+    Register a new ``ResponseSet`` object.
+
+    The response set may be specified as a dict or a ResponseSet object.
+
+    :param set_id: The ID used to retrieve the response set later
+    :type set_id: any
+    :param rset: The response set to register
+    :type rset: dict or ResponseSet
+    :param metadata: Metadata dict to assign to the response set when it is specified
+        as a dict. If the response set is an object, this argument is ignored.
+    :type metadata: dict, optional
+    """
     if isinstance(rset, dict):
         rset = ResponseSet.from_dict(rset, metadata=metadata)
     _RESPONSE_SET_REGISTRY[set_id] = rset
@@ -45,6 +58,10 @@ def _resolve_qualname(name: str) -> str:
 
 
 def get_response_set(set_id: t.Any) -> ResponseSet:
+    """
+    Lookup a ``ResponseSet`` as in ``load_response_set``, but without
+    activating it.
+    """
     # first priority: check the explicit registry
     if set_id in _RESPONSE_SET_REGISTRY:
         return _RESPONSE_SET_REGISTRY[set_id]
@@ -76,6 +93,11 @@ def get_response_set(set_id: t.Any) -> ResponseSet:
 def load_response_set(
     set_id: t.Any, *, requests_mock: t.Optional[responses.RequestsMock] = None
 ) -> ResponseSet:
+    """
+    Optionally lookup a response set and activate all of its responses. If
+    passed a ``ResponseSet``, activate it, otherwise the first argument is an
+    ID used for lookup.
+    """
     if isinstance(set_id, ResponseSet):
         return set_id.activate_all(requests_mock=requests_mock)
     ret = get_response_set(set_id)
@@ -89,6 +111,12 @@ def load_response(
     case: str = "default",
     requests_mock: t.Optional[responses.RequestsMock] = None,
 ) -> t.Union[RegisteredResponse, ResponseList]:
+    """
+    Optionally lookup and activate an individual response. If given a
+    ``RegisteredResponse``, activate it, otherwise the first argument is an ID
+    of a ``ResponseSet`` used for lookup. By default, looks for the response
+    registered under ``case="default"``.
+    """
     if isinstance(set_id, RegisteredResponse):
         return set_id.add(requests_mock=requests_mock)
     rset = get_response_set(set_id)


### PR DESCRIPTION
Mark the root testing doc as `:orphan:`, thus excluding it from any toctree and furo behaviors.
Within this space, define a toctree for documents and manually present links back to the testing root.

Move documentation from the _testing readme into the new doc tree and into the _testing source tree in docstrings, then load said documentation via autofunction and autoclass.

Minor refinements were made to some, but not all, docstrings, in the interest of time.