### PR TITLE
More testsuite cleanup: work on moving everything to _testing

### DIFF
--- a/src/globus_sdk/_testing/data/auth/get_identities.py
+++ b/src/globus_sdk/_testing/data/auth/get_identities.py
@@ -1,3 +1,5 @@
+import uuid
+
 from globus_sdk._testing.models import RegisteredResponse, ResponseSet
 
 from ._common import ERROR_ID, UNAUTHORIZED_AUTH_RESPONSE_JSON
@@ -20,6 +22,16 @@ _sirosen_at_globus_data = {
     "status": "used",
     "username": "sirosen@globus.org",
 }
+_globus_at_globusid_data = {
+    "email": "support@globus.org",
+    "id": str(uuid.UUID(int=1)),
+    "identity_provider": "41143743-f3c8-4d60-bbdb-eeecaba85bd9",
+    "identity_type": "login",
+    "name": "Globus Team",
+    "organization": "University of Chicago",
+    "status": "used",
+    "username": "globus@globusid.org",
+}
 
 RESPONSES = ResponseSet(
     default=RegisteredResponse(
@@ -31,6 +43,11 @@ RESPONSES = ResponseSet(
             "username": _globus_at_globus_data["username"],
         },
     ),
+    empty=RegisteredResponse(
+        service="auth",
+        path="/v2/api/identities",
+        json={"identities": []},
+    ),
     multiple=RegisteredResponse(
         service="auth",
         path="/v2/api/identities",
@@ -41,6 +58,17 @@ RESPONSES = ResponseSet(
                 _globus_at_globus_data["username"],
                 _sirosen_at_globus_data["username"],
             ],
+        },
+    ),
+    globusid=RegisteredResponse(
+        service="auth",
+        path="/v2/api/identities",
+        json={"identities": [_globus_at_globusid_data]},
+        metadata={
+            "id": _globus_at_globusid_data["id"],
+            "username": _globus_at_globusid_data["username"],
+            "short_username": _globus_at_globusid_data["username"].partition("@")[0],
+            "org": _globus_at_globusid_data["organization"],
         },
     ),
     sirosen=RegisteredResponse(

--- a/tests/common.py
+++ b/tests/common.py
@@ -10,17 +10,12 @@ from unittest import mock
 import requests
 import responses
 
-import globus_sdk
 from globus_sdk import utils
 
 # constants
 
 GO_EP1_ID = "ddb59aef-6d04-11e5-ba46-22000b92c6ec"
 GO_EP2_ID = "ddb59af0-6d04-11e5-ba46-22000b92c6ec"
-# TODO: stop using EP3 once EP1 and EP2 support symlinks
-GO_EP3_ID = "4be6107f-634d-11e7-a979-22000bf2d287"
-GO_S3_ID = "cf9bcaa5-6d04-11e5-ba46-22000b92c6ec"
-GO_EP1_SERVER_ID = 207976
 
 # end constants
 
@@ -152,26 +147,3 @@ class PickleableMockResponse(mock.NonCallableMock):
             _unpickle_pickleable_mock_response,
             (self.status_code, self.__getstate__()),
         )
-
-
-def make_response(
-    response_class=None,
-    status=200,
-    headers=None,
-    json_body=None,
-    text=None,
-    client=None,
-):
-    """
-    Construct and return an SDK response object with a mocked requests.Response
-
-    Unlike mocking of an API route, this is meant for unit testing in which we
-    want to directly create the response.
-    """
-    r = PickleableMockResponse(status, headers=headers, json_body=json_body, text=text)
-    http_res = globus_sdk.GlobusHTTPResponse(
-        r, client=client if client is not None else mock.Mock()
-    )
-    if response_class is not None:
-        return response_class(http_res)
-    return http_res

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ from unittest import mock
 import pytest
 import responses
 
+import globus_sdk
 from globus_sdk.transport import RequestsTransport
 
 
