### PR TITLE
Update the CONTRIBUTING doc

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -66,6 +66,5 @@ Code Style
 
 Style guidance which doesn't get handled by linters and fixers:
 
-  - When using `typing`, always import from `typing`, as in `from typing import ...`
   - If a docstring contains special characters like `\\`, consider using a raw
     string to ensure it renders correctly


### PR DESCRIPTION
`import typing as t` is enforced by a linter.

<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--754.org.readthedocs.build/en/754/

<!-- readthedocs-preview globus-sdk-python end -->