### PR TITLE
Fix gcs client pagination

### DIFF
--- a/changelog.d/20230602_150941_derek_fix_gcs_list_pagination.rst
+++ b/changelog.d/20230602_150941_derek_fix_gcs_list_pagination.rst
@@ -1,0 +1,2 @@
+
+* Fix pagination on iterable gcs client routes  (:pr:`NUMBER`)

--- a/src/globus_sdk/services/gcs/client.py
+++ b/src/globus_sdk/services/gcs/client.py
@@ -298,6 +298,8 @@ class GCSClient(client.BaseClient):
         self,
         *,
         include: None | str | t.Iterable[str] = None,
+        page_size: int | None = None,
+        marker: str | None = None,
         query_params: dict[str, t.Any] | None = None,
     ) -> IterableGCSResponse:
         """
@@ -308,6 +310,11 @@ class GCSClient(client.BaseClient):
             policies in the attached storage_gateways document. This requires an
             ``administrator`` role on the Endpoint.
         :type include: str or iterable of str, optional
+        :param page_size: Number of results to return per page
+        :type page_size: int, optional
+        :param marker: Pagination marker supplied by previous API calls in the event
+            a request returns more values than the page size
+        :type marker: str, optional
         :param query_params: Additional passthrough query parameters
         :type query_params: dict, optional
 
@@ -329,6 +336,10 @@ class GCSClient(client.BaseClient):
             query_params = {}
         if include is not None:
             query_params["include"] = ",".join(utils.safe_strseq_iter(include))
+        if page_size is not None:
+            query_params["page_size"] = page_size
+        if marker is not None:
+            query_params["marker"] = marker
         return IterableGCSResponse(
             self.get("/storage_gateways", query_params=query_params)
         )
@@ -480,6 +491,8 @@ class GCSClient(client.BaseClient):
         self,
         collection_id: UUIDLike | None = None,
         include: str | None = None,
+        page_size: int | None = None,
+        marker: str | None = None,
         query_params: dict[str, t.Any] | None = None,
     ) -> IterableGCSResponse:
         """
@@ -492,6 +505,11 @@ class GCSClient(client.BaseClient):
         :param include: Pass "all_roles" to request all roles all roles
             relevant to the resource instead of only those the caller has on
             the resource
+        :param page_size: Number of results to return per page
+        :type page_size: int, optional
+        :param marker: Pagination marker supplied by previous API calls in the event
+            a request returns more values than the page size
+        :type marker: str, optional
         :type include: str, optional
         :param query_params: Additional passthrough query parameters
         :type query_params: dict, optional
@@ -510,6 +528,10 @@ class GCSClient(client.BaseClient):
             query_params = {}
         if include is not None:
             query_params["include"] = include
+        if page_size is not None:
+            query_params["page_size"] = page_size
+        if marker is not None:
+            query_params["marker"] = marker
         if collection_id is not None:
             query_params["collection_id"] = collection_id
 


### PR DESCRIPTION
## What?
* Added `marker` and `page_size` parameters to 2 iterable gcs_client routes
  * `gcs_client.get_storage_gateway_list(...)`
  * `gcs_client.get_role_list(...)`

## Why?
* Pagination on those two routes is broken
  * As describe in [this ticket](https://globusonline.zendesk.com/agent/tickets/371621), iterating through `gcs_client.paginated.get_storage_gateway_list()` raises an `unexpected keyword argument 'marker'`.

## Testing
Manually tested in python console:
```python
data = gcs.paginated.get_storage_gateway_list(page_size=1)
for idx, page in enumerate(data.pages()):
    print(f"Page {idx}: {len(page['data'])} item")
    
Page 0: 1 item
Page 1: 1 item
```


<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--738.org.readthedocs.build/en/738/

<!-- readthedocs-preview globus-sdk-python end -->