### PR TITLE
Allow 'required_scope' singular variant

### DIFF
--- a/changelog.d/20230502_174303_sirosen_required_scope_accept_alternative.rst
+++ b/changelog.d/20230502_174303_sirosen_required_scope_accept_alternative.rst
@@ -1,0 +1,3 @@
+* ``ConsentRequiredInfo`` now accepts ``required_scope`` (singular) containing
+  a single string as an alternative to ``required_scopes``. However, it will
+  parse both formats into a ``required_scopes`` list. (:pr:`NUMBER`)

--- a/tests/unit/errors/test_common_functionality.py
+++ b/tests/unit/errors/test_common_functionality.py
@@ -117,23 +117,44 @@ def test_info_is_falsey_on_non_dict_json(make_json_response):
     assert str(err.info) == "AuthorizationParameterInfo(:)|ConsentRequiredInfo(:)"
 
 
-def test_consent_required_info(make_json_response):
-    res = make_json_response(
-        {"code": "ConsentRequired", "required_scopes": ["foo", "bar"]}, 401
-    )
+@pytest.mark.parametrize(
+    "body, is_detected, required_scopes",
+    (
+        (
+            {"code": "ConsentRequired", "required_scopes": ["foo", "bar"]},
+            True,
+            ["foo", "bar"],
+        ),
+        (
+            {"code": "ConsentRequired", "required_scope": "foo bar"},
+            True,
+            ["foo bar"],
+        ),
+        ({"code": "ConsentRequired"}, False, None),
+        ({"code": "ConsentRequired", "required_scopes": []}, False, None),
+        ({"code": "ConsentRequired", "required_scopes": ["foo", 123]}, False, None),
+        ({"code": "ConsentRequired", "required_scope": 1}, False, None),
+    ),
+)
+def test_consent_required_info(make_json_response, body, is_detected, required_scopes):
+    res = make_json_response(body, 401)
     err = GlobusAPIError(res.r)
-    assert bool(err.info.consent_required) is True
-    assert err.info.consent_required.required_scopes == ["foo", "bar"]
-    assert str(err.info.consent_required) == (
-        "ConsentRequiredInfo(required_scopes=['foo', 'bar'])"
-    )
 
-    # if the code is right but the scope list is missing, it should be falsey
-    res = make_json_response({"code": "ConsentRequired"}, 401)
-    err = GlobusAPIError(res.r)
-    assert bool(err.info.consent_required) is False
-    assert err.info.consent_required.required_scopes is None
-    assert str(err.info.consent_required) == "ConsentRequiredInfo(:)"
+    if is_detected:
+        assert bool(err.info.consent_required) is True
+        assert err.info.consent_required.required_scopes == required_scopes
+    else:
+        assert bool(err.info.consent_required) is False
+
+
+def test_consent_required_info_str(make_json_response):
+    info = exc.ConsentRequiredInfo(
+        {"code": "ConsentRequired", "required_scopes": ["foo", "bar"]}
+    )
+    assert str(info) == "ConsentRequiredInfo(required_scopes=['foo', 'bar'])"
+
+    info = exc.ConsentRequiredInfo({})
+    assert str(info) == "ConsentRequiredInfo(:)"
 
 
 def test_authz_params_info_containing_session_message(make_json_response):

--- a/tests/unit/errors/test_common_functionality.py
+++ b/tests/unit/errors/test_common_functionality.py
@@ -137,7 +137,7 @@ def test_info_is_falsey_on_non_dict_json(make_json_response):
     ),
 )
 def test_consent_required_info(make_json_response, body, is_detected, required_scopes):
-    res = make_json_response(body, 401)
+    res = make_json_response(body, 403)
     err = GlobusAPIError(res.r)
 
     if is_detected:


### PR DESCRIPTION
ConsentRequiredInfo now accepts 'required_scope' containing an individual string as an alternative to 'required_scopes'. The validation of these values has also been made slightly stricter.

Additionally, `ConsentRequiredInfo.required_scopes` is now the empty list rather than `None` in the falsy case. This is not a very significant change, since

1. the documented usage pattern is that the truthiness of `ConsentRequiredInfo` should always be checked before it is used
2. the resulting value is still itself falsy

This subtlety is not covered in the changelog, on the grounds that it would only bring undue attention to a minor implementation detail.

<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--726.org.readthedocs.build/en/726/

<!-- readthedocs-preview globus-sdk-python end -->