### PR TITLE
Added flows.update_flow(...)

### DIFF
--- a/changelog.d/20230317_154719_derek_implement_update_flow_sc_22685.rst
+++ b/changelog.d/20230317_154719_derek_implement_update_flow_sc_22685.rst
@@ -1,0 +1,2 @@
+
+* Added `FlowsClient.update_flow(...)` (:pr:`NUMBER`)

--- a/src/globus_sdk/_testing/data/flows/update_flow.py
+++ b/src/globus_sdk/_testing/data/flows/update_flow.py
@@ -1,0 +1,31 @@
+from copy import deepcopy
+
+from responses import matchers
+
+from globus_sdk._testing.models import RegisteredResponse, ResponseSet
+
+from ._common import TWO_HOP_TRANSFER_FLOW_DOC, TWO_HOP_TRANSFER_FLOW_ID
+
+_two_hop_transfer_update_request = {
+    "subtitle": "Specifically, in two steps",
+    "description": "Transfer from source to destination, stopping off at staging",
+}
+
+
+_updated_two_hop_transfer_flow_doc = deepcopy(TWO_HOP_TRANSFER_FLOW_DOC)
+_updated_two_hop_transfer_flow_doc.update(_two_hop_transfer_update_request)
+
+
+RESPONSES = ResponseSet(
+    metadata={
+        "flow_id": TWO_HOP_TRANSFER_FLOW_ID,
+        "params": _two_hop_transfer_update_request,
+    },
+    default=RegisteredResponse(
+        service="flows",
+        path=f"/flows/{TWO_HOP_TRANSFER_FLOW_ID}",
+        method="PUT",
+        json=_updated_two_hop_transfer_flow_doc,
+        match=[matchers.json_params_matcher(params=_two_hop_transfer_update_request)],
+    ),
+)

