### PR TITLE
git-ignore intermediary coverage files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ env/
 # pytest
 .pytest_cache
 .coverage
+.coverage.*


### PR DESCRIPTION
These were showing up in my git manager, which watches the directory and provides live updates.

<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--750.org.readthedocs.build/en/750/

<!-- readthedocs-preview globus-sdk-python end -->