### PR TITLE
Add 'refresh_tokens' to dependent token method

### DIFF
--- a/changelog.d/20230307_200009_sirosen_add_dependent_refresh_tokens_param.rst
+++ b/changelog.d/20230307_200009_sirosen_add_dependent_refresh_tokens_param.rst
@@ -1,0 +1,2 @@
+* ``ConfidentialAppAuthClient.oauth2_get_dependent_tokens`` now supports the
+  ``refresh_tokens`` parameter to enable requests for dependent refresh tokens (:pr:`NUMBER`)

--- a/src/globus_sdk/_testing/data/auth/oauth2_get_dependent_tokens.py
+++ b/src/globus_sdk/_testing/data/auth/oauth2_get_dependent_tokens.py
@@ -1,0 +1,50 @@
+from globus_sdk._testing.models import RegisteredResponse, ResponseSet
+
+RESPONSES = ResponseSet(
+    groups=RegisteredResponse(
+        service="auth",
+        path="/v2/oauth2/token",
+        method="POST",
+        json=[
+            {
+                "scope": "urn:globus:auth:scope:groups.api.globus.org:view_my_groups_and_memberships",  # noqa: E501
+                "access_token": "groupsToken",
+                "token_type": "bearer",
+                "expires_in": 120,
+                "resource_server": "groups.api.globus.org",
+            }
+        ],
+        metadata={
+            "rs_data": {
+                "groups.api.globus.org": {
+                    "access_token": "groupsToken",
+                    "scope": "urn:globus:auth:scope:groups.api.globus.org:view_my_groups_and_memberships",  # noqa: E501
+                }
+            }
+        },
+    ),
+    groups_with_refresh_token=RegisteredResponse(
+        service="auth",
+        path="/v2/oauth2/token",
+        method="POST",
+        json=[
+            {
+                "scope": "urn:globus:auth:scope:groups.api.globus.org:view_my_groups_and_memberships",  # noqa: E501
+                "access_token": "groupsToken",
+                "refresh_token": "groupsRefreshToken",
+                "token_type": "bearer",
+                "expires_in": 120,
+                "resource_server": "groups.api.globus.org",
+            }
+        ],
+        metadata={
+            "rs_data": {
+                "groups.api.globus.org": {
+                    "access_token": "groupsToken",
+                    "refresh_token": "groupsRefreshToken",
+                    "scope": "urn:globus:auth:scope:groups.api.globus.org:view_my_groups_and_memberships",  # noqa: E501
+                }
+            }
+        },
+    ),
+)

--- a/src/globus_sdk/services/auth/client/confidential_client.py
+++ b/src/globus_sdk/services/auth/client/confidential_client.py
@@ -140,6 +140,7 @@ class ConfidentialAppAuthClient(AuthClient):
         self,
         token: str,
         *,
+        refresh_tokens: bool = False,
         additional_params: dict[str, t.Any] | None = None,
     ) -> OAuthDependentTokenResponse:
         """
@@ -160,11 +161,13 @@ class ConfidentialAppAuthClient(AuthClient):
         In order to do this exchange, the tokens for Service A must have scopes
         which depend on scopes for Service B (the services' scopes must encode
         their relationship). As long as that is the case, Service A can use
-        this Grant to get those "Dependent" or "Downstream" tokens for Service
-        B.
+        this Grant to get those "Dependent" or "Downstream" tokens for Service B.
 
         :param token: A Globus Access Token as a string
         :type token: str
+        :param refresh_tokens: When True, request dependent refresh tokens in addition
+            to access tokens. [Default: ``False``]
+        :type refresh_tokens: bool, optional
         :param additional_params: Additional parameters to include in the request body
         :type additional_params: dict, optional
         :rtype: :class:`OAuthDependentTokenResponse <.OAuthDependentTokenResponse>`
@@ -175,6 +178,11 @@ class ConfidentialAppAuthClient(AuthClient):
             "grant_type": "urn:globus:auth:grant_type:dependent_token",
             "token": token,
         }
+        # the internal parameter is 'access_type', but using the name 'refresh_tokens'
+        # is consistent with the rest of the SDK and better communicates expectations
+        # back to the user than the OAuth2 spec wording
+        if refresh_tokens:
+            form_data["access_type"] = "offline"
         if additional_params:
             form_data.update(additional_params)
 

--- a/tests/functional/services/auth/confidential_client/test_oauth2_get_dependent_tokens.py
+++ b/tests/functional/services/auth/confidential_client/test_oauth2_get_dependent_tokens.py
@@ -1,6 +1,47 @@
-import pytest
+import urllib.parse
+
+from globus_sdk._testing import get_last_request, load_response
 
 
-@pytest.mark.xfail
-def test_oauth2_get_dependent_tokens():
-    raise NotImplementedError
+def test_oauth2_get_dependent_tokens(auth_client):
+    meta = load_response(
+        auth_client.oauth2_get_dependent_tokens, case="groups"
+    ).metadata
+
+    response = auth_client.oauth2_get_dependent_tokens("dummy_token")
+    full_response_by_rs = response.by_resource_server
+
+    # data matches fully in the by_resource_server layout
+    expected_data = meta["rs_data"]
+    assert set(expected_data) == set(full_response_by_rs)
+    for rs_name, values in expected_data.items():
+        assert full_response_by_rs[rs_name]["access_token"] == values["access_token"]
+        assert full_response_by_rs[rs_name]["scope"] == values["scope"]
+
+
+def test_oauth2_get_dependent_tokens_with_refresh_token(auth_client):
+    meta = load_response(
+        auth_client.oauth2_get_dependent_tokens, case="groups_with_refresh_token"
+    ).metadata
+
+    response = auth_client.oauth2_get_dependent_tokens(
+        "dummy_token", refresh_tokens=True
+    )
+    full_response_by_rs = response.by_resource_server
+
+    # data matches fully in the by_resource_server layout
+    expected_data = meta["rs_data"]
+    assert set(expected_data) == set(full_response_by_rs)
+    for rs_name, values in expected_data.items():
+        assert full_response_by_rs[rs_name]["access_token"] == values["access_token"]
+        assert full_response_by_rs[rs_name]["refresh_token"] == values["refresh_token"]
+        assert full_response_by_rs[rs_name]["scope"] == values["scope"]
+
+    # parse sent request and ensure that refresh_tokens translated correctly
+    # to `access_type=offline`
+    last_req = get_last_request()
+    assert last_req.body
+    body = last_req.body
+    assert body != ""
+    parsed_body = urllib.parse.parse_qs(body)
+    assert parsed_body["access_type"] == ["offline"]


### PR DESCRIPTION
Dependent token grants support `access_type=offline`, which is represented elsewhere in the SDK as `refresh_tokens=True`. Add support for this parameter/translation as it currently exists. The default (False) will be translated to parameter omission rather than `access_type=online`.

In addition to the parameter change, test data and two tests are added to test the method with and without this option.

<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--698.org.readthedocs.build/en/698/

<!-- readthedocs-preview globus-sdk-python end -->