### PR TITLE
Fix the `FlowsClient.get_run()` `include_flow_description` parameter

### DIFF
--- a/changelog.d/20230706_111957_kurtmckee_fix_include_flow_description_parameter_sc_25534.rst
+++ b/changelog.d/20230706_111957_kurtmckee_fix_include_flow_description_parameter_sc_25534.rst
@@ -2,4 +2,4 @@ Fixed
 ~~~~~
 
 -   Adjust the ``FlowsClient.get_run()`` ``include_flow_description`` parameter
-    so it is sent as a lowercase string (``true`` or ``false``). (:pr:`NUMBER`)
+    so it is submitted only when it has a value. (:pr:`NUMBER`)

--- a/changelog.d/20230706_111957_kurtmckee_fix_include_flow_description_parameter_sc_25534.rst
+++ b/changelog.d/20230706_111957_kurtmckee_fix_include_flow_description_parameter_sc_25534.rst
@@ -1,0 +1,5 @@
+Fixed
+~~~~~
+
+-   Adjust the ``FlowsClient.get_run()`` ``include_flow_description`` parameter
+    so it is sent as a lowercase string (``true`` or ``false``). (:pr:`NUMBER`)

--- a/src/globus_sdk/_testing/data/flows/get_run.py
+++ b/src/globus_sdk/_testing/data/flows/get_run.py
@@ -78,14 +78,21 @@ RESPONSES = ResponseSet(
             method="GET",
             path=f"/runs/{RUN_ID}",
             json=RUN,
-            match=[query_param_matcher(params={"include_flow_description": False})],
+            match=[query_param_matcher(params={})],
+        ),
+        RegisteredResponse(
+            service="flows",
+            method="GET",
+            path=f"/runs/{RUN_ID}",
+            json=RUN,
+            match=[query_param_matcher(params={"include_flow_description": "false"})],
         ),
         RegisteredResponse(
             service="flows",
             method="GET",
             path=f"/runs/{RUN_ID}",
             json=RUN_WITH_FLOW_DESCRIPTION,
-            match=[query_param_matcher(params={"include_flow_description": True})],
+            match=[query_param_matcher(params={"include_flow_description": "true"})],
         ),
     ),
 )

--- a/src/globus_sdk/_testing/data/flows/get_run.py
+++ b/src/globus_sdk/_testing/data/flows/get_run.py
@@ -85,14 +85,14 @@ RESPONSES = ResponseSet(
             method="GET",
             path=f"/runs/{RUN_ID}",
             json=RUN,
-            match=[query_param_matcher(params={"include_flow_description": "false"})],
+            match=[query_param_matcher(params={"include_flow_description": "False"})],
         ),
         RegisteredResponse(
             service="flows",
             method="GET",
             path=f"/runs/{RUN_ID}",
             json=RUN_WITH_FLOW_DESCRIPTION,
-            match=[query_param_matcher(params={"include_flow_description": "true"})],
+            match=[query_param_matcher(params={"include_flow_description": "True"})],
         ),
     ),
 )

--- a/src/globus_sdk/services/flows/client.py
+++ b/src/globus_sdk/services/flows/client.py
@@ -549,7 +549,7 @@ class FlowsClient(client.BaseClient):
         self,
         run_id: UUIDLike,
         *,
-        include_flow_description: bool = False,
+        include_flow_description: bool | None = None,
         query_params: dict[str, t.Any] | None = None,
     ) -> GlobusHTTPResponse:
         """
@@ -587,14 +587,14 @@ class FlowsClient(client.BaseClient):
                     :ref: Flows/paths/~1runs~1{run_id}/get
         """
 
-        additional_query_params = query_params or {}
+        consolidated_query_params = query_params or {}
+        if include_flow_description is not None:
+            value = str(include_flow_description).lower()  # "true" or "false"
+            consolidated_query_params["include_flow_description"] = value
 
         return self.get(
             f"/runs/{run_id}",
-            query_params={
-                "include_flow_description": include_flow_description,
-                **additional_query_params,
-            },
+            query_params=consolidated_query_params,
         )
 
     def cancel_run(self, run_id: UUIDLike) -> GlobusHTTPResponse:

--- a/src/globus_sdk/services/flows/client.py
+++ b/src/globus_sdk/services/flows/client.py
@@ -587,15 +587,11 @@ class FlowsClient(client.BaseClient):
                     :ref: Flows/paths/~1runs~1{run_id}/get
         """
 
-        consolidated_query_params = query_params or {}
+        query_params = query_params or {}
         if include_flow_description is not None:
-            value = str(include_flow_description).lower()  # "true" or "false"
-            consolidated_query_params["include_flow_description"] = value
+            query_params["include_flow_description"] = include_flow_description
 
-        return self.get(
-            f"/runs/{run_id}",
-            query_params=consolidated_query_params,
-        )
+        return self.get(f"/runs/{run_id}", query_params=query_params)
 
     def cancel_run(self, run_id: UUIDLike) -> GlobusHTTPResponse:
         """

--- a/tests/functional/services/flows/test_get_run.py
+++ b/tests/functional/services/flows/test_get_run.py
@@ -1,17 +1,25 @@
-from globus_sdk._testing import load_response
+import pytest
+
+from globus_sdk._testing import get_last_request, load_response
 
 
-def test_get_run(flows_client):
+@pytest.mark.parametrize("include_flow_description", (None, False, True))
+def test_get_run(flows_client, include_flow_description):
     metadata = load_response(flows_client.get_run).metadata
 
-    resp = flows_client.get_run(metadata["run_id"])
-    assert resp.http_status == 200
-    assert "flow_description" not in resp
+    response = flows_client.get_run(
+        metadata["run_id"],
+        include_flow_description=include_flow_description,
+    )
+    assert response.http_status == 200
 
-
-def test_get_run_with_flow_description(flows_client):
-    metadata = load_response(flows_client.get_run).metadata
-
-    resp = flows_client.get_run(metadata["run_id"], include_flow_description=True)
-    assert resp.http_status == 200
-    assert "flow_description" in resp
+    request = get_last_request()
+    if include_flow_description is None:
+        assert "flow_description" not in response
+        assert "include_flow_description" not in request.url
+    elif include_flow_description is False:
+        assert "flow_description" not in response
+        assert "include_flow_description=false" in request.url
+    else:  # include_flow_description is True
+        assert "flow_description" in response
+        assert "include_flow_description=true" in request.url

--- a/tests/functional/services/flows/test_get_run.py
+++ b/tests/functional/services/flows/test_get_run.py
@@ -19,7 +19,7 @@ def test_get_run(flows_client, include_flow_description):
         assert "include_flow_description" not in request.url
     elif include_flow_description is False:
         assert "flow_description" not in response
-        assert "include_flow_description=false" in request.url
+        assert "include_flow_description=False" in request.url
     else:  # include_flow_description is True
         assert "flow_description" in response
-        assert "include_flow_description=true" in request.url
+        assert "include_flow_description=True" in request.url


### PR DESCRIPTION
Fixed
-----

-   Adjust the ``FlowsClient.get_run()`` ``include_flow_description`` parameter
    so it is sent as a lowercase string (``true`` or ``false``).


<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--778.org.readthedocs.build/en/778/

<!-- readthedocs-preview globus-sdk-python end -->