### PR TITLE
Minor refinements to response classes

### DIFF
--- a/changelog.d/20230207_032037_sirosen_remove_cast_one_of_many.rst
+++ b/changelog.d/20230207_032037_sirosen_remove_cast_one_of_many.rst
@@ -1,0 +1,6 @@
+* ``globus_sdk.ArrayResponse`` and ``globus_sdk.IterableResponse`` are now
+  available as names. Previously, these were only importable from
+  ``globus_sdk.response`` (:pr:`NUMBER`)
+
+* ``ArrayResponse`` and ``IterableResponse`` have better error behaviors when
+  the API data does not match their expected types (:pr:`NUMBER`)

--- a/src/globus_sdk/__init__.py
+++ b/src/globus_sdk/__init__.py
@@ -46,6 +46,8 @@ _LAZY_IMPORT_TABLE = {
     },
     "response": {
         "GlobusHTTPResponse",
+        "IterableResponse",
+        "ArrayResponse",
     },
     "services.auth": {
         "AuthAPIError",
@@ -140,6 +142,8 @@ if t.TYPE_CHECKING or sys.version_info < (3, 7):
     from .local_endpoint import LocalGlobusConnectPersonal
     from .local_endpoint import LocalGlobusConnectServer
     from .response import GlobusHTTPResponse
+    from .response import IterableResponse
+    from .response import ArrayResponse
     from .services.auth import AuthAPIError
     from .services.auth import AuthClient
     from .services.auth import ConfidentialAppAuthClient
@@ -233,6 +237,7 @@ __all__ = (
     "AccessTokenAuthorizer",
     "ActivationRequirementsResponse",
     "ActiveScaleStoragePolicies",
+    "ArrayResponse",
     "AuthAPIError",
     "AuthClient",
     "AzureBlobStoragePolicies",
@@ -276,6 +281,7 @@ __all__ = (
     "IdentityMap",
     "IrodsStoragePolicies",
     "IterableFlowsResponse",
+    "IterableResponse",
     "IterableTransferResponse",
     "LocalGlobusConnectPersonal",
     "LocalGlobusConnectServer",

--- a/src/globus_sdk/_generate_init.py
+++ b/src/globus_sdk/_generate_init.py
@@ -68,7 +68,14 @@ _LAZY_IMPORT_TABLE: t.List[t.Tuple[str, t.Tuple[str, ...]]] = [
             "LocalGlobusConnectServer",
         ),
     ),
-    ("response", ("GlobusHTTPResponse",)),
+    (
+        "response",
+        (
+            "GlobusHTTPResponse",
+            "IterableResponse",
+            "ArrayResponse",
+        ),
+    ),
     (
         "services.auth",
         (

--- a/src/globus_sdk/response.py
+++ b/src/globus_sdk/response.py
@@ -201,7 +201,12 @@ class IterableResponse(GlobusHTTPResponse):
         super().__init__(response, client)
 
     def __iter__(self) -> t.Iterator[t.Mapping[t.Any, t.Any]]:
-        return iter(t.cast(t.Mapping[t.Any, t.Any], self)[self.iter_key])
+        if not isinstance(self.data, dict):
+            raise TypeError(
+                "Cannot iterate on IterableResponse data when "
+                f"type is '{type(self.data).__name__}'"
+            )
+        return iter(self.data[self.iter_key])
 
 
 class ArrayResponse(GlobusHTTPResponse):
@@ -209,7 +214,12 @@ class ArrayResponse(GlobusHTTPResponse):
     data of the response is a JSON array."""
 
     def __iter__(self) -> t.Iterator[t.Any]:
-        return iter(t.cast(t.List[t.Any], self.data))
+        if not isinstance(self.data, list):
+            raise TypeError(
+                "Cannot iterate on ArrayResponse data when "
+                f"type is '{type(self.data).__name__}'"
+            )
+        return iter(self.data)
 
     def __len__(self) -> int:
         """
@@ -217,6 +227,7 @@ class ArrayResponse(GlobusHTTPResponse):
         """
         if not isinstance(self.data, collections.abc.Sequence):
             raise TypeError(
-                f"Cannot take len() on data when type is '{type(self.data).__name__}'"
+                "Cannot take len() on ArrayResponse data when "
+                f"type is '{type(self.data).__name__}'"
             )
         return len(self.data)

--- a/tests/unit/responses/test_response.py
+++ b/tests/unit/responses/test_response.py
@@ -164,7 +164,7 @@ def test_bool(dict_response, list_response):
     assert bool(null.r) is False
 
 
-def test_len(list_response):
+def test_len_array(list_response):
     array = ArrayResponse(list_response.r)
     assert len(array) == len(list_response.data)
 
@@ -174,18 +174,38 @@ def test_len(list_response):
     assert len(empty_array) == 0
 
 
-def test_len_bad_data(dict_response):
+def test_len_array_bad_data(dict_response):
     null_array = ArrayResponse(_mk_json_response(None).r)
     with pytest.raises(
-        TypeError, match=re.escape("Cannot take len() on data when type is 'NoneType'")
+        TypeError,
+        match=re.escape(
+            "Cannot take len() on ArrayResponse data when type is 'NoneType'"
+        ),
     ):
         len(null_array)
 
     dict_array = ArrayResponse(dict_response.r)
     with pytest.raises(
-        TypeError, match=re.escape("Cannot take len() on data when type is 'dict'")
+        TypeError,
+        match=re.escape("Cannot take len() on ArrayResponse data when type is 'dict'"),
     ):
         len(dict_array)
+
+
+def test_iter_array_bad_data(dict_response):
+    null_array = ArrayResponse(_mk_json_response(None).r)
+    with pytest.raises(
+        TypeError,
+        match=re.escape("Cannot iterate on ArrayResponse data when type is 'NoneType'"),
+    ):
+        list(null_array)
+
+    dict_array = ArrayResponse(dict_response.r)
+    with pytest.raises(
+        TypeError,
+        match=re.escape("Cannot iterate on ArrayResponse data when type is 'dict'"),
+    ):
+        list(dict_array)
 
 
 def test_get(dict_response, list_response, text_http_response):
@@ -259,6 +279,28 @@ def test_iterable_response_using_iter_key():
 
     withkey = MyIterableResponse(raw, client=mock.Mock(), iter_key="other_iter")
     assert list(withkey) == [3, 4]
+
+
+def test_iterable_response_errors_on_non_dict_data(list_response):
+    class MyIterableResponse(IterableResponse):
+        default_iter_key = "default_iter"
+
+    list_iterable = MyIterableResponse(list_response.r)
+    null_iterable = MyIterableResponse(_mk_json_response(None).r)
+
+    with pytest.raises(
+        TypeError,
+        match=re.escape("Cannot iterate on IterableResponse data when type is 'list'"),
+    ):
+        list(list_iterable)
+
+    with pytest.raises(
+        TypeError,
+        match=re.escape(
+            "Cannot iterate on IterableResponse data when type is 'NoneType'"
+        ),
+    ):
+        list(null_iterable)
 
 
 def test_can_iter_array_response(list_response):


### PR DESCRIPTION
As the branch name here suggests, this is part of a series of changes which I'd like to make over time to the SDK. Right now, we have a lot of cases of untrusted data (usually supplied by some API) which is then `cast()` to coerce it to the expected type. This isn't generally a problem in practice, but it means that some of the type-safety we provide to SDK consumers is illusory.

As a general rule, any location where we use `cast()` in the `src/` tree should be evaluated to see if it can be improved. I'm sure there are more of these.
When an "unsafe" `cast` is found, our options are to error, as in this PR, or coerce the value silently to `None` or some other missing/invalid marker (as was done in #678, which inspired me to look at this again).

I think our behaviors will vary depending on the context (and that is okay), but I'm open to other arguments, as long as they can articulate how we should behave in the concrete cases seen here and in #678.

---

IterableResponse and ArrayResponse were not available as top-level names exported by `globus_sdk`, whereas `GlobusHTTPResponse` was available. This doesn't stem from any design decision, but is merely an artifact of whatever evolved over time. It's potentially useful to be able to pull up the response classes more directly -- at the very least, it can make type annotations simpler and more accurate, with little effort.

At the same time as this improvement is made, both ArrayResponse and IterableResponse are given an improvement to the way that malformed data is handled. Previously, payload data is `typing.cast` to the correct type, ignoring potential runtime failures from trying to index into or take the length of non-dict or non-list data. Instead, explicitly check the types and raise TypeError if they are not correct, as is already done by `ArrayResponse.__len__`. New tests exercise the behavior.