### PR TITLE
Fix mkdir and rename to not send null local_user

### DIFF
--- a/changelog.d/20230606_113241_sirosen_avoid_null_local_user.rst
+++ b/changelog.d/20230606_113241_sirosen_avoid_null_local_user.rst
@@ -1,0 +1,2 @@
+* Fix ``TransferClient.operation_mkdir`` and ``TransferClient.operation_rename`` to no
+  longer send null ``local_user`` by default (:pr:`NUMBER`)

--- a/src/globus_sdk/services/transfer/client.py
+++ b/src/globus_sdk/services/transfer/client.py
@@ -1345,7 +1345,9 @@ class TransferClient(client.BaseClient):
                 endpoint_id, path, query_params
             )
         )
-        json_body = {"DATA_TYPE": "mkdir", "path": path, "local_user": local_user}
+        json_body = {"DATA_TYPE": "mkdir", "path": path}
+        if local_user is not None:
+            json_body["local_user"] = local_user
         return self.post(
             f"operation/endpoint/{endpoint_id}/mkdir",
             data=json_body,
@@ -1400,8 +1402,9 @@ class TransferClient(client.BaseClient):
             "DATA_TYPE": "rename",
             "old_path": oldpath,
             "new_path": newpath,
-            "local_user": local_user,
         }
+        if local_user is not None:
+            json_body["local_user"] = local_user
         return self.post(
             f"operation/endpoint/{endpoint_id}/rename",
             data=json_body,

--- a/tests/functional/services/transfer/test_operation_mkdir.py
+++ b/tests/functional/services/transfer/test_operation_mkdir.py
@@ -1,25 +1,40 @@
 import json
 import urllib.parse
 
+import pytest
+
 from globus_sdk._testing import get_last_request, load_response
 
+_OMIT = object()
 
-def test_operation_mkdir(client):
+
+@pytest.mark.parametrize("local_user", ("my-user", None, _OMIT))
+def test_operation_mkdir(client, local_user):
     meta = load_response(client.operation_mkdir).metadata
     endpoint_id = meta["endpoint_id"]
 
-    res = client.operation_mkdir(
-        endpoint_id=endpoint_id,
-        path="~/dir/",
-        local_user="my-user",
-        query_params={"foo": "bar"},
-    )
+    if local_user is not _OMIT:
+        res = client.operation_mkdir(
+            endpoint_id=endpoint_id,
+            path="~/dir/",
+            local_user=local_user,
+            query_params={"foo": "bar"},
+        )
+    else:
+        res = client.operation_mkdir(
+            endpoint_id=endpoint_id,
+            path="~/dir/",
+            query_params={"foo": "bar"},
+        )
     assert res["DATA_TYPE"] == "mkdir_result"
     assert res["code"] == "DirectoryCreated"
 
     req = get_last_request()
     body = json.loads(req.body)
     assert body["path"] == "~/dir/"
-    assert body["local_user"] == "my-user"
+    if local_user not in (_OMIT, None):
+        assert body["local_user"] == local_user
+    else:
+        assert "local_user" not in body
     query_params = urllib.parse.parse_qs(urllib.parse.urlparse(req.url).query)
     assert query_params["foo"] == ["bar"]

--- a/tests/functional/services/transfer/test_operation_rename.py
+++ b/tests/functional/services/transfer/test_operation_rename.py
@@ -1,20 +1,33 @@
 import json
 import urllib.parse
 
+import pytest
+
 from globus_sdk._testing import get_last_request, load_response
 
+_OMIT = object()
 
-def test_operation_rename(client):
+
+@pytest.mark.parametrize("local_user", ("my-user", None, _OMIT))
+def test_operation_rename(client, local_user):
     meta = load_response(client.operation_rename).metadata
     endpoint_id = meta["endpoint_id"]
 
-    res = client.operation_rename(
-        endpoint_id=endpoint_id,
-        oldpath="~/old-name",
-        newpath="~/new-name",
-        local_user="my-user",
-        query_params={"foo": "bar"},
-    )
+    if local_user is not _OMIT:
+        res = client.operation_rename(
+            endpoint_id=endpoint_id,
+            oldpath="~/old-name",
+            newpath="~/new-name",
+            local_user=local_user,
+            query_params={"foo": "bar"},
+        )
+    else:
+        res = client.operation_rename(
+            endpoint_id=endpoint_id,
+            oldpath="~/old-name",
+            newpath="~/new-name",
+            query_params={"foo": "bar"},
+        )
     assert res["DATA_TYPE"] == "result"
     assert res["code"] == "FileRenamed"
 
@@ -22,6 +35,9 @@ def test_operation_rename(client):
     body = json.loads(req.body)
     assert body["old_path"] == "~/old-name"
     assert body["new_path"] == "~/new-name"
-    assert body["local_user"] == "my-user"
+    if local_user not in (_OMIT, None):
+        assert body["local_user"] == local_user
+    else:
+        assert "local_user" not in body
     query_params = urllib.parse.parse_qs(urllib.parse.urlparse(req.url).query)
     assert query_params["foo"] == ["bar"]


### PR DESCRIPTION
This was noted as a bug after the 3.20.0 release.