### PR TITLE
Add BaseAuthClient to separate methods

### DIFF
--- a/changelog.d/20230718_140424_sirosen_separate_auth_base.rst
+++ b/changelog.d/20230718_140424_sirosen_separate_auth_base.rst
@@ -1,0 +1,14 @@
+Changed
+~~~~~~~
+
+- The inheritance hierarchy for Globus Auth client classes has changed. (:pr:`NUMBER`)
+
+  - A new class, ``BaseAuthClient`` is used as the base for the other three
+    existing Globus Auth clients
+
+  - ``NativeAppAuthClient`` and ``ConfidentialAppAuthClient`` inherit from
+    ``BaseAuthClient``, not ``AuthClient``
+
+  - ``NativeAppAuthClient`` and ``ConfidentialAppAuthClient`` have lost methods
+    which would never work in practice for these client types, e.g.
+    ``create_project``

--- a/docs/services/auth.rst
+++ b/docs/services/auth.rst
@@ -4,10 +4,23 @@ Globus Auth
 .. currentmodule:: globus_sdk
 
 There are several types of client object for communicating with the Globus Auth
-service. A client object may represent your application (as the driver of
-authentication and authorization flows), in which case the
-:class:`NativeAppAuthClient` or :class:`ConfidentialAppAuthClient` classes should
-generally be used.
+service.
+
+A client object may represent an application (as the driver of authentication and
+authorization flows), in which case the :class:`NativeAppAuthClient` or
+:class:`ConfidentialAppAuthClient` classes should generally be used.
+
+For authentication using token auth, generally the appropriate choice is
+:class:`AuthClient`.
+
+:class:`BaseAuthClient` defines shared interfaces for the other three but is
+generally not recommended for direct instantiation.
+
+.. autoclass:: BaseAuthClient
+   :members:
+   :member-order: bysource
+   :show-inheritance:
+   :exclude-members: error_class
 
 .. autoclass:: AuthClient
    :members:

