### PR TITLE
Make `MutableScope.scope_string` public

### DIFF
--- a/changelog.d/20230217_212410_sirosen.rst
+++ b/changelog.d/20230217_212410_sirosen.rst
@@ -1,0 +1,2 @@
+* Make ``MutableScope.scope_string`` a public instance attribute (was
+  ``_scope_string``) (:pr:`NUMBER`)

--- a/src/globus_sdk/scopes/scope_definition.py
+++ b/src/globus_sdk/scopes/scope_definition.py
@@ -164,7 +164,7 @@ class Scope:
                 "Scope instances may not contain the special characters '[]* '. "
                 "Use either Scope.deserialize or Scope.parse instead"
             )
-        self._scope_string = scope_string
+        self.scope_string = scope_string
         self.optional = optional
         self.dependencies: list[Scope] = [] if dependencies is None else dependencies
 
@@ -196,7 +196,7 @@ class Scope:
         return data[0]
 
     def serialize(self) -> str:
-        base_scope = ("*" if self.optional else "") + self._scope_string
+        base_scope = ("*" if self.optional else "") + self.scope_string
         if not self.dependencies:
             return base_scope
         return (
@@ -238,7 +238,7 @@ class Scope:
         return self
 
     def __repr__(self) -> str:
-        parts: list[str] = [f"'{self._scope_string}'"]
+        parts: list[str] = [f"'{self.scope_string}'"]
         if self.optional:
             parts.append("optional=True")
         if self.dependencies:
@@ -294,7 +294,7 @@ class Scope:
             return False
 
         # top-level scope must match
-        if self._scope_string != other._scope_string:
+        if self.scope_string != other.scope_string:
             return False
 
         # between self.optional and other.optional, there are four possibilities,
@@ -363,14 +363,14 @@ class MutableScope:
             raise ValueError(
                 "MutableScope instances may not contain the special characters '[]* '."
             )
-        self._scope_string = scope_string
+        self.scope_string = scope_string
         self.optional = optional
         self.dependencies: list[MutableScope] = (
             [] if dependencies is None else dependencies
         )
 
     def serialize(self) -> str:
-        base_scope = ("*" if self.optional else "") + self._scope_string
+        base_scope = ("*" if self.optional else "") + self.scope_string
         if not self.dependencies:
             return base_scope
         return (
@@ -415,7 +415,7 @@ class MutableScope:
         return self
 
     def __repr__(self) -> str:
-        parts: list[str] = [f"'{self._scope_string}'"]
+        parts: list[str] = [f"'{self.scope_string}'"]
         if self.optional:
             parts.append("optional=True")
         if self.dependencies:

--- a/tests/unit/test_scopes.py
+++ b/tests/unit/test_scopes.py
@@ -204,10 +204,10 @@ def test_scope_parsing_ignores_non_semantic_whitespace(scope_string1, scope_stri
     s1, s2 = list1[0], list2[0]
     # Scope.__eq__ is not defined, so equivalence checking is manual (and somewhat error
     # prone) for now
-    assert s1._scope_string == s2._scope_string
+    assert s1.scope_string == s2.scope_string
     assert s1.optional == s2.optional
     for i in range(len(s1.dependencies)):
-        assert s1.dependencies[i]._scope_string == s2.dependencies[i]._scope_string
+        assert s1.dependencies[i].scope_string == s2.dependencies[i].scope_string
         assert s1.dependencies[i].optional == s2.dependencies[i].optional
 
 


### PR DESCRIPTION
This is a private attribute, but it turns out that there is at least one legitimate use-case for creating MutableScope objects and then accessing the `scope_string`:

In the CLI, we have a case in which we're tracking our scope requirements as strings. If we wanted to add scope dependency info to that mapping, it would be nice to do so as MutableScope objects. However, on startup, we want to compare the top-level scopes against the tokens we have in storage to ensure they are valid. This is most naturally phrased as accessing the `scope_string` member of any complex scopes we have in our requirements data.

We don't need to advertise the change heavily, but move this out of an underscore-prefixed member and include it in the changelog.