### PR TITLE
Set SpecificFlowClient default scope object and adjust utils.classproperty

### DIFF
--- a/changelog.d/20230726_115057_sirosen_specific_flow_client_default_scope_object.rst
+++ b/changelog.d/20230726_115057_sirosen_specific_flow_client_default_scope_object.rst
@@ -1,0 +1,8 @@
+Changed
+~~~~~~~
+
+- The ``scopes`` class attribute of ``SpecificFlowClient`` is now specialized
+  to ensure that type checkers will allow access to ``SpecificFlowClient``
+  scopes and ``resource_server`` values without ``cast``\ing. The value used is
+  a specialized stub which raises useful errors when class-based access is
+  performed. The ``scopes`` instance attribute is unchanged. (:pr:`NUMBER`)

--- a/src/globus_sdk/client.py
+++ b/src/globus_sdk/client.py
@@ -114,16 +114,16 @@ class BaseClient:
         self._app_name = self.transport.user_agent = value
 
     @utils.classproperty
-    def resource_server(cls) -> str | None:
+    def resource_server(self_or_cls) -> str | None:
         """
         The resource_server name for the API and scopes associated with this client.
 
         This information is pulled from the ``scopes`` attribute of the client class.
         If the client does not have associated scopes, this value will be ``None``.
         """
-        if cls.scopes is None:
+        if self_or_cls.scopes is None:
             return None
