### PR TITLE
Allow base_url without service_name in clients

### DIFF
--- a/changelog.d/20230717_162222_sirosen_improve_url_enforcement_logic.rst
+++ b/changelog.d/20230717_162222_sirosen_improve_url_enforcement_logic.rst
@@ -1,0 +1,13 @@
+Changed
+~~~~~~~
+
+- The enforcement logic for URLs in ``BaseClient`` instantiation has been
+  improved to only require that ``service_name`` be set if ``base_url`` is not
+  provided. (:pr:`NUMBER`)
+
+  - This change primarily impacts subclasses, which no longer need to set the
+    ``service_name`` class variable if they ensure that the ``base_url`` is
+    always passed with a non-null value.
+
+  - Direct instantiation of ``BaseClient`` is now possible, although not
+    recommended for most use-cases.

--- a/src/globus_sdk/services/gcs/client.py
+++ b/src/globus_sdk/services/gcs/client.py
@@ -36,6 +36,7 @@ class GCSClient(client.BaseClient):
     .. automethodlist:: globus_sdk.GCSClient
     """
 
+    # TODO: under SDK v4.0, service_name should not be set
     service_name = "globus_connect_server"
     error_class = GCSAPIError
 

--- a/tests/unit/test_base_client.py
+++ b/tests/unit/test_base_client.py
@@ -42,6 +42,14 @@ def test_cannot_instantiate_plain_base_client():
         globus_sdk.BaseClient()
 
 
+def test_can_instantiate_base_client_with_explicit_url():
+    # note how a trailing slash is added due to the default
+    # base_path of '/'
+    # this may change in a future major version, to preserve the base_url exactly
+    client = globus_sdk.BaseClient(base_url="https://example.org")
+    assert client.base_url == "https://example.org/"
+
+
 def test_set_http_timeout(base_client):
     class FooClient(globus_sdk.BaseClient):
         service_name = "foo"


### PR DESCRIPTION
base_url can now be used to effectively skip the check for `service_name == "_base"`, which has two significant impacts.

The first is simply that it is now possible to instantiate a BaseClient directly, which may prove useful for ad-hoc scripting. Although not generally a recommended approach (e.g. there is no benefit to using a BaseClient in lieu of a TransferClient), the possibility only makes the SDK more flexible.

The second effect is that a class inheriting from BaseClient no longer needs to set `service_name` if the setting has no appropriate value. This is relevant for 3rd party clients with nonstandard URL schemes (e.g. FuncX before the Compute rebranding) and for clients to an array of potential hosts, like GCSClient and any future
ActionProviderClient.

The only new test ensures that it is possible to instantiate a BaseClient directly, and the GCSClient.service_name value, although unchanged, is marked for a v4.0 update.

<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--786.org.readthedocs.build/en/786/

<!-- readthedocs-preview globus-sdk-python end -->