### PR TITLE
Add a 1px pad around tab-sets in the docs

### DIFF
--- a/docs/_static/css/globus_sdk_tab_borders.css
+++ b/docs/_static/css/globus_sdk_tab_borders.css
@@ -18,6 +18,7 @@
   border-width: 1px;
   border-radius: 3px;
   border-color: var(--tabset-border-color);
+  padding: 1px;
 }
 .sd-tab-set .sd-tab-content {
   padding: 4px;


### PR DESCRIPTION
This ensures that the bottom border of the tabset renders cleanly with no overhang from the tab items. Without some padding, the border easily clipped with the content by about 0.5px, which looked odd.

1px might be bigger than is necessary, but the resulting spacing looks comfortable.

<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--709.org.readthedocs.build/en/709/

<!-- readthedocs-preview globus-sdk-python end -->