### PR TITLE
Add pyright to CI and make it pass

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,6 +27,16 @@ jobs:
       - run: python -m pip install -U tox
       - run: tox -e mypy,mypy-mindeps,mypy-test
 
+  pyright:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - run: python -m pip install -U tox
+      - run: tox -e pyright
+
   test:
     strategy:
       matrix:

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,8 @@
+{
+  "include": ["src"],
+  "executionEnvironments": [
+    {
+      "root": "src"
+    }
+  ]
+}

--- a/src/globus_sdk/config/env_vars.py
+++ b/src/globus_sdk/config/env_vars.py
@@ -53,7 +53,7 @@ def _load_var(
     default: t.Any,
     explicit_value: t.Any | None = None,
     convert: t.Callable[[t.Any, t.Any], T] | None = None,
-) -> t.Any:
+) -> t.Any | T:
     # use the explicit value if given and non-None, otherwise, do an env lookup
     value = (
         explicit_value if explicit_value is not None else os.getenv(varname, default)

--- a/src/globus_sdk/paging/table.py
+++ b/src/globus_sdk/paging/table.py
@@ -40,14 +40,16 @@ class PaginatorTable:
         self._client = client
         # _bindings is a lazily loaded table of names -> callables which
         # return paginators
-        self._bindings: dict[str, t.Callable[..., Paginator[PageT]]] = {}
+        self._bindings: dict[str, t.Callable[..., Paginator[GlobusHTTPResponse]]] = {}
 
     def _add_binding(
         self, methodname: str, bound_method: t.Callable[..., PageT]
     ) -> None:
         self._bindings[methodname] = Paginator.wrap(bound_method)
 
-    def __getattr__(self, attrname: str) -> t.Callable[..., Paginator[PageT]]:
+    def __getattr__(
+        self, attrname: str
+    ) -> t.Callable[..., Paginator[GlobusHTTPResponse]]:
         if attrname not in self._bindings:
             # this could raise AttributeError -- in which case, let it!
             method = getattr(self._client, attrname)

--- a/src/globus_sdk/services/gcs/data/_common.py
+++ b/src/globus_sdk/services/gcs/data/_common.py
@@ -22,7 +22,7 @@ class DocumentWithInducedDatatype(Protocol):
     def __contains__(self, key: str) -> bool:  # pragma: no cover
         ...
 
-    def __setitem__(self, key: str, value: t.Any) -> None:  # pragma: no cover
+    def __setitem__(self, key: str, item: t.Any) -> None:  # pragma: no cover
         ...
 
     def __getitem__(self, key: str) -> t.Any:  # pragma: no cover

--- a/src/globus_sdk/utils.py
+++ b/src/globus_sdk/utils.py
@@ -168,16 +168,21 @@ class _classproperty(t.Generic[T, R]):
 
 # if running under sphinx, define this as the stacked classmethod(property(...))
 # decoration, so that proper autodoc generation happens
+
+
+def _sphinx_classproperty(func: t.Callable[[T], R]) -> _classproperty[T, R]:
+    # type ignore this because
+    # - it doesn't match the return type
+    # - mypy doesn't understand classmethod(property(...)) on older pythons
+    return classmethod(property(func))  # type: ignore
+
+
+def _runtime_classproperty(func: t.Callable[[T], R]) -> _classproperty[T, R]:
+    # type cast to convert instance method to class method
+    return _classproperty(t.cast(t.Callable[[t.Type[T]], R], func))
+
+
 if in_sphinx_build():  # pragma: no cover
-
-    def classproperty(func: t.Callable[[T], R]) -> _classproperty[T, R]:
-        # type ignore this because
-        # - it doesn't match the return type
-        # - mypy doesn't understand classmethod(property(...)) on older pythons
-        return classmethod(property(func))  # type: ignore
-
+    classproperty = _sphinx_classproperty
 else:
-
-    def classproperty(func: t.Callable[[T], R]) -> _classproperty[T, R]:
-        # type cast to convert instance method to class method
-        return _classproperty(t.cast(t.Callable[[t.Type[T]], R], func))
+    classproperty = _runtime_classproperty

--- a/tox.ini
+++ b/tox.ini
@@ -60,7 +60,9 @@ deps = pylint
 commands = pylint src/
 
 [testenv:pyright]
-deps = pyright
+deps =
+    pyright
+    -r requirements/typing.txt
 commands = pyright src/ {posargs}
 
 [testenv:docs]


### PR DESCRIPTION
I've had this in a branch for a little and figured it might be good to merge.
However, I'm opening it as a draft because I want to see if it's possible to make `tox r -e pyright -- --verifytypes globus_sdk` pass.
If we can achieve "type completeness", we might have some stronger typing guarantees out of the SDK.

---

pyright had a tox environment which was not fully up to date and which was not passing even when its deps were corrected to include `-r deps/typing.txt`

A pyrightconfig.json is added to configure pyright for our needs, and pyright is added to the build workflow in GHA.

In order for this to work, several changes are needed in src/ to satisfy pyright's rules. Generally speaking, this is a matter of pyright being stricter about certain things than mypy:
- Return `Any | T` from an overloaded function to explicitly match all types from the overloads
- `__setitem__` on a UserDict subclass must use the same exact argument names as UserDict to pass. This applies to Protocol matching as well, and therefore a protocol for UserDict subclasses must use the exact same argument names
- Using a TypeVar where it is not bound is ambiguous (and probably means Any). Instead, use the concrete type which is the upper-bound for the TypeVar
- Redefining a function in different conditional branches fails in pyright, even if the signatures match. A simple rearrangement to make the conditional part an assignment fixes this

<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--717.org.readthedocs.build/en/717/

<!-- readthedocs-preview globus-sdk-python end -->