### PR TITLE
Update TransferData.add_item to omit recursive

### DIFF
--- a/changelog.d/20230301_175502_sirosen_no_default_recursive.rst
+++ b/changelog.d/20230301_175502_sirosen_no_default_recursive.rst
@@ -1,6 +1,6 @@
 * ``TransferData.add_item`` now defaults to omitting ``recursive`` rather than
   setting its value to ``False``. This change better matches new Transfer API
   behaviors which treat the absence of the ``recursive`` flag as meaning
-  autodetect, rather than the previous default of ``False``. Users are
-  recommended to avoid explicitly setting the value unless they would like
-  to avoid using the autodetection logic (:pr:`NUMBER`)
+  autodetect, rather than the previous default of ``False``. Setting the
+  recursive flag can still have beneficial behaviors, but should not be
+  necessary for many use-cases (:pr:`NUMBER`)

--- a/changelog.d/20230301_175502_sirosen_no_default_recursive.rst
+++ b/changelog.d/20230301_175502_sirosen_no_default_recursive.rst
@@ -1,0 +1,6 @@
+* ``TransferData.add_item`` now defaults to omitting ``recursive`` rather than
+  setting its value to ``False``. This change better matches new Transfer API
+  behaviors which treat the absence of the ``recursive`` flag as meaning
+  autodetect, rather than the previous default of ``False``. Users are
+  recommended to avoid explicitly setting the value unless they would like
+  to avoid using the autodetection logic (:pr:`NUMBER`)

--- a/src/globus_sdk/services/transfer/data/transfer_data.py
+++ b/src/globus_sdk/services/transfer/data/transfer_data.py
@@ -296,7 +296,7 @@ class TransferData(utils.PayloadWrapper):
         :param additional_fields: additional fields to be added to the transfer item
         :type additional_fields: dict, optional
         """
-        item_data = {
+        item_data: dict[str, t.Any] = {
             "DATA_TYPE": "transfer_item",
             "source_path": source_path,
             "destination_path": destination_path,

--- a/src/globus_sdk/services/transfer/data/transfer_data.py
+++ b/src/globus_sdk/services/transfer/data/transfer_data.py
@@ -256,7 +256,7 @@ class TransferData(utils.PayloadWrapper):
         source_path: str,
         destination_path: str,
         *,
-        recursive: bool = False,
+        recursive: bool | None = None,
         external_checksum: str | None = None,
         checksum_algorithm: str | None = None,
         additional_fields: dict[str, t.Any] | None = None,
@@ -283,7 +283,7 @@ class TransferData(utils.PayloadWrapper):
             transferred to
         :type destination_path: str
         :param recursive: Set to True if the target at source path is a directory
-        :type recursive: bool
+        :type recursive: bool, optional
         :param external_checksum: A checksum to verify both source file and destination
             file integrity. The checksum will be verified after the data transfer and a
             failure will cause the entire task to fail. Cannot be used with directories.
@@ -300,8 +300,9 @@ class TransferData(utils.PayloadWrapper):
             "DATA_TYPE": "transfer_item",
             "source_path": source_path,
             "destination_path": destination_path,
-            "recursive": recursive,
         }
+        if recursive is not None:
+            item_data["recursive"] = recursive
         if external_checksum is not None:
             item_data["external_checksum"] = external_checksum
         if checksum_algorithm is not None:

--- a/tests/unit/helpers/test_transfer.py
+++ b/tests/unit/helpers/test_transfer.py
@@ -90,7 +90,7 @@ def test_transfer_add_item():
     assert data["DATA_TYPE"] == "transfer_item"
     assert data["source_path"] == source_path
     assert data["destination_path"] == dest_path
-    assert not data["recursive"]
+    assert "recursive" not in data
     assert "external_checksum" not in data
     assert "checksum_algorithm" not in data
 
@@ -117,7 +117,7 @@ def test_transfer_add_item():
     assert c_data["DATA_TYPE"] == "transfer_item"
     assert c_data["source_path"] == source_path
     assert c_data["destination_path"] == dest_path
-    assert not c_data["recursive"]
+    assert "recursive" not in c_data
     assert c_data["external_checksum"] == checksum
     assert c_data["checksum_algorithm"] == algorithm
 
@@ -129,7 +129,7 @@ def test_transfer_add_item():
     assert fields_data["DATA_TYPE"] == "transfer_item"
     assert fields_data["source_path"] == source_path
     assert fields_data["destination_path"] == dest_path
-    assert not fields_data["recursive"]
+    assert "recursive" not in fields_data
     assert all(fields_data[k] == v for k, v in addfields.items())
 
 


### PR DESCRIPTION
By default today, `add_item` will create a subdocument with `{"recursive": false}`. This update defaults to omission of the `"recursive"` key to match the new behavior being released by the Transfer API.

This change is technically backwards incompatible in that we're changing the document we generate. However, our previous default (`False`) was chosen to match API behaviors and the new default (omission) is chosen to match new API behaviors. This can impact users, but is likely acceptable without a major version bump. To have a noticeable negative impact, a user would have to not be specifying `recursive` but also explicitly want the behavior of `recursive=False`.

The changelog entry encourages users to be explicit about their desired usage if they are concerned.

<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--696.org.readthedocs.build/en/696/

<!-- readthedocs-preview globus-sdk-python end -->