### PR TITLE
Allow a float for max_sleep in types

### DIFF
--- a/changelog.d/20230302_202418_sirosen_fix_type_for_max_sleep.rst
+++ b/changelog.d/20230302_202418_sirosen_fix_type_for_max_sleep.rst
@@ -1,0 +1,2 @@
+* Fix the type annotation for `max_sleep` on client transports to allow `float`
+  values (:pr:`NUMBER`)

--- a/src/globus_sdk/transport/requests.py
+++ b/src/globus_sdk/transport/requests.py
@@ -84,7 +84,7 @@ class RequestsTransport:
     :param max_sleep: The maximum sleep time between retries (in seconds). If the
         computed sleep time or the backoff requested by a retry check exceeds this
         value, this amount of time will be used instead
-    :type max_sleep: int, optional
+    :type max_sleep: float or int, optional
     :param max_retries: The maximum number of retries allowed by this transport
     :type max_retries: int, optional
     """
@@ -114,7 +114,7 @@ class RequestsTransport:
         http_timeout: float | None = None,
         retry_backoff: t.Callable[[RetryContext], float] = _exponential_backoff,
         retry_checks: list[RetryCheck] | None = None,
-        max_sleep: int = 10,
+        max_sleep: float | int = 10,
         max_retries: int | None = None,
     ):
         self.session = requests.Session()
@@ -151,7 +151,7 @@ class RequestsTransport:
         verify_ssl: bool | None = None,
         http_timeout: float | None = None,
         retry_backoff: t.Callable[[RetryContext], float] | None = None,
-        max_sleep: int | None = None,
+        max_sleep: float | int | None = None,
         max_retries: int | None = None,
     ) -> t.Iterator[None]:
         """
@@ -172,7 +172,7 @@ class RequestsTransport:
         :param max_sleep: The maximum sleep time between retries (in seconds). If the
             computed sleep time or the backoff requested by a retry check exceeds this
             value, this amount of time will be used instead
-        :type max_sleep: int, optional
+        :type max_sleep: float or int, optional
         :param max_retries: The maximum number of retries allowed by this transport
         :type max_retries: int, optional
 


### PR DESCRIPTION
This already works at runtime, but it's incorrect in the type annotations. `max_sleep=0.5` is a very reasonable value to set (if you want very short sleeps).

<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--697.org.readthedocs.build/en/697/

<!-- readthedocs-preview globus-sdk-python end -->