### PR TITLE
Tighten up the AuthClient init signatures

### DIFF
--- a/changelog.d/20230623_102145_sirosen_auth_client_init_signatures.rst
+++ b/changelog.d/20230623_102145_sirosen_auth_client_init_signatures.rst
@@ -1,0 +1,10 @@
+* ``AuthClient``, ``NativeAppAuthClient``, and ``ConfidentialAppAuthClient``
+  have had their init signatures updated to explicitly list available
+  parameters. (:pr:`NUMBER`)
+
+  * Type annotations for these classes are now more accurate
+
+  * The ``NativeAppAuthClient`` and ``ConfidentialAppAuthClient`` classes do
+    not accept ``authorizer`` in their init signatures. Previously this was
+    accepted but raised a ``GlobusSDKUsageError``. Attempting to pass an
+    ``authorizer`` will now result in a ``TypeError``.

--- a/src/globus_sdk/services/auth/client/base.py
+++ b/src/globus_sdk/services/auth/client/base.py
@@ -9,6 +9,8 @@ import typing as t
 import jwt
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 
+from globus_sdk.authorizers import GlobusAuthorizer
+
 if sys.version_info >= (3, 8):
     # pylint can't handle quoted annotations yet:
     # https://github.com/PyCQA/pylint/issues/3299
@@ -72,13 +74,32 @@ class AuthClient(client.BaseClient):
     error_class = AuthAPIError
     scopes = AuthScopes
 
-    def __init__(self, client_id: UUIDLike | None = None, **kwargs: t.Any) -> None:
-        super().__init__(**kwargs)
+    def __init__(
+        self,
+        client_id: UUIDLike | None = None,
+        environment: str | None = None,
+        base_url: str | None = None,
+        authorizer: GlobusAuthorizer | None = None,
+        app_name: str | None = None,
+        transport_params: dict[str, t.Any] | None = None,
+    ) -> None:
+        super().__init__(
+            environment=environment,
+            base_url=base_url,
+            authorizer=authorizer,
+            app_name=app_name,
+            transport_params=transport_params,
+        )
         self.client_id: str | None = str(client_id) if client_id is not None else None
         # an AuthClient may contain a GlobusOAuth2FlowManager in order to
         # encapsulate the functionality of various different types of flow
         # managers
         self.current_oauth2_flow_manager: GlobusOAuthFlowManager | None = None
