### PR TITLE
Improve SearchClient docs, deprecate entry methods

### DIFF
--- a/changelog.d/20230301_174601_sirosen_improve_search_method_docs.rst
+++ b/changelog.d/20230301_174601_sirosen_improve_search_method_docs.rst
@@ -1,0 +1,4 @@
+* ``SearchClient.update_entry`` and ``SearchClient.create_entry`` are
+  officially deprecated. These APIs are aliases of ``SearchClient.ingest``, but
+  their existence has caused confusion. Users are encouraged to switch to
+  ``SearchClient.ingest`` instead (:pr:`NUMBER`)


### PR DESCRIPTION
The create_entry and update_entry methods are misleadingly named. We may or may not be able to remove these aliasing APIs from the service, but we should at least discourage their use via the SDK. Redirect users of these methods to Ingest, which is the only behavior offered by all three of these APIs.

Even if we were to support this operation in the SDK, having a single API with two methods is confusing because it suggests that there is some difference.

Instead, we would probably want to implement `write_entry` if we need a succcessor method.

<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--695.org.readthedocs.build/en/695/

<!-- readthedocs-preview globus-sdk-python end -->