### PR TITLE
Convert Exception to LookupError to appease pylint

### DIFF
--- a/src/globus_sdk/_testing/models.py
+++ b/src/globus_sdk/_testing/models.py
@@ -149,7 +149,7 @@ class ResponseSet:
         try:
             return self._data[case]
         except KeyError as e:
-            raise Exception("did not find a matching registered response") from e
+            raise LookupError("did not find a matching registered response") from e
 
     def __bool__(self) -> bool:
         return bool(self._data)


### PR DESCRIPTION
This is a generic error being raised to help give us some better context when `load_response` and `load_response_set` fail. pylint now frowns upon use of `raise Exception`, so use `LookupError` as a slightly more generic thing than `KeyError`.