### PR TITLE
Adding pagination for credential_list and user_credential_list

### DIFF
--- a/src/globus_sdk/services/gcs/client.py
+++ b/src/globus_sdk/services/gcs/client.py
@@ -116,6 +116,10 @@ class GCSClient(client.BaseClient):
     # collection methods
     #
 
+    @paging.has_paginator(
+        paging.MarkerPaginator,
+        items_key="data",
+    )
     def get_collection_list(
         self,
         *,
@@ -124,6 +128,8 @@ class GCSClient(client.BaseClient):
             str | t.Iterable[str] | None
         ) = None,
         include: str | t.Iterable[str] | None = None,
+        page_size: int | None = None,
+        marker: str | None = None,
         query_params: dict[str, t.Any] | None = None,
     ) -> IterableGCSResponse:
         """
@@ -138,6 +144,11 @@ class GCSClient(client.BaseClient):
         :type filter: str or iterable of str, optional
         :param include: Names of additional documents to include in the response
         :type include: str or iterable of str, optional
+        :param page_size: Number of results to return per page
+        :type page_size: int, optional
+        :param marker: Pagination marker supplied by previous API calls in the event
+            a request returns more values than the page size
+        :type marker: str, optional
         :param query_params: Additional passthrough query parameters
         :type query_params: dict, optional
 
@@ -155,6 +166,10 @@ class GCSClient(client.BaseClient):
             query_params = {}
         if include is not None:
             query_params["include"] = ",".join(utils.safe_strseq_iter(include))
+        if page_size is not None:
+            query_params["page_size"] = page_size
+        if marker is not None:
+            query_params["marker"] = marker
         if mapped_collection_id is not None:
             query_params["mapped_collection_id"] = mapped_collection_id
         if filter is not None:
@@ -620,10 +635,16 @@ class GCSClient(client.BaseClient):
         path = f"/roles/{role_id}"
         return self.delete(path, query_params=query_params)
 
+    @paging.has_paginator(
+        paging.MarkerPaginator,
+        items_key="data",
+    )
     def get_user_credential_list(
         self,
         storage_gateway: UUIDLike | None = None,
         query_params: dict[str, t.Any] | None = None,
+        page_size: int | None = None,
+        marker: str | None = None,
     ) -> IterableGCSResponse:
         """
         List User Credentials
@@ -632,6 +653,11 @@ class GCSClient(client.BaseClient):
         :type storage_gateway: str or UUID, optional
         :param query_params: Additional passthrough query parameters
         :type query_params: dict, optional
+        :param page_size: Number of results to return per page
+        :type page_size: int, optional
+        :param marker: Pagination marker supplied by previous API calls in the event
+            a request returns more values than the page size
+        :type marker: str, optional
 
         .. tab-set::
 
@@ -647,6 +673,10 @@ class GCSClient(client.BaseClient):
             query_params = {}
         if storage_gateway is not None:
             query_params["storage_gateway"] = storage_gateway
+        if page_size is not None:
+            query_params["page_size"] = page_size
+        if marker is not None:
+            query_params["marker"] = marker
 
         path = "/user_credentials"
         return IterableGCSResponse(self.get(path, query_params=query_params))


### PR DESCRIPTION
This is similar to https://github.com/globus/globus-sdk-python/pull/738 from the ticket I opened and @derek-globus fixed.

My next goal was to list the collections and found it wasn't paginated so I could only get the first page. I added in similar changes to the other pull request to make these two methods paginated and tested `get_collection_list` like before.

```python
data = client.paginated.get_collection_list(page_size=1)
for idx, page in enumerate(data.pages()):
    print(f"Page {idx}: {len(page['data'])} item")

Page 0: 1 item
Page 1: 1 item
```

<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--739.org.readthedocs.build/en/739/

<!-- readthedocs-preview globus-sdk-python end -->