### PR TITLE
Parse 'session_required_policies' to a list

### DIFF
--- a/changelog.d/20230206_204150_sirosen_parse_required_policies.rst
+++ b/changelog.d/20230206_204150_sirosen_parse_required_policies.rst
@@ -1,0 +1,2 @@
+* The ``session_required_policies`` attribute of ``AuthorizationInfo`` is now
+  parsed as a list of strings when present, and ``None`` when absent. (:pr:`NUMBER`)

--- a/src/globus_sdk/exc/err_info.py
+++ b/src/globus_sdk/exc/err_info.py
@@ -1,4 +1,7 @@
+import logging
 import typing as t
+
+log = logging.getLogger(__name__)
 
 
 class ErrorInfo:
@@ -66,13 +69,16 @@ class AuthorizationParameterInfo(ErrorInfo):
         )
 
         # get str|None and parse as appropriate
+        self.session_required_policies: t.Optional[t.List[str]] = None
         session_required_policies = data.get("session_required_policies")
         if isinstance(session_required_policies, str):
-            self.session_required_policies: t.Optional[
-                t.List[str]
-            ] = session_required_policies.split(",")
-        else:
-            self.session_required_policies = None
+            self.session_required_policies = session_required_policies.split(",")
+        elif session_required_policies is not None:
+            log.warning(
+                "during ErrorInfo parsing, got unexpected type for "
+                "'session_required_policies'. "
+                "Expected 'str', but got '{type(session_required_policies)}'"
+            )
 
 
 class ConsentRequiredInfo(ErrorInfo):

--- a/src/globus_sdk/exc/err_info.py
+++ b/src/globus_sdk/exc/err_info.py
@@ -64,9 +64,15 @@ class AuthorizationParameterInfo(ErrorInfo):
         self.session_required_single_domain = t.cast(
             t.Optional[t.List[str]], data.get("session_required_single_domain")
         )
-        self.session_required_policies = t.cast(
-            t.Optional[str], data.get("session_required_policies")
-        )
+
+        # get str|None and parse as appropriate
+        session_required_policies = data.get("session_required_policies")
+        if isinstance(session_required_policies, str):
+            self.session_required_policies: t.Optional[
+                t.List[str]
+            ] = session_required_policies.split(",")
+        else:
+            self.session_required_policies = None
 
 
 class ConsentRequiredInfo(ErrorInfo):

--- a/src/globus_sdk/exc/err_info.py
+++ b/src/globus_sdk/exc/err_info.py
@@ -75,9 +75,9 @@ class AuthorizationParameterInfo(ErrorInfo):
             self.session_required_policies = session_required_policies.split(",")
         elif session_required_policies is not None:
             log.warning(
-                "during ErrorInfo parsing, got unexpected type for "
+                "During ErrorInfo instantiation, got unexpected type for "
                 "'session_required_policies'. "
-                "Expected 'str', but got '{type(session_required_policies)}'"
+                f"Expected 'str', but got '{type(session_required_policies)}'"
             )
 
 

--- a/tests/unit/test_exc.py
+++ b/tests/unit/test_exc.py
@@ -323,7 +323,7 @@ def test_consent_required_info():
     assert str(err.info.consent_required) == "ConsentRequiredInfo(:)"
 
 
-def test_authz_params_info():
+def test_authz_params_info_containing_session_message():
     res = _mk_json_response(
         {"authorization_parameters": {"session_message": "foo"}}, 401
     )
@@ -345,6 +345,8 @@ def test_authz_params_info():
         ")",
     )
 
+
+def test_authz_params_info_containing_session_required_identities():
     res = _mk_json_response(
         {"authorization_parameters": {"session_required_identities": ["foo", "bar"]}},
         401,
@@ -370,6 +372,8 @@ def test_authz_params_info():
         ")",
     )
 
+
+def test_authz_params_info_containing_session_required_single_domain():
     res = _mk_json_response(
         {
             "authorization_parameters": {
@@ -399,6 +403,8 @@ def test_authz_params_info():
         ")",
     )
 
+
+def test_authz_params_info_containing_session_required_policies():
     res = _mk_json_response(
         {"authorization_parameters": {"session_required_policies": "foo,bar"}}, 401
     )
@@ -407,7 +413,7 @@ def test_authz_params_info():
     assert err.info.authorization_parameters.session_message is None
     assert err.info.authorization_parameters.session_required_identities is None
     assert err.info.authorization_parameters.session_required_single_domain is None
-    assert err.info.authorization_parameters.session_required_policies == "foo,bar"
+    assert err.info.authorization_parameters.session_required_policies == ["foo", "bar"]
     _strmatch_any_order(
         str(err.info.authorization_parameters),
         "AuthorizationParameterInfo(",
@@ -415,7 +421,29 @@ def test_authz_params_info():
             "session_message=None",
             "session_required_identities=None",
             "session_required_single_domain=None",
-            "session_required_policies=foo,bar",
+            "session_required_policies=['foo', 'bar']",
+        ],
+        ")",
+    )
+
+
+def test_authz_params_info_containing_malformed_session_required_policies():
+    # confirm that if `session_required_policies` is not a string,
+    # it will parse as `None`
+    res = _mk_json_response(
+        {"authorization_parameters": {"session_required_policies": ["foo"]}}, 401
+    )
+    err = exc.GlobusAPIError(res.r)
+    assert bool(err.info.authorization_parameters) is True
+    assert err.info.authorization_parameters.session_required_policies is None
+    _strmatch_any_order(
+        str(err.info.authorization_parameters),
+        "AuthorizationParameterInfo(",
+        [
+            "session_message=None",
+            "session_required_identities=None",
+            "session_required_single_domain=None",
+            "session_required_policies=None",
         ],
         ")",
     )


### PR DESCRIPTION
Rather than keeping the string which an API may pass back, convert it to the list of IDs by comma-splitting the value. If the value is not a string, the comma split won't be possible, so this is handled by treating anything other than a string as invalid (and setting the attribute to None).

This also makes this property a little bit safer than many of our other computed properties, which are cast to the "right" types by the SDK but aren't validated.

The change is technically backwards incompatible, but surrounds the use of a feature which is not in production use yet, and we have therefore agreed upon pragmatic treatment of this case as not requiring a major version bump.

The test changes include updates to check the parsed value(s), but also a general update to the ErrorInfo tests to split a monolithic test into more individual cases.