### PR TITLE
Add support for Auth "Get Projects"

### DIFF
--- a/changelog.d/20230623_162743_sirosen_add_get_projects.rst
+++ b/changelog.d/20230623_162743_sirosen_add_get_projects.rst
@@ -1,0 +1,4 @@
+Added
+~~~~~
+
+- Add ``AuthClient.get_projects`` to support the Get Projects API (:pr:`NUMBER`)

--- a/src/globus_sdk/_testing/data/auth/get_projects.py
+++ b/src/globus_sdk/_testing/data/auth/get_projects.py
@@ -1,0 +1,70 @@
+import uuid
+
+from globus_sdk._testing.models import RegisteredResponse, ResponseSet
+
+GUARDIANS_IDP_ID = str(uuid.uuid1())
+STAR_LORD = {
+    "identity_provider": GUARDIANS_IDP_ID,
+    "identity_type": "login",
+    "organization": "Guardians of the Galaxy",
+    "status": "used",
+    "id": str(uuid.uuid1()),
+    "name": "Star Lord",
+    "username": "star.lord@guardians.galaxy",
+    # I thought it would be funny if he didn't get 'star.lord'
+    # because someone else got it first
+    "email": "star.lord2@guardians.galaxy",
+}
+ROCKET_RACCOON = {
+    "identity_provider": GUARDIANS_IDP_ID,
+    "identity_type": "login",
+    "organization": "Guardians of the Galaxy",
+    "status": "used",
+    "id": str(uuid.uuid1()),
+    "name": "Rocket",
+    "username": "rocket@guardians.galaxy",
+    # and think about it, who else would try to lay claim
+    # to that email address?
+    "email": "star.lord@guardians.galaxy",
+}
+
+EVIL_TEST_PROJECT = {
+    "admin_ids": [ROCKET_RACCOON["id"]],
+    "contact_email": "eviltestproject@guardians.galaxy",
+    "display_name": "Evil Test Project Full of Evil",
+    "admin_group_ids": None,
+    "id": str(uuid.uuid1()),
+    "project_name": "Evil Test Project Full of Evil",
+    "admins": {
+        "identities": [ROCKET_RACCOON],
+        "groups": [],
+    },
+}
+
+GUARDIANS_PROJECT = {
+    "admin_ids": [ROCKET_RACCOON["id"]],
+    "contact_email": "support@guardians.galaxy",
+    "display_name": "Guardians of the Galaxy Portal",
+    "admin_group_ids": None,
+    "id": str(uuid.uuid1()),
+    "project_name": "Guardians of the Galaxy Portal",
+    "admins": {
+        "identities": [STAR_LORD, ROCKET_RACCOON],
+        "groups": [],
+    },
+}
+
+RESPONSES = ResponseSet(
+    default=RegisteredResponse(
+        service="auth",
+        path="/v2/api/projects",
+        json={"projects": [EVIL_TEST_PROJECT, GUARDIANS_PROJECT]},
+        metadata={
+            "project_ids": [EVIL_TEST_PROJECT["id"], GUARDIANS_PROJECT["id"]],
+            "admin_map": {
+                EVIL_TEST_PROJECT["id"]: [ROCKET_RACCOON["id"]],
+                GUARDIANS_PROJECT["id"]: [STAR_LORD["id"], ROCKET_RACCOON["id"]],
+            },
+        },
+    )
+)

--- a/src/globus_sdk/services/auth/client/base.py
+++ b/src/globus_sdk/services/auth/client/base.py
@@ -21,7 +21,7 @@ else:
 from globus_sdk import client, exc, utils
 from globus_sdk._types import UUIDLike
 from globus_sdk.authorizers import NullAuthorizer
-from globus_sdk.response import GlobusHTTPResponse
+from globus_sdk.response import GlobusHTTPResponse, IterableResponse
 from globus_sdk.scopes import AuthScopes
 
 from ..errors import AuthAPIError
