### PR TITLE
Fix the return type annotation for get_identities

### DIFF
--- a/changelog.d/20230412_144457_sirosen_fix_type_error.rst
+++ b/changelog.d/20230412_144457_sirosen_fix_type_error.rst
@@ -1,0 +1,2 @@
+* The return type of ``AuthClient.get_identities`` is now correctly annotated as
+  an iterable type, ``globus_sdk.GetIdentitiesResponse`` (:pr:`NUMBER`)

--- a/src/globus_sdk/__init__.py
+++ b/src/globus_sdk/__init__.py
@@ -56,6 +56,7 @@ _LAZY_IMPORT_TABLE = {
         "ConfidentialAppAuthClient",
         "IdentityMap",
         "NativeAppAuthClient",
+        "GetIdentitiesResponse",
         "OAuthDependentTokenResponse",
         "OAuthTokenResponse",
     },
@@ -151,6 +152,7 @@ if t.TYPE_CHECKING:
     from .services.auth import ConfidentialAppAuthClient
     from .services.auth import IdentityMap
     from .services.auth import NativeAppAuthClient
+    from .services.auth import GetIdentitiesResponse
     from .services.auth import OAuthDependentTokenResponse
     from .services.auth import OAuthTokenResponse
     from .services.gcs import CollectionDocument
@@ -260,6 +262,7 @@ __all__ = (
     "GCSAPIError",
     "GCSClient",
     "GCSRoleDocument",
+    "GetIdentitiesResponse",
     "GlobusAPIError",
     "GlobusConnectPersonalOwnerInfo",
     "GlobusConnectionError",

--- a/src/globus_sdk/_generate_init.py
+++ b/src/globus_sdk/_generate_init.py
@@ -114,6 +114,7 @@ _LAZY_IMPORT_TABLE: list[tuple[str, tuple[str, ...]]] = [
             "ConfidentialAppAuthClient",
             "IdentityMap",
             "NativeAppAuthClient",
+            "GetIdentitiesResponse",
             "OAuthDependentTokenResponse",
             "OAuthTokenResponse",
         ),

--- a/src/globus_sdk/services/auth/__init__.py
+++ b/src/globus_sdk/services/auth/__init__.py
@@ -5,7 +5,11 @@ from .flow_managers import (
     GlobusNativeAppFlowManager,
 )
 from .identity_map import IdentityMap
-from .response import OAuthDependentTokenResponse, OAuthTokenResponse
+from .response import (
+    GetIdentitiesResponse,
+    OAuthDependentTokenResponse,
+    OAuthTokenResponse,
+)
 
 __all__ = [
     "AuthClient",
@@ -15,6 +19,7 @@ __all__ = [
     "IdentityMap",
     "GlobusNativeAppFlowManager",
     "GlobusAuthorizationCodeFlowManager",
+    "GetIdentitiesResponse",
     "OAuthDependentTokenResponse",
     "OAuthTokenResponse",
 ]

--- a/src/globus_sdk/services/auth/client/base.py
+++ b/src/globus_sdk/services/auth/client/base.py
@@ -83,7 +83,7 @@ class AuthClient(client.BaseClient):
         ids: t.Iterable[UUIDLike] | UUIDLike | None = None,
         provision: bool = False,
         query_params: dict[str, t.Any] | None = None,
-    ) -> GlobusHTTPResponse:
+    ) -> GetIdentitiesResponse:
         r"""
         Given ``usernames=<U>`` or (exclusive) ``ids=<I>`` as keyword
         arguments, looks up identity information for the set of identities

--- a/tests/non-pytest/mypy-ignore-tests/get_identities.py
+++ b/tests/non-pytest/mypy-ignore-tests/get_identities.py
@@ -1,0 +1,26 @@
+import uuid
+
+from globus_sdk import AuthClient
+
+zero_id = uuid.UUID(int=0)
+
+# ok usages
+ac = AuthClient()
+ac.get_identities(ids="foo")
+ac.get_identities(ids=zero_id)
+ac.get_identities(ids=("foo", "bar"))
+ac.get_identities(ids=(zero_id,))
+ac.get_identities(usernames="foo,bar")
+ac.get_identities(usernames=("foo", "bar"))
+ac.get_identities(usernames=("foo", "bar"), provision=True)
+ac.get_identities(usernames=("foo", "bar"), query_params={"provision": False})
+
+# bad usage
+ac.get_identities(usernames=zero_id)  # type: ignore[arg-type]
+ac.get_identities(usernames=(zero_id,))  # type: ignore[arg-type]
+
+
+# test the response object is iterable
+res = ac.get_identities(usernames="foo")
+for x in res:
+    print(x)


### PR DESCRIPTION
This was annotated as GlobusHTTPResponse when it should have been GetIdentitiesResponse. The result is that type checkers could not see that an iterable type was returned.

A new mypy test case confirms that the type is now seen correctly, as well as validating several arguments and usages for get_identities.

<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--716.org.readthedocs.build/en/716/

<!-- readthedocs-preview globus-sdk-python end -->