### PR TITLE
Expand sdk error testing & support AuthAPIError.request_id

### DIFF
--- a/changelog.d/20230608_122306_sirosen_expand_sdk_error_testing.rst
+++ b/changelog.d/20230608_122306_sirosen_expand_sdk_error_testing.rst
@@ -1,0 +1,2 @@
+* ``AuthAPIError`` will now parse a unique ``id`` found in the error
+  subdocuments as the ``request_id`` attribute (:pr:`NUMBER`)

--- a/src/globus_sdk/_testing/data/auth/_common.py
+++ b/src/globus_sdk/_testing/data/auth/_common.py
@@ -1,14 +1,50 @@
-ERROR_ID = "cb6a50f8-ac67-11e8-b5fd-0e54e5d1d510"
-UNAUTHORIZED_AUTH_RESPONSE_JSON = {
-    "errors": [
-        {
-            "status": "401",
-            "id": "cb6a50f8-ac67-11e8-b5fd-0e54e5d1d510",
-            "code": "UNAUTHORIZED",
-            "detail": "Call must be authenticated",
-            "title": "Unauthorized",
-        }
-    ],
-    "error_description": "Unauthorized",
-    "error": "unauthorized",
-}
+import uuid
+from collections import namedtuple
+
+_ErrorData = namedtuple("_ErrorData", ("error_id", "json", "metadata_include"))
+
+_error_id = str(uuid.uuid1())
+UNAUTHORIZED_AUTH_RESPONSE = _ErrorData(
+    _error_id,
+    {
+        "errors": [
+            {
+                "status": "401",
+                "id": _error_id,
+                "code": "UNAUTHORIZED",
+                "detail": "Call must be authenticated",
+                "title": "Unauthorized",
+            }
+        ],
+        "error_description": "Unauthorized",
+        "error": "unauthorized",
+    },
+    {
+        "http_status": 401,
+        "code": "UNAUTHORIZED",
+        "message": "Call must be authenticated",
+    },
+)
+
+_error_id = str(uuid.uuid1())
+FORBIDDEN_AUTH_RESPONSE = _ErrorData(
+    _error_id,
+    {
+        "errors": [
+            {
+                "status": "403",
+                "id": _error_id,
+                "code": "FORBIDDEN",
+                "detail": "Call must be authenticated",
+                "title": "Unauthorized",
+            }
+        ],
+        "error_description": "Unauthorized",
+        "error": "unauthorized",
+    },
+    {
+        "http_status": 403,
+        "code": "FORBIDDEN",
+        "message": "Call must be authenticated",
+    },
+)

--- a/src/globus_sdk/_testing/data/auth/get_identities.py
+++ b/src/globus_sdk/_testing/data/auth/get_identities.py
@@ -2,7 +2,7 @@ import uuid
 
 from globus_sdk._testing.models import RegisteredResponse, ResponseSet
 
-from ._common import ERROR_ID, UNAUTHORIZED_AUTH_RESPONSE_JSON
+from ._common import UNAUTHORIZED_AUTH_RESPONSE
 
 _globus_at_globus_data = {
     "email": None,
@@ -85,7 +85,7 @@ RESPONSES = ResponseSet(
         service="auth",
         path="/v2/api/identities",
         status=401,
-        json=UNAUTHORIZED_AUTH_RESPONSE_JSON,
-        metadata={"error_id": ERROR_ID},
+        json=UNAUTHORIZED_AUTH_RESPONSE.json,
+        metadata={"error_id": UNAUTHORIZED_AUTH_RESPONSE.error_id},
     ),
 )

--- a/src/globus_sdk/_testing/data/auth/oauth2_userinfo.py
+++ b/src/globus_sdk/_testing/data/auth/oauth2_userinfo.py
@@ -1,13 +1,26 @@
 from globus_sdk._testing.models import RegisteredResponse, ResponseSet
 
