### PR TITLE
Allow `pathlib.Path` filenames for token storage adapters

### DIFF
--- a/changelog.d/20230524_105741_kurtmckee_support_paths_sc_24551.rst
+++ b/changelog.d/20230524_105741_kurtmckee_support_paths_sc_24551.rst
@@ -1,0 +1,1 @@
+* Support ``pathlib.Path`` objects as filenames for the JSON and sqlite token storage adapters. (:pr:`NUMBER`)

--- a/src/globus_sdk/tokenstorage/file_adapters.py
+++ b/src/globus_sdk/tokenstorage/file_adapters.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import pathlib
 import typing as t
 
 from globus_sdk.services.auth import OAuthTokenResponse
@@ -23,8 +24,8 @@ class SimpleJSONFileAdapter(FileAdapter):
     # the supported versions (data not in these versions causes an error)
     supported_versions = ("1.0",)
 
-    def __init__(self, filename: str):
-        self.filename = filename
+    def __init__(self, filename: pathlib.Path | str):
+        self.filename = str(filename)
 
     def _raw_load(self) -> dict[str, t.Any]:
         """

--- a/src/globus_sdk/tokenstorage/sqlite_adapter.py
+++ b/src/globus_sdk/tokenstorage/sqlite_adapter.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import pathlib
 import sqlite3
 import typing as t
 
@@ -43,12 +44,12 @@ class SQLiteAdapter(FileAdapter):
 
     def __init__(
         self,
-        dbname: str,
+        dbname: pathlib.Path | str,
         *,
         namespace: str = "DEFAULT",
         connect_params: dict[str, t.Any] | None = None,
     ):
-        self.filename = self.dbname = dbname
+        self.filename = self.dbname = str(dbname)
         self.namespace = namespace
         self._connection = self._init_and_connect(connect_params)
 


### PR DESCRIPTION
No new tests were added because mypy linting confirms that the type is coerced to `str` during assignment to `self.filename`.

<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--734.org.readthedocs.build/en/734/

<!-- readthedocs-preview globus-sdk-python end -->