### PR TITLE
Update authorization params parsing: support list[str] for policies and more type safety

### DIFF
--- a/changelog.d/20230629_121831_sirosen_update_authorization_params_parsing.rst
+++ b/changelog.d/20230629_121831_sirosen_update_authorization_params_parsing.rst
@@ -4,3 +4,10 @@ Changed
 - ``session_required_policies`` parsing in ``AuthorizationParameterInfo`` now
   supports the policies being returned as a ``list[str]`` in addition to
   supporting ``str`` (:pr:`NUMBER`)
+
+Fixed
+~~~~~
+
+- ``AuthorizationParameterInfo`` is now more type-safe, and will not return
+  parsed data from a response without checking that the data has correct types
+  (:pr:`NUMBER`)

--- a/changelog.d/20230629_121831_sirosen_update_authorization_params_parsing.rst
+++ b/changelog.d/20230629_121831_sirosen_update_authorization_params_parsing.rst
@@ -1,0 +1,6 @@
+Changed
+~~~~~~~
+
+- ``session_required_policies`` parsing in ``AuthorizationParameterInfo`` now
+  supports the policies being returned as a ``list[str]`` in addition to
+  supporting ``str`` (:pr:`NUMBER`)

--- a/src/globus_sdk/exc/err_info.py
+++ b/src/globus_sdk/exc/err_info.py
@@ -71,16 +71,20 @@ class AuthorizationParameterInfo(ErrorInfo):
             data.get("session_required_single_domain"),
         )
 
-        # get str|None and parse as appropriate
+        # get str|list[str]|None and parse as appropriate
         self.session_required_policies: list[str] | None = None
         session_required_policies = data.get("session_required_policies")
         if isinstance(session_required_policies, str):
             self.session_required_policies = session_required_policies.split(",")
+        elif isinstance(session_required_policies, list):
+            self.session_required_policies = [
+                p for p in session_required_policies if isinstance(p, str)
+            ]
         elif session_required_policies is not None:
             log.warning(
                 "During ErrorInfo instantiation, got unexpected type for "
                 "'session_required_policies'. "
-                f"Expected 'str', but got '{type(session_required_policies)}'"
+                f"Expected 'str' or 'list', but got '{type(session_required_policies)}'"
             )
 
 

--- a/src/globus_sdk/exc/err_info.py
+++ b/src/globus_sdk/exc/err_info.py
@@ -1,12 +1,18 @@
 from __future__ import annotations
 
 import logging
+import sys
 import typing as t
+
+if sys.version_info < (3, 10):
+    from typing_extensions import TypeGuard
+else:
+    from typing import TypeGuard
 
 log = logging.getLogger(__name__)
 
 
-def _is_list_of_strs(obj: t.Any) -> bool:
+def _is_list_of_strs(obj: t.Any) -> TypeGuard[list[str]]:
     return isinstance(obj, list) and all(isinstance(item, str) for item in obj)
 
 

--- a/src/globus_sdk/exc/err_info.py
+++ b/src/globus_sdk/exc/err_info.py
@@ -6,6 +6,10 @@ import typing as t
 log = logging.getLogger(__name__)
 
 