-from ._common import ERROR_ID, UNAUTHORIZED_AUTH_RESPONSE_JSON
+from ._common import FORBIDDEN_AUTH_RESPONSE, UNAUTHORIZED_AUTH_RESPONSE
 
 RESPONSES = ResponseSet(
-    metadata={"error_id": ERROR_ID},
     unauthorized=RegisteredResponse(
         service="auth",
         path="/v2/oauth2/userinfo",
         status=401,
-        json=UNAUTHORIZED_AUTH_RESPONSE_JSON,
+        json=UNAUTHORIZED_AUTH_RESPONSE.json,
+        metadata={
+            "error_id": UNAUTHORIZED_AUTH_RESPONSE.error_id,
+            **UNAUTHORIZED_AUTH_RESPONSE.metadata_include,
+        },
+    ),
+    forbidden=RegisteredResponse(
+        service="auth",
+        path="/v2/oauth2/userinfo",
+        status=403,
+        json=FORBIDDEN_AUTH_RESPONSE.json,
+        metadata={
+            "error_id": FORBIDDEN_AUTH_RESPONSE.error_id,
+            **FORBIDDEN_AUTH_RESPONSE.metadata_include,
+        },
     ),
 )

--- a/src/globus_sdk/_testing/data/globus_connect_server/create_storage_gateway.py
+++ b/src/globus_sdk/_testing/data/globus_connect_server/create_storage_gateway.py
@@ -44,4 +44,22 @@ RESPONSES = ResponseSet(
             ],
         },
     ),
+    validation_error=RegisteredResponse(
+        path="/storage_gateways",
+        service="gcs",
+        method="POST",
+        status=422,
+        json={
+            "DATA_TYPE": "result#1.0.0",
+            "code": "unprocessable_entity",
+            "detail": "",
+            "http_response_code": 422,
+            "message": "Data Validation Error",
+        },
+        metadata={
+            "http_status": 422,
+            "code": "unprocessable_entity",
+            "message": "Data Validation Error",
+        },
+    ),
 )

--- a/src/globus_sdk/_testing/data/globus_connect_server/delete_storage_gateway.py
+++ b/src/globus_sdk/_testing/data/globus_connect_server/delete_storage_gateway.py
@@ -20,4 +20,23 @@ RESPONSES = ResponseSet(
             "data": [{}],
         },
     ),
+    permission_denied_error=RegisteredResponse(
+        service="gcs",
+        method="DELETE",
+        path=f"/storage_gateways/{metadata['id']}",
+        status=403,
+        json={
+            "DATA_TYPE": "result#1.0.0",
+            "code": "permission_denied",
+            "detail": "",
+            "http_response_code": 403,
+            "message": None,
+        },
+        metadata={
+            "http_status": 403,
+            "code": "permission_denied",
+            "message": "",
+            **metadata,
+        },
+    ),
 )

--- a/src/globus_sdk/services/auth/errors.py
+++ b/src/globus_sdk/services/auth/errors.py
@@ -11,3 +11,30 @@ class AuthAPIError(exc.GlobusAPIError):
     """
     Error class for the API components of Globus Auth.
     """
+
+    def _post_parse_hook(self) -> bool:
+        # if there was only one error ID set in the response, use that as the request_id
+        # this allows for some errors to omit the 'id':
+        #
+        #    errors=[{"id": "foo"}, {}]
+        #
+        # or for all errors to have the same 'id':
+        #
+        #    errors=[{"id": "foo"}, {"id": "foo"}]
+        #
+        # but not for errors to have mixed/different 'id' values:
+        #
+        #    errors=[{"id": "foo"}, {"id": "bar"}]
+
+        # step 1, collect error IDs
+        error_ids = {suberror.get("id") for suberror in self.errors}
+        # step 2, remove `None` from any sub-errors which did not set error_id or
+        # explicitly set it to null
+        error_ids.discard(None)
+        # step 3, check if there was exactly one error ID and it was a string
+        if len(error_ids) == 1:
+            maybe_error_id = error_ids.pop()
+            if isinstance(maybe_error_id, str):
+                self.request_id = maybe_error_id
+
+        return True

--- a/tests/functional/services/auth/base/test_oauth2_userinfo.py
+++ b/tests/functional/services/auth/base/test_oauth2_userinfo.py
@@ -1,6 +1,23 @@
 import pytest
 