-        return cls.scopes.resource_server
+        return self_or_cls.scopes.resource_server
 
     def get(
         self,

--- a/src/globus_sdk/services/flows/client.py
+++ b/src/globus_sdk/services/flows/client.py
@@ -10,6 +10,7 @@ from globus_sdk.scopes import ScopeBuilder
 
 from .errors import FlowsAPIError
 from .response import IterableFlowsResponse, IterableRunsResponse
+from .scopes import SpecificFlowScopesClassStub
 
 log = logging.getLogger(__name__)
 
@@ -791,6 +792,7 @@ class SpecificFlowClient(client.BaseClient):
 
     error_class = FlowsAPIError
     service_name = "flows"
+    scopes: ScopeBuilder = SpecificFlowScopesClassStub()
 
     def __init__(
         self,

--- a/src/globus_sdk/services/flows/scopes.py
+++ b/src/globus_sdk/services/flows/scopes.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import typing as t
+
+from globus_sdk.scopes import ScopeBuilder
+
+
+class SpecificFlowScopesClassStub(ScopeBuilder):
+    """
+    This stub object ensures that the type deductions for type checkers (e.g. mypy) on
+    SpecificFlowClient.scopes are correct.
+
+    Primarily, it should be possible to access the `scopes` attribute, the `user`
+    scope, and the `resource_server`, but these usages should raise specific and
+    informative runtime errors.
+
+    Our types are therefore less accurate for class-var access, but more accurate for
+    instance-var access.
+    """
+
+    def __init__(self, *args: t.Any, **kwargs: t.Any) -> None:
+        pass
+
+    def __getattr__(self, name: str) -> t.Any:
+        if name == "user":
+            _raise_attr_error("scopes")
+        elif name == "resource_server":
+            _raise_attr_error("resource_server")
+        return super().__getattr__(name)
+
+
+def _raise_attr_error(name: str) -> t.NoReturn:
+    raise AttributeError(
+        f"It is not valid to attempt to access the {name} of the "
+        "SpecificFlowClient class. "
+        f"Instead, instantiate a SpecificFlowClient and access the {name} "
+        "from that instance."
+    )

--- a/src/globus_sdk/services/flows/scopes.py
+++ b/src/globus_sdk/services/flows/scopes.py
@@ -19,7 +19,7 @@ class SpecificFlowScopesClassStub(ScopeBuilder):
     """
 
     def __init__(self, *args: t.Any, **kwargs: t.Any) -> None:
-        pass
+        super().__init__("<stub>")
 
     def __getattr__(self, name: str) -> t.Any:
         if name == "user":
@@ -27,6 +27,11 @@ class SpecificFlowScopesClassStub(ScopeBuilder):
         elif name == "resource_server":
             _raise_attr_error("resource_server")
         return super().__getattr__(name)
+
+    def __getattribute__(self, name: str) -> t.Any:
+        if name == "resource_server":
+            _raise_attr_error("resource_server")
+        return object.__getattribute__(self, name)
 
 
 def _raise_attr_error(name: str) -> t.NoReturn:

--- a/src/globus_sdk/utils.py
+++ b/src/globus_sdk/utils.py
@@ -144,20 +144,14 @@ class _classproperty(t.Generic[T, R]):
     Everything in `globus_sdk.utils` is meant to be internal only, but that holds
     for this class **in particular**.
 
-    This is a well-typed Generic Descriptor which can be used to wrap `classmethod`
-    decorated functions. Usage should be:
+    This is a well-typed Generic Descriptor which can be used to wrap decorated
+    functions. Usage should be:
 
         @utils.classproperty
-        def foo(...): ...
+        def foo(self_or_cls): ...
 
-    After python3.8 EOL, this should be replaced with
-
-        @classmethod
-        @property
-        def foo(...): ...
-
-    However, this will also require proper mypy support. See also:
-      https://github.com/python/mypy/issues/2563
+    Note that this descriptor will pass an instance (self) if possible, and the
+    class (cls) only if there is no instance. This is unlike ``classmethod``.
 
     For more guidance on how this works, see the python3 descriptor guide:
       https://docs.python.org/3/howto/descriptor.html#properties
@@ -167,11 +161,20 @@ class _classproperty(t.Generic[T, R]):
         self.func = func
 
     def __get__(self, obj: t.Any, cls: type[T]) -> R:
-        return self.func(cls)
+        # NOTE: our __get__ here prefers the object over the class when possible
+        # although well-defined behavior for a descriptor, this contradicts the
+        # expectation that developers may have from `classmethod`
+        if obj is None:
+            return self.func(cls)
+        return self.func(obj)
 
 
 # if running under sphinx, define this as the stacked classmethod(property(...))
 # decoration, so that proper autodoc generation happens
+# this is based on the python3.9 behavior which supported stacking these decorators
+# however, that support was pulled in 3.10 and is not going to be reintroduced at
+# present
+# therefore, this sphinx behavior may not be stable in the long term
 if in_sphinx_build():  # pragma: no cover
 
     def classproperty(func: t.Callable[[T], R]) -> _classproperty[T, R]:

--- a/tests/non-pytest/mypy-ignore-tests/specific_flow_scopes.py
+++ b/tests/non-pytest/mypy-ignore-tests/specific_flow_scopes.py
@@ -1,0 +1,15 @@
+import typing as t
+
+import globus_sdk
+
+# test that a SpecificFlowClient allows assignments of scope strings and resource_server
+# even though the class-level default is a specialized stub object
+flow_id = "foo"
+specific_flow_client = globus_sdk.SpecificFlowClient(flow_id)
+
+scopes_object = specific_flow_client.scopes
+t.assert_type(scopes_object, globus_sdk.scopes.ScopeBuilder)
+
+scope: str = scopes_object.user
+x: int = scopes_object.user  # type: ignore[assignment]
+resource_server: str = specific_flow_client.scopes.resource_server

--- a/tests/unit/test_specific_flows_client.py
+++ b/tests/unit/test_specific_flows_client.py
@@ -1,0 +1,75 @@
+import pytest
+
+import globus_sdk
+
+
+def test_specific_flow_client_class_errors_on_scope_access():
+    scopes = globus_sdk.SpecificFlowClient.scopes
+    assert scopes is not None
+
+    # for the 'user' scope, which is well-defined, we get a special error
+    with pytest.raises(AttributeError) as excinfo:
+        scopes.user
+
+    err = excinfo.value
+    assert (
+        "It is not valid to attempt to access the scopes of the "
+        "SpecificFlowClient class."
+    ) in str(err)
+
+    # but for any other scope we get something a little more generic
+    with pytest.raises(AttributeError) as excinfo:
+        scopes.demuddle
+
+    err = excinfo.value
+    assert str(err) == "Unrecognized Attribute 'demuddle'"
+
+
+def test_specific_flow_client_class_errors_on_resource_server_access():
+    scopes = globus_sdk.SpecificFlowClient.scopes
+    assert scopes is not None
+
+    # access via the scopes object raises an error
+    with pytest.raises(AttributeError) as excinfo:
+        scopes.resource_server
+
+    err = excinfo.value
+    assert (
+        "It is not valid to attempt to access the resource_server of the "
+        "SpecificFlowClient class."
+    ) in str(err)
+
+    # and access via the client class raises the same error
+    with pytest.raises(AttributeError) as excinfo:
+        globus_sdk.SpecificFlowClient.resource_server
+
+    err = excinfo.value
+    assert (
+        "It is not valid to attempt to access the resource_server of the "
+        "SpecificFlowClient class."
+    ) in str(err)
+
+
+def test_specific_flow_client_instance_supports_scope_access():
+    client = globus_sdk.SpecificFlowClient("foo")
+    scopes = client.scopes
+    assert scopes is not None
+
+    # for the 'user' scope, we get a string
+    user_scope = scopes.user
+    assert isinstance(user_scope, str)
+    assert user_scope.endswith("flow_foo_user")
+
+    # but for any other scope we still get the generic attribute error
+    with pytest.raises(AttributeError) as excinfo:
+        scopes.demuddle
+
+    err = excinfo.value
+    assert str(err) == "Unrecognized Attribute 'demuddle'"
+
+
+def test_specific_flow_client_instance_supports_resource_server_access():
+    client = globus_sdk.SpecificFlowClient("foo")
+    resource_server = client.resource_server
+    assert isinstance(resource_server, str)
+    assert resource_server == "foo"

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -66,10 +66,25 @@ def test_classproperty_simple():
         x = {"x": 1}
 
         @utils.classproperty
-        def y(cls):
-            return cls.x["x"]
+        def y(self_or_cls):
+            return self_or_cls.x["x"]
 
     assert Foo.y == 1
+
+
+def test_classproperty_prefers_instance():
+    class Foo:
+        x = {"x": 1}
+
+        def __init__(self):
+            self.x = {"x": 2}
+
+        @utils.classproperty
+        def y(self_or_cls):
+            return self_or_cls.x["x"]
+
+    assert Foo.y == 1
+    assert Foo().y == 2
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
There are two changes here.
Primarily, this changeset drives at improving the behavior at typing time and runtime for users of SpecificFlowClient.
1. `mypy` should allow `scope: str = myclient.scopes.user` -- for this, we need to manipulate the `scopes` classvar a little.
2. `SpecificFlowClient.scopes.user` should still error, but with a useful message which points at instance-only usage

In service of these changes, it turns out that our internal classproperty descriptor needs a minor adjustment. Although it is only used to implement the `BaseClient.resource_server` classproperty today, some pains are taken here to ensure that the behavior is kept unsurprising for future uses.

<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--793.org.readthedocs.build/en/793/

<!-- readthedocs-preview globus-sdk-python end -->