### PR TITLE
Make HTTP responses and errors more similar

### DIFF
--- a/changelog.d/20230413_105535_sirosen_response_like_protocol.rst
+++ b/changelog.d/20230413_105535_sirosen_response_like_protocol.rst
@@ -1,0 +1,11 @@
+* Make the request-like interface for response objects and errors more uniform. (:pr:`NUMBER`)
+
+  * Both ``GlobusHTTPResponse`` and ``GlobusAPIError`` are updated to ensure
+    that they have the following properties in common: ``http_status``,
+    ``http_reason``, ``headers``, ``content_type``, ``text``
+
+  * ``GlobusAPIError.raw_text`` is deprecated in favor of ``text``
+
+  * ``GlobusHTTPResponse`` and ``GlobusAPIError`` have both gained a new
+    property, ``binary_content``, which returns the unencoded response data as
+    bytes

--- a/src/globus_sdk/_types.py
+++ b/src/globus_sdk/_types.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
 import datetime
+import sys
 import typing as t
 import uuid
+
+if sys.version_info < (3, 8):
+    from typing_extensions import Protocol
+else:
+    from typing import Protocol
 
 if t.TYPE_CHECKING:
     from globus_sdk.scopes import MutableScope
@@ -25,3 +31,29 @@ ScopeCollectionType = t.Union[
     t.Iterable[t.Union[str, "MutableScope"]],
     t.Iterable[t.Union["Scope", "MutableScope"]],
 ]
+
+
+class ResponseLike(Protocol):
+    @property
+    def http_status(self) -> int:
+        ...
+
+    @property
+    def http_reason(self) -> str:
+        ...
+
+    @property
+    def headers(self) -> t.Mapping[str, str]:
+        ...
+
+    @property
+    def content_type(self) -> str | None:
+        ...
+
+    @property
+    def text(self) -> str:
+        ...
+
+    @property
+    def binary_content(self) -> bytes:
+        ...

--- a/src/globus_sdk/exc/api.py
+++ b/src/globus_sdk/exc/api.py
@@ -7,6 +7,7 @@ import requests
 
 from .base import GlobusError
 from .err_info import ErrorInfoContainer
+from .warnings import warn_deprecated
 
 log = logging.getLogger(__name__)
 
@@ -58,6 +59,10 @@ class GlobusAPIError(GlobusError):
         """
         return self._underlying_response.headers
 
+    @property
+    def content_type(self) -> str | None:
+        return self.headers.get("Content-Type")
+
     def _json_content_type(self) -> bool:
         r = self._underlying_response
         return "Content-Type" in r.headers and (
@@ -89,11 +94,29 @@ class GlobusAPIError(GlobusError):
             return None
 
     @property
-    def raw_text(self) -> str:
+    def text(self) -> str:
         """
         Get the verbatim error message received from a Globus API as a *string*
         """
         return self._underlying_response.text
+
+    @property
+    def raw_text(self) -> str:
+        """
+        Deprecated alias of the ``text`` property.
+        """
+        warn_deprecated(
+            "The 'raw_text' property of GlobusAPIError objects is deprecated. "
+            "Use the 'text' property instead."
+        )
+        return self.text
+
+    @property
+    def binary_content(self) -> bytes:
+        """
+        The error message received from a Globus API in bytes.
+        """
+        return self._underlying_response.content
 
     @property
     def info(self) -> ErrorInfoContainer:

--- a/src/globus_sdk/response.py
+++ b/src/globus_sdk/response.py
@@ -119,6 +119,13 @@ class GlobusHTTPResponse:
         return self._raw_response.text
 
     @property
+    def binary_content(self) -> bytes:
+        """
+        The raw response data in bytes.
+        """
+        return self._raw_response.content
+
+    @property
     def data(self) -> t.Any:
         return self._parsed_json
 

--- a/tests/functional/services/auth/test_simple_auth_usage.py
+++ b/tests/functional/services/auth/test_simple_auth_usage.py
@@ -32,7 +32,7 @@ def test_get_identities_unauthorized(client):
 
     err = excinfo.value
     assert err.code == "UNAUTHORIZED"
-    assert data.metadata["error_id"] in err.raw_text
+    assert data.metadata["error_id"] in err.text
     assert err.raw_json == data.json
 
 

--- a/tests/non-pytest/mypy-ignore-tests/responselike_protocol.py
+++ b/tests/non-pytest/mypy-ignore-tests/responselike_protocol.py
@@ -1,0 +1,47 @@
+# validate that GlobusAPIError and GlobusHTTPResponse both satisfy the SDK's
+# ResponseLike protocol
+
+import sys
+import typing as t
+
+import requests
+
+from globus_sdk import GlobusAPIError, GlobusHTTPResponse
+from globus_sdk._types import ResponseLike
+
+if sys.version_info < (3, 11):
+    from typing_extensions import assert_type
+else:
+    from typing import assert_type
+
+sample_response = requests.Response()
+
+
+def get_length_of_response(r: ResponseLike) -> int:
+    return len(r.binary_content)
+
+
+# confirm this test function is well-declared
+get_length_of_response("foo")  # type: ignore[arg-type]
+
+
+# check an error object
+err = GlobusAPIError(sample_response)
+assert_type(err.http_status, int)
+assert_type(err.http_reason, str)
+assert_type(err.headers, t.Mapping[str, str])
+assert_type(err.content_type, str | None)
+assert_type(err.text, str)
+assert_type(err.binary_content, bytes)
+assert_type(get_length_of_response(err), int)
+
+
+# check an HTTP response object
+resp = GlobusHTTPResponse(sample_response)
+assert_type(resp.http_status, int)
+assert_type(resp.http_reason, str)
+assert_type(resp.headers, t.Mapping[str, str])
+assert_type(resp.content_type, str | None)
+assert_type(resp.text, str)
+assert_type(resp.binary_content, bytes)
+assert_type(get_length_of_response(resp), int)

--- a/tests/unit/responses/test_response.py
+++ b/tests/unit/responses/test_response.py
@@ -231,6 +231,16 @@ def test_text(malformed_http_response, text_http_response):
     assert text_http_response.r.text == text_http_response.data
 
 
+def test_binary_content_property(malformed_http_response, text_http_response):
+    """
+    Gets the text from each HTTPResponse, confirms expected results
+    """
+    assert malformed_http_response.r.binary_content == b"{"
+    assert text_http_response.r.binary_content == text_http_response.data.encode(
+        "utf-8"
+    )
+
+
 def test_no_content_type_header(http_no_content_type_response):
     """
     Response without a Content-Type HTTP header should be okay


### PR DESCRIPTION
Ensure that these provide the same suite of properties for interacting with HTTP response data. Importantly, the error class gains `text` (to replace `raw_text`) and `content_type`.

Furthermore, accessing `raw_text` will now emit a RemovedInV4Warning flavor of DeprecationWarning, indicating that we intend to remove the property in SDK v4.

We could take the similarity further, making the error objects use `data` to replace `raw_json`, but it is not clear that the "data part" of the responses should be made uniform.

To encapsulate the suite of matching properties, the type helpers module now includes a protocol class, `ResponseLike`. `ResponseLike` is not exported by the SDK at the top level but is used to implement testing to confirm that the types match. (This is open to future change.)

Additionally, ResponseLike defines, and both classes are updated to provide, `binary_content`. This points to `requests.Response.content`, which is the response body as a bytestring.

Testing-wise, several tests are modified or introduced here:
- tests which access `raw_text` on errors expect RemovedInV4Warning
- tests now check `binary_content` for responses and errors
- mypy test cases enforce that GlobusAPIError and GlobusHTTPResponse both implement ResponseLike