### PR TITLE
Update requirements

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -8,15 +8,15 @@ alabaster==0.7.13
     # via sphinx
 babel==2.12.1
     # via sphinx
-beautifulsoup4==4.11.2
+beautifulsoup4==4.12.2
     # via furo
-certifi==2022.12.7
+certifi==2023.5.7
     # via requests
 charset-normalizer==3.1.0
     # via requests
 docutils==0.19
     # via sphinx
-furo==2022.12.7
+furo==2023.5.20
     # via -r docs.in
 idna==3.4
     # via requests
@@ -26,15 +26,15 @@ jinja2==3.1.2
     # via sphinx
 markupsafe==2.1.2
     # via jinja2
-packaging==23.0
+packaging==23.1
     # via sphinx
-pygments==2.14.0
+pygments==2.15.1
     # via
     #   furo
     #   sphinx
 pyyaml==6.0
     # via responses
-requests==2.28.2
+requests==2.31.0
     # via
     #   responses
     #   sphinx
@@ -42,9 +42,9 @@ responses==0.23.1
     # via -r docs.in
 snowballstemmer==2.2.0
     # via sphinx
-soupsieve==2.4
+soupsieve==2.4.1
     # via beautifulsoup4
-sphinx==5.3.0
+sphinx==6.2.1
     # via
     #   -r docs.in
     #   furo
@@ -54,9 +54,9 @@ sphinx==5.3.0
     #   sphinx-issues
 sphinx-basic-ng==1.0.0b1
     # via furo
-sphinx-copybutton==0.5.1
+sphinx-copybutton==0.5.2
     # via -r docs.in
-sphinx-design==0.3.0
+sphinx-design==0.4.1
     # via -r docs.in
 sphinx-issues==3.0.1
     # via -r docs.in
@@ -72,9 +72,9 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-types-pyyaml==6.0.12.8
+types-pyyaml==6.0.12.10
     # via responses
-urllib3==1.26.15
+urllib3==2.0.2
     # via
     #   requests
     #   responses

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -17,7 +17,7 @@ charset-normalizer==3.1.0
 docutils==0.19
     # via sphinx
 furo==2022.12.7
-    # via -r requirements/docs.in
+    # via -r docs.in
 idna==3.4
     # via requests
 imagesize==1.4.1
@@ -39,14 +39,14 @@ requests==2.28.2
     #   responses
     #   sphinx
 responses==0.23.1
-    # via -r requirements/docs.in
+    # via -r docs.in
 snowballstemmer==2.2.0
     # via sphinx
 soupsieve==2.4
     # via beautifulsoup4
 sphinx==5.3.0
     # via
-    #   -r requirements/docs.in
+    #   -r docs.in
     #   furo
     #   sphinx-basic-ng
     #   sphinx-copybutton
@@ -55,11 +55,11 @@ sphinx==5.3.0
 sphinx-basic-ng==1.0.0b1
     # via furo
 sphinx-copybutton==0.5.1
-    # via -r requirements/docs.in
+    # via -r docs.in
 sphinx-design==0.3.0
-    # via -r requirements/docs.in
+    # via -r docs.in
 sphinx-issues==3.0.1
-    # via -r requirements/docs.in
+    # via -r docs.in
 sphinxcontrib-applehelp==1.0.4
     # via sphinx
 sphinxcontrib-devhelp==1.0.2

--- a/requirements/test-mindeps.txt
+++ b/requirements/test-mindeps.txt
@@ -13,9 +13,9 @@ cffi==1.15.1
 chardet==3.0.4
     # via requests
 coverage==7.2.1
-    # via -r requirements/test.in
+    # via -r test.in
 cryptography==3.3.1
-    # via -r requirements/test-mindeps.in
+    # via -r test-mindeps.in
 execnet==1.9.0
     # via pytest-xdist
 idna==2.8
@@ -29,27 +29,27 @@ pluggy==1.0.0
 pycparser==2.21
     # via cffi
 pyjwt==2.0.0
-    # via -r requirements/test-mindeps.in
+    # via -r test-mindeps.in
 pytest==7.2.2
     # via
-    #   -r requirements/test.in
+    #   -r test.in
     #   pytest-xdist
 pytest-xdist==3.2.0
-    # via -r requirements/test.in
+    # via -r test.in
 pyyaml==6.0
     # via responses
 requests==2.22.0
     # via
-    #   -r requirements/test-mindeps.in
+    #   -r test-mindeps.in
     #   responses
 responses==0.23.1
-    # via -r requirements/test.in
+    # via -r test.in
 six==1.16.0
     # via cryptography
 types-pyyaml==6.0.12.8
     # via responses
 typing-extensions==4.0.0
-    # via -r requirements/test-mindeps.in
+    # via -r test-mindeps.in
 urllib3==1.25.11
     # via
     #   requests

--- a/requirements/test-mindeps.txt
+++ b/requirements/test-mindeps.txt
@@ -4,15 +4,13 @@
 #
 #    tox run -e freezedeps
 #
-attrs==22.2.0
-    # via pytest
-certifi==2022.12.7
+certifi==2023.5.7
     # via requests
 cffi==1.15.1
     # via cryptography
 chardet==3.0.4
     # via requests
