### PR TITLE
Disable Dependabot, as it doesn't understand pip-compile well

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,6 @@
 version: 2
 # check for python package and github-actions updates weekly
 updates:
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "weekly"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Currently, Dependabot is doing more harm (distracting us) than good (finding outdated dependencies). For now, turn it off.

A future option: try using the `directory` config to put `.in` configs in one dir and `.txt` configs in another.

<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--706.org.readthedocs.build/en/706/

<!-- readthedocs-preview globus-sdk-python end -->