+
+        log.info(
+            "Finished initializing AuthClient. "
+            f"client_id='{client_id}', type(authorizer)={type(authorizer)}"
+        )
 
     def get_identities(
         self,

--- a/src/globus_sdk/services/auth/client/confidential_client.py
+++ b/src/globus_sdk/services/auth/client/confidential_client.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import logging
 import typing as t
 
-from globus_sdk import exc
 from globus_sdk._types import ScopeCollectionType, UUIDLike
 from globus_sdk.authorizers import BasicAuthorizer
 from globus_sdk.response import GlobusHTTPResponse
@@ -36,18 +35,23 @@ class ConfidentialAppAuthClient(AuthClient):
     .. automethodlist:: globus_sdk.ConfidentialAppAuthClient
     """
 
-    def __init__(self, client_id: UUIDLike, client_secret: str, **kwargs: t.Any):
-        if "authorizer" in kwargs:
-            log.error("ArgumentError(ConfidentialAppClient.authorizer)")
-            raise exc.GlobusSDKUsageError(
-                "Cannot give a ConfidentialAppAuthClient an authorizer"
-            )
+    def __init__(
+        self,
+        client_id: UUIDLike,
+        client_secret: str,
+        environment: str | None = None,
+        base_url: str | None = None,
+        app_name: str | None = None,
+        transport_params: dict[str, t.Any] | None = None,
+    ) -> None:
         super().__init__(
             client_id=client_id,
             authorizer=BasicAuthorizer(str(client_id), client_secret),
-            **kwargs,
+            environment=environment,
+            base_url=base_url,
+            app_name=app_name,
+            transport_params=transport_params,
         )
-        log.info(f"Finished initializing client, client_id={client_id}")
 
     def oauth2_client_credentials_tokens(
         self,

--- a/src/globus_sdk/services/auth/client/native_client.py
+++ b/src/globus_sdk/services/auth/client/native_client.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import logging
 import typing as t
 
-from globus_sdk import exc
 from globus_sdk._types import ScopeCollectionType, UUIDLike
 from globus_sdk.authorizers import NullAuthorizer
 
@@ -31,15 +30,22 @@ class NativeAppAuthClient(AuthClient):
     .. automethodlist:: globus_sdk.NativeAppAuthClient
     """
 
-    def __init__(self, client_id: UUIDLike, **kwargs: t.Any) -> None:
-        if "authorizer" in kwargs:
-            log.error("ArgumentError(NativeAppClient.authorizer)")
-            raise exc.GlobusSDKUsageError(
-                "Cannot give a NativeAppAuthClient an authorizer"
-            )
-
-        super().__init__(client_id=client_id, authorizer=NullAuthorizer(), **kwargs)
-        log.info(f"Finished initializing client, client_id={client_id}")
+    def __init__(
+        self,
+        client_id: UUIDLike,
+        environment: str | None = None,
+        base_url: str | None = None,
+        app_name: str | None = None,
+        transport_params: dict[str, t.Any] | None = None,
+    ) -> None:
+        super().__init__(
+            client_id=client_id,
+            authorizer=NullAuthorizer(),
+            environment=environment,
+            base_url=base_url,
+            app_name=app_name,
+            transport_params=transport_params,
+        )
 
     def oauth2_start_flow(
         self,

--- a/tests/non-pytest/mypy-ignore-tests/auth_client_initialization.py
+++ b/tests/non-pytest/mypy-ignore-tests/auth_client_initialization.py
@@ -1,0 +1,18 @@
+import globus_sdk
+
+# ok usage
+ac = globus_sdk.AuthClient()
+nc = globus_sdk.NativeAppAuthClient("foo_client_id")
+cc = globus_sdk.ConfidentialAppAuthClient("foo_client_id", "foo_client_secret")
+
+# base class allows authorizer
+authorizer = globus_sdk.AccessTokenAuthorizer("dummytoken")
+ac = globus_sdk.AuthClient(authorizer=authorizer)
+
+# subclasses forbid authorizers
+nc = globus_sdk.NativeAppAuthClient(  # type: ignore[call-arg]
+    "foo_client_id", authorizer=authorizer
+)
+cc = globus_sdk.ConfidentialAppAuthClient(  # type: ignore[call-arg]
+    "foo_client_id", "foo_client_secret", authorizer=authorizer
+)

--- a/tests/unit/test_auth_clients.py
+++ b/tests/unit/test_auth_clients.py
@@ -1,3 +1,4 @@
+import unittest.mock
 import uuid
 
 import pytest
@@ -28,3 +29,15 @@ def test_can_use_uuid_or_str_for_client_id(client_type, pass_value_as):
         raise NotImplementedError
 
     assert client.client_id == CLIENT_ID_STR
+
+
+def test_native_app_auth_client_rejects_authorizer():
+    authorizer = unittest.mock.Mock()
+    with pytest.raises(TypeError):
+        NativeAppAuthClient(CLIENT_ID_UUID, authorizer=authorizer)
+
+
+def test_confidential_app_auth_client_rejects_authorizer():
+    authorizer = unittest.mock.Mock()
+    with pytest.raises(TypeError):
+        ConfidentialAppAuthClient(CLIENT_ID_UUID, "foo-secret", authorizer=authorizer)


### PR DESCRIPTION
This change serves three purposes:
- improve type annotations
- forbid the use of `authorizer` merely by omitting it from the signatures
- add tests which ensure that `authorizer` is rejected (previously missing)

The change is backwards compatible under most definitions of compatibility.

The new tests cover runtime (TypeError) and typing-time.

<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--764.org.readthedocs.build/en/764/

<!-- readthedocs-preview globus-sdk-python end -->