-coverage==7.2.1
+coverage==7.2.5
     # via -r test.in
 cryptography==3.3.1
     # via -r test-mindeps.in
@@ -22,7 +20,7 @@ idna==2.8
     # via requests
 iniconfig==2.0.0
     # via pytest
-packaging==23.0
+packaging==23.1
     # via pytest
 pluggy==1.0.0
     # via pytest
@@ -30,11 +28,11 @@ pycparser==2.21
     # via cffi
 pyjwt==2.0.0
     # via -r test-mindeps.in
-pytest==7.2.2
+pytest==7.3.1
     # via
     #   -r test.in
     #   pytest-xdist
-pytest-xdist==3.2.0
+pytest-xdist==3.3.1
     # via -r test.in
 pyyaml==6.0
     # via responses
@@ -46,7 +44,7 @@ responses==0.23.1
     # via -r test.in
 six==1.16.0
     # via cryptography
-types-pyyaml==6.0.12.8
+types-pyyaml==6.0.12.10
     # via responses
 typing-extensions==4.0.0
     # via -r test-mindeps.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -11,7 +11,7 @@ certifi==2022.12.7
 charset-normalizer==3.1.0
     # via requests
 coverage==7.2.1
-    # via -r requirements/test.in
+    # via -r test.in
 execnet==1.9.0
     # via pytest-xdist
 idna==3.4
@@ -24,16 +24,16 @@ pluggy==1.0.0
     # via pytest
 pytest==7.2.2
     # via
-    #   -r requirements/test.in
+    #   -r test.in
     #   pytest-xdist
 pytest-xdist==3.2.1
-    # via -r requirements/test.in
+    # via -r test.in
 pyyaml==6.0
     # via responses
 requests==2.28.2
     # via responses
 responses==0.23.1
-    # via -r requirements/test.in
+    # via -r test.in
 types-pyyaml==6.0.12.8
     # via responses
 urllib3==1.26.15

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,13 +4,11 @@
 #
 #    tox run -e freezedeps
 #
-attrs==22.2.0
-    # via pytest
-certifi==2022.12.7
+certifi==2023.5.7
     # via requests
 charset-normalizer==3.1.0
     # via requests
-coverage==7.2.1
+coverage==7.2.5
     # via -r test.in
 execnet==1.9.0
     # via pytest-xdist
@@ -18,25 +16,25 @@ idna==3.4
     # via requests
 iniconfig==2.0.0
     # via pytest
-packaging==23.0
+packaging==23.1
     # via pytest
 pluggy==1.0.0
     # via pytest
-pytest==7.2.2
+pytest==7.3.1
     # via
     #   -r test.in
     #   pytest-xdist
-pytest-xdist==3.2.1
+pytest-xdist==3.3.1
     # via -r test.in
 pyyaml==6.0
     # via responses
-requests==2.28.2
+requests==2.31.0
     # via responses
 responses==0.23.1
     # via -r test.in
-types-pyyaml==6.0.12.8
+types-pyyaml==6.0.12.10
     # via responses
-urllib3==1.26.15
+urllib3==2.0.2
     # via
     #   requests
     #   responses

--- a/requirements/typing-mindeps.txt
+++ b/requirements/typing-mindeps.txt
@@ -11,7 +11,7 @@ charset-normalizer==3.1.0
 idna==3.4
     # via requests
 mypy==0.991
-    # via -r requirements/typing.in
+    # via -r typing.in
 mypy-extensions==1.0.0
     # via mypy
 pyyaml==6.0
@@ -19,23 +19,23 @@ pyyaml==6.0
 requests==2.28.2
     # via responses
 responses==0.23.1
-    # via -r requirements/typing.in
+    # via -r typing.in
 types-cryptography==3.3.23.2
     # via types-jwt
 types-docutils==0.19.1.6
-    # via -r requirements/typing.in
+    # via -r typing.in
 types-jwt==0.1.3
-    # via -r requirements/typing.in
+    # via -r typing.in
 types-pyyaml==6.0.12.8
     # via responses
 types-requests==2.28.11.15
-    # via -r requirements/typing.in
+    # via -r typing.in
 types-urllib3==1.26.25.8
     # via types-requests
 typing-extensions==4.0.0
     # via
-    #   -r requirements/typing-mindeps.in
-    #   -r requirements/typing.in
+    #   -r typing-mindeps.in
+    #   -r typing.in
     #   mypy
 urllib3==1.26.15
     # via

--- a/requirements/typing-mindeps.txt
+++ b/requirements/typing-mindeps.txt
@@ -4,7 +4,7 @@
 #
 #    tox run -e freezedeps
 #
-certifi==2022.12.7
+certifi==2023.5.7
     # via requests
 charset-normalizer==3.1.0
     # via requests
@@ -16,28 +16,28 @@ mypy-extensions==1.0.0
     # via mypy
 pyyaml==6.0
     # via responses
-requests==2.28.2
+requests==2.31.0
     # via responses
 responses==0.23.1
     # via -r typing.in
 types-cryptography==3.3.23.2
     # via types-jwt