--- a/src/globus_sdk/services/flows/client.py
+++ b/src/globus_sdk/services/flows/client.py
@@ -56,30 +56,6 @@ class FlowsClient(client.BaseClient):
         """
         Create a Flow
 
-        Example Usage:
-
-        .. code-block:: python
-
-            from globus_sdk import FlowsClient
-
-            ...
-            flows = FlowsClient(...)
-            flows.create_flow(
-                title="my-cool-flow",
-                definition={
-                    "StartAt": "the-one-true-state",
-                    "States": {"the-one-true-state": {"Type": "Pass", "End": True}},
-                },
-                input_schema={
-                    "type": "object",
-                    "properties": {
-                        "input-a": {"type": "string"},
-                        "input-b": {"type": "number"},
-                        "input-c": {"type": "boolean"},
-                    },
-                },
-            )
-
         :param title: A non-unique, human-friendly name used for displaying the
             flow to end users.
         :type title: str (1 - 128 characters)
@@ -97,18 +73,18 @@ class FlowsClient(client.BaseClient):
         :param flow_viewers: A set of Principal URN values, or the value "public"
             indicating entities who can view the flow
 
-            Examples:
+            .. dropdown:: Example Values
 
-            .. code-block:: json
+                .. code-block:: json
 
-                [ "public" ]
+                    [ "public" ]
 
-            .. code-block:: json
+                .. code-block:: json
 
-                [
-                    "urn:globus:auth:identity:b44bddda-d274-11e5-978a-9f15789a8150",
-                    "urn:globus:groups:id:c1dcd951-3f35-4ea3-9f28-a7cdeaf8b68f"
-                ]
+                    [
+                        "urn:globus:auth:identity:b44bddda-d274-11e5-978a-9f15789a8150",
+                        "urn:globus:groups:id:c1dcd951-3f35-4ea3-9f28-a7cdeaf8b68f"
+                    ]
 
 
         :type flow_viewers: list[str], optional
@@ -116,33 +92,33 @@ class FlowsClient(client.BaseClient):
             "all_authenticated_users" indicating entities who can initiate a *Run* of
             the flow
 
-            Examples:
+            .. dropdown:: Example Values
 
-            .. code-block:: json
+                .. code-block:: json
 
-                [ "all_authenticated_users" ]
+                    [ "all_authenticated_users" ]
 
 
-            .. code-block:: json
+                .. code-block:: json
 
-                [
-                    "urn:globus:auth:identity:b44bddda-d274-11e5-978a-9f15789a8150",
-                    "urn:globus:groups:id:c1dcd951-3f35-4ea3-9f28-a7cdeaf8b68f"
-                ]
+                    [
+                        "urn:globus:auth:identity:b44bddda-d274-11e5-978a-9f15789a8150",
+                        "urn:globus:groups:id:c1dcd951-3f35-4ea3-9f28-a7cdeaf8b68f"
+                    ]
 
         :type flow_starters: list[str], optional
         :param flow_administrators: A set of Principal URN values indicating entities
             who can perform administrative operations on the flow (create, delete,
             update)
 
-            Example:
+            .. dropdown:: Example Values
 
-            .. code-block:: json
+                .. code-block:: json
 
-                [
-                    "urn:globus:auth:identity:b44bddda-d274-11e5-978a-9f15789a8150",
-                    "urn:globus:groups:id:c1dcd951-3f35-4ea3-9f28-a7cdeaf8b68f"
-                ]
+                    [
+                        "urn:globus:auth:identity:b44bddda-d274-11e5-978a-9f15789a8150",
+                        "urn:globus:groups:id:c1dcd951-3f35-4ea3-9f28-a7cdeaf8b68f"
+                    ]
 
         :type flow_administrators: list[str], optional
         :param keywords: A set of terms used to categorize the flow used in query and
@@ -150,6 +126,36 @@ class FlowsClient(client.BaseClient):
         :type keywords: list[str] (0 - 1024 items), optional
         :param additional_fields: Additional Key/Value pairs sent to the create API
         :type additional_fields: dict or str -> any, optional
+
+        .. tab-set::
+
+            .. tab-item:: Example Usage
+
+                .. code-block:: python
+
+                    from globus_sdk import FlowsClient
+
+                    ...
+                    flows = FlowsClient(...)
+                    flows.create_flow(
+                        title="my-cool-flow",
+                        definition={
+                            "StartAt": "the-one-true-state",
+                            "States": {"the-one-true-state": {"Type": "Pass", "End": True}},
+                        },
+                        input_schema={
+                            "type": "object",
+                            "properties": {
+                                "input-a": {"type": "string"},
+                                "input-b": {"type": "number"},
+                                "input-c": {"type": "boolean"},
+                            },
+                        },
+                    )
+
+            .. tab-item:: Example Response Data
+
+                .. expandtestfixture:: flows.create_flow
         """  # noqa E501
 
         data = {
@@ -269,6 +275,143 @@ class FlowsClient(client.BaseClient):
             query_params["marker"] = marker
 
         return IterableFlowsResponse(self.get("/flows", query_params=query_params))
+
+    @_flowdoc("Update Flow", "Flows/paths/~1flows~1{flow_id}/put")
+    def update_flow(
+        self,
+        flow_id: UUIDLike,
+        title: str | None = None,
+        definition: dict[str, t.Any] | None = None,
+        input_schema: dict[str, t.Any] | None = None,
+        subtitle: str | None = None,
+        description: str | None = None,
+        flow_owner: str | None = None,
+        flow_viewers: list[str] | None = None,
+        flow_starters: list[str] | None = None,
+        flow_administrators: list[str] | None = None,
+        keywords: list[str] | None = None,
+        additional_fields: dict[str, t.Any] | None = None,
+    ) -> GlobusHTTPResponse:
+        """
+        Update a Flow
+
+        Only the parameter `flow_id` is required.
+        Any fields omitted from the request will be unchanged
+
+        :param flow_id: The ID of the Flow to fetch
+        :type flow_id: str or UUID
+        :param title: A non-unique, human-friendly name used for displaying the
+            flow to end users.
+        :type title: str (1 - 128 characters), optional
+        :param definition: JSON object specifying flows states and execution order. For
+            a more detailed explanation of the flow definition, see
+            `Authoring Flows <https://globus-automate-client.readthedocs.io/en/latest/authoring_flows.html>`_
+        :type definition: dict, optional
+        :param input_schema: A JSON Schema to which Flow Invocation input must conform
+        :type input_schema: dict, optional
+        :param subtitle: A concise summary of the flow’s purpose.
+        :type subtitle: str (0 - 128 characters), optional
+        :param description: A detailed description of the flow's purpose for end user
+            display.
+        :type description: str (0 - 4096 characters), optional
+        :param flow_owner: An Auth Identity URN to set as flow owner; this must match
+            the Identity URN of the entity calling `update_flow`
+        :type flow_owner: str, optional
+        :param flow_viewers: A set of Principal URN values, or the value "public"
+            indicating entities who can view the flow
+
+            .. dropdown:: Example Values
+
+                .. code-block:: json
+
+                    [ "public" ]
+
+                .. code-block:: json
+
+                    [
+                        "urn:globus:auth:identity:b44bddda-d274-11e5-978a-9f15789a8150",
+                        "urn:globus:groups:id:c1dcd951-3f35-4ea3-9f28-a7cdeaf8b68f"
+                    ]
+
+        :type flow_viewers: list[str], optional
+        :param flow_starters: A set of Principal URN values, or the value
+            "all_authenticated_users" indicating entities who can initiate a *Run* of
+            the flow
+
+            .. dropdown:: Example Values
+
+                .. code-block:: json
+
+                    [ "all_authenticated_users" ]
+
+
+                .. code-block:: json
+
+                    [
+                        "urn:globus:auth:identity:b44bddda-d274-11e5-978a-9f15789a8150",
+                        "urn:globus:groups:id:c1dcd951-3f35-4ea3-9f28-a7cdeaf8b68f"
+                    ]
+
+        :type flow_starters: list[str], optional
+        :param flow_administrators: A set of Principal URN values indicating entities
+            who can perform administrative operations on the flow (create, delete,
+            update)
+
+            .. dropdown:: Example Value
+
+                .. code-block:: json
+
+                    [
+                        "urn:globus:auth:identity:b44bddda-d274-11e5-978a-9f15789a8150",
+                        "urn:globus:groups:id:c1dcd951-3f35-4ea3-9f28-a7cdeaf8b68f"
+                    ]
+
+        :type flow_administrators: list[str], optional
+        :param keywords: A set of terms used to categorize the flow used in query and
+            discovery operations
+        :type keywords: list[str] (0 - 1024 items), optional
+        :param additional_fields: Additional Key/Value pairs sent to the create API
+        :type additional_fields: dict or str -> any, optional
+
+        .. tab-set::
+
+            .. tab-item:: Example Usage
+
+                .. code-block::
+
+                    from globus_sdk import FlowsClient
+
+                    ...
+                    flows = FlowsClient(...)
+                    flows.update_flow(
+                        flow_id="581753c7-45da-43d3-ad73-246b46e7cb6b",
+                        keywords=["new", "overriding", "keywords"]
+                    )
+
+            .. tab-item:: Example Response Data
+
+                .. expandtestfixture:: flows.update_flow
+        """  # noqa E501
+
+        data = {
+            k: v
+            for k, v in {
+                "title": title,
+                "definition": definition,
+                "input_schema": input_schema,
+                "subtitle": subtitle,
+                "description": description,
+                "flow_owner": flow_owner,
+                "flow_viewers": flow_viewers,
+                "flow_starters": flow_starters,
+                "flow_administrators": flow_administrators,
+                "keywords": keywords,
+            }.items()
+            if v is not None
+        }
+        data.update(additional_fields or {})
+
+        return self.put(f"/flows/{flow_id}", data=data)
 
     @_flowdoc("Delete Flow", "Flows/paths/~1flows~1{flow_id}/delete")
     def delete_flow(

--- a/src/globus_sdk/services/flows/client.py
+++ b/src/globus_sdk/services/flows/client.py
@@ -61,7 +61,7 @@ class FlowsClient(client.BaseClient):
         :type title: str (1 - 128 characters)
         :param definition: JSON object specifying flows states and execution order. For
             a more detailed explanation of the flow definition, see
-            `Authoring Flows <https://globus-automate-client.readthedocs.io/en/latest/authoring_flows.html>`_
+            `Authoring Flows <https://docs.globus.org/api/flows/authoring-flows>`_
         :type definition: dict
         :param input_schema: A JSON Schema to which Flow Invocation input must conform
         :type input_schema: dict
@@ -70,7 +70,7 @@ class FlowsClient(client.BaseClient):
         :param description: A detailed description of the flow's purpose for end user
             display.
         :type description: str (0 - 4096 characters), optional
-        :param flow_viewers: A set of Principal URN values, or the value "public"
+        :param flow_viewers: A set of Principal URN values, or the value "public",
             indicating entities who can view the flow
 
             .. dropdown:: Example Values
@@ -89,7 +89,7 @@ class FlowsClient(client.BaseClient):
 
         :type flow_viewers: list[str], optional
         :param flow_starters: A set of Principal URN values, or the value
-            "all_authenticated_users" indicating entities who can initiate a *Run* of
+            "all_authenticated_users", indicating entities who can initiate a *Run* of
             the flow
 
             .. dropdown:: Example Values
@@ -125,7 +125,7 @@ class FlowsClient(client.BaseClient):
             discovery operations
         :type keywords: list[str] (0 - 1024 items), optional
         :param additional_fields: Additional Key/Value pairs sent to the create API
-        :type additional_fields: dict or str -> any, optional
+        :type additional_fields: dict of str -> any, optional
 
         .. tab-set::
 
@@ -280,6 +280,7 @@ class FlowsClient(client.BaseClient):
     def update_flow(
         self,
         flow_id: UUIDLike,
+        *,
         title: str | None = None,
         definition: dict[str, t.Any] | None = None,
         input_schema: dict[str, t.Any] | None = None,
@@ -305,7 +306,7 @@ class FlowsClient(client.BaseClient):
         :type title: str (1 - 128 characters), optional
         :param definition: JSON object specifying flows states and execution order. For
             a more detailed explanation of the flow definition, see
-            `Authoring Flows <https://globus-automate-client.readthedocs.io/en/latest/authoring_flows.html>`_
+            `Authoring Flows <https://docs.globus.org/api/flows/authoring-flows>`_
         :type definition: dict, optional
         :param input_schema: A JSON Schema to which Flow Invocation input must conform
         :type input_schema: dict, optional
@@ -317,7 +318,7 @@ class FlowsClient(client.BaseClient):
         :param flow_owner: An Auth Identity URN to set as flow owner; this must match
             the Identity URN of the entity calling `update_flow`
         :type flow_owner: str, optional
-        :param flow_viewers: A set of Principal URN values, or the value "public"
+        :param flow_viewers: A set of Principal URN values, or the value "public",
             indicating entities who can view the flow
 
             .. dropdown:: Example Values
@@ -335,7 +336,7 @@ class FlowsClient(client.BaseClient):
 
         :type flow_viewers: list[str], optional
         :param flow_starters: A set of Principal URN values, or the value
-            "all_authenticated_users" indicating entities who can initiate a *Run* of
+            "all_authenticated_users", indicating entities who can initiate a *Run* of
             the flow
 
             .. dropdown:: Example Values
@@ -371,7 +372,7 @@ class FlowsClient(client.BaseClient):
             discovery operations
         :type keywords: list[str] (0 - 1024 items), optional
         :param additional_fields: Additional Key/Value pairs sent to the create API
-        :type additional_fields: dict or str -> any, optional
+        :type additional_fields: dict of str -> any, optional
 
         .. tab-set::
 

--- a/tests/functional/services/flows/test_flow_crud.py
+++ b/tests/functional/services/flows/test_flow_crud.py
@@ -18,6 +18,14 @@ def test_get_flow(flows_client):
     assert resp.data["title"] == meta["title"]
 
 
+def test_update_flow(flows_client):
+    meta = load_response(flows_client.update_flow).metadata
+    resp = flows_client.update_flow(meta["flow_id"], **meta["params"])
+    for k, v in meta["params"].items():
+        assert k in resp
+        assert resp[k] == v
+
+
 def test_delete_flow(flows_client):
     metadata = load_response(flows_client.delete_flow).metadata
 


### PR DESCRIPTION
[sc-22685](https://app.shortcut.com/globus/story/22685)
Added the `update_flow` method to `FlowsClient`

Direct Generated Docs Link: [FlowsClient.update_flow()](https://globus-sdk-python--710.org.readthedocs.build/en/710/services/flows.html#globus_sdk.FlowsClient.update_flow)


## Related Changes
I additionally modified the `create_flow` docs to be slightly shorter (by using [sphinx-design dropdowns](https://sphinx-design.readthedocs.io/en/furo-theme/dropdowns.html)) and pulled the example usage into a tabbed view along with an example response
  * This change felt small & related enough to `update_flow` but I can rip it out of this PR if anyone would prefer I submit it separately


## Testing
* Hit flows with various normal editing permutations of flow definition, input_schema, flow_viewers, etc.
* Tested the flow_owner update (this one felt fairly special-cased so I wanted to verify it specifically)
   * Created a flow with user A with user B as flow_administrator
   * As user B, called `flows.update_flow(flow_id, flow_owner=user_b_urn)
   * Observed user B now owned the Flow



<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--710.org.readthedocs.build/en/710/

<!-- readthedocs-preview globus-sdk-python end -->