### PR TITLE
Add unit tests for TimerAPIError class

### DIFF
--- a/tests/unit/errors/conftest.py
+++ b/tests/unit/errors/conftest.py
@@ -1,0 +1,84 @@
+import json
+from collections import namedtuple
+
+import pytest
+import requests
+
+_TestResponse = namedtuple("_TestResponse", ("data", "r", "method", "url"))
+
+
+def _mk_response(
+    data, status, method=None, url=None, headers=None, data_transform=None
+):
+    resp = requests.Response()
+
+    if data_transform:
+        resp._content = data_transform(data).encode("utf-8")
+    else:
+        resp._content = data.encode("utf-8")
+    resp.encoding = "utf-8"
+
+    if headers:
+        resp.headers.update(headers)
+
+    resp.status_code = str(status)
+    resp.reason = {
+        200: "OK",
+        400: "Bad Request",
+        401: "Unauthorized",
+        403: "Forbidden",
+        404: "Not Found",
+        500: "Server Error",
+    }.get(status, "Unknown")
+    method = method or "GET"
+    url = url or "default-example-url.bogus"
+    resp.url = url
+    resp.request = requests.Request(method=method, url=url, headers=headers)
+    return _TestResponse(data, resp, method, url)
+
+
+@pytest.fixture
+def make_response():
+    return _mk_response
+
+
+@pytest.fixture
+def make_json_response():
+    def func(data, status):
+        return _mk_response(
+            data,
+            status,
+            data_transform=json.dumps,
+            headers={"Content-Type": "application/json"},
+        )
+
+    return func
+
+
+@pytest.fixture
+def success_response():
+    return _mk_response("{}", 200)
+
+
+@pytest.fixture
+def default_json_response(make_json_response):
+    json_data = {
+        "errors": [
+            {
+                "message": "json error message",
+                "title": "json error message",
+                "code": "Json Error",
+            }
+        ]
+    }
+    return make_json_response(json_data, 400)
+
+
+@pytest.fixture
+def default_text_response():
+    return _mk_response("error message", 401)
+
+
+@pytest.fixture
+def malformed_response():
+    return _mk_response("{", 403, headers={"Content-Type": "application/json"})

--- a/tests/unit/errors/conftest.py
+++ b/tests/unit/errors/conftest.py
@@ -1,3 +1,4 @@
+import http.client
 import json
 from collections import namedtuple
 
@@ -8,7 +9,13 @@ _TestResponse = namedtuple("_TestResponse", ("data", "r", "method", "url"))
 
 
 def _mk_response(
-    data, status, method=None, url=None, headers=None, data_transform=None
+    data,
+    status,
+    method=None,
+    url=None,
+    headers=None,
+    request_headers=None,
+    data_transform=None,
 ):
     resp = requests.Response()
 
@@ -22,18 +29,11 @@ def _mk_response(
         resp.headers.update(headers)
 
     resp.status_code = str(status)
-    resp.reason = {
-        200: "OK",
-        400: "Bad Request",
-        401: "Unauthorized",
-        403: "Forbidden",
-        404: "Not Found",
-        500: "Server Error",
-    }.get(status, "Unknown")
+    resp.reason = http.client.responses.get(status, "Unknown")
     method = method or "GET"
     url = url or "default-example-url.bogus"
     resp.url = url
-    resp.request = requests.Request(method=method, url=url, headers=headers)
+    resp.request = requests.Request(method=method, url=url, headers=request_headers)
     return _TestResponse(data, resp, method, url)
 
 

--- a/tests/unit/errors/test_auth_errors.py
+++ b/tests/unit/errors/test_auth_errors.py
@@ -1,0 +1,51 @@
+import pytest
+
+from globus_sdk import AuthAPIError
+
+
+@pytest.fixture
+def simple_auth_response(make_json_response):
+    auth_data = {"detail": "simple auth error message"}
+    return make_json_response(auth_data, 404)
+
+
+@pytest.fixture
+def nested_auth_response(make_json_response):
+    auth_data = {
+        "errors": [
+            {"detail": "nested auth error message", "code": "Auth Error"},
+            {
+                "title": "some other error which will not be seen",
+                "code": "HiddenError",
+            },
+        ]
+    }
+    return make_json_response(auth_data, 404)
+
+
+@pytest.mark.parametrize(
+    "response_fixture_name, status, code, message",
+    (
+        # normal auth error data
+        ("simple_auth_response", "404", "Error", "simple auth error message"),
+        ("nested_auth_response", "404", "Auth Error", "nested auth error message"),
+        # wrong format (but still parseable)
+        ("default_json_response", "400", "Json Error", "json error message"),
+        # defaults for non-json data
+        ("default_text_response", "401", "Error", "error message"),
+        # malformed data is at least rendered successully into an error
+        ("malformed_response", "403", "Error", "{"),
+    ),
+)
+def test_get_args_auth(request, response_fixture_name, status, code, message):
+    response = request.getfixturevalue(response_fixture_name)
+
+    err = AuthAPIError(response.r)
+    assert err._get_args() == [
+        response.method,
+        response.url,
+        None,
+        status,
+        code,
+        message,
+    ]

--- a/tests/unit/errors/test_common_functionality.py
+++ b/tests/unit/errors/test_common_functionality.py
@@ -288,7 +288,7 @@ def test_convert_requests_exception(orig, conv_class):
     "status, expect_reason",
     [
         (400, "Bad Request"),
-        (500, "Server Error"),
+        (500, "Internal Server Error"),
     ],
 )
 def test_http_reason_exposure(make_response, status, expect_reason):