-types-docutils==0.19.1.6
+types-docutils==0.20.0.1
     # via -r typing.in
 types-jwt==0.1.3
     # via -r typing.in
-types-pyyaml==6.0.12.8
+types-pyyaml==6.0.12.10
     # via responses
-types-requests==2.28.11.15
+types-requests==2.31.0.0
     # via -r typing.in
-types-urllib3==1.26.25.8
+types-urllib3==1.26.25.13
     # via types-requests
 typing-extensions==4.0.0
     # via
     #   -r typing-mindeps.in
     #   -r typing.in
     #   mypy
-urllib3==1.26.15
+urllib3==2.0.2
     # via
     #   requests
     #   responses

--- a/requirements/typing.txt
+++ b/requirements/typing.txt
@@ -4,7 +4,7 @@
 #
 #    tox run -e freezedeps
 #
-certifi==2022.12.7
+certifi==2023.5.7
     # via requests
 charset-normalizer==3.1.0
     # via requests
@@ -16,27 +16,27 @@ mypy-extensions==1.0.0
     # via mypy
 pyyaml==6.0
     # via responses
-requests==2.28.2
+requests==2.31.0
     # via responses
 responses==0.23.1
     # via -r typing.in
 types-cryptography==3.3.23.2
     # via types-jwt
-types-docutils==0.19.1.6
+types-docutils==0.20.0.1
     # via -r typing.in
 types-jwt==0.1.3
     # via -r typing.in
-types-pyyaml==6.0.12.8
+types-pyyaml==6.0.12.10
     # via responses
-types-requests==2.28.11.15
+types-requests==2.31.0.0
     # via -r typing.in
-types-urllib3==1.26.25.8
+types-urllib3==1.26.25.13
     # via types-requests
-typing-extensions==4.5.0
+typing-extensions==4.6.0
     # via
     #   -r typing.in
     #   mypy
-urllib3==1.26.15
+urllib3==2.0.2
     # via
     #   requests
     #   responses

--- a/requirements/typing.txt
+++ b/requirements/typing.txt
@@ -11,7 +11,7 @@ charset-normalizer==3.1.0
 idna==3.4
     # via requests
 mypy==0.991
-    # via -r requirements/typing.in
+    # via -r typing.in
 mypy-extensions==1.0.0
     # via mypy
 pyyaml==6.0
@@ -19,22 +19,22 @@ pyyaml==6.0
 requests==2.28.2
     # via responses
 responses==0.23.1
-    # via -r requirements/typing.in
+    # via -r typing.in
 types-cryptography==3.3.23.2
     # via types-jwt
 types-docutils==0.19.1.6
-    # via -r requirements/typing.in
+    # via -r typing.in
 types-jwt==0.1.3
-    # via -r requirements/typing.in
+    # via -r typing.in
 types-pyyaml==6.0.12.8
     # via responses
 types-requests==2.28.11.15
-    # via -r requirements/typing.in
+    # via -r typing.in
 types-urllib3==1.26.25.8
     # via types-requests
 typing-extensions==4.5.0
     # via
-    #   -r requirements/typing.in
+    #   -r typing.in
     #   mypy
 urllib3==1.26.15
     # via

--- a/scripts/freezedeps.py
+++ b/scripts/freezedeps.py
@@ -37,6 +37,7 @@ def main():
                 str(source),
                 "-o",
                 str(dest),
+                "--upgrade",
             ],
             check=True,
             cwd=REQS_DIR,

--- a/scripts/freezedeps.py
+++ b/scripts/freezedeps.py
@@ -23,7 +23,7 @@ def main():
     reqs_in_files = REQS_DIR.glob("*.in")
     print(f'running pip-compile on "{REQS_DIR}/*.in"')
     for absolute_source in reqs_in_files:
-        source = absolute_source.relative_to(REPO_ROOT)
+        source = absolute_source.relative_to(REQS_DIR)
         dest = source.with_suffix(".txt")
         print(f"{source} -> {dest}")
         subprocess.run(
@@ -39,7 +39,7 @@ def main():
                 str(dest),
             ],
             check=True,
-            cwd=REPO_ROOT,
+            cwd=REQS_DIR,
             env={"CUSTOM_COMPILE_COMMAND": "tox run -e freezedeps"},
         )
 

--- a/tests/functional/base_client/test_advanced_http_options.py
+++ b/tests/functional/base_client/test_advanced_http_options.py
@@ -10,7 +10,6 @@ def test_allow_redirects_false(client):
             headers={
                 "Date": "Fri, 15 Apr 2022 15:35:44 GMT",
                 "Content-Type": "text/html",
-                "Content-Length": "138",
                 "Connection": "keep-alive",
                 "Server": "nginx",
                 "Location": "https://www.globus.org/",


### PR DESCRIPTION
This addresses a security issue identified by dependabot, but also aligns our requirement file formatting with dependabot's, and adds an `--upgrade` flag so requirements are upgraded when `tox -e freezedeps` is run.

<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--733.org.readthedocs.build/en/733/

<!-- readthedocs-preview globus-sdk-python end -->