### PR TITLE
Support updating runs metadata in the Flows service

### DIFF
--- a/changelog.d/20230612_110500_kurtmckee_flows_client_update_run_sc_19956.rst
+++ b/changelog.d/20230612_110500_kurtmckee_flows_client_update_run_sc_19956.rst
@@ -1,0 +1,1 @@
+* Support updating run metadata in the Flows service. (:pr:`NUMBER`)

--- a/src/globus_sdk/_testing/data/flows/update_run.py
+++ b/src/globus_sdk/_testing/data/flows/update_run.py
@@ -1,0 +1,15 @@
+from globus_sdk._testing import RegisteredResponse, ResponseSet
+
+from ._common import TWO_HOP_TRANSFER_RUN
+
+FLOW_ID = TWO_HOP_TRANSFER_RUN["flow_id"]
+RUN_ID = TWO_HOP_TRANSFER_RUN["run_id"]
+RESPONSES = ResponseSet(
+    metadata={"run_id": RUN_ID, "flow_id": FLOW_ID},
+    default=RegisteredResponse(
+        service="flows",
+        method="PUT",
+        path=f"/runs/{RUN_ID}",
+        json=TWO_HOP_TRANSFER_RUN,
+    ),
+)

--- a/src/globus_sdk/services/flows/client.py
+++ b/src/globus_sdk/services/flows/client.py
@@ -597,6 +597,77 @@ class FlowsClient(client.BaseClient):
             },
         )
 
+    def update_run(
+        self,
+        run_id: UUIDLike,
+        *,
+        label: str | None = None,
+        tags: list[str] | None = None,
+        run_monitors: list[str] | None = None,
+        run_managers: list[str] | None = None,
+        additional_fields: dict[str, t.Any] | None = None,
+    ) -> GlobusHTTPResponse:
+        """
+        Retrieve information about a particular Run of a Flow
+
+        :param run_id: The ID of the run to get
+        :type run_id: str or UUID
+        :param label: A short human-readable title
+        :type label: Optional string (1 - 64 chars)
+        :param tags: A collection of searchable tags associated with the run.
+            Tags are normalized by stripping leading and trailing whitespace,
+            and replacing all whitespace with a single space.
+        :type tags: Optional list of strings
+        :param run_monitors: A list of authenticated entities (identified by URN)
+            authorized to view this run in addition to the run owner
+        :type run_monitors: Optional list of strings
+        :param run_managers: A list of authenticated entities (identified by URN)
+            authorized to view & cancel this run in addition to the run owner
+        :type run_managers: Optional list of strings
+        :param additional_fields: Additional Key/Value pairs sent to the run API
+            (this parameter is used to bypass local sdk key validation helping)
+        :type additional_fields: Optional dictionary
+
+
+        .. tab-set::
+
+            .. tab-item:: Example Usage
+
+                .. code-block:: python
+
+                    from globus_sdk import FlowsClient
+
+                    flows = FlowsClient(...)
+                    flows.update_run(
+                        "581753c7-45da-43d3-ad73-246b46e7cb6b",
+                        label="Crunch numbers for experiment xDA202-batch-10",
+                    )
+
+            .. tab-item:: Example Response Data
+
+                .. expandtestfixture:: flows.update_run
+
+            .. tab-item:: API Info
+
+                .. extdoclink:: Update Run
+                    :service: flows
+                    :ref: Runs/paths/~1runs~1{run_id}/put
+        """
+
+        data = {
+            k: v
+            for k, v in {
+                "tags": tags,
+                "label": label,
+                "run_monitors": run_monitors,
+                "run_managers": run_managers,
+            }.items()
+            if v is not None
+        }
+        data.update(additional_fields or {})
+
+        return self.put(f"/runs/{run_id}", data=data)
+
 
 class SpecificFlowClient(client.BaseClient):
     r"""

--- a/src/globus_sdk/services/flows/client.py
+++ b/src/globus_sdk/services/flows/client.py
@@ -608,9 +608,9 @@ class FlowsClient(client.BaseClient):
         additional_fields: dict[str, t.Any] | None = None,
     ) -> GlobusHTTPResponse:
         """
-        Retrieve information about a particular Run of a Flow
+        Update the metadata of a specific run.
 
-        :param run_id: The ID of the run to get
+        :param run_id: The ID of the run to update
         :type run_id: str or UUID
         :param label: A short human-readable title
         :type label: Optional string (1 - 64 chars)

--- a/tests/functional/services/flows/test_run_crud.py
+++ b/tests/functional/services/flows/test_run_crud.py
@@ -1,0 +1,57 @@
+import json
+
+import pytest
+
+from globus_sdk._testing import get_last_request, load_response
+
+
+@pytest.mark.parametrize(
+    "values",
+    (
+        {},
+        {"label": "x"},
+        {"run_monitors": []},
+        {"run_monitors": ["me", "you"]},
+        {"run_managers": []},
+        {"run_managers": ["me", "you"]},
+        {"tags": []},
+        {"tags": ["x"]},
+    ),
+)
+def test_update_run(flows_client, values):
+    metadata = load_response(flows_client.update_run).metadata
+
+    flows_client.update_run(metadata["run_id"], **values)
+    request = get_last_request()
+    assert request.method == "PUT"
+    assert request.url.endswith(f"/runs/{metadata['run_id']}")
+    assert json.loads(request.body) == values
+
+    # Ensure deprecated routes are not used.
+    assert f"/flows/{metadata['flow_id']}" not in request.url
+
+
+def test_update_run_additional_fields(flows_client):
+    """*addition_fields* must override all other parameters."""
+
+    metadata = load_response(flows_client.update_run).metadata
+
+    additional_fields = {
+        "label": "x",
+        "run_monitors": ["x"],
+        "run_managers": ["x"],
+        "tags": ["x"],
+    }
+
+    flows_client.update_run(
+        metadata["run_id"],
+        label="a",
+        run_managers=["a"],
+        run_monitors=["a"],
+        tags=["a"],
+        additional_fields=additional_fields,
+    )
+    request = get_last_request()
+    assert request.method == "PUT"
+    assert request.url.endswith(f"/runs/{metadata['run_id']}")
+    assert json.loads(request.body) == additional_fields


### PR DESCRIPTION
* Support updating run metadata in the Flows service.

The generated OpenAPI documentation link was tested for correctness.

<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--744.org.readthedocs.build/en/744/

<!-- readthedocs-preview globus-sdk-python end -->