### PR TITLE
Revise Example Timer Script

### DIFF
--- a/changelog.d/20230124_141218_ada_revise_timer_example.rst
+++ b/changelog.d/20230124_141218_ada_revise_timer_example.rst
@@ -1,0 +1,1 @@
+* Fix the Timer code example (:pr:`NUMBER`)

--- a/docs/examples/timer_operations.rst
+++ b/docs/examples/timer_operations.rst
@@ -1,9 +1,8 @@
 Timer Operations Script
 -----------------------
 
-This example demonstrates the usage of methods on the Timer client. Note that we first
-need a Transfer client set up in order to create the ``TransferData`` we will use to
-define our recurring Timer job.
+This example demonstrates the usage of methods on the Timer client to
+schedule a recurring Transfer task.
 
 .. code-block:: python
 
@@ -15,32 +14,60 @@ define our recurring Timer job.
         NativeAppAuthClient,
         TimerClient,
         TimerJob,
-        TransferClient,
         TransferData,
+    )
+    from globus_sdk.scopes import (
+        GCSCollectionScopeBuilder,
+        MutableScope,
+        TimerScopes,
+        TransferScopes,
     )
 
     GOEP1 = "ddb59aef-6d04-11e5-ba46-22000b92c6ec"
     GOEP2 = "ddb59af0-6d04-11e5-ba46-22000b92c6ec"
+    NATIVE_CLIENT_ID = "61338d24-54d5-408f-a10d-66c06b59f6d2"
     TIMER_CLIENT_ID = "524230d7-ea86-4a52-8312-86065a9e0417"
-    TIMER_SCOPE = f"https://auth.globus.org/scopes/{TIMER_CLIENT_ID}/timer"
-    TRANSFER_SCOPE = "urn:globus:auth:scope:transfer.api.globus.org:all"
-    SCOPES = [TIMER_SCOPE, TRANSFER_SCOPE]
+
+    # If any of the collections you're targeting are mapped collections
+    # that require data_access scopes, include them in this list
+    MAPPED_COLLECTION_IDS = []
+
+    # Build a scope that will give the Timer service
+    # access to perform transfers on your behalf
+    timer_scope = TimerScopes.make_mutable("timer")
+    transfer_scope = TransferScopes.make_mutable("all")
+    transfer_action_provider_scope_string = (
+        "https://auth.globus.org/scopes/actions.globus.org/transfer/transfer"
+    )
+    transfer_action_provider_scope = MutableScope(transfer_action_provider_scope_string)
+
+    # If you declared and mapped collections above, add them to the transfer scope
+    for id in MAPPED_COLLECTION_IDS:
+        gcs_data_access_scope = GCSCollectionScopeBuilder(id).make_mutable(
+            "data_access",
+            optional=True,
+        )
+        transfer_scope.add_dependency(gcs_data_access_scope)
+
+    transfer_action_provider_scope.add_dependency(transfer_scope)
+    timer_scope.add_dependency(transfer_action_provider_scope)
+
+    print(f"Requesting scopes: {timer_scope}")
+
+    # Initialize your native app auth client
+    native_client = NativeAppAuthClient(NATIVE_CLIENT_ID)
 
     # Get access tokens to use for both Transfer and Timer
-    native_client.oauth2_start_flow(requested_scopes=SCOPES)
+    native_client.oauth2_start_flow(requested_scopes=timer_scope)
     authorize_url = native_client.oauth2_get_authorize_url()
     print(f"Please go to this URL and login:\n\n{authorize_url}\n")
     auth_code = input("Enter the auth code here: ").strip()
+
     token_response = native_client.oauth2_exchange_code_for_tokens(auth_code)
     timer_token = token_response.by_resource_server[TIMER_CLIENT_ID]["access_token"]
-    transfer_token = token_response.by_resource_server["transfer.api.globus.org"][
-        "access_token"
-    ]
 
-    # Set up a transfer client and create a `TransferData` object
-    transfer_authorizer = AccessTokenAuthorizer(transfer_token)
-    transfer_client = TransferClient(authorizer=transfer_authorizer)
-    data = TransferData(transfer_client, GOEP1, GOEP2)
+    # Create a `TransferData` object
+    data = TransferData(source_endpoint=GOEP1, destination_endpoint=GOEP2)
     data.add_item("/share/godata/file1.txt", "/~/file1.txt")
 
     # Set up the Timer client
@@ -51,7 +78,14 @@ define our recurring Timer job.
     start = datetime.utcnow()
     interval = timedelta(minutes=30)
     name = "sdk-timer-example"
-    job = TimerJob.from_transfer_data(data, start, interval, stop_after_n=2, name=name)
+    job = TimerJob.from_transfer_data(
+        data,
+        start,
+        interval,
+        stop_after_n=2,
+        name=name,
+        scope=transfer_action_provider_scope_string,
+    )
     response = timer_client.create_job(job)
     assert response.http_status == 201
     job_id = response["job_id"]


### PR DESCRIPTION
![dsc_3114_jt-1](https://user-images.githubusercontent.com/107940310/214434472-26e32c11-7a2a-4f2b-bf2c-f4ed36e6021c.jpg)

# Description

Makes some changes to the example Timer script based on discoveries while supporting a user that was running into trouble getting this running:

- Instantiate the native client
- Handle mapped collections
- Remove Transfer client from TransferData invocation
- Use Transfer action provider in scope tree and revise dependencies
- Specifically send the constructed Transfer AP scope