### PR TITLE
Switch to GHA automated package publishing

### DIFF
--- a/.github/workflows/publish_to_pypi.yaml
+++ b/.github/workflows/publish_to_pypi.yaml
@@ -1,0 +1,24 @@
+name: Publish PyPI Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - run: python -m pip install build
+      - run: python -m build .
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish_to_test_pypi.yaml
+++ b/.github/workflows/publish_to_test_pypi.yaml
@@ -1,0 +1,25 @@
+name: Publish Test PyPI Release
+
+on:
+  push:
+    tags: ["*"]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - run: python -m pip install build
+      - run: python -m build .
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/

--- a/Makefile
+++ b/Makefile
@@ -11,16 +11,15 @@ docs:
 all-checks:
 	tox -e lint,pylint,mypy,mypy-test,test-lazy-imports,py37,py310,poetry-check,twine-check,docs
 
-.PHONY: showvars release prepare-release
+.PHONY: showvars tag-release prepare-release
 showvars:
 	@echo "SDK_VERSION=$(SDK_VERSION)"
 prepare-release:
 	tox -e prepare-release
 	$(EDITOR) changelog.rst
-release:
+tag-release:
 	git tag -s "$(SDK_VERSION)" -m "v$(SDK_VERSION)"
 	-git push $(shell git rev-parse --abbrev-ref @{push} | cut -d '/' -f1) refs/tags/$(SDK_VERSION)
-	tox -e publish-release
 
 .PHONY: clean
 clean:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -18,5 +18,7 @@
     `git add changelog.d/ docs/changelog.rst src/globus_sdk/version.py`
 - Commit; `git commit -m 'Bump version and changelog for release'`
 - Push to main; `git push origin main`
-- Publish and tag the release; `make release`
+- Tag the release; `make tag-release`
+    _This will run a workflow to publish to test-pypi_
 - Create a GitHub release with a copy of the changelog
+    _This will run a workflow to publish to pypi_

--- a/tox.ini
+++ b/tox.ini
@@ -108,13 +108,3 @@ deps = scriv
 commands =
     python changelog.d/check-version-is-new.py
     scriv collect
-
-[testenv:publish-release]
-skip_install = true
-deps = build
-       twine
-# clean the build dir before rebuilding
-allowlist_externals = rm
-commands_pre = rm -rf dist/
-commands = python -m build
-           twine upload dist/*


### PR DESCRIPTION
We run a workflow to publish to test-pypi on tag, and a workflow to publish to pypi on GitHub release.

The tox environment for publishing has been removed (it can always be restored if it turns out to be necessary in the future).

`make release` has been replaced with `make tag-release`, which is slightly more clear about where this step fits into the workflow, and no longer tries to run the publishing step.

The `RELEASING.md` doc has been updated to accord with these details.

<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--692.org.readthedocs.build/en/692/

<!-- readthedocs-preview globus-sdk-python end -->