@@ -352,8 +352,9 @@ def test_error_repr_has_expected_info(
         body["message"] = error_message
 
     headers = {"Content-Type": "application/json", "Spam": "Eggs"}
+    request_headers = {}
     if authz_scheme is not None:
-        headers["Authorization"] = f"{authz_scheme} TOKENINFO"
+        request_headers["Authorization"] = f"{authz_scheme} TOKENINFO"
 
     # build the response -> error -> error repr
     res = make_response(
@@ -363,6 +364,7 @@ def test_error_repr_has_expected_info(
         data_transform=json.dumps,
         url=request_url,
         headers=headers,
+        request_headers=request_headers,
     )
     err = GlobusAPIError(res.r)
     stringified = repr(err)

--- a/tests/unit/errors/test_common_functionality.py
+++ b/tests/unit/errors/test_common_functionality.py
@@ -1,13 +1,10 @@
 import itertools
 import json
-from collections import namedtuple
 
 import pytest
 import requests
 
-from globus_sdk import AuthAPIError, TransferAPIError, exc
-
-_TestResponse = namedtuple("_TestResponse", ("data", "r", "method", "url"))
+from globus_sdk import GlobusAPIError, exc
 
 
 def _strmatch_any_order(inputstr, prefix, midfixes, suffix, sep=", "):
@@ -17,146 +14,49 @@ def _strmatch_any_order(inputstr, prefix, midfixes, suffix, sep=", "):
     ]
 
 
-def _mk_response(
-    data, status, method=None, url=None, headers=None, data_transform=None
-):
-    resp = requests.Response()
-
-    if data_transform:
-        resp._content = data_transform(data).encode("utf-8")
-    else:
-        resp._content = data.encode("utf-8")
-    resp.encoding = "utf-8"
-
-    if headers:
-        resp.headers.update(headers)
-
-    resp.status_code = str(status)
-    resp.reason = {
-        200: "OK",
-        400: "Bad Request",
-        401: "Unauthorized",
-        403: "Forbidden",
-        404: "Not Found",
-        500: "Server Error",
-    }.get(status, "Unknown")
-    method = method or "GET"
-    url = url or "default-example-url.bogus"
-    resp.url = url
-    resp.request = requests.Request(method=method, url=url, headers=headers)
-    return _TestResponse(data, resp, method, url)
+def test_raw_json_works(default_json_response):
+    err = GlobusAPIError(default_json_response.r)
+    assert err.raw_json == default_json_response.data
 
 
-_DEFAULT_RESPONSE = _mk_response("{}", 200)
-
-
-def _mk_json_response(data, status):
-    return _mk_response(
-        data,
-        status,
-        data_transform=json.dumps,
-        headers={"Content-Type": "application/json"},
-    )
-
-
-@pytest.fixture
-def json_response():
-    json_data = {
-        "errors": [
-            {
-                "message": "json error message",
-                "title": "json error message",
-                "code": "Json Error",
-            }
-        ]
-    }
-    return _mk_json_response(json_data, 400)
-
-
-@pytest.fixture
-def text_response():
-    text_data = "error message"
-    return _mk_response(text_data, 401)
-
-
-@pytest.fixture
-def malformed_response():
-    return _mk_response("{", 403, headers={"Content-Type": "application/json"})
-
-
-@pytest.fixture
-def transfer_response():
-    transfer_data = {
-        "message": "transfer error message",
-        "code": "Transfer Error",
-        "request_id": 123,
-    }
-    return _mk_json_response(transfer_data, 404)
-
-
-@pytest.fixture
-def simple_auth_response():
-    auth_data = {"detail": "simple auth error message"}
-    return _mk_json_response(auth_data, 404)
-
-
-@pytest.fixture
-def nested_auth_response():
-    auth_data = {
-        "errors": [
-            {"detail": "nested auth error message", "code": "Auth Error"},
-            {
-                "title": "some other error which will not be seen",
-                "code": "HiddenError",
-            },
-        ]
-    }
-    return _mk_json_response(auth_data, 404)
-
-
-def test_raw_json_works(json_response):
-    err = exc.GlobusAPIError(json_response.r)
-    assert err.raw_json == json_response.data
-
-
-def test_raw_json_fail(text_response, malformed_response):
-    err = exc.GlobusAPIError(text_response.r)
+def test_raw_json_fail(default_text_response, malformed_response):
+    err = GlobusAPIError(default_text_response.r)
     assert err.raw_json is None
 
-    err = exc.GlobusAPIError(malformed_response.r)
+    err = GlobusAPIError(malformed_response.r)
     assert err.raw_json is None
 
 
-def test_raw_text_works(json_response, text_response):
-    err = exc.GlobusAPIError(json_response.r)
-    assert err.raw_text == json.dumps(json_response.data)
-    err = exc.GlobusAPIError(text_response.r)
-    assert err.raw_text == text_response.data
+def test_raw_text_works(default_json_response, default_text_response):
+    err = GlobusAPIError(default_json_response.r)
+    assert err.raw_text == json.dumps(default_json_response.data)
+    err = GlobusAPIError(default_text_response.r)
+    assert err.raw_text == default_text_response.data
 
 
-def test_get_args(json_response, text_response, malformed_response):
-    err = exc.GlobusAPIError(json_response.r)
+def test_get_args(default_json_response, default_text_response, malformed_response):
+    err = GlobusAPIError(default_json_response.r)
     assert err._get_args() == [
-        json_response.method,
-        json_response.url,
+        default_json_response.method,
+        default_json_response.url,
         None,
         "400",
         "Json Error",
         "json error message",
     ]
-    err = exc.GlobusAPIError(text_response.r)
+    err = GlobusAPIError(default_text_response.r)
     assert err._get_args() == [
-        text_response.method,
-        text_response.url,
+        default_text_response.method,
+        default_text_response.url,
         None,
         "401",
         "Error",
         "error message",
     ]
-    err = exc.GlobusAPIError(malformed_response.r)
+    err = GlobusAPIError(malformed_response.r)
     assert err._get_args() == [
-        text_response.method,
-        text_response.url,
+        default_text_response.method,
+        default_text_response.url,
         None,
         "403",
         "Error",
@@ -164,115 +64,9 @@ def test_get_args(json_response, text_response, malformed_response):
     ]
 
 
-def test_get_args_transfer(
-    json_response, text_response, malformed_response, transfer_response
-):
-    err = TransferAPIError(transfer_response.r)
-    assert err._get_args() == [
-        _DEFAULT_RESPONSE.method,
-        _DEFAULT_RESPONSE.url,
-        None,
-        "404",
-        "Transfer Error",
-        "transfer error message",
-        123,
-    ]
-
-    # wrong format (but still parseable)
-    err = TransferAPIError(json_response.r)
-    assert err._get_args() == [
-        _DEFAULT_RESPONSE.method,
-        _DEFAULT_RESPONSE.url,
-        None,
-        "400",
-        "Json Error",
-        "json error message",
-        None,
-    ]
-    # defaults for non-json
-    err = TransferAPIError(text_response.r)
-    assert err._get_args() == [
-        _DEFAULT_RESPONSE.method,
-        _DEFAULT_RESPONSE.url,
-        None,
-        "401",
-        "Error",
-        "error message",
-        None,
-    ]
-    err = TransferAPIError(malformed_response.r)
-    assert err._get_args() == [
-        _DEFAULT_RESPONSE.method,
-        _DEFAULT_RESPONSE.url,
-        None,
-        "403",
-        "Error",
-        "{",
-        None,
-    ]
-
-
-def test_get_args_auth(
-    json_response,
-    text_response,
-    malformed_response,
-    simple_auth_response,
-    nested_auth_response,
-):
-    err = AuthAPIError(simple_auth_response.r)
-    assert err._get_args() == [
-        _DEFAULT_RESPONSE.method,
-        _DEFAULT_RESPONSE.url,
-        None,
-        "404",
-        "Error",
-        "simple auth error message",
-    ]
-    err = AuthAPIError(nested_auth_response.r)
-    assert err._get_args() == [
-        _DEFAULT_RESPONSE.method,
-        _DEFAULT_RESPONSE.url,
-        None,
-        "404",
-        "Auth Error",
-        "nested auth error message",
-    ]
-
-    # wrong format, but similar/close
-    err = AuthAPIError(json_response.r)
-    assert err._get_args() == [
-        _DEFAULT_RESPONSE.method,
-        _DEFAULT_RESPONSE.url,
-        None,
-        "400",
-        "Json Error",
-        "json error message",
-    ]
-
-    # non-json
-    err = AuthAPIError(text_response.r)
-    assert err._get_args() == [
-        _DEFAULT_RESPONSE.method,
-        _DEFAULT_RESPONSE.url,
-        None,
-        "401",
-        "Error",
-        "error message",
-    ]
-    err = AuthAPIError(malformed_response.r)
-    assert err._get_args() == [
-        _DEFAULT_RESPONSE.method,
-        _DEFAULT_RESPONSE.url,
-        None,
-        "403",
-        "Error",
-        "{",
-    ]
-
-
-def test_get_args_on_unknown_json():
-    res = _mk_json_response({"foo": "bar"}, 400)
-    err = exc.GlobusAPIError(res.r)
+def test_get_args_on_unknown_json(make_json_response):
+    res = make_json_response({"foo": "bar"}, 400)
+    err = GlobusAPIError(res.r)
     assert err._get_args() == [
         res.method,
         res.url,
@@ -283,9 +77,9 @@ def test_get_args_on_unknown_json():
     ]
 
 
-def test_get_args_on_non_dict_json():
-    res = _mk_json_response(["foo", "bar"], 400)
-    err = exc.GlobusAPIError(res.r)
+def test_get_args_on_non_dict_json(make_json_response):
+    res = make_json_response(["foo", "bar"], 400)
+    err = GlobusAPIError(res.r)
     assert err._get_args() == [
         res.method,
         res.url,
@@ -296,19 +90,19 @@ def test_get_args_on_non_dict_json():
     ]
 
 
-def test_info_is_falsey_on_non_dict_json():
-    res = _mk_json_response(["foo", "bar"], 400)
-    err = exc.GlobusAPIError(res.r)
+def test_info_is_falsey_on_non_dict_json(make_json_response):
+    res = make_json_response(["foo", "bar"], 400)
+    err = GlobusAPIError(res.r)
     assert bool(err.info.consent_required) is False
     assert bool(err.info.authorization_parameters) is False
     assert str(err.info) == "AuthorizationParameterInfo(:)|ConsentRequiredInfo(:)"
 
 
-def test_consent_required_info():
-    res = _mk_json_response(
+def test_consent_required_info(make_json_response):
+    res = make_json_response(
         {"code": "ConsentRequired", "required_scopes": ["foo", "bar"]}, 401
     )
-    err = exc.GlobusAPIError(res.r)
+    err = GlobusAPIError(res.r)
     assert bool(err.info.consent_required) is True
     assert err.info.consent_required.required_scopes == ["foo", "bar"]
     assert str(err.info.consent_required) == (
@@ -316,18 +110,18 @@ def test_consent_required_info():
     )
 
     # if the code is right but the scope list is missing, it should be falsey
-    res = _mk_json_response({"code": "ConsentRequired"}, 401)
-    err = exc.GlobusAPIError(res.r)
+    res = make_json_response({"code": "ConsentRequired"}, 401)
+    err = GlobusAPIError(res.r)
     assert bool(err.info.consent_required) is False
     assert err.info.consent_required.required_scopes is None
     assert str(err.info.consent_required) == "ConsentRequiredInfo(:)"
 
 
-def test_authz_params_info_containing_session_message():
-    res = _mk_json_response(
+def test_authz_params_info_containing_session_message(make_json_response):
+    res = make_json_response(
         {"authorization_parameters": {"session_message": "foo"}}, 401
     )
-    err = exc.GlobusAPIError(res.r)
+    err = GlobusAPIError(res.r)
     assert bool(err.info.authorization_parameters) is True
     assert err.info.authorization_parameters.session_message == "foo"
     assert err.info.authorization_parameters.session_required_identities is None
@@ -346,12 +140,12 @@ def test_authz_params_info_containing_session_message():
     )
 
 
-def test_authz_params_info_containing_session_required_identities():
-    res = _mk_json_response(
+def test_authz_params_info_containing_session_required_identities(make_json_response):
+    res = make_json_response(
         {"authorization_parameters": {"session_required_identities": ["foo", "bar"]}},
         401,
     )
-    err = exc.GlobusAPIError(res.r)
+    err = GlobusAPIError(res.r)
     assert bool(err.info.authorization_parameters) is True
     assert err.info.authorization_parameters.session_message is None
     assert err.info.authorization_parameters.session_required_identities == [
@@ -373,8 +167,10 @@ def test_authz_params_info_containing_session_required_identities():
     )
 
 
-def test_authz_params_info_containing_session_required_single_domain():
-    res = _mk_json_response(
+def test_authz_params_info_containing_session_required_single_domain(
+    make_json_response,
+):
+    res = make_json_response(
         {
             "authorization_parameters": {
                 "session_required_single_domain": ["foo", "bar"]
@@ -382,7 +178,7 @@ def test_authz_params_info_containing_session_required_single_domain():
         },
         401,
     )
-    err = exc.GlobusAPIError(res.r)
+    err = GlobusAPIError(res.r)
     assert bool(err.info.authorization_parameters) is True
     assert err.info.authorization_parameters.session_message is None
     assert err.info.authorization_parameters.session_required_identities is None
@@ -404,11 +200,11 @@ def test_authz_params_info_containing_session_required_single_domain():
     )
 
 
-def test_authz_params_info_containing_session_required_policies():
-    res = _mk_json_response(
+def test_authz_params_info_containing_session_required_policies(make_json_response):
+    res = make_json_response(
         {"authorization_parameters": {"session_required_policies": "foo,bar"}}, 401
     )
-    err = exc.GlobusAPIError(res.r)
+    err = GlobusAPIError(res.r)
     assert bool(err.info.authorization_parameters) is True
     assert err.info.authorization_parameters.session_message is None
     assert err.info.authorization_parameters.session_required_identities is None
@@ -427,13 +223,15 @@ def test_authz_params_info_containing_session_required_policies():
     )
 
 
-def test_authz_params_info_containing_malformed_session_required_policies():
+def test_authz_params_info_containing_malformed_session_required_policies(
+    make_json_response,
+):
     # confirm that if `session_required_policies` is not a string,
     # it will parse as `None`
-    res = _mk_json_response(
+    res = make_json_response(
         {"authorization_parameters": {"session_required_policies": ["foo"]}}, 401
     )
-    err = exc.GlobusAPIError(res.r)
+    err = GlobusAPIError(res.r)
     assert bool(err.info.authorization_parameters) is True
     assert err.info.authorization_parameters.session_required_policies is None
     _strmatch_any_order(
@@ -493,25 +291,25 @@ def test_convert_requests_exception(orig, conv_class):
         (500, "Server Error"),
     ],
 )
-def test_http_reason_exposure(status, expect_reason):
-    res = _mk_response(
+def test_http_reason_exposure(make_response, status, expect_reason):
+    res = make_response(
         {"errors": [{"message": "json error message", "code": "Json Error"}]},
         status,
         data_transform=json.dumps,
         headers={"Content-Type": "application/json"},
     )
-    err = exc.GlobusAPIError(res.r)
+    err = GlobusAPIError(res.r)
     assert err.http_reason == expect_reason
 
 
-def test_http_header_exposure():
-    res = _mk_response(
+def test_http_header_exposure(make_response):
+    res = make_response(
         {"errors": [{"message": "json error message", "code": "Json Error"}]},
         400,
         data_transform=json.dumps,
         headers={"Content-Type": "application/json", "Spam": "Eggs"},
     )
-    err = exc.GlobusAPIError(res.r)
+    err = GlobusAPIError(res.r)
     assert err.headers["spam"] == "Eggs"
     assert err.headers["Content-Type"] == "application/json"
 
@@ -535,7 +333,13 @@ def test_http_header_exposure():
     ],
 )
 def test_error_repr_has_expected_info(
-    http_method, http_status, authz_scheme, request_url, error_code, error_message
+    make_response,
+    http_method,
+    http_status,
+    authz_scheme,
+    request_url,
+    error_code,
+    error_message,
 ):
     http_reason = {404: "Not Found", 500: "Server Error", 501: "Not Implemented"}.get(
         http_status
@@ -552,7 +356,7 @@ def test_error_repr_has_expected_info(
         headers["Authorization"] = f"{authz_scheme} TOKENINFO"
 
     # build the response -> error -> error repr
-    res = _mk_response(
+    res = make_response(
         body,
         http_status,
         method=http_method,
@@ -560,13 +364,13 @@ def test_error_repr_has_expected_info(
         url=request_url,
         headers=headers,
     )
-    err = exc.GlobusAPIError(res.r)
+    err = GlobusAPIError(res.r)
     stringified = repr(err)
 
     # check using substring -- do not check exact format
     assert http_method in stringified
     assert request_url in stringified
-    if authz_scheme in exc.GlobusAPIError.RECOGNIZED_AUTHZ_SCHEMES:
+    if authz_scheme in GlobusAPIError.RECOGNIZED_AUTHZ_SCHEMES:
         assert authz_scheme in stringified
     # confirm that actual tokens don't get into the repr, regardless of authz scheme
     assert "TOKENINFO" not in stringified

--- a/tests/unit/errors/test_timer_errors.py
+++ b/tests/unit/errors/test_timer_errors.py
@@ -1,0 +1,44 @@
+from globus_sdk import TimerAPIError
+
+
+def test_timer_error_load_simple(make_json_response):
+    response = make_json_response(
+        {"error": {"code": "ERROR", "detail": "Request failed", "status": 500}},
+        500,
+    )
+
+    err = TimerAPIError(response.r)
+    assert err.code == "ERROR"
+    assert err.message == "Request failed"
+
+
+def test_timer_error_load_nested(make_json_response):
+    response = make_json_response(
+        {
+            "detail": [
+                {
+                    "loc": ["body", "start"],
+                    "msg": "field required",
+                    "type": "value_error.missing",
+                },
+                {
+                    "loc": ["body", "end"],
+                    "msg": "field required",
+                    "type": "value_error.missing",
+                },
+            ]
+        },
+        422,
+    )
+
+    err = TimerAPIError(response.r)
+    assert err.code == "Validation Error"
+    assert err.message == "field required: body.start; field required: body.end"
+
+
+def test_timer_error_load_unrecognize_format(make_json_response):
+    response = make_json_response({}, 400)
+
+    err = TimerAPIError(response.r)
+    assert err.code == "Unknown Error"
+    assert err.message == "Could not parse error details from the response"

--- a/tests/unit/errors/test_transfer_errors.py
+++ b/tests/unit/errors/test_transfer_errors.py
@@ -1,0 +1,42 @@
+import pytest
+
+from globus_sdk import TransferAPIError
+
+
+@pytest.fixture
+def transfer_response(make_json_response):
+    transfer_data = {
+        "message": "transfer error message",
+        "code": "Transfer Error",
+        "request_id": 123,
+    }
+    return make_json_response(transfer_data, 404)
+
+
+@pytest.mark.parametrize(
+    "response_fixture_name, status, code, message, request_id",
+    (
+        # normal transfer error data
+        ("transfer_response", "404", "Transfer Error", "transfer error message", 123),
+        # wrong format (but still parseable)
+        ("default_json_response", "400", "Json Error", "json error message", None),
+        # defaults for non-json data
+        ("default_text_response", "401", "Error", "error message", None),
+        # malformed data is at least rendered successully into an error
+        ("malformed_response", "403", "Error", "{", None),
+    ),
+)
+def test_get_args_transfer(
+    request, response_fixture_name, status, code, message, request_id
+):
+    response = request.getfixturevalue(response_fixture_name)
+    err = TransferAPIError(response.r)
+    assert err._get_args() == [
+        response.method,
+        response.url,
+        None,
+        status,
+        code,
+        message,
+        request_id,
+    ]


### PR DESCRIPTION
This also refactors some of the existing API error class unit tests in order to make the addition simpler and part of a more uniform and extensible style for testing various service-specific customizations.