@@ -32,3 +33,34 @@ def mocked_responses():
 
     responses.stop()
     responses.reset()
+
+
+@pytest.fixture
+def make_response():
+    def _make_response(
+        response_class=None,
+        status=200,
+        headers=None,
+        json_body=None,
+        text=None,
+        client=None,
+    ):
+        """
+        Construct and return an SDK response object with a mocked requests.Response
+
+        Unlike mocking of an API route, this is meant for unit testing in which we
+        want to directly create the response.
+        """
+        from tests.common import PickleableMockResponse
+
+        r = PickleableMockResponse(
+            status, headers=headers, json_body=json_body, text=text
+        )
+        http_res = globus_sdk.GlobusHTTPResponse(
+            r, client=client if client is not None else mock.Mock()
+        )
+        if response_class is not None:
+            return response_class(http_res)
+        return http_res
+
+    return _make_response

--- a/tests/unit/responses/conftest.py
+++ b/tests/unit/responses/conftest.py
@@ -1,11 +1,10 @@
 import pytest
 
 import globus_sdk
-from tests.common import make_response
 
 
 @pytest.fixture
-def make_oauth_token_response():
+def make_oauth_token_response(make_response):
     """
     response with conveniently formatted names to help with iteration in tests
     """
@@ -48,7 +47,7 @@ def make_oauth_token_response():
 
 
 @pytest.fixture
-def make_oauth_dependent_token_response():
+def make_oauth_dependent_token_response(make_response):
     """
     response with conveniently formatted names to help with iteration in tests
     """

--- a/tests/unit/responses/test_unpacking_gcs_response.py
+++ b/tests/unit/responses/test_unpacking_gcs_response.py
@@ -1,10 +1,9 @@
 import pytest
 
 from globus_sdk.services.gcs import UnpackingGCSResponse
-from tests.common import make_response
 
 
-def test_unpacking_response_with_callback():
+def test_unpacking_response_with_callback(make_response):
     def identify_desired_data(d):
         return "foo" in d
 
@@ -24,7 +23,7 @@ def test_unpacking_response_with_callback():
 
 
 @pytest.mark.parametrize("datatype", ["foo#1.0.1", "foo#1", "foo#0.0.1", "foo#2.0.0.1"])
-def test_unpacking_response_matches_datatype(datatype):
+def test_unpacking_response_matches_datatype(make_response, datatype):
     base_resp = make_response(json_body={"data": [{"x": 1, "DATA_TYPE": datatype}]})
     resp = UnpackingGCSResponse(base_resp, "foo")
     assert "x" in resp
@@ -33,13 +32,13 @@ def test_unpacking_response_matches_datatype(datatype):
     assert "x" not in resp_bar
 
 
-def test_unpacking_response_invalid_spec():
+def test_unpacking_response_invalid_spec(make_response):
     base_resp = make_response(json_body={"data": [{"x": 1, "DATA_TYPE": "foo#1.0.0"}]})
     with pytest.raises(ValueError):
         UnpackingGCSResponse(base_resp, "foo 1.0")
 
 
-def test_unpacking_response_invalid_datatype():
+def test_unpacking_response_invalid_datatype(make_response):
     # we'll never return a match if the DATA_TYPE doesn't appear to be valid
     base_resp = make_response(json_body={"data": [{"x": 1, "DATA_TYPE": "foo"}]})
     resp = UnpackingGCSResponse(base_resp, "foo")


### PR DESCRIPTION
I made what progress I could today and this is as far as I got.
I wish I had the stamina to do the complete overhaul and remove all of the use of the older fixture registration helpers, but there's just too much ground to cover.

The commits should be pretty much self-explanatory, and the work is primarily a lift-and-shift of data from the tests into the `_testing` registry. Or a rewrite of some manual fixtures into a newer style.

<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--693.org.readthedocs.build/en/693/

<!-- readthedocs-preview globus-sdk-python end -->