### PR TITLE
Widen AuthClient client_id types to include UUID

### DIFF
--- a/changelog.d/20230131_205819_sirosen_allow_uuid_for_client_id.rst
+++ b/changelog.d/20230131_205819_sirosen_allow_uuid_for_client_id.rst
@@ -1,0 +1,2 @@
+* Allow UUID values for the ``client_id`` parameter to ``AuthClient`` and its
+  subclasses (:pr:`NUMBER`)

--- a/src/globus_sdk/services/auth/client/base.py
+++ b/src/globus_sdk/services/auth/client/base.py
@@ -66,9 +66,11 @@ class AuthClient(client.BaseClient):
     error_class = AuthAPIError
     scopes = AuthScopes
 
-    def __init__(self, client_id: t.Optional[str] = None, **kwargs: t.Any) -> None:
+    def __init__(self, client_id: t.Optional[UUIDLike] = None, **kwargs: t.Any) -> None:
         super().__init__(**kwargs)
-        self.client_id = client_id
+        self.client_id: t.Optional[str] = (
+            str(client_id) if client_id is not None else None
+        )
         # an AuthClient may contain a GlobusOAuth2FlowManager in order to
         # encapsulate the functionality of various different types of flow
         # managers

--- a/src/globus_sdk/services/auth/client/confidential_client.py
+++ b/src/globus_sdk/services/auth/client/confidential_client.py
@@ -2,6 +2,7 @@ import logging
 import typing as t
 
 from globus_sdk import exc, utils
+from globus_sdk._types import UUIDLike
 from globus_sdk.authorizers import BasicAuthorizer
 from globus_sdk.response import GlobusHTTPResponse
 
@@ -33,7 +34,7 @@ class ConfidentialAppAuthClient(AuthClient):
     .. automethodlist:: globus_sdk.ConfidentialAppAuthClient
     """
 
-    def __init__(self, client_id: str, client_secret: str, **kwargs: t.Any):
+    def __init__(self, client_id: UUIDLike, client_secret: str, **kwargs: t.Any):
         if "authorizer" in kwargs:
             log.error("ArgumentError(ConfidentialAppClient.authorizer)")
             raise exc.GlobusSDKUsageError(
@@ -41,7 +42,7 @@ class ConfidentialAppAuthClient(AuthClient):
             )
         super().__init__(
             client_id=client_id,
-            authorizer=BasicAuthorizer(client_id, client_secret),
+            authorizer=BasicAuthorizer(str(client_id), client_secret),
             **kwargs,
         )
         log.info(f"Finished initializing client, client_id={client_id}")

--- a/src/globus_sdk/services/auth/client/native_client.py
+++ b/src/globus_sdk/services/auth/client/native_client.py
@@ -2,6 +2,7 @@ import logging
 import typing as t
 
 from globus_sdk import exc, utils
+from globus_sdk._types import UUIDLike
 from globus_sdk.authorizers import NullAuthorizer
 
 from ..flow_managers import GlobusNativeAppFlowManager
@@ -28,7 +29,7 @@ class NativeAppAuthClient(AuthClient):
     .. automethodlist:: globus_sdk.NativeAppAuthClient
     """
 
-    def __init__(self, client_id: str, **kwargs: t.Any) -> None:
+    def __init__(self, client_id: UUIDLike, **kwargs: t.Any) -> None:
         if "authorizer" in kwargs:
             log.error("ArgumentError(NativeAppClient.authorizer)")
             raise exc.GlobusSDKUsageError(

--- a/tests/unit/test_auth_clients.py
+++ b/tests/unit/test_auth_clients.py
@@ -1,0 +1,30 @@
+import uuid
+
+import pytest
+
+from globus_sdk import AuthClient, ConfidentialAppAuthClient, NativeAppAuthClient
+
+CLIENT_ID_UUID = uuid.uuid4()
+CLIENT_ID_STR = str(CLIENT_ID_UUID)
+
+
+def test_base_auth_client_does_not_require_client_id():
+    client = AuthClient()
+    assert client.client_id is None
+
+
+@pytest.mark.parametrize(
+    "client_type", (AuthClient, ConfidentialAppAuthClient, NativeAppAuthClient)
+)
+@pytest.mark.parametrize("pass_value_as", ("str", "uuid"))
+def test_can_use_uuid_or_str_for_client_id(client_type, pass_value_as):
+    pass_value = CLIENT_ID_UUID if pass_value_as == "uuid" else CLIENT_ID_STR
+
+    if client_type in (AuthClient, NativeAppAuthClient):
+        client = client_type(client_id=pass_value)
+    elif client_type is ConfidentialAppAuthClient:
+        client = ConfidentialAppAuthClient(pass_value, "bogus_secret")
+    else:
+        raise NotImplementedError
+
+    assert client.client_id == CLIENT_ID_STR


### PR DESCRIPTION
Users are now permitted to pass UUID objects to AuthClient and its subclasses. The UUID is converted to a string on init, but this is more accepting in terms of inputs and matches some usage we have seen in the wild which *probably* works but is not guaranteed.

New unit tests simply assert that the UUID values are accepted and converted to str values on init.