### PR TITLE
Support deleting runs from the Flows service

### DIFF
--- a/changelog.d/20230612_140806_kurtmckee_flows_client_delete_run_sc_19953.rst
+++ b/changelog.d/20230612_140806_kurtmckee_flows_client_delete_run_sc_19953.rst
@@ -1,1 +1,1 @@
-* Support deleting runs from the Flows service. (:pr:`NUMBER`)
+* Add a ``FlowsClient.delete_run()`` method. (:pr:`NUMBER`)

--- a/changelog.d/20230612_140806_kurtmckee_flows_client_delete_run_sc_19953.rst
+++ b/changelog.d/20230612_140806_kurtmckee_flows_client_delete_run_sc_19953.rst
@@ -1,0 +1,1 @@
+* Support deleting runs from the Flows service. (:pr:`NUMBER`)

--- a/src/globus_sdk/_testing/data/flows/delete_run.py
+++ b/src/globus_sdk/_testing/data/flows/delete_run.py
@@ -1,0 +1,48 @@
+import copy
+
+from globus_sdk._testing import RegisteredResponse, ResponseSet
+
+from ._common import TWO_HOP_TRANSFER_RUN
+
+RUN_ID = TWO_HOP_TRANSFER_RUN["run_id"]
+
+SUCCESSFUL_DELETE_RESPONSE = copy.deepcopy(TWO_HOP_TRANSFER_RUN)
+SUCCESSFUL_DELETE_RESPONSE.update(
+    {
+        "status": "SUCCEEDED",
+        "display_status": "SUCCEEDED",
+        "details": {
+            "code": "FlowSucceeded",
+            "output": {},
+            "description": "The Flow run reached a successful completion state",
+        },
+    }
+)
+
+CONFLICT_RESPONSE = {
+    "error": {
+        "code": "STATE_CONFLICT",
+        "detail": (
+            f"Run {RUN_ID} has status 'ACTIVE' but must have status"
+            f" in {{'ENDED', 'SUCCEEDED', 'FAILED'}} for requested operation"
+        ),
+    },
+    "debug_id": "80d920b6-66cf-4254-bcbd-7d3efe814e1a",
+}
+
+RESPONSES = ResponseSet(
+    metadata={"run_id": RUN_ID},
+    default=RegisteredResponse(
+        service="flows",
+        method="POST",
+        path=f"/runs/{RUN_ID}/release",
+        json=SUCCESSFUL_DELETE_RESPONSE,
+    ),
+    conflict=RegisteredResponse(
+        service="flows",
+        method="POST",
+        path=f"/runs/{RUN_ID}/release",
+        status=409,
+        json=CONFLICT_RESPONSE,
+    ),
+)

--- a/src/globus_sdk/services/flows/client.py
+++ b/src/globus_sdk/services/flows/client.py
@@ -672,7 +672,7 @@ class FlowsClient(client.BaseClient):
         """
         Delete a run.
 
-        :param run_id: The ID of the run to update
+        :param run_id: The ID of the run to delete
         :type run_id: str or UUID
 
 

--- a/src/globus_sdk/services/flows/client.py
+++ b/src/globus_sdk/services/flows/client.py
@@ -668,6 +668,38 @@ class FlowsClient(client.BaseClient):
 
         return self.put(f"/runs/{run_id}", data=data)
 
+    def delete_run(self, run_id: UUIDLike) -> GlobusHTTPResponse:
+        """
+        Delete a run.
+
+        :param run_id: The ID of the run to update
+        :type run_id: str or UUID
+
+
+        .. tab-set::
+
+            .. tab-item:: Example Usage
+
+                .. code-block:: python
+
+                    from globus_sdk import FlowsClient
+
+                    flows = FlowsClient(...)
+                    flows.delete_run("581753c7-45da-43d3-ad73-246b46e7cb6b")
+
+            .. tab-item:: Example Response Data
+
+                .. expandtestfixture:: flows.delete_run
+
+            .. tab-item:: API Info
+
+                .. extdoclink:: Delete Run
+                    :service: flows
+                    :ref: Runs/paths/~1runs~1{run_id}~1release/post
+        """
+
+        return self.post(f"/runs/{run_id}/release")
+
 
 class SpecificFlowClient(client.BaseClient):
     r"""


### PR DESCRIPTION
* Support deleting runs from the Flows service.

The SDK API documentation was built and verified. The link to the Flows OpenAPI page will be verified once the associated PR is merged and the OpenAPI docs are rebuilt and published.

<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--745.org.readthedocs.build/en/745/

<!-- readthedocs-preview globus-sdk-python end -->