### PR TITLE
Enable use of MutableScopes in client methods

### DIFF
--- a/changelog.d/20230223_195632_sirosen_allow_mutable_scopes_via_client_methods.rst
+++ b/changelog.d/20230223_195632_sirosen_allow_mutable_scopes_via_client_methods.rst
@@ -1,0 +1,3 @@
+* ``MutableScope`` objects can now be used in the ``oauth2_start_flow`` and
+  ``oauth2_client_credentials_tokens`` methods of ``AuthClient`` classes as part
+  of ``requested_scopes`` (:pr:`NUMBER`)

--- a/src/globus_sdk/_testing/data/auth/oauth2_client_credentials_tokens.py
+++ b/src/globus_sdk/_testing/data/auth/oauth2_client_credentials_tokens.py
@@ -1,0 +1,27 @@
+from globus_sdk._testing.models import RegisteredResponse, ResponseSet
+
+_token = "DUMMY_TRANSFER_TOKEN_FROM_THE_INTERTUBES"
+_scope = "urn:globus:auth:scope:transfer.api.globus.org:all"
+
+RESPONSES = ResponseSet(
+    default=RegisteredResponse(
+        service="auth",
+        path="/v2/oauth2/token",
+        method="POST",
+        status=200,
+        json={
+            "access_token": _token,
+            "scope": _scope,
+            "expires_in": 172800,
+            "token_type": "Bearer",
+            "resource_server": "transfer.api.globus.org",
+            "other_tokens": [],
+        },
+        metadata={
+            "service": "transfer",
+            "resource_server": "transfer.api.globus.org",
+            "access_token": _token,
+            "scope": _scope,
+        },
+    )
+)

--- a/src/globus_sdk/services/auth/client/native_client.py
+++ b/src/globus_sdk/services/auth/client/native_client.py
@@ -4,7 +4,7 @@ import logging
 import typing as t
 
 from globus_sdk import exc, utils
-from globus_sdk._types import UUIDLike
+from globus_sdk._types import ScopeCollectionType, UUIDLike
 from globus_sdk.authorizers import NullAuthorizer
 
 from ..flow_managers import GlobusNativeAppFlowManager
