### PR TITLE
Changelog refinement part 2

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -7,18 +7,41 @@
 
 ## Procedure
 
-- Make sure your repo is on `main` and up to date; `git checkout main; git pull`
+- Make sure your repo is on `main` and up to date
+
+```
+git checkout main
+git pull
+```
+
 - Read `changelog.d/` and decide if the release is MINOR or PATCH
 - Update the version in `src/globus_sdk/version.py`
-- Update metadata and changelog; `make prepare-release`
-- Verify changes are listed correctly in `changelog.rst`
-- Add changed files;
-    `git add changelog.d/ docs/changelog.rst src/globus_sdk/version.py`
-- Commit; `git commit -m 'Bump version and changelog for release'`
-- Push to main; `git push origin main`
-- Tag the release; `make tag-release`
-    _This will run a workflow to publish to test-pypi_
-- Create a GitHub release with a copy of the changelog
-    _This will run a workflow to publish to pypi_
-    - You can use `./scripts/changelog2md.py` to get GitHub-flavored
-      markdown from the last changelog section
+- Update metadata and changelog, then verify changes in `changelog.rst`
+
+```
+make prepare-release
+$EDITOR changelog.rst
+```
+
+- Add and commit changed files, then push to `main`
+
+```
+git add changelog.d/ docs/changelog.rst src/globus_sdk/version.py
+git commit -m 'Bump version and changelog for release'
+git push origin main
+```
+
+- Tag the release. _This will run a workflow to publish to test-pypi._
+
+```
+make tag-release
+```
+
+- Create a GitHub release with a copy of the changelog. _This will run a workflow to publish to pypi._
+
+Generate the release body by running
+```
+./scripts/changelog2md.py
+```
+
+The name of the GitHub release should be `v$SDK_VERSION`.

--- a/changelog.d/20230623_102145_sirosen_auth_client_init_signatures.rst
+++ b/changelog.d/20230623_102145_sirosen_auth_client_init_signatures.rst
@@ -1,3 +1,6 @@
+Changed
+~~~~~~~
+
 * ``AuthClient``, ``NativeAppAuthClient``, and ``ConfidentialAppAuthClient``
   have had their init signatures updated to explicitly list available
   parameters. (:pr:`764`)


### PR DESCRIPTION
Mostly, this is a refinement to the releasing doc in response to some conversation around #763.
In particular, it seemed that the doc could be clearer by being more direct and imperative about using the changelog2md.py script. More generally, such a change is reasonable to couple with a re-drafting of the full procedure text to try to make it easier to follow.

<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--765.org.readthedocs.build/en/765/

<!-- readthedocs-preview globus-sdk-python end -->