--- a/src/globus_sdk/__init__.py
+++ b/src/globus_sdk/__init__.py
@@ -53,6 +53,7 @@ _LAZY_IMPORT_TABLE = {
     },
     "services.auth": {
         "AuthAPIError",
+        "BaseAuthClient",
         "AuthClient",
         "ConfidentialAppAuthClient",
         "IdentityMap",
@@ -150,6 +151,7 @@ if t.TYPE_CHECKING:
     from .response import IterableResponse
     from .response import ArrayResponse
     from .services.auth import AuthAPIError
+    from .services.auth import BaseAuthClient
     from .services.auth import AuthClient
     from .services.auth import ConfidentialAppAuthClient
     from .services.auth import IdentityMap
@@ -248,6 +250,7 @@ __all__ = (
     "AuthAPIError",
     "AuthClient",
     "AzureBlobStoragePolicies",
+    "BaseAuthClient",
     "BaseClient",
     "BasicAuthorizer",
     "BatchMembershipActions",

--- a/src/globus_sdk/_generate_init.py
+++ b/src/globus_sdk/_generate_init.py
@@ -111,6 +111,7 @@ _LAZY_IMPORT_TABLE: list[tuple[str, tuple[str, ...]]] = [
         "services.auth",
         (
             "AuthAPIError",
+            "BaseAuthClient",
             "AuthClient",
             "ConfidentialAppAuthClient",
             "IdentityMap",

--- a/src/globus_sdk/services/auth/__init__.py
+++ b/src/globus_sdk/services/auth/__init__.py
@@ -1,4 +1,9 @@
-from .client import AuthClient, ConfidentialAppAuthClient, NativeAppAuthClient
+from .client import (
+    AuthClient,
+    BaseAuthClient,
+    ConfidentialAppAuthClient,
+    NativeAppAuthClient,
+)
 from .errors import AuthAPIError
 from .flow_managers import (
     GlobusAuthorizationCodeFlowManager,
@@ -12,6 +17,7 @@ from .response import (
 )
 
 __all__ = [
+    "BaseAuthClient",
     "AuthClient",
     "AuthAPIError",
     "NativeAppAuthClient",

--- a/src/globus_sdk/services/auth/client/__init__.py
+++ b/src/globus_sdk/services/auth/client/__init__.py
@@ -1,5 +1,10 @@
-from .base import AuthClient
+from .base import AuthClient, BaseAuthClient
 from .confidential_client import ConfidentialAppAuthClient
 from .native_client import NativeAppAuthClient
 
-__all__ = ["AuthClient", "NativeAppAuthClient", "ConfidentialAppAuthClient"]
+__all__ = [
+    "BaseAuthClient",
+    "AuthClient",
+    "NativeAppAuthClient",
+    "ConfidentialAppAuthClient",
+]

--- a/src/globus_sdk/services/auth/client/confidential_client.py
+++ b/src/globus_sdk/services/auth/client/confidential_client.py
@@ -10,15 +10,15 @@ from globus_sdk.response import GlobusHTTPResponse
 from .._common import stringify_requested_scopes
 from ..flow_managers import GlobusAuthorizationCodeFlowManager
 from ..response import OAuthDependentTokenResponse, OAuthTokenResponse
-from .base import AuthClient
+from .base import BaseAuthClient
 
 log = logging.getLogger(__name__)
 
 
-class ConfidentialAppAuthClient(AuthClient):
+class ConfidentialAppAuthClient(BaseAuthClient):
     """
-    This is a specialized type of ``AuthClient`` used to represent an App with
-    a Client ID and Client Secret wishing to communicate with Globus Auth.
+    This is a specialized type of :class:`BaseAuthClient` used to represent an App
+    with a Client ID and Client Secret wishing to communicate with Globus Auth.
     It must be given a Client ID and a Client Secret, and furthermore, these
     will be used to establish a :class:`BasicAuthorizer <globus_sdk.BasicAuthorizer>`
     for authorization purposes.
@@ -29,7 +29,10 @@ class ConfidentialAppAuthClient(AuthClient):
     <https://github.com/globus/globus-sample-data-portal>`_, which have their
     own credentials for authenticating against Globus Auth.
 
-    Any keyword arguments given are passed through to the ``AuthClient``
+    :param client_secret: The client secret used for authentication
+    :type client_secret: str
+
+    All other arguments given are passed through to the :class:`BaseAuthClient`
     constructor.
 
     .. automethodlist:: globus_sdk.ConfidentialAppAuthClient

--- a/src/globus_sdk/services/auth/client/native_client.py
+++ b/src/globus_sdk/services/auth/client/native_client.py
@@ -8,14 +8,14 @@ from globus_sdk.authorizers import NullAuthorizer
 
 from ..flow_managers import GlobusNativeAppFlowManager
 from ..response import OAuthTokenResponse
-from .base import AuthClient
+from .base import BaseAuthClient
 
 log = logging.getLogger(__name__)
 
 
-class NativeAppAuthClient(AuthClient):
+class NativeAppAuthClient(BaseAuthClient):
     """
-    This type of ``AuthClient`` is used to represent a Native App's
+    This type of :class:`BaseAuthClient` is used to represent a Native App's
     communications with Globus Auth.
     It requires a Client ID, and cannot take an ``authorizer``.
 
@@ -24,7 +24,7 @@ class NativeAppAuthClient(AuthClient):
     credentials, several Globus Auth interactions have to be specialized to
     accommodate the absence of a secret.
 
-    Any keyword arguments given are passed through to the ``AuthClient``
+    All arguments given are passed through to the :class:`BaseAuthClient`
     constructor.
 
     .. automethodlist:: globus_sdk.NativeAppAuthClient

--- a/src/globus_sdk/services/auth/flow_managers/authorization_code.py
+++ b/src/globus_sdk/services/auth/flow_managers/authorization_code.py
@@ -32,8 +32,8 @@ class GlobusAuthorizationCodeFlowManager(GlobusOAuthFlowManager):
     Secret (to prove that it really is the application that the user just
     authorized).
 
-    :param auth_client: The ``AuthClient`` used to extract default values for the flow,
-        and also to make calls to the Auth service.
+    :param auth_client: The client used to extract default values for the flow, and also
+        to make calls to the Auth service.
     :type auth_client: :class:`ConfidentialAppAuthClient \
         <globus_sdk.ConfidentialAppAuthClient>`
     :param redirect_uri: The page that users should be directed to after authenticating
@@ -55,7 +55,7 @@ class GlobusAuthorizationCodeFlowManager(GlobusOAuthFlowManager):
 
     def __init__(
         self,
-        auth_client: globus_sdk.AuthClient,
+        auth_client: globus_sdk.ConfidentialAppAuthClient,
         redirect_uri: str,
         requested_scopes: ScopeCollectionType | None = None,
         state: str = "_default",

--- a/src/globus_sdk/services/auth/flow_managers/native_app.py
+++ b/src/globus_sdk/services/auth/flow_managers/native_app.py
@@ -78,9 +78,8 @@ class GlobusNativeAppFlowManager(GlobusOAuthFlowManager):
     Instead, a temporary secret is generated solely for this authentication
     attempt.
 
-    :param auth_client: The ``NativeAppAuthClient`` object on which this flow is based.
-        It is used to extract default values for the flow, and also to make calls to the
-        Auth service.
+    :param auth_client: The client object on which this flow is based. It is used to
+        extract default values for the flow, and also to make calls to the Auth service.
     :type auth_client: :class:`NativeAppAuthClient <globus_sdk.NativeAppAuthClient>`
     :param requested_scopes: The scopes on the token(s) being requested. Defaults to
         ``openid profile email urn:globus:auth:scope:transfer.api.globus.org:all``
@@ -109,7 +108,7 @@ class GlobusNativeAppFlowManager(GlobusOAuthFlowManager):
 
     def __init__(
         self,
-        auth_client: globus_sdk.AuthClient,
+        auth_client: globus_sdk.NativeAppAuthClient,
         requested_scopes: ScopeCollectionType | None = None,
         redirect_uri: str | None = None,
         state: str = "_default",

--- a/tests/non-pytest/mypy-ignore-tests/scope_collection_type.py
+++ b/tests/non-pytest/mypy-ignore-tests/scope_collection_type.py
@@ -30,70 +30,76 @@ foo(1)  # type: ignore[arg-type]
 foo((False,))  # type: ignore[arg-type]
 
 
+# setup clients for use below
+native_client = globus_sdk.NativeAppAuthClient("dummy_client_id")
+cc_client = globus_sdk.ConfidentialAppAuthClient(
+    "dummy_client_id", "dummy_client_secret"
+)
+
+
 # now, verify that we can pass scope collections to flow managers
-bare_client = globus_sdk.AuthClient()
 GlobusAuthorizationCodeFlowManager(
-    bare_client,
+    cc_client,
     "https://example.org/redirect-uri",
     requested_scopes="foo",
 )
 GlobusNativeAppFlowManager(
-    bare_client,
+    native_client,
     requested_scopes="foo",
 )
 GlobusAuthorizationCodeFlowManager(
-    bare_client,
+    cc_client,
     "https://example.org/redirect-uri",
     requested_scopes=("foo", "bar"),
 )
 GlobusNativeAppFlowManager(
-    bare_client,
+    native_client,
     requested_scopes=("foo", "bar"),
 )
 GlobusAuthorizationCodeFlowManager(
-    bare_client,
+    cc_client,
     "https://example.org/redirect-uri",
     requested_scopes=MutableScope("foo"),
 )
 GlobusNativeAppFlowManager(
-    bare_client,
+    native_client,
     requested_scopes=MutableScope("foo"),
 )
 GlobusAuthorizationCodeFlowManager(
-    bare_client,
+    cc_client,
     "https://example.org/redirect-uri",
     requested_scopes=[MutableScope("foo")],
 )
 GlobusNativeAppFlowManager(
-    bare_client,
+    native_client,
     requested_scopes=[MutableScope("foo")],
 )
 GlobusAuthorizationCodeFlowManager(
-    bare_client,
+    cc_client,
     "https://example.org/redirect-uri",
     requested_scopes=[MutableScope("foo"), "bar"],
 )
 GlobusNativeAppFlowManager(
-    bare_client,
+    native_client,
     requested_scopes=[MutableScope("foo"), "bar"],
 )
 # bad usages
 GlobusAuthorizationCodeFlowManager(
-    bare_client,
+    cc_client,
     "https://example.org/redirect-uri",
     requested_scopes=1,  # type: ignore[arg-type]
 )
 GlobusNativeAppFlowManager(
-    bare_client,
+    native_client,
     requested_scopes=1,  # type: ignore[arg-type]
 )
 GlobusAuthorizationCodeFlowManager(
-    bare_client,
+    cc_client,
     "https://example.org/redirect-uri",
     requested_scopes=none_list,  # type: ignore[arg-type]
 )
 GlobusNativeAppFlowManager(
-    bare_client,
+    native_client,
     requested_scopes=none_list,  # type: ignore[arg-type]
 )
 
@@ -101,11 +107,6 @@ GlobusNativeAppFlowManager(
 # furthermore, verify that we can pass these collection types to the client classes
 # which wrap the flow managers
 # note that oauth2_start_flow allows the scopes as a positional arg
-native_client = globus_sdk.NativeAppAuthClient("dummy_client_id")
-cc_client = globus_sdk.ConfidentialAppAuthClient(
-    "dummy_client_id", "dummy_client_secret"
-)
-
 native_client.oauth2_start_flow("foo")
 cc_client.oauth2_start_flow("https://example.org/redirect-uri", "foo")
 native_client.oauth2_start_flow(requested_scopes="foo")


### PR DESCRIPTION
This should be viewed as my alternative pitch to #783 . Although #783 was more fun to implement, I believe this is a more correct path forward.

While testing I caught a surprise in that `ConfidentialAppAuthClient.get_identities` needs to be supported, which also serves to highlight how this separation is beneficial in terms of clarity.
For now, I've made no change to `NativeAppAuthClient.get_identities`, though we could remove that in a future version (at the very least, we should make sure it disappears in v4).

`git` and GitHub don't do a great job with this diff. Despite the noisy diff, client methods were not changed at all. They were mostly rearranged without even modified docstrings or comments.

---

Introduce a new base class for the Auth client hierarchy in order to split the developer API methods from the previously existing "base" methods. The important exception is `get_identities`, which supports client credentials authorization and therefore needs to stay on the base.

The changelog explains this change without drawing undue attention to the ways in which it could, in theory, be compatibility breaking for users relying on the inheritance relationship (e.g. via `isinstance` or type annotations).

No new tests are added and no tests are broken by this change.

<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--788.org.readthedocs.build/en/788/

<!-- readthedocs-preview globus-sdk-python end -->