@@ -51,7 +51,7 @@ class NativeAppAuthClient(AuthClient):
     )
     def oauth2_start_flow(
         self,
-        requested_scopes: None | (str | t.Iterable[str]) = None,
+        requested_scopes: ScopeCollectionType | None = None,
         *,
         redirect_uri: str | None = None,
         state: str = "_default",
@@ -68,10 +68,10 @@ class NativeAppAuthClient(AuthClient):
         While the flow is in progress, the ``NativeAppAuthClient`` becomes
         non thread-safe as temporary state is stored during the flow.
 
-        :param requested_scopes: The scopes on the token(s) being requested, as a
-            space-separated string or iterable of strings. Defaults to
+        :param requested_scopes: The scopes on the token(s) being requested. Defaults to
             ``openid profile email urn:globus:auth:scope:transfer.api.globus.org:all``
-        :type requested_scopes: str or iterable of str, optional
+        :type requested_scopes: str, MutableScope, or iterable of str or MutableScope,
+            optional
         :param redirect_uri: The page that users should be directed to after
             authenticating at the authorize URL. Defaults to
             'https://auth.globus.org/v2/web/auth-code', which displays the resulting

--- a/src/globus_sdk/services/auth/flow_managers/authorization_code.py
+++ b/src/globus_sdk/services/auth/flow_managers/authorization_code.py
@@ -39,12 +39,10 @@ class GlobusAuthorizationCodeFlowManager(GlobusOAuthFlowManager):
     :param redirect_uri: The page that users should be directed to after authenticating
         at the authorize URL.
     :type redirect_uri: str
-    :param requested_scopes: The scopes on the token(s) being requested, as a
-        space-separated string or iterable of strings. Defaults to
+    :param requested_scopes: The scopes on the token(s) being requested. Defaults to
         ``openid profile email urn:globus:auth:scope:transfer.api.globus.org:all``
-        (that is, ``DEFAULT_REQUESTED_SCOPES`` from
-        ``globus_sdk.services.auth.oauth2_constants``)
-    :type requested_scopes: str or iterable of str, optional
+    :type requested_scopes: str, MutableScope, or iterable of str or MutableScope,
+        optional
     :param state: This string allows an application to pass information back to itself
         in the course of the OAuth flow. Because the user will navigate away from the
         application to complete the flow, this parameter lets the app pass an arbitrary

--- a/src/globus_sdk/services/auth/flow_managers/native_app.py
+++ b/src/globus_sdk/services/auth/flow_managers/native_app.py
@@ -82,8 +82,7 @@ class GlobusNativeAppFlowManager(GlobusOAuthFlowManager):
         It is used to extract default values for the flow, and also to make calls to the
         Auth service.
     :type auth_client: :class:`NativeAppAuthClient <globus_sdk.NativeAppAuthClient>`
-    :param requested_scopes: The scopes on the token(s) being requested, as a
-        space-separated string or iterable of strings. Defaults to
+    :param requested_scopes: The scopes on the token(s) being requested. Defaults to
         ``openid profile email urn:globus:auth:scope:transfer.api.globus.org:all``
     :type requested_scopes: str, MutableScope, or iterable of str or MutableScope,
         optional

--- a/tests/functional/services/auth/confidential_client/conftest.py
+++ b/tests/functional/services/auth/confidential_client/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+
+import globus_sdk
+
+
+@pytest.fixture
+def auth_client(no_retry_transport):
+    class CustomAuthClient(globus_sdk.ConfidentialAppAuthClient):
+        transport_class = no_retry_transport
+
+    return CustomAuthClient("dummy_client_id", "dummy_client_secret")

--- a/tests/functional/services/auth/confidential_client/test_oauth2_client_credentials_tokens.py
+++ b/tests/functional/services/auth/confidential_client/test_oauth2_client_credentials_tokens.py
@@ -1,6 +1,31 @@
-import pytest
+import urllib.parse
+
+from globus_sdk._testing import get_last_request, load_response
+from globus_sdk.scopes import MutableScope
 
 
-@pytest.mark.xfail
-def test_oauth2_client_credentials_tokens():
-    raise NotImplementedError
+def test_oauth2_client_credentials_tokens(auth_client):
+    meta = load_response(auth_client.oauth2_client_credentials_tokens).metadata
+
+    response = auth_client.oauth2_client_credentials_tokens(meta["scope"])
+    assert (
+        response.by_resource_server[meta["resource_server"]]["access_token"]
+        == meta["access_token"]
+    )
+
+
+def test_oauth2_client_credentials_tokens_can_accept_mutable_scope_object(auth_client):
+    meta = load_response(auth_client.oauth2_client_credentials_tokens).metadata
+
+    response = auth_client.oauth2_client_credentials_tokens(MutableScope(meta["scope"]))
+    assert (
+        response.by_resource_server[meta["resource_server"]]["access_token"]
+        == meta["access_token"]
+    )
+
+    last_req = get_last_request()
+    assert last_req.body
+    body = last_req.body
+    assert body != ""
+    parsed_body = urllib.parse.parse_qs(body)
+    assert parsed_body["scope"] == [meta["scope"]]

--- a/tests/non-pytest/mypy-ignore-tests/scope_collection_type.py
+++ b/tests/non-pytest/mypy-ignore-tests/scope_collection_type.py
@@ -1,0 +1,161 @@
+import globus_sdk
+from globus_sdk._types import ScopeCollectionType
+from globus_sdk.scopes import MutableScope
+from globus_sdk.services.auth import (
+    GlobusAuthorizationCodeFlowManager,
+    GlobusNativeAppFlowManager,
+)
+
+# in tests below, passing `[None]` inline does not result in an arg-type error
+# but instead in a list-item error because mypy effectively identifies that your
+# argument type is "correct" (a list or iterable) and that it contains a
+# bad item (the None value)
+#
+# therefore, define the none_list explicitly to control the error behavior better
+none_list: list[None] = [None]
+
+
+# this function should type-check okay
+def foo(x: ScopeCollectionType) -> str:
+    return MutableScope.scopes2str(x)
+
+
+foo("somestring")
+foo(["somestring", "otherstring"])
+foo(MutableScope("bar"))
+foo((MutableScope("bar"),))
+foo({MutableScope("bar"), "baz"})
+# bad usages
+foo(1)  # type: ignore[arg-type]
+foo((False,))  # type: ignore[arg-type]
+
+
+# now, verify that we can pass scope collections to flow managers
+bare_client = globus_sdk.AuthClient()
+GlobusAuthorizationCodeFlowManager(
+    bare_client,
+    "https://example.org/redirect-uri",
+    requested_scopes="foo",
+)
+GlobusNativeAppFlowManager(
+    bare_client,
+    requested_scopes="foo",
+)
+GlobusAuthorizationCodeFlowManager(
+    bare_client,
+    "https://example.org/redirect-uri",
+    requested_scopes=("foo", "bar"),
+)
+GlobusNativeAppFlowManager(
+    bare_client,
+    requested_scopes=("foo", "bar"),
+)
+GlobusAuthorizationCodeFlowManager(
+    bare_client,
+    "https://example.org/redirect-uri",
+    requested_scopes=MutableScope("foo"),
+)
+GlobusNativeAppFlowManager(
+    bare_client,
+    requested_scopes=MutableScope("foo"),
+)
+GlobusAuthorizationCodeFlowManager(
+    bare_client,
+    "https://example.org/redirect-uri",
+    requested_scopes=[MutableScope("foo")],
+)
+GlobusNativeAppFlowManager(
+    bare_client,
+    requested_scopes=[MutableScope("foo")],
+)
+GlobusAuthorizationCodeFlowManager(
+    bare_client,
+    "https://example.org/redirect-uri",
+    requested_scopes=[MutableScope("foo"), "bar"],
+)
+GlobusNativeAppFlowManager(
+    bare_client,
+    requested_scopes=[MutableScope("foo"), "bar"],
+)
+# bad usages
+GlobusAuthorizationCodeFlowManager(
+    bare_client,
+    "https://example.org/redirect-uri",
+    requested_scopes=1,  # type: ignore[arg-type]
+)
+GlobusNativeAppFlowManager(
+    bare_client,
+    requested_scopes=1,  # type: ignore[arg-type]
+)
+GlobusAuthorizationCodeFlowManager(
+    bare_client,
+    "https://example.org/redirect-uri",
+    requested_scopes=none_list,  # type: ignore[arg-type]
+)
+GlobusNativeAppFlowManager(
+    bare_client,
+    requested_scopes=none_list,  # type: ignore[arg-type]
+)
+
+
+# furthermore, verify that we can pass these collection types to the client classes
+# which wrap the flow managers
+# note that oauth2_start_flow allows the scopes as a positional arg
+native_client = globus_sdk.NativeAppAuthClient("dummy_client_id")
+cc_client = globus_sdk.ConfidentialAppAuthClient(
+    "dummy_client_id", "dummy_client_secret"
+)
+
+native_client.oauth2_start_flow("foo")
+cc_client.oauth2_start_flow("https://example.org/redirect-uri", "foo")
+native_client.oauth2_start_flow(requested_scopes="foo")
+cc_client.oauth2_start_flow("https://example.org/redirect-uri", requested_scopes="foo")
+native_client.oauth2_start_flow(("foo", "bar"))
+cc_client.oauth2_start_flow("https://example.org/redirect-uri", ("foo", "bar"))
+native_client.oauth2_start_flow(requested_scopes=("foo", "bar"))
+cc_client.oauth2_start_flow(
+    "https://example.org/redirect-uri", requested_scopes=("foo", "bar")
+)
+native_client.oauth2_start_flow(MutableScope("foo"))
+cc_client.oauth2_start_flow("https://example.org/redirect-uri", MutableScope("foo"))
+native_client.oauth2_start_flow(requested_scopes=MutableScope("foo"))
+cc_client.oauth2_start_flow(
+    "https://example.org/redirect-uri", requested_scopes=MutableScope("foo")
+)
+native_client.oauth2_start_flow([MutableScope("foo"), "bar"])
+cc_client.oauth2_start_flow(
+    "https://example.org/redirect-uri", [MutableScope("foo"), "bar"]
+)
+native_client.oauth2_start_flow(requested_scopes=[MutableScope("foo"), "bar"])
+cc_client.oauth2_start_flow(
+    "https://example.org/redirect-uri", requested_scopes=[MutableScope("foo"), "bar"]
+)
+# bad usages
+native_client.oauth2_start_flow(1)  # type: ignore[arg-type]
+cc_client.oauth2_start_flow(
+    "https://example.org/redirect-uri",
+    1,  # type: ignore[arg-type]
+)
+native_client.oauth2_start_flow(requested_scopes=1)  # type: ignore[arg-type]
+cc_client.oauth2_start_flow(
+    "https://example.org/redirect-uri",
+    requested_scopes=1,  # type: ignore[arg-type]
+)
+
+
+# finally, requested_scopes for oauth2_client_credentials_tokens should follow these
+# same constraints
+cc_client.oauth2_client_credentials_tokens("foo")
+cc_client.oauth2_client_credentials_tokens(requested_scopes="foo")
+cc_client.oauth2_client_credentials_tokens(("foo", "bar"))
+cc_client.oauth2_client_credentials_tokens(requested_scopes=("foo", "bar"))
+cc_client.oauth2_client_credentials_tokens(MutableScope("foo"))
+cc_client.oauth2_client_credentials_tokens(requested_scopes=MutableScope("foo"))
+cc_client.oauth2_client_credentials_tokens([MutableScope("foo"), "bar"])
+cc_client.oauth2_client_credentials_tokens(
+    requested_scopes=[MutableScope("foo"), "bar"]
+)
+cc_client.oauth2_client_credentials_tokens(1)  # type: ignore[arg-type]
+cc_client.oauth2_client_credentials_tokens(
+    requested_scopes=none_list,  # type: ignore[arg-type]
+)


### PR DESCRIPTION
Two quick notes to set the stage:
- I ran into this being forbidden by `mypy` in globus-cli and was a bit surprised, which is what drives this change
- If you haven't seen the mypy "ignore tests" before, [the readme for these is here](https://github.com/globus/globus-sdk-python/tree/main/tests/non-pytest/mypy-ignore-tests)

---

The use of a MutableScope object, iterable thereof, or mixed iterable of MutableScope and str objects, was already supported by the underlying OAuth2 Flow Manager objects. However, the types used there were not "propagated upwards" to the auth client methods which wrap those manager objects.

Firstly, this change updates the annotations for the passthrough methods and adds a typing test which ensures that the correct types are allowed and defined by the ScopeCollectionType helper.

Secondarily, this adds the same capability to the
``oauth2_client_credentials_tokens`` method to make our scope interfaces more uniform. Unlike the other cases, this isn't just a typing change -- a new runtime behavior is being introduced here. As a result, a new test is wanted to validate that behavior. It turns out that this new test is the first test for this method, so fixture data must be included.

<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--689.org.readthedocs.build/en/689/

<!-- readthedocs-preview globus-sdk-python end -->