### PR TITLE
Support canceling runs in the Flows service

### DIFF
--- a/changelog.d/20230612_181404_kurtmckee_flows_client_cancel_run_sc_19954.rst
+++ b/changelog.d/20230612_181404_kurtmckee_flows_client_cancel_run_sc_19954.rst
@@ -1,0 +1,1 @@
+* Support canceling runs in the Flows service. (:pr:`NUMBER`)

--- a/changelog.d/20230612_181404_kurtmckee_flows_client_cancel_run_sc_19954.rst
+++ b/changelog.d/20230612_181404_kurtmckee_flows_client_cancel_run_sc_19954.rst
@@ -1,1 +1,1 @@
-* Support canceling runs in the Flows service. (:pr:`NUMBER`)
+* Add a ``FlowsClient.cancel_run()`` method. (:pr:`NUMBER`)

--- a/src/globus_sdk/_testing/data/flows/cancel_run.py
+++ b/src/globus_sdk/_testing/data/flows/cancel_run.py
@@ -1,0 +1,30 @@
+import copy
+
+from globus_sdk._testing import RegisteredResponse, ResponseSet
+
+from ._common import TWO_HOP_TRANSFER_RUN
+
+RUN_ID = TWO_HOP_TRANSFER_RUN["run_id"]
+SUCCESS_RESPONSE = copy.deepcopy(TWO_HOP_TRANSFER_RUN)
+SUCCESS_RESPONSE.update(
+    {
+        "status": "FAILED",
+        "display_status": "FAILED",
+        "details": {
+            "time": "2023-06-12T23:04:42.121000+00:00",
+            "code": "FlowCanceled",
+            "description": "The Flow Instance was canceled by the user",
+            "details": {},
+        },
+    }
+)
+
+RESPONSES = ResponseSet(
+    metadata={"run_id": RUN_ID},
+    default=RegisteredResponse(
+        service="flows",
+        method="POST",
+        path=f"/runs/{RUN_ID}/cancel",
+        json=SUCCESS_RESPONSE,
+    ),
+)

--- a/src/globus_sdk/services/flows/client.py
+++ b/src/globus_sdk/services/flows/client.py
@@ -597,6 +597,38 @@ class FlowsClient(client.BaseClient):
             },
         )
 
+    def cancel_run(self, run_id: UUIDLike) -> GlobusHTTPResponse:
+        """
+        Cancel a run.
+
+        :param run_id: The ID of the run to cancel
+        :type run_id: str or UUID
+
+
+        .. tab-set::
+
+            .. tab-item:: Example Usage
+
+                .. code-block:: python
+
+                    from globus_sdk import FlowsClient
+
+                    flows = FlowsClient(...)
+                    flows.cancel_run("581753c7-45da-43d3-ad73-246b46e7cb6b")
+
+            .. tab-item:: Example Response Data
+
+                .. expandtestfixture:: flows.cancel_run
+
+            .. tab-item:: API Info
+
+                .. extdoclink:: Cancel Run
+                    :service: flows
+                    :ref: Runs/paths/~1runs~1{run_id}~1cancel/post
+        """
+
+        return self.post(f"/runs/{run_id}/cancel")
+
     def update_run(
         self,
         run_id: UUIDLike,

--- a/tests/functional/services/flows/test_run_crud.py
+++ b/tests/functional/services/flows/test_run_crud.py
@@ -5,6 +5,17 @@ import pytest
 from globus_sdk._testing import get_last_request, load_response
 
 
+def test_cancel_run(flows_client):
+    """Verify that run cancellation requests meet expectations."""
+
+    run_id = load_response(flows_client.cancel_run).metadata["run_id"]
+
+    flows_client.cancel_run(run_id)
+    request = get_last_request()
+    assert request.method == "POST"
+    assert request.url.endswith(f"/runs/{run_id}/cancel")
+
+
 @pytest.mark.parametrize(
     "values",
     (


### PR DESCRIPTION
* Support canceling runs in the Flows service.

<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--747.org.readthedocs.build/en/747/

<!-- readthedocs-preview globus-sdk-python end -->