### PR TITLE
Proof of concept: reject invalid inherited methods

### DIFF
--- a/src/globus_sdk/services/auth/client/native_client.py
+++ b/src/globus_sdk/services/auth/client/native_client.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import typing as t
 
+from globus_sdk import utils
 from globus_sdk._types import ScopeCollectionType, UUIDLike
 from globus_sdk.authorizers import NullAuthorizer
 
@@ -13,6 +14,9 @@ from .base import AuthClient
 log = logging.getLogger(__name__)
 
 
+@utils.replace_notimplemented_methods(
+    "get_identities",
+)
 class NativeAppAuthClient(AuthClient):
     """
     This type of ``AuthClient`` is used to represent a Native App's

--- a/src/globus_sdk/utils.py
+++ b/src/globus_sdk/utils.py
@@ -28,6 +28,23 @@ def b64str(s: str) -> str:
     return b64encode(s.encode("utf-8")).decode("utf-8")
 
 
+def replace_notimplemented_methods(*methodnames: str) -> t.Callable[[T], T]:
+    def gen_notimplemented(method: str) -> t.Callable[..., t.NoReturn]:
+        def injected_method(self: t.Any, *args: t.Any, **kwargs: t.Any) -> t.NoReturn:
+            raise NotImplementedError(
+                f"{self.__class__.__name__} does not support {method}"
+            )
+
+        return injected_method
+
+    def decorator(cls: T) -> T:
+        for methodname in methodnames:
+            setattr(cls, methodname, gen_notimplemented(methodname))
+        return cls
+
+    return decorator
+
+
 def slash_join(a: str, b: str | None) -> str:
     """
     Join a and b with a single slash, regardless of whether they already


### PR DESCRIPTION
AuthClient is gaining a number of methods related to authenticated usages which require token auth. These methods will not be functional for NativeAppAuthClient and ConfidentialAppAuthClient.

Because it is difficult to make a backwards-compatible change which alters the inheritance relationship for AuthClient and the other client types, it may be worth exploring other methods for ensuring that these "never functional" methods provide clear user-feedback that they do not work.
Possibly -- arguably -- the inheritance relationship that produces `isinstance(NativeAppAuthClient("foo"), AuthClient)` could be considered outside of our public interfaces. That would leave us free to make all three client types inherit from a new base (`BaseAuthClient`?) and attach the new methods only to `AuthClient`. However, if we consider this part of the public interface, then an alternative solution is needed.

This changeset introduces a class decorator
(`globus_sdk.utils.replace_notimplemented_methods`) which replaces named inherited methods with stubs which raise `NotImplementedError` with a generated message. The result is a slightly awkward trace, but a clear error on bad usage:

    >>> nc.get_identities(ids="foo")
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File ".../foo/bar/globus_sdk/utils.py", line 34, in injected_method
        raise NotImplementedError(
    NotImplementedError: NativeAppAuthClient does not support get_identities

If the methodology is considered sound, we can decorate NativeAppAuthClient and ConfidentialAppAuthClient with known-unsupported method names for SDK v3.x and plan to change the inheritance structure in v4.0 . A full enumeration of supported and unsupported usages would be needed to make this feasible, along with a detailed changelog enumerating the now NotImplementedError-raising methods.

<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--783.org.readthedocs.build/en/783/

<!-- readthedocs-preview globus-sdk-python end -->