### PR TITLE
Allow list_flows to take orderby as a tuple

### DIFF
--- a/changelog.d/20230508_122208_sirosen_flows_orderby_tuples.rst
+++ b/changelog.d/20230508_122208_sirosen_flows_orderby_tuples.rst
@@ -1,0 +1,5 @@
+* ``FlowsClient.list_flows`` now supports a tuple for the ``orderby``
+  parameter. The type of the tuple is a 2-tuple whose second element is one of
+  ``"ASC"`` or ``"DESC"``. For example,
+  ``client.list_flows(orderby=("created_at", "DESC"))```. This gives improved
+  type annotations when the tuple form is used. (:pr:`NUMBER`)

--- a/tests/functional/services/flows/test_flow_crud.py
+++ b/tests/functional/services/flows/test_flow_crud.py
@@ -36,7 +36,7 @@ def test_delete_flow(flows_client):
 
 @pytest.mark.parametrize("filter_fulltext", [None, "foo"])
 @pytest.mark.parametrize("filter_role", [None, "bar"])
-@pytest.mark.parametrize("orderby", [None, "created_at ASC"])
+@pytest.mark.parametrize("orderby", [None, "created_at ASC", ("created_by", "DESC")])
 def test_list_flows_simple(flows_client, filter_fulltext, filter_role, orderby):
     meta = load_response(flows_client.list_flows).metadata
 
@@ -47,6 +47,12 @@ def test_list_flows_simple(flows_client, filter_fulltext, filter_role, orderby):
         add_kwargs["filter_role"] = filter_role
     if orderby:
         add_kwargs["orderby"] = orderby
+
+    expect_orderby_param = None
+    if isinstance(orderby, str):
+        expect_orderby_param = orderby
+    elif isinstance(orderby, tuple):
+        expect_orderby_param = " ".join(orderby)
 
     res = flows_client.list_flows(**add_kwargs)
     assert res.http_status == 200
@@ -63,7 +69,7 @@ def test_list_flows_simple(flows_client, filter_fulltext, filter_role, orderby):
         for k, v in (
             ("filter_fulltext", filter_fulltext),
             ("filter_role", filter_role),
-            ("orderby", orderby),
+            ("orderby", expect_orderby_param),
         )
         if v is not None
     }

--- a/tests/non-pytest/mypy-ignore-tests/flows_orderby.py
+++ b/tests/non-pytest/mypy-ignore-tests/flows_orderby.py
@@ -1,0 +1,29 @@
+# test the `orderby` param for `FlowsClient.list_flows()`
+# str or tuple, but the tuple's right value is validated (the left value is not)
+import globus_sdk
+
+fc = globus_sdk.FlowsClient()
+
+# no params as a safety/sanity check
+fc.list_flows()
+# orderby as a string, any string (valid or not)
+fc.list_flows(orderby="title DESC")
+fc.list_flows(orderby="scope_string ASC")
+fc.list_flows(orderby="title DESC ASC DESC")
+fc.list_flows(orderby="scope_string")
+fc.list_flows(orderby="frobulators INVERTED COROLLARY")
+
+# orderby as a tuple, all the valid styles
+# note that the field name isn't checked against a literal
+fc.list_flows(orderby=("title", "DESC"))
+fc.list_flows(orderby=("scope_string", "ASC"))
+fc.list_flows(orderby=("title DESC ASC", "DESC"))
+fc.list_flows(orderby=("frobulators", "ASC"))
+
+# orderby as a tuple, but invalid odering -- type errors
+fc.list_flows(orderby=("scope_string", "AGE"))  # type: ignore[arg-type]
+fc.list_flows(orderby=("frobulator", "normcore_demuddler"))  # type: ignore[arg-type]
+
+# and the tuple arity has to be right too
+fc.list_flows(orderby=("frobulator",))  # type: ignore[arg-type]
+fc.list_flows(orderby=("frobulator", "ASC", "ASC"))  # type: ignore[arg-type]


### PR DESCRIPTION
The new type for orderby allows str or `tuple[str, Literal["ASC", "DESC"]]`.

The result is that the new ordering style can be validated by mypy, but the existing string style is kept in place.

The validation is intentionally very limited, and primarily provides a nicety for any type-based editor integrations and type checked codebases. The goal is not to fully validate possible `orderby` values.

---

This idea may or may not be beneficial. We should discuss before potentially merging it. We've done something like this for the filters on `TransferClient` because users very consistently had difficulty assembling correct filters.
But will users have trouble with `orderby`, and is this the right way to assist them? This PR makes this option, which was proposed in a conversation, more concrete so that we can evaluate it.

<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--727.org.readthedocs.build/en/727/

<!-- readthedocs-preview globus-sdk-python end -->