### PR TITLE
Fix missing f-string in EP manager method + test

### DIFF
--- a/changelog.d/20230214_193302_sirosen_fix_missing_fstring.rst
+++ b/changelog.d/20230214_193302_sirosen_fix_missing_fstring.rst
@@ -1,0 +1,2 @@
+* Fix a typo in ``TransferClient.endpoint_manager_task_successful_transfers``
+  which prevented calls from being made correctly (:pr:`NUMBER`)

--- a/src/globus_sdk/_testing/data/transfer/endpoint_manager_task_successful_transfers.py
+++ b/src/globus_sdk/_testing/data/transfer/endpoint_manager_task_successful_transfers.py
@@ -1,0 +1,24 @@
+from globus_sdk._testing.models import RegisteredResponse, ResponseSet
+
+from ._common import TASK_ID
+
+RESPONSES = ResponseSet(
+    metadata={"task_id": TASK_ID},
+    default=RegisteredResponse(
+        service="transfer",
+        method="GET",
+        path=f"/endpoint_manager/task/{TASK_ID}/successful_transfers",
+        json={
+            "DATA_TYPE": "successful_transfers",
+            "marker": 0,
+            "next_marker": 93979,
+            "DATA": [
+                {
+                    "destination_path": "/path/to/destination",
+                    "source_path": "/path/to/source",
+                    "DATA_TYPE": "successful_transfer",
+                }
+            ],
+        },
+    ),
+)

--- a/src/globus_sdk/services/transfer/client.py
+++ b/src/globus_sdk/services/transfer/client.py
@@ -2159,7 +2159,7 @@ class TransferClient(client.BaseClient):
             query_params["marker"] = marker
         return IterableTransferResponse(
             self.get(
-                "endpoint_manager/task/{task_id}/successful_transfers",
+                f"endpoint_manager/task/{task_id}/successful_transfers",
                 query_params=query_params,
             )
         )

--- a/tests/functional/services/transfer/endpoint_manager/test_endpoint_manager_task_successful_transfers.py
+++ b/tests/functional/services/transfer/endpoint_manager/test_endpoint_manager_task_successful_transfers.py
@@ -1,6 +1,10 @@
-import pytest
+from globus_sdk._testing import load_response
 
 
-@pytest.mark.xfail
-def test_endpoint_manager_task_successful_transfers():
-    raise NotImplementedError
+def test_endpoint_manager_task_successful_transfers(client):
+    meta = load_response(client.endpoint_manager_task_successful_transfers).metadata
+
+    response = client.endpoint_manager_task_successful_transfers(meta["task_id"])
+
+    assert response.http_status == 200
+    assert response["DATA_TYPE"] == "successful_transfers"


### PR DESCRIPTION
`TransferClient.endpoint_manager_task_successful_transfers` was not making calls correctly.

Setup fixture data for a response, add a relevant test, and add the missing `f` prefix.

resolves #682