### PR TITLE
Begin using tabs to refactor method docs

### DIFF
--- a/docs/_static/css/globus_sdk_tab_borders.css
+++ b/docs/_static/css/globus_sdk_tab_borders.css
@@ -13,12 +13,12 @@
     --tabset-border-color: #777;
   }
 }
-.tab-set.container {
+.sd-tab-set {
   border-style: solid;
   border-width: 1px;
   border-radius: 3px;
   border-color: var(--tabset-border-color);
 }
-.tab-set.container .tab-content.container {
+.sd-tab-set .sd-tab-content {
   padding: 4px;
 }

--- a/docs/_static/css/globus_sdk_tab_borders.css
+++ b/docs/_static/css/globus_sdk_tab_borders.css
@@ -1,0 +1,21 @@
+/* custom CSS to add a border to tab groups
+ * see also:
+ * https://github.com/pradyunsg/furo/discussions/633 */
+:root {
+  /* default to '#aaa', which looks okay in both light and dark */
+  --tabset-border-color: #aaa;
+}
+/* set the border color to decrease contrast a little on dark theme
+ * this detection logic is taken from furo, which sets data-theme on the body
+ * element when the user toggles the color scheme */
+@media (prefers-color-scheme: dark) {
+  body:not([data-theme="light"]) {
+    --tabset-border-color: #777;
+  }
+}
+.tab-set.container {
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 3px;
+  border-color: var(--tabset-border-color);
+}

--- a/docs/_static/css/globus_sdk_tab_borders.css
+++ b/docs/_static/css/globus_sdk_tab_borders.css
@@ -19,3 +19,6 @@
   border-radius: 3px;
   border-color: var(--tabset-border-color);
 }
+.tab-set.container .tab-content.container {
+  padding: 4px;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,6 +34,7 @@ extensions = [
     # other packages
     "sphinx_copybutton",
     "sphinx_issues",
+    "sphinx_inline_tabs",
     # our custom one
     "globus_sdk._sphinxext",
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -71,6 +71,10 @@ html_theme_options = {
     },
 }
 html_logo = "_static/logo.png"
+html_static_path = ["_static"]
+html_css_files = [
+    "css/globus_sdk_tab_borders.css"
+]
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = "friendly"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,8 +33,8 @@ extensions = [
     "sphinx.ext.viewcode",
     # other packages
     "sphinx_copybutton",
+    "sphinx_design",
     "sphinx_issues",
-    "sphinx_inline_tabs",
     # our custom one
     "globus_sdk._sphinxext",
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,9 +72,7 @@ html_theme_options = {
 }
 html_logo = "_static/logo.png"
 html_static_path = ["_static"]
-html_css_files = [
-    "css/globus_sdk_tab_borders.css"
-]
+html_css_files = ["css/globus_sdk_tab_borders.css"]
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = "friendly"

--- a/requirements/docs.in
+++ b/requirements/docs.in
@@ -2,6 +2,7 @@ sphinx
 sphinx-copybutton
 sphinx-issues
 furo
-sphinx-inline-tabs
+sphinx-design
+
 # required for testing modules to load
 responses

--- a/requirements/docs.in
+++ b/requirements/docs.in
@@ -2,5 +2,6 @@ sphinx
 sphinx-copybutton
 sphinx-issues
 furo
+sphinx-inline-tabs
 # required for testing modules to load
 responses

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -44,19 +44,19 @@ snowballstemmer==2.2.0
     # via sphinx
 soupsieve==2.4
     # via beautifulsoup4
-sphinx==6.1.3
+sphinx==5.3.0
     # via
     #   -r requirements/docs.in
     #   furo
     #   sphinx-basic-ng
     #   sphinx-copybutton
-    #   sphinx-inline-tabs
+    #   sphinx-design
     #   sphinx-issues
 sphinx-basic-ng==1.0.0b1
     # via furo
 sphinx-copybutton==0.5.1
     # via -r requirements/docs.in
-sphinx-inline-tabs==2022.1.2b11
+sphinx-design==0.3.0
     # via -r requirements/docs.in
 sphinx-issues==3.0.1
     # via -r requirements/docs.in

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -50,10 +50,13 @@ sphinx==6.1.3
     #   furo
     #   sphinx-basic-ng
     #   sphinx-copybutton
+    #   sphinx-inline-tabs
     #   sphinx-issues
 sphinx-basic-ng==1.0.0b1
     # via furo
 sphinx-copybutton==0.5.1
+    # via -r requirements/docs.in
+sphinx-inline-tabs==2022.1.2b11
     # via -r requirements/docs.in
 sphinx-issues==3.0.1
     # via -r requirements/docs.in

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ exclude = .git,.tox,__pycache__,.eggs,dist,venv,.venv*,venv27,virtualenv,docs,do
 # not fail on up to 88 chars of width
 max-line-length = 88
 
-ignore = W503,W504
+extend-ignore = W503,W504,E203
 
 
 [mypy]

--- a/src/globus_sdk/_sphinxext.py
+++ b/src/globus_sdk/_sphinxext.py
@@ -232,7 +232,7 @@ class ExpandTestingFixture(AddContentDirective):
             for line in output_lines:
                 yield f"    {line}"
         elif response.body is not None:
-            yield ".. code-block::"
+            yield ".. code-block:: text"
             yield ""
             output_lines = response.body.split("\n")
             for line in output_lines:
@@ -254,7 +254,9 @@ class PaginatedUsage(AddContentDirective):
         yield "To use the paginated variant, give the same arguments as normal, "
         yield "but prefix the method name with ``paginated``, as in"
         yield ""
-        yield f">>> client.paginated.{self.arguments[0]}(...)"
+        yield ".. code-block:: pycon"
+        yield ""
+        yield f"    >>> client.paginated.{self.arguments[0]}(...)"
         yield ""
         yield "For more information, see"
         yield ":ref:`how to make paginated calls <making_paginated_calls>`."

--- a/src/globus_sdk/_sphinxext.py
+++ b/src/globus_sdk/_sphinxext.py
@@ -5,10 +5,11 @@ A Globus SDK Sphinx Extension for Autodoc of Class Methods
 from __future__ import annotations
 
 import inspect
+import json
 from pydoc import locate
 
 from docutils import nodes
-from docutils.parsers.rst import Directive
+from docutils.parsers.rst import Directive, directives
 from docutils.statemachine import ViewList
 from sphinx.util.nodes import nested_parse_with_titles
 
@@ -18,19 +19,22 @@ def _extract_known_scopes(scope_builder_name):
     return sb.scope_names
 
 
+def _locate_class(classname):
+    cls = locate(classname)
+    if not inspect.isclass(cls):
+        raise RuntimeError(
+            f"uh-oh, {classname} is not a class name? type(classname)={type(cls)}"
+        )
+    return cls
+
+
 def _classname2methods(classname, include_methods):
     """resolve a class name to a list of (public) method names
     takes a classname and a list of method names to avoid filtering out"""
-    klass = locate(classname)
-    if not inspect.isclass(klass):
-        raise RuntimeError(
-            "uh-oh, {} is not a class name? type(classname)={}".format(
-                classname, type(klass)
-            )
-        )
+    cls = _locate_class(classname)
 
     # get methods of the object as [(name, <unbound method>), ...]
-    methods = inspect.getmembers(klass, predicate=inspect.isfunction)
+    methods = inspect.getmembers(cls, predicate=inspect.isfunction)
 
     def _methodname_is_good(m):
         if m in include_methods:
@@ -39,7 +43,7 @@ def _classname2methods(classname, include_methods):
         if m.startswith("_"):
             return False
         # filter out any inherited methods which are not overloaded
-        if m not in klass.__dict__:
+        if m not in cls.__dict__:
             return False
         return True
 
@@ -85,15 +89,15 @@ class AddContentDirective(Directive):
 class AutoMethodList(AddContentDirective):
     has_content = False
     required_arguments = 1
-    optional_arguments = 1
+    optional_arguments = 0
+    option_spec = {"include_methods": directives.unchanged}
 
     def gen_rst(self):
         classname = self.arguments[0]
 
         include_methods = []
-        for arg in self.arguments[1:]:
-            if arg.startswith("include_methods="):
-                include_methods = arg.split("=")[1].split(",")
+        if "include_methods" in self.options:
+            include_methods = self.options["include_methods"].strip().split(",")
 
         yield ""
         yield "**Methods**"
@@ -113,16 +117,16 @@ class AutoMethodList(AddContentDirective):
 class ListKnownScopes(AddContentDirective):
     has_content = False
     required_arguments = 1
-    optional_arguments = 2
+    optional_arguments = 0
+    option_spec = {"example_scope": directives.unchanged}
 
     def gen_rst(self):
         sb_name = self.arguments[0]
         sb_basename = sb_name.split(".")[-1]
 
         example_scope = None
-        for arg in self.arguments[1:]:
-            if arg.startswith("example_scope="):
-                example_scope = arg.split("=")[1]
+        if "example_scope" in self.options:
+            example_scope = self.options["example_scope"].strip()
         known_scopes = _extract_known_scopes(sb_name)
         if example_scope is None:
             example_scope = known_scopes[0]
@@ -170,7 +174,96 @@ class EnumerateTestingFixtures(AddContentDirective):
         yield ""
 
 
+class ExternalDocLink(AddContentDirective):
+    has_content = False
+    required_arguments = 1
+    optional_arguments = 0
+    # allow for spaces in the argument string
+    final_argument_whitespace = True
+    option_spec = {"mode": directives.unchanged, "ref": directives.unchanged_required}
+
+    def gen_rst(self):
+        message = self.arguments[0].strip()
+
+        mode = "default"
+        if "mode" in self.options:
+            mode = self.options["mode"]
+
+        if mode == "default":
+            base_url = "https://docs.globus.org/api"
+            relative_link = self.options["ref"]
+
+            yield (
+                f"See `{message} <{base_url}/{relative_link}>`_ in the "
+                "API documentation for details."
+            )
+        elif mode in (
+            "groups",
+            "gcs",
+        ):
+            raise ValueError(f"Unsupported extdoclink mode {mode}. TODO: add support")
+        else:
+            raise ValueError(f"Unsupported extdoclink mode {mode}")
+
+
+class ExpandTestingFixture(AddContentDirective):
+    has_content = False
+    required_arguments = 1
+    optional_arguments = 0
+    option_spec = {
+        "case": directives.unchanged,
+    }
+
+    def gen_rst(self):
+        from globus_sdk._testing import get_response_set
+
+        response_set_name = self.arguments[0]
+        casename = "default"
+        if "case" in self.options:
+            casename = self.options["case"].strip()
+        response_set = get_response_set(response_set_name)
+        response = response_set.lookup(casename)
+        if response.json is not None:
+            yield ".. code-block:: json"
+            yield ""
+            output_lines = json.dumps(
+                response.json, indent=2, separators=(",", ": ")
+            ).split("\n")
+            for line in output_lines:
+                yield f"    {line}"
+        elif response.body is not None:
+            yield ".. code-block::"
+            yield ""
+            output_lines = response.body.split("\n")
+            for line in output_lines:
+                yield f"    {line}"
+        else:
+            raise RuntimeError(
+                "Error loading example content for response "
+                f"{response_set_name}:{casename}. Neither JSON nor text body was found."
+            )
+
+
+class PaginatedUsage(AddContentDirective):
+    has_content = False
+    required_arguments = 1
+    optional_arguments = 0
+
+    def gen_rst(self):
+        yield "This method supports paginated access. "
+        yield "To use the paginated variant, give the same arguments as normal, "
+        yield "but prefix the method name with ``paginated``, as in"
+        yield ""
+        yield f">>> client.paginated.{self.arguments[0]}(...)"
+        yield ""
+        yield "For more information, see"
+        yield ":ref:`how to make paginated calls <making_paginated_calls>`."
+
+
 def setup(app):
     app.add_directive("automethodlist", AutoMethodList)
     app.add_directive("listknownscopes", ListKnownScopes)
     app.add_directive("enumeratetestingfixtures", EnumerateTestingFixtures)
+    app.add_directive("expandtestfixture", ExpandTestingFixture)
+    app.add_directive("extdoclink", ExternalDocLink)
+    app.add_directive("paginatedusage", PaginatedUsage)

--- a/src/globus_sdk/_testing/data/transfer/_common.py
+++ b/src/globus_sdk/_testing/data/transfer/_common.py
@@ -1,5 +1,10 @@
 import uuid
 
-SUBMISSION_ID = str(uuid.UUID(int=2020))
-ENDPOINT_ID = str(uuid.UUID(int=1234))
-TASK_ID = str(uuid.UUID(int=1001))
+
+def _as_uuid(s: str) -> str:
+    return str(uuid.UUID(int=int(s, 36)))
+
+
+SUBMISSION_ID = _as_uuid("submission_id")
+ENDPOINT_ID = _as_uuid("endpoint_id")
+TASK_ID = _as_uuid("task_id")

--- a/src/globus_sdk/_testing/models.py
+++ b/src/globus_sdk/_testing/models.py
@@ -40,7 +40,7 @@ class RegisteredResponse:
         method: str = responses.GET,
         headers: dict[str, str] | None = None,
         metadata: dict[str, t.Any] | None = None,
-        json: (None | list[t.Any] | dict[str, t.Any]) = None,
+        json: None | list[t.Any] | dict[str, t.Any] = None,
         body: str | None = None,
         **kwargs: t.Any,
     ) -> None:

--- a/src/globus_sdk/paging/base.py
+++ b/src/globus_sdk/paging/base.py
@@ -161,7 +161,10 @@ def has_paginator(
         as_paginated._paginator_items_key = items_key
         as_paginated._paginator_params = paginator_params
 
-        func.__doc__ = f"""{func.__doc__}
+        # do not append doc if the paginatedusage sphinx directive is in use
+        if ".. paginatedusage::" not in func.__doc__:
+            # but if not, append the desired text
+            func.__doc__ = f"""{func.__doc__}
 
         **Paginated Usage**
 

--- a/src/globus_sdk/paging/base.py
+++ b/src/globus_sdk/paging/base.py
@@ -162,9 +162,11 @@ def has_paginator(
         as_paginated._paginator_params = paginator_params
 
         # do not append doc if the paginatedusage sphinx directive is in use
-        if ".. paginatedusage::" not in func.__doc__:
-            # but if not, append the desired text
-            func.__doc__ = f"""{func.__doc__}
+        if not func.__doc__ or ".. paginatedusage::" in func.__doc__:
+            return func
+
+        # but if not, append the desired text
+        func.__doc__ = f"""{func.__doc__}
 
         **Paginated Usage**
 

--- a/src/globus_sdk/paging/base.py
+++ b/src/globus_sdk/paging/base.py
@@ -160,27 +160,6 @@ def has_paginator(
         as_paginated._paginator_class = paginator_class
         as_paginated._paginator_items_key = items_key
         as_paginated._paginator_params = paginator_params
-
-        # do not append doc if the paginatedusage sphinx directive is in use
-        if not func.__doc__ or ".. paginatedusage::" in func.__doc__:
-            return func
-
-        # but if not, append the desired text
-        func.__doc__ = f"""{func.__doc__}
-
-        **Paginated Usage**
-
-        This method supports paginated access.
-        To use the paginated variant, give the same arguments as normal, but
-        prefix the method name with ``paginated``, as in
-
-        .. code-block:: pycon
-
-            >>> client.paginated.{func.__name__}(...)
-
-        For more information, see
-        :ref:`how to make paginated calls <making_paginated_calls>`.
-        """
         return func
 
     return decorate

--- a/src/globus_sdk/paging/base.py
+++ b/src/globus_sdk/paging/base.py
@@ -172,7 +172,9 @@ def has_paginator(
         To use the paginated variant, give the same arguments as normal, but
         prefix the method name with ``paginated``, as in
 
-        >>> client.paginated.{func.__name__}(...)
+        .. code-block:: pycon
+
+            >>> client.paginated.{func.__name__}(...)
 
         For more information, see
         :ref:`how to make paginated calls <making_paginated_calls>`.

--- a/src/globus_sdk/scopes/data.py
+++ b/src/globus_sdk/scopes/data.py
@@ -65,7 +65,7 @@ AuthScopes = _AuthScopesBuilder(
 """Globus Auth scopes.
 
 .. listknownscopes:: globus_sdk.scopes.AuthScopes
-    example_scope=view_identity_set
+    :example_scope: view_identity_set
 """
 
 

--- a/src/globus_sdk/services/auth/identity_map.py
+++ b/src/globus_sdk/services/auth/identity_map.py
@@ -130,7 +130,7 @@ class IdentityMap:
     :type cache: MutableMapping, optional
 
     .. automethodlist:: globus_sdk.IdentityMap
-        include_methods=__getitem__,__delitem__
+        :include_methods: __getitem__,__delitem__
     """  # noqa
 
     _default_id_batch_size = 100

--- a/src/globus_sdk/services/flows/client.py
+++ b/src/globus_sdk/services/flows/client.py
@@ -249,6 +249,12 @@ class FlowsClient(client.BaseClient):
 
         For example, ``orderby="updated_at DESC"`` requests a descending sort on update
         times, getting the most recently updated flow first.
+
+        .. tab-set::
+
+            .. tab-item:: Paginated Usage
+
+                .. paginatedusage:: list_flows
         """
 
         if query_params is None:

--- a/src/globus_sdk/services/gcs/client.py
+++ b/src/globus_sdk/services/gcs/client.py
@@ -285,6 +285,12 @@ class GCSClient(client.BaseClient):
         :type include: str or iterable of str, optional
         :param query_params: Additional passthrough query parameters
         :type query_params: dict, optional
+
+        .. tab-set::
+
+            .. tab-item:: Paginated Usage
+
+                .. paginatedusage:: get_storage_gateway_list
         """
         if query_params is None:
             query_params = {}

--- a/src/globus_sdk/services/search/client.py
+++ b/src/globus_sdk/services/search/client.py
@@ -107,28 +107,31 @@ class SearchClient(client.BaseClient):
         :param query_params: additional parameters to pass as query params
         :type query_params: dict, optional
 
-        .. tab:: Example Usage
+        .. tab-set::
 
-            >>> sc = globus_sdk.SearchClient(...)
-            >>> result = sc.search(index_id, 'query string')
-            >>> advanced_result = sc.search(index_id, 'author: "Ada Lovelace"',
-            >>>                             advanced=True)
+            .. tab-item:: Example Usage
 
-        .. tab:: Paginated Usage
+                .. code-block:: pycon
 
-            .. paginatedusage:: search
+                    >>> sc = globus_sdk.SearchClient(...)
+                    >>> result = sc.search(index_id, "query string")
+                    >>> advanced_result = sc.search(index_id, 'author: "Ada Lovelace"', advanced=True)
 
-        .. tab:: API Info
+            .. tab-item:: Paginated Usage
 
-            ``GET /v1/index/<index_id>/search``
+                .. paginatedusage:: search
 
-            .. extdoclink:: GET Search Query
-                :ref: search/reference/get_query/
+            .. tab-item:: API Info
 
-        .. tab:: Example Response Data
+                ``GET /v1/index/<index_id>/search``
 
-            .. expandtestfixture:: search.search
-        """
+                .. extdoclink:: GET Search Query
+                    :ref: search/reference/get_query/
+
+            .. tab-item:: Example Response Data
+
+                .. expandtestfixture:: search.search
+        """  # noqa: E501
         if query_params is None:
             query_params = {}
         query_params.update(
@@ -143,7 +146,6 @@ class SearchClient(client.BaseClient):
         log.info(f"SearchClient.search({index_id}, ...)")
         return self.get(f"/v1/index/{index_id}/search", query_params=query_params)
 
-    @utils.doc_api_method("POST Search Query", "search/reference/post_query")
     @paging.has_paginator(
         paging.HasNextPaginator,
         items_key="gmeta",
@@ -160,8 +162,6 @@ class SearchClient(client.BaseClient):
         limit: int | None = None,
     ) -> response.GlobusHTTPResponse:
         """
-        ``POST /v1/index/<index_id>/search``
-
         Execute a complex Search Query, using a query document to express filters,
         facets, sorting, field boostring, and other behaviors.
 
@@ -174,33 +174,44 @@ class SearchClient(client.BaseClient):
         :param limit: limit the number of results (overwrites any limit in ``data``)
         :type limit: int, optional
 
-        **Examples**
+        .. tab-set::
 
-        >>> sc = globus_sdk.SearchClient(...)
-        >>> query_data = {
-        >>>   "q": "user query",
-        >>>   "filters": [
-        >>>     {
-        >>>       "type": "range",
-        >>>       "field_name": "path.to.date",
-        >>>       "values": [
-        >>>         {"from": "*",
-        >>>          "to": "2014-11-07"}
-        >>>       ]
-        >>>     }
-        >>>   ],
-        >>>   "facets": [
-        >>>     {"name": "Publication Date",
-        >>>      "field_name": "path.to.date",
-        >>>      "type": "date_histogram",
-        >>>      "date_interval": "year"}
-        >>>   ],
-        >>>   "sort": [
-        >>>     {"field_name": "path.to.date",
-        >>>      "order": "asc"}
-        >>>   ]
-        >>> }
-        >>> search_result = sc.post_search(index_id, query_data)
+            .. tab-item:: Example Usage
+
+                .. code-block:: pycon
+
+                    >>> sc = globus_sdk.SearchClient(...)
+                    ... query_data = {
+                    ...     "q": "user query",
+                    ...     "filters": [
+                    ...         {
+                    ...             "type": "range",
+                    ...             "field_name": "path.to.date",
+                    ...             "values": [{"from": "*", "to": "2014-11-07"}],
+                    ...         }
+                    ...     ],
+                    ...     "facets": [
+                    ...         {
+                    ...             "name": "Publication Date",
+                    ...             "field_name": "path.to.date",
+                    ...             "type": "date_histogram",
+                    ...             "date_interval": "year",
+                    ...         }
+                    ...     ],
+                    ...     "sort": [{"field_name": "path.to.date", "order": "asc"}],
+                    ... }
+                    ... search_result = sc.post_search(index_id, query_data)
+
+            .. tab-item:: Paginated Usage
+
+                .. paginatedusage:: post_search
+
+            .. tab-item:: API Info
+
+                ``POST /v1/index/<index_id>/search``
+
+                .. extdoclink:: POST Search Query
+                    :ref: search/reference/post_query/
         """
         log.info(f"SearchClient.post_search({index_id}, ...)")
         add_kwargs = {}
@@ -212,7 +223,6 @@ class SearchClient(client.BaseClient):
             data = {**data, **add_kwargs}
         return self.post(f"v1/index/{index_id}/search", data=data)
 
-    @utils.doc_api_method("Scroll Query", "search/reference/scroll_query")
     @paging.has_paginator(paging.MarkerPaginator, items_key="gmeta")
     def scroll(
         self,
@@ -222,8 +232,6 @@ class SearchClient(client.BaseClient):
         marker: str | None = None,
     ) -> response.GlobusHTTPResponse:
         """
-        ``POST /v1/index/<index_id>/scroll``
-
         Scroll all data in a Search index. The paginated version of this API should
         typically be preferred, as it is the intended mode of usage.
 
@@ -237,10 +245,25 @@ class SearchClient(client.BaseClient):
         :param marker: marker used in paging (overwrites any marker in ``data``)
         :type marker: str, optional
 
-        **Examples**
+        .. tab-set::
 
-        >>> sc = globus_sdk.SearchClient(...)
-        >>> scroll_result = sc.scroll(index_id, {"q": "*"})
+            .. tab-item:: Example Usage
+
+                .. code-block:: pycon
+
+                    >>> sc = globus_sdk.SearchClient(...)
+                    ... scroll_result = sc.scroll(index_id, {"q": "*"})
+
+            .. tab-item:: Paginated Usage
+
+                .. paginatedusage:: scroll
+
+            .. tab-item:: API Info
+
+                ``POST /v1/index/<index_id>/scroll``
+
+                .. extdoclink:: Scroll Query
+                    :ref: search/reference/scroll_query/
         """
         log.info(f"SearchClient.scroll({index_id}, ...)")
         add_kwargs = {}

--- a/src/globus_sdk/services/search/client.py
+++ b/src/globus_sdk/services/search/client.py
@@ -73,7 +73,6 @@ class SearchClient(client.BaseClient):
     # Search queries
     #
 
-    @utils.doc_api_method("GET Search Query", "search/reference/get_query/")
     @paging.has_paginator(
         paging.HasNextPaginator,
         items_key="gmeta",
@@ -110,12 +109,25 @@ class SearchClient(client.BaseClient):
         :param query_params: additional parameters to pass as query params
         :type query_params: dict, optional
 
-        **Examples**
+        .. tab:: Example Usage
 
-        >>> sc = globus_sdk.SearchClient(...)
-        >>> result = sc.search(index_id, 'query string')
-        >>> advanced_result = sc.search(index_id, 'author: "Ada Lovelace"',
-        >>>                             advanced=True)
+            >>> sc = globus_sdk.SearchClient(...)
+            >>> result = sc.search(index_id, 'query string')
+            >>> advanced_result = sc.search(index_id, 'author: "Ada Lovelace"',
+            >>>                             advanced=True)
+
+        .. tab:: Paginated Usage
+
+            .. paginatedusage:: search
+
+        .. tab:: External Documentation
+
+            .. extdoclink:: GET Search Query
+                :ref: search/reference/get_query/
+
+        .. tab:: Example Response Data
+
+            .. expandtestfixture:: search.search
         """
         if query_params is None:
             query_params = {}

--- a/src/globus_sdk/services/search/client.py
+++ b/src/globus_sdk/services/search/client.py
@@ -181,7 +181,7 @@ class SearchClient(client.BaseClient):
                 .. code-block:: pycon
 
                     >>> sc = globus_sdk.SearchClient(...)
-                    ... query_data = {
+                    >>> query_data = {
                     ...     "q": "user query",
                     ...     "filters": [
                     ...         {
@@ -200,7 +200,7 @@ class SearchClient(client.BaseClient):
                     ...     ],
                     ...     "sort": [{"field_name": "path.to.date", "order": "asc"}],
                     ... }
-                    ... search_result = sc.post_search(index_id, query_data)
+                    >>> search_result = sc.post_search(index_id, query_data)
 
             .. tab-item:: Paginated Usage
 
@@ -252,7 +252,7 @@ class SearchClient(client.BaseClient):
                 .. code-block:: pycon
 
                     >>> sc = globus_sdk.SearchClient(...)
-                    ... scroll_result = sc.scroll(index_id, {"q": "*"})
+                    >>> scroll_result = sc.scroll(index_id, {"q": "*"})
 
             .. tab-item:: Paginated Usage
 

--- a/src/globus_sdk/services/search/client.py
+++ b/src/globus_sdk/services/search/client.py
@@ -91,8 +91,6 @@ class SearchClient(client.BaseClient):
         query_params: dict[str, t.Any] | None = None,
     ) -> response.GlobusHTTPResponse:
         """
-        ``GET /v1/index/<index_id>/search``
-
         Execute a simple Search Query, described by the query string ``q``.
 
         :param index_id: the ID of the index
@@ -120,7 +118,9 @@ class SearchClient(client.BaseClient):
 
             .. paginatedusage:: search
 
-        .. tab:: External Documentation
+        .. tab:: API Info
+
+            ``GET /v1/index/<index_id>/search``
 
             .. extdoclink:: GET Search Query
                 :ref: search/reference/get_query/

--- a/src/globus_sdk/services/transfer/client.py
+++ b/src/globus_sdk/services/transfer/client.py
@@ -1252,9 +1252,6 @@ class TransferClient(client.BaseClient):
     # Task Submission
     #
 
-    @utils.doc_api_method(
-        "Get a submission ID", "transfer/task_submit/#get_submission_id"
-    )
     def get_submission_id(
         self, *, query_params: dict[str, t.Any] | None = None
     ) -> response.GlobusHTTPResponse:
@@ -1271,6 +1268,15 @@ class TransferClient(client.BaseClient):
         Most users will not need to call this method directly, as the
         methods :meth:`~submit_transfer` and :meth:`~submit_delete` will call it
         automatically if the data does not contain a ``submission_id``.
+
+        .. tab:: External Documentation
+
+            .. extdoclink:: Get a submission ID
+                :ref: transfer/task_submit/#get_submission_id
+
+        .. tab:: Example Response Data
+
+            .. expandtestfixture:: transfer.get_submission_id
         """
         log.info(f"TransferClient.get_submission_id({query_params})")
         return self.get("submission_id", query_params=query_params)

--- a/src/globus_sdk/services/transfer/client.py
+++ b/src/globus_sdk/services/transfer/client.py
@@ -1256,8 +1256,6 @@ class TransferClient(client.BaseClient):
         self, *, query_params: dict[str, t.Any] | None = None
     ) -> response.GlobusHTTPResponse:
         """
-        ``GET /submission_id``
-
         :param query_params: Additional passthrough query parameters
         :type query_params: dict, optional
 
@@ -1269,7 +1267,9 @@ class TransferClient(client.BaseClient):
         methods :meth:`~submit_transfer` and :meth:`~submit_delete` will call it
         automatically if the data does not contain a ``submission_id``.
 
-        .. tab:: External Documentation
+        .. tab:: API Info
+
+            ``GET /submission_id``
 
             .. extdoclink:: Get a submission ID
                 :ref: transfer/task_submit/#get_submission_id

--- a/src/globus_sdk/services/transfer/client.py
+++ b/src/globus_sdk/services/transfer/client.py
@@ -243,7 +243,6 @@ class TransferClient(client.BaseClient):
         log.info(f"TransferClient.delete_endpoint({endpoint_id})")
         return self.delete(f"endpoint/{endpoint_id}")
 
-    @utils.doc_api_method("Endpoint Search", "transfer/endpoint_search")
     @paging.has_paginator(
         paging.HasNextPaginator,
         items_key="DATA",
@@ -264,11 +263,6 @@ class TransferClient(client.BaseClient):
         query_params: dict[str, t.Any] | None = None,
     ) -> IterableTransferResponse:
         r"""
-        .. parsed-literal::
-
-            GET /endpoint_search\
-            ?filter_fulltext=<filter_fulltext>&filter_scope=<filter_scope>
-
         :param filter_fulltext: The string to use in a full text search on endpoints.
             Effectively, the "search query" which is being requested. May be omitted
             with specific ``filter_scope`` values.
@@ -297,22 +291,44 @@ class TransferClient(client.BaseClient):
             as query params.
         :type query_params: dict, optional
 
-        **Examples**
-
-        Search for a given string as a fulltext search:
-
-        >>> tc = globus_sdk.TransferClient(...)
-        >>> for ep in tc.endpoint_search('String to search for!'):
-        >>>     print(ep['display_name'])
-
-        Search for a given string, but only on endpoints that you own:
-
-        >>> for ep in tc.endpoint_search('foo', filter_scope='my-endpoints'):
-        >>>     print('{0} has ID {1}'.format(ep['display_name'], ep['id']))
-
         It is important to be aware that the Endpoint Search API limits
         you to 1000 results for any search query.
-        """
+
+        .. tab-set::
+
+            .. tab-item:: Example Usage
+
+                Search for a given string as a fulltext search:
+
+                .. code-block:: pycon
+
+                    >>> tc = globus_sdk.TransferClient(...)
+                    >>> for ep in tc.endpoint_search("String to search for!"):
+                    ...     print(ep["display_name"])
+                    ...
+
+                Search for a given string, but only on endpoints that you own:
+
+                .. code-block:: pycon
+
+                    >>> for ep in tc.endpoint_search("foo", filter_scope="my-endpoints"):
+                    ...     print("{0} has ID {1}".format(ep["display_name"], ep["id"]))
+                    ...
+
+            .. tab-item:: Paginated Usage
+
+                .. paginatedusage:: endpoint_search
+
+            .. tab-item:: API Info
+
+                .. parsed-literal::
+
+                    GET /endpoint_search\
+                    ?filter_fulltext=<filter_fulltext>&filter_scope=<filter_scope>
+
+                .. extdoclink:: Endpoint Search
+                    :ref: transfer/endpoint_search
+        """  # noqa: E501
         if query_params is None:
             query_params = {}
         if filter_scope is not None:
@@ -554,9 +570,6 @@ class TransferClient(client.BaseClient):
             )
         )
 
-    @utils.doc_api_method(
-        "Get shared endpoint list (2)", "transfer/endpoint/#get_shared_endpoint_list2"
-    )
     @paging.has_paginator(paging.NextTokenPaginator, items_key="shared_endpoints")
     def get_shared_endpoint_list(
         self,
@@ -567,8 +580,6 @@ class TransferClient(client.BaseClient):
         query_params: dict[str, t.Any] | None = None,
     ) -> IterableTransferResponse:
         """
-        ``GET /endpoint/<endpoint_id>/shared_endpoint_list``
-
         :param endpoint_id: the host endpoint whose shares are listed
         :type endpoint_id: str or UUID
         :param max_results: cap to the number of results
@@ -580,6 +591,19 @@ class TransferClient(client.BaseClient):
         :type query_params: dict, optional
 
         Get a list of all shared endpoints on a given host endpoint.
+
+        .. tab-set::
+
+            .. tab-item:: Paginated Usage
+
+                .. paginatedusage:: get_shared_endpoint_list
+
+            .. tab-item:: API Info
+
+                ``GET /endpoint/<endpoint_id>/shared_endpoint_list``
+
+                .. extdoclink:: Get shared endpoint list (2)
+                    :ref: transfer/endpoint/#get_shared_endpoint_list2
         """
         log.info(f"TransferClient.get_shared_endpoint_list({endpoint_id}, ...)")
         if query_params is None:
@@ -1267,16 +1291,18 @@ class TransferClient(client.BaseClient):
         methods :meth:`~submit_transfer` and :meth:`~submit_delete` will call it
         automatically if the data does not contain a ``submission_id``.
 
-        .. tab:: API Info
+        .. tab-set::
 
-            ``GET /submission_id``
+            .. tab-item:: API Info
 
-            .. extdoclink:: Get a submission ID
-                :ref: transfer/task_submit/#get_submission_id
+                ``GET /submission_id``
 
-        .. tab:: Example Response Data
+                .. extdoclink:: Get a submission ID
+                    :ref: transfer/task_submit/#get_submission_id
 
-            .. expandtestfixture:: transfer.get_submission_id
+            .. tab-item:: Example Response Data
+
+                .. expandtestfixture:: transfer.get_submission_id
         """
         log.info(f"TransferClient.get_submission_id({query_params})")
         return self.get("submission_id", query_params=query_params)
@@ -1366,7 +1392,6 @@ class TransferClient(client.BaseClient):
     # Task inspection and management
     #
 
-    @utils.doc_api_method("Task list", "transfer/task/#get_task_list")
     @paging.has_paginator(
         paging.LimitOffsetTotalPaginator,
         items_key="DATA",
@@ -1384,8 +1409,6 @@ class TransferClient(client.BaseClient):
         query_params: dict[str, t.Any] | None = None,
     ) -> IterableTransferResponse:
         """
-        ``GET /task_list``
-
         Get an iterable of task documents owned by the current user.
 
         :param limit: limit the number of results
@@ -1400,37 +1423,52 @@ class TransferClient(client.BaseClient):
         :param query_params: Additional passthrough query parameters
         :type query_params: dict, optional
 
-        **Examples**
+        .. tab-set::
 
-        Fetch 10 tasks and print some basic info:
+            .. tab-item:: Example Usage
 
-        >>> tc = TransferClient(...)
-        >>> for task in tc.task_list(limit=10):
-        >>>     print(
-        >>>         "Task({}): {} -> {}".format(
-        >>>             task["task_id"],
-        >>>             task["source_endpoint"],
-        >>>             task["destination_endpoint"]
-        >>>         )
-        >>>     )
+                Fetch 10 tasks and print some basic info:
 
-        Fetch 3 *specific* tasks using a ``task_id`` filter:
+                .. code-block:: pycon
 
-        >>> tc = TransferClient(...)
-        >>> task_ids = [
-        >>>     "acb4b581-b3f3-403a-a42a-9da97aaa9961",
-        >>>     "39447a3c-e002-401a-b95c-f48b69b4c60a",
-        >>>     "02330d3a-987b-4abb-97ed-6a22f8fa365e",
-        >>> ]
-        >>> for task in tc.task_list(filter={"task_id": task_ids}):
-        >>>     print(
-        >>>         "Task({}): {} -> {}".format(
-        >>>             task["task_id"],
-        >>>             task["source_endpoint"],
-        >>>             task["destination_endpoint"]
-        >>>         )
-        >>>     )
-        """
+                    >>> tc = TransferClient(...)
+                    >>> for task in tc.task_list(limit=10):
+                    ...     print(
+                    ...         "Task({}): {} -> {}".format(
+                    ...             task["task_id"], task["source_endpoint"], task["destination_endpoint"]
+                    ...         )
+                    ...     )
+                    ...
+
+                Fetch 3 *specific* tasks using a ``task_id`` filter:
+
+                .. code-block:: pycon
+
+                    >>> tc = TransferClient(...)
+                    >>> task_ids = [
+                    ...     "acb4b581-b3f3-403a-a42a-9da97aaa9961",
+                    ...     "39447a3c-e002-401a-b95c-f48b69b4c60a",
+                    ...     "02330d3a-987b-4abb-97ed-6a22f8fa365e",
+                    ... ]
+                    >>> for task in tc.task_list(filter={"task_id": task_ids}):
+                    ...     print(
+                    ...         "Task({}): {} -> {}".format(
+                    ...             task["task_id"], task["source_endpoint"], task["destination_endpoint"]
+                    ...         )
+                    ...     )
+                    ...
+
+            .. tab-item:: Paginated Usage
+
+                .. paginatedusage:: task_list
+
+            .. tab-item:: API Info
+
+                ``GET /task_list``
+
+                .. extdoclink:: Task List
+                    :ref: transfer/task/#get_task_list
+        """  # noqa: E501
         log.info("TransferClient.task_list(...)")
         if query_params is None:
             query_params = {}
@@ -1444,7 +1482,6 @@ class TransferClient(client.BaseClient):
             self.get("task_list", query_params=query_params)
         )
 
-    @utils.doc_api_method("Get event list", "transfer/task/#get_event_list")
     @paging.has_paginator(
         paging.LimitOffsetTotalPaginator,
         items_key="DATA",
@@ -1461,8 +1498,6 @@ class TransferClient(client.BaseClient):
         query_params: dict[str, t.Any] | None = None,
     ) -> IterableTransferResponse:
         r"""
-        ``GET /task/<task_id>/event_list``
-
         List events (for example, faults and errors) for a given Task.
 
         :param task_id: The ID of the task to inspect
@@ -1474,15 +1509,34 @@ class TransferClient(client.BaseClient):
         :param query_params: Additional passthrough query parameters
         :type query_params: dict, optional
 
-        **Examples**
+        .. tab-set::
 
-        Fetch 10 events and print some basic info:
+            .. tab-item:: Example Usage
 
-        >>> tc = TransferClient(...)
-        >>> task_id = ...
-        >>> for event in tc.task_event_list(task_id, limit=10):
-        >>>     print("Event on Task({}) at {}:\n{}".format(
-        >>>         task_id, event["time"], event["description"])
+                Fetch 10 events and print some basic info:
+
+                .. code-block:: pycon
+
+                    >>> tc = TransferClient(...)
+                    >>> task_id = ...
+                    >>> for event in tc.task_event_list(task_id, limit=10):
+                    ...     print(
+                    ...         "Event on Task({}) at {}:\n{}".format(
+                    ...             task_id, event["time"], event["description"]
+                    ...         )
+                    ...     )
+                    ...
+
+            .. tab-item:: Paginated Usage
+
+                .. paginatedusage:: task_event_list
+
+            .. tab-item:: API Info
+
+                ``GET /task/<task_id>/event_list``
+
+                .. extdoclink:: Get Event List
+                    :ref: transfer/task/#get_event_list
         """
         log.info(f"TransferClient.task_event_list({task_id}, ...)")
         if query_params is None:
@@ -1670,9 +1724,6 @@ class TransferClient(client.BaseClient):
         log.info(f"TransferClient.task_pause_info({task_id}, ...)")
         return self.get(f"task/{task_id}/pause_info", query_params=query_params)
 
-    @utils.doc_api_method(
-        "Get Task Successful Transfer", "transfer/task/#get_task_successful_transfers"
-    )
     @paging.has_paginator(
         paging.NullableMarkerPaginator, items_key="DATA", marker_key="next_marker"
     )
@@ -1684,8 +1735,6 @@ class TransferClient(client.BaseClient):
         query_params: dict[str, t.Any] | None = None,
     ) -> IterableTransferResponse:
         """
-        ``GET /task/<task_id>/successful_transfers``
-
         Get the successful file transfers for a completed Task.
 
         .. note::
@@ -1702,16 +1751,31 @@ class TransferClient(client.BaseClient):
         :param query_params: Additional passthrough query parameters
         :type query_params: dict, optional
 
-        **Examples**
+        .. tab-set::
 
-        Fetch all transferred files for a task and print some basic info:
+            .. tab-item:: Example Usage
 
-        >>> tc = TransferClient(...)
-        >>> task_id = ...
-        >>> for info in tc.task_successful_transfers(task_id):
-        >>>     print("{} -> {}".format(
-        >>>         info["source_path"], info["destination_path"]))
-        """
+                Fetch all transferred files for a task and print some basic info:
+
+                .. code-block:: pycon
+
+                    >>> tc = TransferClient(...)
+                    >>> task_id = ...
+                    >>> for info in tc.task_successful_transfers(task_id):
+                    ...     print("{} -> {}".format(info["source_path"], info["destination_path"]))
+                    ...
+
+            .. tab-item:: Paginated Usage
+
+                .. paginatedusage:: task_successful_transfers
+
+            .. tab-item:: API Info
+
+                ``GET /task/<task_id>/successful_transfers``
+
+                .. extdoclink:: Get Task Successful Transfers
+                    :ref: transfer/task/#get_task_successful_transfers
+        """  # noqa: E501
         log.info(f"TransferClient.task_successful_transfers({task_id}, ...)")
         if query_params is None:
             query_params = {}
@@ -1721,9 +1785,6 @@ class TransferClient(client.BaseClient):
             self.get(f"task/{task_id}/successful_transfers", query_params=query_params)
         )
 
-    @utils.doc_api_method(
-        "Get Task Skipped Errors", "transfer/task/#get_task_skipped_errors"
-    )
     @paging.has_paginator(
         paging.NullableMarkerPaginator, items_key="DATA", marker_key="next_marker"
     )
@@ -1735,8 +1796,6 @@ class TransferClient(client.BaseClient):
         query_params: dict[str, t.Any] | None = None,
     ) -> IterableTransferResponse:
         """
-        ``GET /task/<task_id>/skipped_errors``
-
         Get path and error information for all paths that were skipped due
         to skip_source_errors being set on a completed transfer Task.
 
@@ -1747,16 +1806,31 @@ class TransferClient(client.BaseClient):
         :param query_params: Additional passthrough query parameters
         :type query_params: dict, optional
 
-        **Examples**
+        .. tab-set::
 
-        Fetch all skipped errors for a task and print some basic info:
+            .. tab-item:: Example Usage
 
-        >>> tc = TransferClient(...)
-        >>> task_id = ...
-        >>> for info in tc.task_skipped_errors(task_id):
-        >>>     print("{} -> {}".format(
-        >>>         info["error_code"], info["source_path"]))
-        """
+                Fetch all skipped errors for a task and print some basic info:
+
+                .. code-block:: pycon
+
+                    >>> tc = TransferClient(...)
+                    >>> task_id = ...
+                    >>> for info in tc.task_skipped_errors(task_id):
+                    ...     print("{} -> {}".format(info["error_code"], info["source_path"]))
+                    ...
+
+            .. tab-item:: Paginated Usage
+
+                .. paginatedusage:: task_skipped_errors
+
+            .. tab-item:: API Info
+
+                ``GET /task/<task_id>/skipped_errors``
+
+                .. extdoclink:: Get Task Skipped Errors
+                    :ref: transfer/task/#get_task_skipped_errors
+        """  # noqa: E501
         log.info("TransferClient.task_skipped_errors(%s, ...)", task_id)
         if query_params is None:
             query_params = {}
@@ -1877,10 +1951,6 @@ class TransferClient(client.BaseClient):
     # endpoint manager task methods
     #
 
-    @utils.doc_api_method(
-        "Advanced Endpoint Management: Get tasks",
-        "transfer/advanced_endpoint_management/#get_tasks",
-    )
     @paging.has_paginator(paging.LastKeyPaginator, items_key="DATA")
     def endpoint_manager_task_list(
         self,
@@ -1897,8 +1967,6 @@ class TransferClient(client.BaseClient):
         query_params: dict[str, t.Any] | None = None,
     ) -> IterableTransferResponse:
         r"""
-        ``GET endpoint_manager/task_list``
-
         Get a list of tasks visible via ``activity_monitor`` role, as opposed
         to tasks owned by the current user.
 
@@ -1966,28 +2034,55 @@ class TransferClient(client.BaseClient):
         :param query_params: Additional passthrough query parameters
         :type query_params: dict, optional
 
-        **Examples**
+        .. tab-set::
 
-        Fetch some tasks and print some basic info:
+            .. tab-item:: Example Usage
 
-        >>> tc = TransferClient(...)
-        >>> for task in tc.endpoint_manager_task_list(filter_status="ACTIVE"):
-        >>>     print("Task({}): {} -> {}\n  was submitted by\n  {}".format(
-        >>>         task["task_id"], task["source_endpoint"],
-        >>>         task["destination_endpoint"], task["owner_string"]))
+                Fetch some tasks and print some basic info:
 
-        Do that same operation on *all* tasks visible via ``activity_monitor``
-        status:
+                .. code-block:: pycon
 
-        >>> tc = TransferClient(...)
-        >>> for page in tc.paginated.endpoint_manager_task_list(
-        >>>     filter_status="ACTIVE"
-        >>> ):
-        >>>     for task in page:
-        >>>         print("Task({}): {} -> {}\n  was submitted by\n  {}".format(
-        >>>             task["task_id"], task["source_endpoint"],
-        >>>             task["destination_endpoint"), task["owner_string"])
-        """
+                    >>> tc = TransferClient(...)
+                    >>> for task in tc.endpoint_manager_task_list(filter_status="ACTIVE"):
+                    ...     print(
+                    ...         "Task({}): {} -> {}\n  was submitted by\n  {}".format(
+                    ...             task["task_id"],
+                    ...             task["source_endpoint"],
+                    ...             task["destination_endpoint"],
+                    ...             task["owner_string"],
+                    ...         )
+                    ...     )
+                    ...
+
+            .. tab-item:: Paginated Usage
+
+                .. paginatedusage:: endpoint_manager_task_list
+
+                For example, fetch and print all active tasks visible via
+                ``activity_monitor`` permissions:
+
+                .. code-block:: pycon
+
+                    >>> tc = TransferClient(...)
+                    >>> for page in tc.paginated.endpoint_manager_task_list(filter_status="ACTIVE"):
+                    ...     for task in page:
+                    ...         print(
+                    ...             "Task({}): {} -> {}\n  was submitted by\n  {}".format(
+                    ...                 task["task_id"],
+                    ...                 task["source_endpoint"],
+                    ...                 task["destination_endpoint"],
+                    ...                 task["owner_string"],
+                    ...             )
+                    ...         )
+                    ...
+
+            .. tab-item:: API Info
+
+                ``GET endpoint_manager/task_list``
+
+                .. extdoclink:: Advanced Endpoint Management: Get tasks
+                    :ref: transfer/advanced_endpoint_management/#get_tasks
+        """  # noqa: E501
         log.info("TransferClient.endpoint_manager_task_list(...)")
         if query_params is None:
             query_params = {}
@@ -2049,10 +2144,6 @@ class TransferClient(client.BaseClient):
         log.info(f"TransferClient.endpoint_manager_get_task({task_id}, ...)")
         return self.get(f"endpoint_manager/task/{task_id}", query_params=query_params)
 
-    @utils.doc_api_method(
-        "Get task events as admin",
-        "transfer/advanced_endpoint_management/#get_task_events",
-    )
     @paging.has_paginator(
         paging.LimitOffsetTotalPaginator,
         items_key="DATA",
@@ -2070,8 +2161,6 @@ class TransferClient(client.BaseClient):
         query_params: dict[str, t.Any] | None = None,
     ) -> IterableTransferResponse:
         """
-        ``GET /task/<task_id>/event_list``
-
         List events (for example, faults and errors) for a given task as an
         admin. Requires activity monitor effective role on the destination
         endpoint of the task.
@@ -2087,6 +2176,19 @@ class TransferClient(client.BaseClient):
         :type filter_is_error: bool, optional
         :param query_params: Additional passthrough query parameters
         :type query_params: dict, optional
+
+        .. tab-set::
+
+            .. tab-item:: Paginated Usage
+
+                .. paginatedusage:: endpoint_manager_task_event_list
+
+            .. tab-item:: API Info
+
+                ``GET /task/<task_id>/event_list``
+
+                .. extdoclink:: Get task events as admin
+                    :ref: transfer/advanced_endpoint_management/#get_task_events
         """
         log.info(f"TransferClient.endpoint_manager_task_event_list({task_id}, ...)")
         if query_params is None:
@@ -2129,10 +2231,6 @@ class TransferClient(client.BaseClient):
             f"endpoint_manager/task/{task_id}/pause_info", query_params=query_params
         )
 
-    @utils.doc_api_method(
-        "Get task successful transfers as admin",
-        "transfer/advanced_endpoint_management/#get_task_successful_transfers_as_admin",
-    )
     @paging.has_paginator(
         paging.NullableMarkerPaginator, items_key="DATA", marker_key="next_marker"
     )
@@ -2143,9 +2241,7 @@ class TransferClient(client.BaseClient):
         marker: str | None = None,
         query_params: dict[str, t.Any] | None = None,
     ) -> IterableTransferResponse:
-        """
-        ``GET /endpoint_manager/task/<task_id>/successful_transfers``
-
+        r"""
         Get the successful file transfers for a completed Task as an admin.
 
         :param task_id: The ID of the task to inspect
@@ -2154,6 +2250,20 @@ class TransferClient(client.BaseClient):
         :type marker: str
         :param query_params: Additional passthrough query parameters
         :type query_params: dict, optional
+
+        .. tab-set::
+
+            .. tab-item:: Paginated Usage
+
+                .. paginatedusage:: endpoint_manager_task_successful_transfers
+
+            .. tab-item:: API Info
+
+                ``GET /endpoint_manager/task/<task_id>/successful_transfers``
+
+                .. extdoclink:: Get task successful transfers as admin
+                    :ref: transfer/advanced_endpoint_management/\
+                            #get_task_successful_transfers_as_admin
         """
         log.info(
             "TransferClient.endpoint_manager_task_successful_transfers(%s, ...)",
@@ -2170,10 +2280,6 @@ class TransferClient(client.BaseClient):
             )
         )
 
-    @utils.doc_api_method(
-        "Get task skipped errors as admin",
-        "transfer/advanced_endpoint_management/#get_task_skipped_errors_as_admin",
-    )
     @paging.has_paginator(
         paging.NullableMarkerPaginator, items_key="DATA", marker_key="next_marker"
     )
@@ -2184,9 +2290,7 @@ class TransferClient(client.BaseClient):
         marker: str | None = None,
         query_params: dict[str, t.Any] | None = None,
     ) -> IterableTransferResponse:
-        """
-        ``GET /endpoint_manager/task/<task_id>/skipped_errors``
-
+        r"""
         Get skipped errors for a completed Task as an admin.
 
         :param task_id: The ID of the task to inspect
@@ -2195,6 +2299,20 @@ class TransferClient(client.BaseClient):
         :type marker: str
         :param query_params: Additional passthrough query parameters
         :type query_params: dict, optional
+
+        .. tab-set::
+
+            .. tab-item:: Paginated Usage
+
+                .. paginatedusage:: endpoint_manager_task_skipped_errors
+
+            .. tab-item:: API Info
+
+                ``GET /endpoint_manager/task/<task_id>/skipped_errors``
+
+                .. extdoclink:: Get task skipped errors as admin
+                    :ref: transfer/advanced_endpoint_management/\
+                            #get_task_skipped_errors_as_admin
         """
         log.info(f"TransferClient.endpoint_manager_task_skipped_errors({task_id}, ...)")
         if query_params is None:


### PR DESCRIPTION
This is a combined set of several minor changes which support a new way of writing docs for client methods. The overall goal is to make use of sphinx-inline-tabs to present several pieces of information in a way which is compact by default, expandable, and allows us to put some more structure to what is currently a long scroll of text.

To wit:
- include the sphinx-inline-tabs extension for sphinx
- cleanup our custom sphinx directives to use docutils' built-in option parsing
- add new custom directives for several small functions:
  - expandtestfixture: expands a JSON or text body from a test fixture as a code-block, for use as example data
  - extdoclink: link to an external doc location (only supports docs.globus.org right now)
  - paginatedusage: emit the standard paginated usage info text
- select two methods which are updated to use the new documentation capabilities: TransferClient.get_submission_id and SearchClient.search. These demonstrate the behavior and what is now possible

It should be noted that `get_submission_id` has no usage example while `search` does, that `search` is paginated while `get_submission_id` is not, and that both refer to docs site docs and have relevant test fixture data for examples. Therefore, they demonstrate the flexibility of this setup to handle different kinds of methods, but also share some commonalities.

The original drive of this work was `expandtestfixture`, but once that was achieved, it demands some solution for better presentation, like tabs. Once tabs are in place, they conflict with the default behavior for the pagination decorator (which appends to the docstring), so some accommodation is needed. A similar need precipitates the refactor of the external doc decorator into a sphinx directive.

<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--700.org.readthedocs.build/en/700/

<!-- readthedocs-preview globus-sdk-python end -->