### PR TITLE
Add the RTD preview workflow

### DIFF
--- a/.github/workflows/readthedocs-pr-links.yaml
+++ b/.github/workflows/readthedocs-pr-links.yaml
@@ -1,0 +1,16 @@
+name: Read the Docs Pull Request Preview
+on:
+  pull_request_target:
+    types:
+      - opened
+
+permissions:
+  pull-requests: write
+
+jobs:
+  documentation-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: readthedocs/actions/preview@v1
+        with:
+          project-slug: "globus-sdk-python"


### PR DESCRIPTION
This GitHub Action appends a doc preview link to all PR descriptions.

See also: https://github.com/readthedocs/actions/tree/v1/preview