### PR TITLE
Update dependency pins for testing and linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,15 +18,15 @@ repos:
   rev: 1.15.0
   hooks:
     - id: blacken-docs
-      additional_dependencies: ['black==23.1.0']
+      additional_dependencies: ['black==23.7.0']
 - repo: https://github.com/PyCQA/flake8
   rev: 6.0.0
   hooks:
     - id: flake8
       name: "Lint python files"
       additional_dependencies:
-        - 'flake8-bugbear==23.2.13'
-        - 'flake8-comprehensions==3.10.1'
+        - 'flake8-bugbear==23.7.10'
+        - 'flake8-comprehensions==3.14.0'
         - 'flake8-typing-as-t==0.0.3'
 - repo: https://github.com/PyCQA/isort
   rev: 5.12.0

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -12,7 +12,7 @@ beautifulsoup4==4.12.2
     # via furo
 certifi==2023.5.7
     # via requests
-charset-normalizer==3.1.0
+charset-normalizer==3.2.0
     # via requests
 docutils==0.19
     # via sphinx
@@ -24,7 +24,7 @@ imagesize==1.4.1
     # via sphinx
 jinja2==3.1.2
     # via sphinx
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via jinja2
 packaging==23.1
     # via sphinx
@@ -32,7 +32,7 @@ pygments==2.15.1
     # via
     #   furo
     #   sphinx
-pyyaml==6.0
+pyyaml==6.0.1
     # via responses
 requests==2.31.0
     # via
@@ -52,7 +52,7 @@ sphinx==6.2.1
     #   sphinx-copybutton
     #   sphinx-design
     #   sphinx-issues
-sphinx-basic-ng==1.0.0b1
+sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
     # via -r docs.in
@@ -74,7 +74,7 @@ sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
 types-pyyaml==6.0.12.10
     # via responses
-urllib3==2.0.2
+urllib3==2.0.3
     # via
     #   requests
     #   responses

--- a/requirements/test-mindeps.txt
+++ b/requirements/test-mindeps.txt
@@ -10,11 +10,11 @@ cffi==1.15.1
     # via cryptography
 chardet==3.0.4
     # via requests
-coverage==7.2.5
+coverage==7.2.7
     # via -r test.in
 cryptography==3.3.1
     # via -r test-mindeps.in
-execnet==1.9.0
+execnet==2.0.2
     # via pytest-xdist
 idna==2.8
     # via requests
@@ -22,19 +22,19 @@ iniconfig==2.0.0
     # via pytest
 packaging==23.1
     # via pytest
-pluggy==1.0.0
+pluggy==1.2.0
     # via pytest
 pycparser==2.21
     # via cffi
 pyjwt==2.0.0
     # via -r test-mindeps.in
-pytest==7.3.1
+pytest==7.4.0
     # via
     #   -r test.in
     #   pytest-xdist
 pytest-xdist==3.3.1
     # via -r test.in
-pyyaml==6.0
+pyyaml==6.0.1
     # via responses
 requests==2.22.0
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,11 +6,11 @@
 #
 certifi==2023.5.7
     # via requests
-charset-normalizer==3.1.0
+charset-normalizer==3.2.0
     # via requests
-coverage==7.2.5
+coverage==7.2.7
     # via -r test.in
-execnet==1.9.0
+execnet==2.0.2
     # via pytest-xdist
 idna==3.4
     # via requests
@@ -18,15 +18,15 @@ iniconfig==2.0.0
     # via pytest
 packaging==23.1
     # via pytest
-pluggy==1.0.0
+pluggy==1.2.0
     # via pytest
-pytest==7.3.1
+pytest==7.4.0
     # via
     #   -r test.in
     #   pytest-xdist
 pytest-xdist==3.3.1
     # via -r test.in
-pyyaml==6.0
+pyyaml==6.0.1
     # via responses
 requests==2.31.0
     # via responses
@@ -34,7 +34,7 @@ responses==0.23.1
     # via -r test.in
 types-pyyaml==6.0.12.10
     # via responses
-urllib3==2.0.2
+urllib3==2.0.3
     # via
     #   requests
     #   responses