+def _is_list_of_strs(obj: t.Any) -> bool:
+    return isinstance(obj, list) and all(isinstance(item, str) for item in obj)
+
+
 class ErrorInfo:
     """
     Errors may contain "containers" of data which are testable (define ``__bool__``).
@@ -62,30 +66,75 @@ class AuthorizationParameterInfo(ErrorInfo):
             t.Dict[str, t.Any], error_data.get("authorization_parameters", {})
         )
 
-        self.session_message = t.cast(t.Optional[str], data.get("session_message"))
-        self.session_required_identities = t.cast(
-            t.Optional[t.List[str]], data.get("session_required_identities")
-        )
-        self.session_required_single_domain = t.cast(
-            t.Optional[t.List[str]],
-            data.get("session_required_single_domain"),
-        )
+        self.session_message: str | None = self._parse_session_message(data)
 
-        # get str|list[str]|None and parse as appropriate
-        self.session_required_policies: list[str] | None = None
+        self.session_required_identities: (
+            list[str] | None
+        ) = self._parse_session_required_identities(data)
+
+        self.session_required_single_domain: (
+            list[str] | None
+        ) = self._parse_session_required_single_domain(data)
+
+        self.session_required_policies: (
+            list[str] | None
+        ) = self._parse_session_required_policies(data)
+
+    def _parse_session_message(self, data: dict[str, t.Any]) -> str | None:
+        session_message = data.get("session_message")
+        if isinstance(session_message, str):
+            return session_message
+        elif session_message is not None:
+            self._warn_type("session_message", "str", session_message)
+        return None
+
+    def _parse_session_required_identities(
+        self, data: dict[str, t.Any]
+    ) -> list[str] | None:
+        session_required_identities = data.get("session_required_identities")
+        if _is_list_of_strs(session_required_identities):
+            return session_required_identities
+        elif session_required_identities is not None:
+            self._warn_type(
+                "session_required_identities",
+                "list[str]",
+                session_required_identities,
+            )
+        return None
+
+    def _parse_session_required_single_domain(
+        self, data: dict[str, t.Any]
+    ) -> list[str] | None:
+        session_required_single_domain = data.get("session_required_single_domain")
+        if _is_list_of_strs(session_required_single_domain):
+            return session_required_single_domain
+        elif session_required_single_domain is not None:
+            self._warn_type(
+                "session_required_single_domain",
+                "list[str]",
+                session_required_single_domain,
+            )
+        return None
+
+    def _parse_session_required_policies(
+        self, data: dict[str, t.Any]
+    ) -> list[str] | None:
         session_required_policies = data.get("session_required_policies")
         if isinstance(session_required_policies, str):
-            self.session_required_policies = session_required_policies.split(",")
-        elif isinstance(session_required_policies, list):
-            self.session_required_policies = [
-                p for p in session_required_policies if isinstance(p, str)
-            ]
+            return session_required_policies.split(",")
+        elif _is_list_of_strs(session_required_policies):
+            return session_required_policies
         elif session_required_policies is not None:
-            log.warning(
-                "During ErrorInfo instantiation, got unexpected type for "
-                "'session_required_policies'. "
-                f"Expected 'str' or 'list', but got '{type(session_required_policies)}'"
+            self._warn_type(
+                "session_required_policies", "list[str]|str", session_required_policies
             )
+        return None
+
+    def _warn_type(self, key: str, expected: str, got: t.Any) -> None:
+        log.warning(
+            f"During ErrorInfo instantiation, got unexpected type for '{key}'. "
+            f"Expected '{expected}'. Got '{got}'"
+        )
 
 
 class ConsentRequiredInfo(ErrorInfo):
@@ -107,11 +156,9 @@ class ConsentRequiredInfo(ErrorInfo):
         self._has_data = has_code and bool(self.required_scopes)
 
     def _parse_required_scopes(self, data: dict[str, t.Any]) -> list[str]:
-        if isinstance(data.get("required_scopes"), list) and all(
-            isinstance(item, str) for item in data["required_scopes"]
-        ):
+        if _is_list_of_strs(data.get("required_scopes")):
             return t.cast("list[str]", data["required_scopes"])
-        if isinstance(data.get("required_scope"), str):
+        elif isinstance(data.get("required_scope"), str):
             return [data["required_scope"]]
         return []
 

--- a/tests/unit/errors/test_common_functionality.py
+++ b/tests/unit/errors/test_common_functionality.py
@@ -180,6 +180,29 @@ def test_authz_params_info_containing_session_message(make_json_response):
     )
 
 
+def test_authz_params_info_containing_malformed_session_message(make_json_response):
+    res = make_json_response(
+        {"authorization_parameters": {"session_message": 100}}, 401
+    )
+    err = GlobusAPIError(res.r)
+    assert bool(err.info.authorization_parameters) is True
+    assert err.info.authorization_parameters.session_message is None
+    assert err.info.authorization_parameters.session_required_identities is None
+    assert err.info.authorization_parameters.session_required_single_domain is None
+    assert err.info.authorization_parameters.session_required_policies is None
+    _strmatch_any_order(
+        str(err.info.authorization_parameters),
+        "AuthorizationParameterInfo(",
+        [
+            "session_message=None",
+            "session_required_identities=None",
+            "session_required_single_domain=None",
+            "session_required_policies=None",
+        ],
+        ")",
+    )
+
+
 def test_authz_params_info_containing_session_required_identities(make_json_response):
     res = make_json_response(
         {"authorization_parameters": {"session_required_identities": ["foo", "bar"]}},
@@ -200,6 +223,32 @@ def test_authz_params_info_containing_session_required_identities(make_json_resp
         [
             "session_message=None",
             "session_required_identities=['foo', 'bar']",
+            "session_required_single_domain=None",
+            "session_required_policies=None",
+        ],
+        ")",
+    )
+
+
+def test_authz_params_info_containing_malformed_session_required_identities(
+    make_json_response,
+):
+    res = make_json_response(
+        {"authorization_parameters": {"session_required_identities": "foo,bar"}},
+        401,
+    )
+    err = GlobusAPIError(res.r)
+    assert bool(err.info.authorization_parameters) is True
+    assert err.info.authorization_parameters.session_message is None
+    assert err.info.authorization_parameters.session_required_identities is None
+    assert err.info.authorization_parameters.session_required_single_domain is None
+    assert err.info.authorization_parameters.session_required_policies is None
+    _strmatch_any_order(
+        str(err.info.authorization_parameters),
+        "AuthorizationParameterInfo(",
+        [
+            "session_message=None",
+            "session_required_identities=None",
             "session_required_single_domain=None",
             "session_required_policies=None",
         ],
@@ -240,9 +289,38 @@ def test_authz_params_info_containing_session_required_single_domain(
     )
 
 
-def test_authz_params_info_containing_session_required_policies(make_json_response):
+def test_authz_params_info_containing_malformed_session_required_single_domain(
+    make_json_response,
+):
     res = make_json_response(
-        {"authorization_parameters": {"session_required_policies": "foo,bar"}}, 401
+        {"authorization_parameters": {"session_required_single_domain": "foo,bar"}},
+        401,
+    )
+    err = GlobusAPIError(res.r)
+    assert bool(err.info.authorization_parameters) is True
+    assert err.info.authorization_parameters.session_message is None
+    assert err.info.authorization_parameters.session_required_identities is None
+    assert err.info.authorization_parameters.session_required_single_domain is None
+    assert err.info.authorization_parameters.session_required_policies is None
+    _strmatch_any_order(
+        str(err.info.authorization_parameters),
+        "AuthorizationParameterInfo(",
+        [
+            "session_message=None",
+            "session_required_identities=None",
+            "session_required_single_domain=None",
+            "session_required_policies=None",
+        ],
+        ")",
+    )
+
+
+@pytest.mark.parametrize("policies_value", ["foo,bar", ["foo", "bar"]])
+def test_authz_params_info_containing_session_required_policies(
+    make_json_response, policies_value
+):
+    res = make_json_response(
+        {"authorization_parameters": {"session_required_policies": policies_value}}, 401
     )
     err = GlobusAPIError(res.r)
     assert bool(err.info.authorization_parameters) is True
@@ -269,7 +347,7 @@ def test_authz_params_info_containing_malformed_session_required_policies(
     # confirm that if `session_required_policies` is not a string,
     # it will parse as `None`
     res = make_json_response(
-        {"authorization_parameters": {"session_required_policies": ["foo"]}}, 401
+        {"authorization_parameters": {"session_required_policies": {"foo": "bar"}}}, 401
     )
     err = GlobusAPIError(res.r)
     assert bool(err.info.authorization_parameters) is True


### PR DESCRIPTION
The changelog pretty much says it all in terms of what is changing.
The implementation was refactored a bit to support these changes.

# Changelog

## Changed

- ``session_required_policies`` parsing in ``AuthorizationParameterInfo`` now supports the policies being returned as a ``list[str]`` in addition to supporting ``str``

## Fixed

- ``AuthorizationParameterInfo`` is now more type-safe, and will not return parsed data from a response without checking that the data has correct types

<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--769.org.readthedocs.build/en/769/

<!-- readthedocs-preview globus-sdk-python end -->