@@ -29,6 +29,7 @@ from ..flow_managers import GlobusOAuthFlowManager
 from ..response import (
     GetIdentitiesResponse,
     GetIdentityProvidersResponse,
+    GetProjectsResponse,
     OAuthTokenResponse,
 )
 
@@ -316,6 +317,58 @@ class AuthClient(client.BaseClient):
         return GetIdentityProvidersResponse(
             self.get("/v2/api/identity_providers", query_params=query_params)
         )
+
+    def get_projects(self) -> IterableResponse:
+        """
+        Look up projects on which the authenticated user is an admin.
+        Requires the ``manage_projects`` scope.
+
+        .. tab-set::
+
+            .. tab-item:: Example Usage
+
+                .. code-block:: pycon
+
+                    >>> ac = globus_sdk.AuthClient(...)
+                    >>> r = ac.get_projects()
+                    >>> r.data
+                    {
+                      'projects": [
+                        {
+                          'admin_ids": ["41143743-f3c8-4d60-bbdb-eeecaba85bd9"]
+                          'contact_email": "support@globus.org",
+                          'display_name": "Globus SDK Demo Project",
+                          'admin_group_ids": None,
+                          'id": "927d7238-f917-4eb2-9ace-c523fa9ba34e",
+                          'project_name": "Globus SDK Demo Project",
+                          'admins": {
+                            'identities": ["41143743-f3c8-4d60-bbdb-eeecaba85bd9"],
+                            'groups": [],
+                          },
+                      ]
+                    }
+
+                The result itself is iterable, so you can use it like so:
+
+                .. code-block:: python
+
+                    for project in ac.get_projects():
+                        print(f"name: {project['display_name']}")
+                        print(f"id: {project['id']}")
+                        print()
+
+            .. tab-item:: Example Response Data
+
+                .. expandtestfixture:: auth.get_projects
+
+            .. tab-item:: API Info
+
+                ``GET /v2/api/projects``
+
+                .. extdoclink:: Get Projects
+                    :ref: auth/reference/#get_projects
+        """  # noqa: E501
+        return GetProjectsResponse(self.get("/v2/api/projects"))
 
     def oauth2_get_authorize_url(
         self, *, query_params: dict[str, t.Any] | None = None

--- a/src/globus_sdk/services/auth/response/__init__.py
+++ b/src/globus_sdk/services/auth/response/__init__.py
@@ -1,9 +1,11 @@
 from .identities import GetIdentitiesResponse, GetIdentityProvidersResponse
 from .oauth import OAuthDependentTokenResponse, OAuthTokenResponse
+from .projects import GetProjectsResponse
 
 __all__ = (
     "GetIdentitiesResponse",
     "GetIdentityProvidersResponse",
+    "GetProjectsResponse",
     "OAuthTokenResponse",
     "OAuthDependentTokenResponse",
 )

--- a/src/globus_sdk/services/auth/response/projects.py
+++ b/src/globus_sdk/services/auth/response/projects.py
@@ -1,0 +1,11 @@
+from globus_sdk.response import IterableResponse
+
+
+class GetProjectsResponse(IterableResponse):
+    """
+    Response class specific to the Get Projects API
+
+    Provides iteration on the "projects" array in the response.
+    """
+
+    default_iter_key = "projects"

--- a/tests/functional/services/auth/base/test_get_projects.py
+++ b/tests/functional/services/auth/base/test_get_projects.py
@@ -1,0 +1,8 @@
+from globus_sdk._testing import load_response
+
+
+def test_get_projects(client):
+    meta = load_response(client.get_projects).metadata
+    res = client.get_projects()
+
+    assert [x["id"] for x in res] == meta["project_ids"]


### PR DESCRIPTION
- Introduce the `AuthClient.get_projects` method + a mock with test data for it. As of today, it takes no parameters.
- This uses a specialized response type, like other iterable responses.

<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--766.org.readthedocs.build/en/766/

<!-- readthedocs-preview globus-sdk-python end -->