+import globus_sdk
+from globus_sdk._testing import load_response
 
+
+# TODO: add data for the success case and test it
 @pytest.mark.xfail
 def test_oauth2_userinfo():
     raise NotImplementedError
+
+
+@pytest.mark.parametrize("casename", ("unauthorized", "forbidden"))
+def test_oauth2_error_handling(client, casename):
+    meta = load_response(client.oauth2_userinfo, case=casename).metadata
+
+    with pytest.raises(globus_sdk.AuthAPIError) as excinfo:
+        client.oauth2_userinfo()
+
+    err = excinfo.value
+    assert err.http_status == meta["http_status"]
+    assert err.code == meta["code"]
+    assert err.request_id == meta["error_id"]

--- a/tests/functional/services/auth/conftest.py
+++ b/tests/functional/services/auth/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+
+import globus_sdk
+
+
+@pytest.fixture
+def client(no_retry_transport):
+    class CustomAuthClient(globus_sdk.AuthClient):
+        transport_class = no_retry_transport
+
+    return CustomAuthClient()

--- a/tests/functional/services/auth/test_simple_auth_usage.py
+++ b/tests/functional/services/auth/test_simple_auth_usage.py
@@ -16,14 +16,6 @@ class StringWrapper:
         return self.s
 
 
-@pytest.fixture
-def client(no_retry_transport):
-    class CustomAuthClient(globus_sdk.AuthClient):
-        transport_class = no_retry_transport
-
-    return CustomAuthClient()
-
-
 def test_get_identities_unauthorized(client):
     data = load_response(client.get_identities, case="unauthorized")
 

--- a/tests/functional/services/gcs/test_storage_gateways.py
+++ b/tests/functional/services/gcs/test_storage_gateways.py
@@ -2,6 +2,7 @@ import urllib.parse
 
 import pytest
 
+import globus_sdk
 from globus_sdk._testing import get_last_request, load_response
 
 
@@ -46,6 +47,20 @@ def test_create_storage_gateway(client):
     # confirm top level access to storage gateway data
     assert res["id"] == meta["id"]
     assert res["display_name"] == meta["display_name"]
+
+
+def test_create_storage_gateway_validation_error(client):
+    meta = load_response(
+        client.create_storage_gateway, case="validation_error"
+    ).metadata
+
+    with pytest.raises(globus_sdk.GCSAPIError) as excinfo:
+        client.create_storage_gateway({})
+
+    error = excinfo.value
+    assert error.http_status == meta["http_status"]
+    assert error.code == meta["code"]
+    assert error.message == meta["message"]
 
 
 @pytest.mark.parametrize(
@@ -95,3 +110,17 @@ def test_delete_storage_gateway(client):
     # confirm top level access to response data
     assert res["code"] == "success"
     assert res["message"] == "Operation successful"
+
+
+def test_delete_storage_gateway_permission_denied(client):
+    meta = load_response(
+        client.delete_storage_gateway, case="permission_denied_error"
+    ).metadata
+
+    with pytest.raises(globus_sdk.GCSAPIError) as excinfo:
+        client.delete_storage_gateway(meta["id"])
+
+    error = excinfo.value
+    assert error.http_status == meta["http_status"]
+    assert error.code == meta["code"]
+    assert error.message == meta["message"]


### PR DESCRIPTION
## Changelog

* ``AuthAPIError`` will now parse a unique ``id`` found in the error subdocuments as the ``request_id`` attribute (:pr:`NUMBER`)

## Why

Following the 3.20 release and some reports of changes behavior, I worked on adding more tests for GCS and Auth error parsing to the testsuite. These don't reveal any bugs with the refined parsing behavior.

However, one thing which surfaced is that Globus Auth errors have an `id` attribute which we can and should surface in the `request_id` if possible. Since the `id` is found in the `errors` subdocument array, the same logic as our current convention for `code` is used.

<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--749.org.readthedocs.build/en/749/

<!-- readthedocs-preview globus-sdk-python end -->