--- a/requirements/typing-mindeps.txt
+++ b/requirements/typing-mindeps.txt
@@ -6,15 +6,15 @@
 #
 certifi==2023.5.7
     # via requests
-charset-normalizer==3.1.0
+charset-normalizer==3.2.0
     # via requests
 idna==3.4
     # via requests
-mypy==0.991
+mypy==1.4.0
     # via -r typing.in
 mypy-extensions==1.0.0
     # via mypy
-pyyaml==6.0
+pyyaml==6.0.1
     # via responses
 requests==2.31.0
     # via responses
@@ -28,7 +28,7 @@ types-jwt==0.1.3
     # via -r typing.in
 types-pyyaml==6.0.12.10
     # via responses
-types-requests==2.31.0.0
+types-requests==2.31.0.1
     # via -r typing.in
 types-urllib3==1.26.25.13
     # via types-requests
@@ -37,7 +37,7 @@ typing-extensions==4.0.0
     #   -r typing-mindeps.in
     #   -r typing.in
     #   mypy
-urllib3==2.0.2
+urllib3==2.0.3
     # via
     #   requests
     #   responses

--- a/requirements/typing.in
+++ b/requirements/typing.in
@@ -1,5 +1,4 @@
-# TODO: update to remove mypy pin
-mypy==0.991
+mypy
 types-docutils
 types-jwt
 types-requests

--- a/requirements/typing.txt
+++ b/requirements/typing.txt
@@ -6,15 +6,15 @@
 #
 certifi==2023.5.7
     # via requests
-charset-normalizer==3.1.0
+charset-normalizer==3.2.0
     # via requests
 idna==3.4
     # via requests
-mypy==0.991
+mypy==1.4.1
     # via -r typing.in
 mypy-extensions==1.0.0
     # via mypy
-pyyaml==6.0
+pyyaml==6.0.1
     # via responses
 requests==2.31.0
     # via responses
@@ -28,15 +28,15 @@ types-jwt==0.1.3
     # via -r typing.in
 types-pyyaml==6.0.12.10
     # via responses
-types-requests==2.31.0.0
+types-requests==2.31.0.1
     # via -r typing.in
 types-urllib3==1.26.25.13
     # via types-requests
-typing-extensions==4.6.0
+typing-extensions==4.7.1
     # via
     #   -r typing.in
     #   mypy
-urllib3==2.0.2
+urllib3==2.0.3
     # via
     #   requests
     #   responses

--- a/src/globus_sdk/paging/table.py
+++ b/src/globus_sdk/paging/table.py
@@ -4,7 +4,7 @@ import typing as t
 
 from globus_sdk.response import GlobusHTTPResponse
 
-from .base import PageT, Paginator
+from .base import Paginator
 
 C = t.TypeVar("C", bound=t.Callable[..., GlobusHTTPResponse])
 
@@ -40,14 +40,14 @@ class PaginatorTable:
         self._client = client
         # _bindings is a lazily loaded table of names -> callables which
         # return paginators
-        self._bindings: dict[str, t.Callable[..., Paginator[PageT]]] = {}
+        self._bindings: dict[str, t.Callable[..., Paginator[t.Any]]] = {}
 
     def _add_binding(
-        self, methodname: str, bound_method: t.Callable[..., PageT]
+        self, methodname: str, bound_method: t.Callable[..., t.Any]
     ) -> None:
         self._bindings[methodname] = Paginator.wrap(bound_method)
 
-    def __getattr__(self, attrname: str) -> t.Callable[..., Paginator[PageT]]:
+    def __getattr__(self, attrname: str) -> t.Callable[..., Paginator[t.Any]]:
         if attrname not in self._bindings:
             # this could raise AttributeError -- in which case, let it!
             method = getattr(self._client, attrname)


### PR DESCRIPTION
A type checking failure in another branch led me to notice that we still have `mypy` pinned in the typing requirements data, which appears to be accidental now that we use pip-tools to get reproducible builds.

I've removed the pin, "refrozen" the dependency sets, fixed a typing bug which this exposed, and applied `upadup` (which necessitated no further changes).

<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--789.org.readthedocs.build/en/789/

<!-- readthedocs-preview globus-sdk-python end -->