### PR TITLE
Add codespell to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,10 @@ repos:
   hooks:
     - id: pyupgrade
       args: ["--py37-plus"]
+- repo: https://github.com/codespell-project/codespell
+  rev: v2.2.4
+  hooks:
+    - id: codespell
 
 # custom local hooks
 - repo: local

--- a/docs/scopes.rst
+++ b/docs/scopes.rst
@@ -131,7 +131,7 @@ Serializing Scopes
 ~~~~~~~~~~~~~~~~~~
 
 Whenever scopes are being sent to Globus services, they need to be encoded as
-strings. All mutabl scope objects support this by means of their defined
+strings. All mutable scope objects support this by means of their defined
 ``serialize`` method. Note that ``__str__`` for a ``MutableScope`` is just an
 alias for ``serialize``. For example, the following is valid usage to demonstrate
 ``str()``, ``repr()``, and ``serialize()``:

--- a/docs/testing/getting_started.rst
+++ b/docs/testing/getting_started.rst
@@ -99,7 +99,7 @@ response is ``"default"``.
     # or just one response from it by name
     rset.activate("default")
 
-Note that activating a whole repsonse set may or may not make sense. For
+Note that activating a whole response set may or may not make sense. For
 example, the response set for ``AuthClient.get_identities`` provides various
 responses for the same API call.
 

--- a/src/globus_sdk/exc/convert.py
+++ b/src/globus_sdk/exc/convert.py
@@ -33,7 +33,7 @@ class GlobusConnectionTimeoutError(GlobusTimeoutError):
 
 
 class GlobusConnectionError(NetworkError):
-    """A connection error occured while making a REST request."""
+    """A connection error occurred while making a REST request."""
 
 
 def convert_request_exception(exc: requests.RequestException) -> GlobusError:

--- a/src/globus_sdk/services/gcs/data/storage_gateway.py
+++ b/src/globus_sdk/services/gcs/data/storage_gateway.py
@@ -533,7 +533,7 @@ class IrodsStoragePolicies(StorageGatewayPolicies):
     :param DATA_TYPE: Versioned document type. Defaults to the appropriate type for
         this class.
     :type DATA_TYPE: str, optional
-    :param irods_environment_file: Path to iRODS environent file on the endpoint
+    :param irods_environment_file: Path to iRODS environment file on the endpoint
     :type irods_environment_file: str
     :param irods_authentication_file: Path to iRODS authentication file on the endpoint
     :type irods_authentication_file: str

--- a/tests/functional/services/transfer/test_task_wait.py
+++ b/tests/functional/services/transfer/test_task_wait.py
@@ -34,7 +34,7 @@ def test_task_wait_bad_args_min_wait(client, mocksleep, add_kwargs):
 
 
 def test_task_wait_success_case(client, mocksleep):
-    # first the task will show as active, then as succeded
+    # first the task will show as active, then as succeeded
     register_api_route_fixture_file(
         "transfer", f"/task/{TASK1_ID}", "get_task1_active.json"
     )

--- a/tests/unit/errors/test_auth_errors.py
+++ b/tests/unit/errors/test_auth_errors.py
@@ -33,7 +33,7 @@ def nested_auth_response(make_json_response):
         ("default_json_response", "400", "Json Error", "json error message"),
         # defaults for non-json data
         ("default_text_response", "401", "Error", "error message"),
-        # malformed data is at least rendered successully into an error
+        # malformed data is at least rendered successfully into an error
         ("malformed_response", "403", "Error", "{"),
     ),
 )

--- a/tests/unit/errors/test_transfer_errors.py
+++ b/tests/unit/errors/test_transfer_errors.py
@@ -22,7 +22,7 @@ def transfer_response(make_json_response):
         ("default_json_response", "400", "Json Error", "json error message", None),
         # defaults for non-json data
         ("default_text_response", "401", "Error", "error message", None),
-        # malformed data is at least rendered successully into an error
+        # malformed data is at least rendered successfully into an error
         ("malformed_response", "403", "Error", "{", None),
     ),
 )


### PR DESCRIPTION
This catches and fixes several typos.

Also, fix 'mutabl->mutable' in docs, which was not caught by codespell.
(For reference, I've tried opening [a PR on codepsell](https://github.com/codespell-project/codespell/pull/2822), to see how hard or easy it is to get our relevant typos included there as we encounter things.)

---

Some background/meta: codepsell lists known words and typos, to keep false negatives to a minimum. For some problem-words like `deque` vs `dequeue`, it features a few different built-in dictionaries which we could apply.

I'd like to try it out here and on the CLI, and maybe replace the custom typo checker I wrote for one of our internal projects with it.