### PR TITLE
Add sphinx directive to list _testing data

### DIFF
--- a/docs/testing/index.rst
+++ b/docs/testing/index.rst
@@ -21,3 +21,4 @@ Globus SDK _testing (alpha)
 
     getting_started
     reference
+    method_list

--- a/docs/testing/method_list.rst
+++ b/docs/testing/method_list.rst
@@ -1,0 +1,43 @@
+.. warning::
+
+    This component is an *alpha*. Interfaces may change outside of the
+    normal semver policy.
+
+_testing Method List
+====================
+
+:ref:`Back to _testing root <testing_root>`.
+
+This page lists all methods which have ``globus_sdk._testing`` response data,
+and the casenames for those data.
+
+Globus Auth & Groups
+--------------------
+
+.. enumeratetestingfixtures:: globus_sdk.AuthClient
+
+.. enumeratetestingfixtures:: globus_sdk.GroupsClient
+
+Globus Transfer & GCS
+---------------------
+
+.. enumeratetestingfixtures:: globus_sdk.TransferClient
+
+.. enumeratetestingfixtures:: globus_sdk.GCSClient
+
+Globus Timer
+------------
+
+.. enumeratetestingfixtures:: globus_sdk.TimerClient
+
+Globus Flows
+------------
+
+.. enumeratetestingfixtures:: globus_sdk.FlowsClient
+
+.. enumeratetestingfixtures:: globus_sdk.SpecificFlowClient
+
+Globus Search
+-------------
+
+.. enumeratetestingfixtures:: globus_sdk.SearchClient

--- a/src/globus_sdk/_sphinxext.py
+++ b/src/globus_sdk/_sphinxext.py
@@ -141,6 +141,36 @@ class ListKnownScopes(AddContentDirective):
         yield ""
 
 
+class EnumerateTestingFixtures(AddContentDirective):
+    has_content = False
+    required_arguments = 1
+    optional_arguments = 0
+
+    def gen_rst(self):
+        from globus_sdk._testing import get_response_set
+
+        classname = self.arguments[0]
+        yield (
+            f":class:`{classname}` has registered responses "
+            "for the following methods:"
+        )
+        yield ""
+        for methodname, method in _classname2methods(classname, []):
+            try:
+                rset = get_response_set(method)
+                # success -> has a response
+            except ValueError:
+                continue
+                # error -> has no response, continue
+            for casename in rset.cases():
+                # use "attr" rather than "meth" so that sphinx does not add parens
+                # the use of the method as an attribute of the class or instance better
+                # matches how `_testing` handles things
+                yield f'* :py:attr:`~{classname}.{methodname}` (``case="{casename}"``)'
+        yield ""
+
+
 def setup(app):
     app.add_directive("automethodlist", AutoMethodList)
     app.add_directive("listknownscopes", ListKnownScopes)
+    app.add_directive("enumeratetestingfixtures", EnumerateTestingFixtures)

--- a/src/globus_sdk/_testing/models.py
+++ b/src/globus_sdk/_testing/models.py
@@ -161,6 +161,9 @@ class ResponseSet:
     ) -> t.Iterator[RegisteredResponse | ResponseList]:
         return iter(self._data.values())
 
+    def cases(self) -> t.Iterator[str]:
+        return iter(self._data.keys())
+
     def activate(
         self,
         case: str,

--- a/src/globus_sdk/_testing/models.py
+++ b/src/globus_sdk/_testing/models.py
@@ -162,7 +162,7 @@ class ResponseSet:
         return iter(self._data.values())
 
     def cases(self) -> t.Iterator[str]:
-        return iter(self._data.keys())
+        return iter(self._data)
 
     def activate(
         self,


### PR DESCRIPTION
This adds a directive to our internal sphinx extension to list the data visible in `_testing`.

It uses the same helper as `AutoMethodList`, but
`EnumerateTestingFixtures` checks those fixtures against the `_testing` registry and emits ReST for those which have defined test cases.

The listing is done on a new method_list page, which follows the existing norms and forms of the ("alpha") testing docs.

<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--694.org.readthedocs.build/en/694/

<!-- readthedocs-preview globus-sdk-python end -->