### PR TITLE
Add doc note on resource_server lookups

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -248,6 +248,20 @@ response, and for each one, the response contains the following info:
   access_token when it expires. ``None`` unless explicitly requested.
   Details on refresh_token are in the next section
 
+.. note::
+
+    The keys into ``by_resource_server`` are the registered ``resource_server``
+    value for the service.
+    In general, the ``resource_server`` value will by the ID of the client used
+    in a service.
+
+    However, for Globus services like Globus Auth and Globus Transfer, the
+    ``resource_server`` has been customized to be the hostname for the service.
+
+    You can lookup the ``resource_server`` for most globus-sdk supported
+    clients by looking at the ``resource_server`` class attribute, e.g.
+    ``globus_sdk.TransferClient.resource_server``.
+
 .. _tutorial_step5:
 
 Step 5: Do a login flow with Refresh Tokens

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -252,15 +252,15 @@ response, and for each one, the response contains the following info:
 
     The keys into ``by_resource_server`` are the registered ``resource_server``
     value for the service.
-    In general, the ``resource_server`` value will by the ID of the client used
-    in a service.
 
-    However, for Globus services like Globus Auth and Globus Transfer, the
-    ``resource_server`` has been customized to be the hostname for the service.
+    For Globus hosted services like Globus Auth and Globus Transfer, the
+    ``resource_server`` is the hostname for the service, and can be retrieved
+    via the ``resource_server`` class attribute for the relevant client.
+    e.g., ``globus_sdk.TransferClient.resource_server``.
 
-    You can lookup the ``resource_server`` for most globus-sdk supported
-    clients by looking at the ``resource_server`` class attribute, e.g.
-    ``globus_sdk.TransferClient.resource_server``.
+    For other services, including Globus Connect Server v5, the ``resource_server``
+    value will be the ID of the service client. For Globus Connect Server v5, this
+    is the ID of the Endpoint.
 
 .. _tutorial_step5:
 


### PR DESCRIPTION
This note is added in response to mention that it was not clear how to do these lookups.

<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--732.org.readthedocs.build/en/732/

<!-- readthedocs-preview globus-sdk-python end -->