### PR TITLE
Add keyword arg guidelines to contrib doc

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -68,3 +68,14 @@ Style guidance which doesn't get handled by linters and fixers:
 
   - If a docstring contains special characters like `\\`, consider using a raw
     string to ensure it renders correctly
+
+  - Use the `*` marker for keyword-only arguments for any signatures which
+    take keyword arguments. (For an explanation, see
+    [PEP 3102](https://peps.python.org/pep-3102/).)
+
+  - Avoid use of `**kwargs` to capture arbitrary keyword arguments.  Instead,
+    always define a named dict argument for any open extension points (see
+    `query_params` for prior art in the SDK, or `extra` in `logging` for a
+    case from the stdlib).
+    This makes type checking more effective and avoids a class of backwards
+    compatibility issues when arguments are added.


### PR DESCRIPTION
In response to some discussion around `**kwargs`, we agreed that I should take a first crack at these guidelines.

I tried to provide some context without lengthy exposition, and I've included a link to the PEP which introduced the `*` marker.
One thing I debated, but decided against, was any note about "new functions" (vs in general) and the theme that these rules are broken not-infrequently for backwards compatibility. I think that's a given in any codebase with this level of history, so I opted to just make the blanket statements and trust that the compatibility concerns are implicitly clear.


### Backwards compatibility around `**kwargs` capturing

I avoided explaining in the text of the contrib doc, but, to illuminate the mention of "a class of backwards compatibility concerns", here's a bit of detail.

There are cases in which adding keyword arguments is not incompatible or not majorly so. This is completely compatible:
```python
# v1
def foo(**kwargs):
    return {k: v for k, v in kwargs.items() if v is not None}

# v2
def foo(bar: str | None = None, **kwargs):
    data = kwargs.copy()
    if bar is not None:
        data["bar"] = bar
    return {k: v for k, v in data.items() if v is not None}
```

But there are simple cases in which it becomes nasty quickly. Here's a trivial-if-silly example:
```python
def foo(a: int | None = None, b: int | None = None, **kwargs):
    data1 = {"a": a, "b": b}
    return (
        {k: v for k, v in data1.items() if v is not None},
        {k: v for k, v in kwargs.items() if v is not None},
    )
```

Because this function was defined to capture all of `**kwargs` into a specific area of functionality, it's not possible to add `c: int | None = None` as an item to include in the `data1` component.

Avoiding `**kwargs` ensures that we don't find ourselves in this sort of unfortunate situation.

<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--775.org.readthedocs.build/en/775/

<!-- readthedocs-preview globus-sdk-python end -->