### PR TITLE
Add support for new GCS collection doc versions

### DIFF
--- a/changelog.d/20230130_224925_sirosen_update_gcs_collection_versions.rst
+++ b/changelog.d/20230130_224925_sirosen_update_gcs_collection_versions.rst
@@ -1,0 +1,6 @@
+* Improved GCS Collection datatype detection to support ``collection#1.6.0``
+  and ``collection#1.7.0`` documents (:pr:`NUMBER`)
+
+  * ``guest_auth_policy_id`` is now supported on ``MappedCollectionDcoument``
+
+  * ``user_message`` strings over 64 characters are now supported

--- a/src/globus_sdk/services/gcs/data/storage_gateway.py
+++ b/src/globus_sdk/services/gcs/data/storage_gateway.py
@@ -4,7 +4,7 @@ import typing as t
 from globus_sdk import utils
 from globus_sdk._types import UUIDLike
 
-from ._common import ensure_datatype
+from ._common import DatatypeCallback, ensure_datatype
 
 
 class StorageGatewayDocument(utils.PayloadWrapper):
@@ -65,6 +65,7 @@ class StorageGatewayDocument(utils.PayloadWrapper):
     DATATYPE_VERSION_IMPLICATIONS: t.Dict[str, t.Tuple[int, int, int]] = {
         "require_mfa": (1, 1, 0),
     }
+    DATATYPE_VERSION_CALLBACKS: t.Tuple[DatatypeCallback, ...] = ()
 
     def __init__(
         self,

--- a/tests/unit/helpers/gcs/test_collections.py
+++ b/tests/unit/helpers/gcs/test_collections.py
@@ -43,6 +43,8 @@ def test_collection_type_field():
         ({"user_message": ""}, "1.1.0"),
         ({"enable_https": True}, "1.1.0"),
         ({"enable_https": False}, "1.1.0"),
+        # a string of length > 64
+        ({"user_message": "long message..." + "x" * 100}, "1.7.0"),
     ],
 )
 def test_datatype_version_deduction(use_kwargs, doc_version):
@@ -63,6 +65,7 @@ def test_datatype_version_deduction(use_kwargs, doc_version):
         ({"force_verify": False}, "1.4.0"),
         ({"disable_anonymous_writes": True}, "1.5.0"),
         ({"disable_anonymous_writes": False}, "1.5.0"),
+        ({"guest_auth_policy_id": str(uuid.uuid4())}, "1.6.0"),
     ],
 )
 def test_datatype_version_deduction_mapped_specific_fields(use_kwargs, doc_version):


### PR DESCRIPTION
Support versions '1.6.0' and '1.7.0' via `guest_auth_policy_id` and long `user_message` handling.

Internally, the `guest_auth_policy_id` is simply a mapped-collection-only field matching the current structure, but the `user_message` treatment requires a new structure.

DocumentWithInducedDatatype now defines `DATATYPE_VERSION_CALLBACKS` as a secondary versioning mechanism alongside the
`DATATYPE_VERSION_IMPLICATIONS` mapping. The callbacks take the entire object and return an optional version number tuple. This is an extremely generic way of allowing a callback to apply arbitrary criteria for the version numbering. In service of that change, the protocol now requires `__getitem__` (trivially satisfied by all instances) so that the contents can be checked.
The callbacks are defined as a classvar tuple.