### PR TITLE
Fix test with bad Content-Length

### DIFF
--- a/tests/functional/base_client/test_advanced_http_options.py
+++ b/tests/functional/base_client/test_advanced_http_options.py
@@ -10,7 +10,6 @@ def test_allow_redirects_false(client):
             headers={
                 "Date": "Fri, 15 Apr 2022 15:35:44 GMT",
                 "Content-Type": "text/html",
-                "Content-Length": "138",
                 "Connection": "keep-alive",
                 "Server": "nginx",
                 "Location": "https://www.globus.org/",


### PR DESCRIPTION
Summary: I figured it out.

---

Under urllib3 v2.0, a Content-Length longer than the response content (leading to an incomplete read) is no longer silently ignored, but raises an error. This surfaced in an apparently unrelated test in which the body was 131 bytes, but Content-Length was specified at 138.

We could correct the Content-Length, but it is not essential to the test at all. Remove it.

<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--735.org.readthedocs.build/en/735/

<!-- readthedocs-preview globus-sdk-python end -->