### PR TITLE
Update pre-commit and resolve lint failures

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
     - id: check-merge-conflict
     - id: trailing-whitespace
 - repo: https://github.com/python-jsonschema/check-jsonschema
-  rev: 0.21.0
+  rev: 0.22.0
   hooks:
     - id: check-github-workflows
     - id: check-readthedocs
@@ -18,14 +18,14 @@ repos:
   rev: 1.13.0
   hooks:
     - id: blacken-docs
-      additional_dependencies: ['black==22.10.0']
+      additional_dependencies: ['black==23.1.0']
 - repo: https://github.com/PyCQA/flake8
   rev: 6.0.0
   hooks:
     - id: flake8
       name: "Lint python files"
       additional_dependencies:
-        - 'flake8-bugbear==22.10.27'
+        - 'flake8-bugbear==23.2.13'
         - 'flake8-comprehensions==3.10.1'
         - 'flake8-typing-as-t==0.0.3'
 - repo: https://github.com/PyCQA/isort

--- a/docs/examples/timer_operations.rst
+++ b/docs/examples/timer_operations.rst
@@ -98,6 +98,7 @@ schedule a recurring Transfer task.
     assert get_job_response.http_status == 200
     assert get_job_response["name"] == name
 
+
     # Later, you could run this function to clean up the job:
     def delete_timer_job(job_id):
         delete_job_response = timer_client.delete_job(job_id)

--- a/src/globus_sdk/scopes/scope_definition.py
+++ b/src/globus_sdk/scopes/scope_definition.py
@@ -227,6 +227,7 @@ class Scope:
                 "Passing 'optional' to add_dependency is deprecated. "
                 "Construct an optional Scope object instead.",
                 DeprecationWarning,
+                stacklevel=2,
             )
             scopeobj = Scope(scope, optional=optional)
         else:
@@ -404,6 +405,7 @@ class MutableScope:
                 "Passing 'optional' to add_dependency is deprecated. "
                 "Construct an optional MutableScope object instead.",
                 DeprecationWarning,
+                stacklevel=2,
             )
             scopeobj = MutableScope(scope, optional=optional)
         else:


### PR DESCRIPTION
- 'pre-commit autoupdate' (latest check-jsonschema)
- 'upadup' (blacken-docs and flake8)
- add explicit stacklevel to warnings (flake8-bugbear, B028)

<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--699.org.readthedocs.build/en/699/

<!-- readthedocs-preview globus-sdk-python end -->