### PR TITLE
Simplify GlobusAuthRequiremenetsError validation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
   rev: v3.10.1
   hooks:
     - id: pyupgrade
-      args: ["--py37-plus", "--keep-runtime-typing"]
+      args: ["--py37-plus"]
 - repo: https://github.com/codespell-project/codespell
   rev: v2.2.5
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
   rev: v3.10.1
   hooks:
     - id: pyupgrade
-      args: ["--py37-plus"]
+      args: ["--py37-plus", "--keep-runtime-typing"]
 - repo: https://github.com/codespell-project/codespell
   rev: v2.2.5
   hooks:

--- a/src/globus_sdk/experimental/auth_requirements_error/_variants.py
+++ b/src/globus_sdk/experimental/auth_requirements_error/_variants.py
@@ -57,9 +57,7 @@ class LegacyConsentRequiredTransferError(LegacyAuthRequirementsErrorVariant):
         required_scopes: list[str] | None,
         extra: dict[str, t.Any] | None = None,
     ):
-        self.code: Literal["ConsentRequired"] = _consent_required_validator(
-            "code", code
-        )
+        self.code = _consent_required_validator("code", code)
         self.required_scopes = validators.ListOfStrings(
             "required_scopes", required_scopes
         )
@@ -93,9 +91,7 @@ class LegacyConsentRequiredAPError(LegacyAuthRequirementsErrorVariant):
         required_scope: str,
         extra: dict[str, t.Any] | None,
     ):
-        self.code: Literal["ConsentRequired"] = _consent_required_validator(
-            "code", code
-        )
+        self.code = _consent_required_validator("code", code)
         self.required_scope = validators.String("required_scope", required_scope)
         self.extra = extra or {}
 

--- a/src/globus_sdk/experimental/auth_requirements_error/_variants.py
+++ b/src/globus_sdk/experimental/auth_requirements_error/_variants.py
@@ -198,8 +198,8 @@ class LegacyAuthorizationParameters:
             for field_name in self.SUPPORTED_FIELDS.keys()
         ):
             raise ValueError(
-                "Must include at least one supported authorization parameter: "
-                ", ".join(self.SUPPORTED_FIELDS.keys())
+                "Must include at least one supported parameter: "
+                + ", ".join(self.SUPPORTED_FIELDS.keys())
             )
 
     def to_authorization_parameters(

--- a/src/globus_sdk/experimental/auth_requirements_error/auth_requirements_error.py
+++ b/src/globus_sdk/experimental/auth_requirements_error/auth_requirements_error.py
@@ -44,20 +44,14 @@ class GlobusAuthorizationParameters:
     :vartype extra_fields: dict
     """
 
-    session_message: Annotated[t.Optional[str], validators.OptionalString]
-    session_required_identities: Annotated[
-        t.Optional[t.List[str]], validators.OptionalListOfStrings
-    ]
-    session_required_policies: Annotated[
-        t.Optional[t.List[str]], validators.OptionalListOfStrings
-    ]
+    session_message: Annotated[t.Optional[str], validators.DEFAULT]
+    session_required_identities: Annotated[t.Optional[t.List[str]], validators.DEFAULT]
+    session_required_policies: Annotated[t.Optional[t.List[str]], validators.DEFAULT]
     session_required_single_domain: Annotated[
-        t.Optional[t.List[str]], validators.OptionalListOfStrings
+        t.Optional[t.List[str]], validators.DEFAULT
     ]
-    session_required_mfa: Annotated[t.Optional[bool], validators.OptionalBool]
-    required_scopes: Annotated[
-        t.Optional[t.List[str]], validators.OptionalListOfStrings
-    ]
+    session_required_mfa: Annotated[t.Optional[bool], validators.DEFAULT]
+    required_scopes: Annotated[t.Optional[t.List[str]], validators.DEFAULT]
     extra_fields: t.Dict[str, t.Any]
 
     def __init__(
@@ -144,7 +138,7 @@ class GlobusAuthRequirementsError(GlobusError):
     :vartype extra_fields: dict
     """
 
-    code: Annotated[str, validators.String]
+    code: Annotated[str, validators.DEFAULT]
     authorization_parameters: Annotated[
         GlobusAuthorizationParameters,
         validators.ClassInstance(GlobusAuthorizationParameters),

--- a/src/globus_sdk/experimental/auth_requirements_error/auth_requirements_error.py
+++ b/src/globus_sdk/experimental/auth_requirements_error/auth_requirements_error.py
@@ -38,15 +38,6 @@ class GlobusAuthorizationParameters:
     :vartype extra: dict
     """
 
-    SUPPORTED_FIELDS = {
-        "session_message",
-        "session_required_identities",
-        "session_required_policies",
-        "session_required_single_domain",
-        "session_required_mfa",
-        "required_scopes",
-    }
-
     def __init__(
         self,
         *,
@@ -58,24 +49,18 @@ class GlobusAuthorizationParameters:
         required_scopes: list[str] | None = None,
         extra: dict[str, t.Any] | None = None,
     ):
-        self.session_message = validators.OptionalString(
-            "session_message", session_message
-        )
+        self.session_message = validators.OptionalString("session_message")
         self.session_required_identities = validators.OptionalListOfStrings(
-            "session_required_identities", session_required_identities
+            "session_required_identities"
         )
         self.session_required_policies = validators.OptionalListOfStrings(
-            "session_required_policies", session_required_policies
+            "session_required_policies"
         )
         self.session_required_single_domain = validators.OptionalListOfStrings(
-            "session_required_single_domain", session_required_single_domain
+            "session_required_single_domain"
         )
-        self.session_required_mfa = validators.OptionalBool(
-            "session_required_mfa", session_required_mfa
-        )
-        self.required_scopes = validators.OptionalListOfStrings(
-            "required_scopes", required_scopes
-        )
+        self.session_required_mfa = validators.OptionalBool("session_required_mfa")
+        self.required_scopes = validators.OptionalListOfStrings("required_scopes")
         self.extra = extra or {}
 
         validators.require_at_least_one_field(
@@ -83,6 +68,8 @@ class GlobusAuthorizationParameters:
             [f for f in self.SUPPORTED_FIELDS if f != "session_message"],
             "supported authorization parameter",
         )
+
+    SUPPORTED_FIELDS: set[str] = validators.derive_supported_fields(__init__)
 
     @classmethod
     def from_dict(cls, param_dict: dict[str, t.Any]) -> GlobusAuthorizationParameters:
@@ -143,8 +130,6 @@ class GlobusAuthRequirementsError(GlobusError):
     :vartype extra: dict
     """
 
-    SUPPORTED_FIELDS = {"code", "authorization_parameters"}
-
     _authz_param_validator: validators.IsInstance[
         GlobusAuthorizationParameters
     ] = validators.IsInstance(GlobusAuthorizationParameters)
@@ -162,11 +147,13 @@ class GlobusAuthRequirementsError(GlobusError):
                 param_dict=authorization_parameters
             )
 
-        self.code = validators.String("code", code)
+        self.code = validators.String("code")
         self.authorization_parameters = self._authz_param_validator(
-            "authorization_parameters", authorization_parameters
+            "authorization_parameters"
         )
         self.extra = extra or {}
+
+    SUPPORTED_FIELDS: set[str] = validators.derive_supported_fields(__init__)
 
     @classmethod
     def from_dict(cls, error_dict: dict[str, t.Any]) -> GlobusAuthRequirementsError:

--- a/src/globus_sdk/experimental/auth_requirements_error/validators.py
+++ b/src/globus_sdk/experimental/auth_requirements_error/validators.py
@@ -1,172 +1,168 @@
 from __future__ import annotations
 
+import inspect
 import sys
 import typing as t
 from contextlib import suppress
 
-if sys.version_info >= (3, 9):
-    from typing import get_type_hints
+if sys.version_info >= (3, 8):
+    from typing import Protocol
 else:
-    from typing_extensions import get_type_hints
+    from typing_extensions import Protocol
 
-T = t.TypeVar("T")
-
-
-def _string(value: t.Any) -> str:
-    if not isinstance(value, str):
-        raise ValueError("Must be a string")
-
-    return value
+T = t.TypeVar("T", covariant=True)
 
 
-def _string_literal(literal: str) -> t.Callable[[t.Any], str]:
-    def validator(value: t.Any) -> str:
-        value = _string(value)
-        if value != literal:
-            raise ValueError(f"Must be '{literal}'")
-
-        return t.cast(str, value)
-
-    return validator
+# NB: the type parameter of a Validator is what it *produces*
+# meaning that a validator which converts `"foo,bar"` to `["foo", "bar"]` should
+# be typed with `T=list[str]`, not `T=str`
+class Validator(Protocol[T]):
+    def __call__(self, name: str, value: t.Any) -> T:
+        ...
 
 
-def _class_instance(cls: t.Type[T]) -> t.Callable[[t.Any], T]:
-    def validator(value: t.Any) -> T:
-        if not isinstance(value, cls):
-            raise ValueError(f"Must be an instance of {cls.__name__}")
+class HasErrorMessage(Protocol):
+    error_message: str
+
+
+def _fail(o: HasErrorMessage, name: str) -> t.NoReturn:
+    raise ValueError(f"Error validating field '{name}': {o.error_message}")
+
+
+class _String(Validator[str]):
+    error_message = "must be a string"
+
+    def __call__(self, name: str, value: t.Any) -> str:
+        if not isinstance(value, str):
+            _fail(self, name)
 
         return value
 
-    return validator
+
+String = _String()
 
 
-def _list_of_strings(value: t.Any) -> list[str]:
-    if not (isinstance(value, list) and all(isinstance(v, str) for v in value)):
-        raise ValueError("Must be a list of strings")
+class StringLiteral(Validator[T]):
+    def __init__(self, literal: str) -> None:
+        self._value = literal
+        self.error_message = f"must be '{literal}'"
 
-    return value
-
-
-def _comma_delimited_strings(value: t.Any) -> list[str]:
-    if not isinstance(value, str):
-        raise ValueError("Must be a comma-delimited string")
-
-    return value.split(",")
+    def __call__(self, name: str, value: t.Any) -> T:
+        value = String(name, value)
+        if value != self._value:
+            _fail(self, name)
+        return t.cast(T, value)
 
 
-def _boolean(value: t.Any) -> bool:
-    if not isinstance(value, bool):
-        raise ValueError("Must be a bool")
+class IsInstance(Validator[T]):
+    def __init__(self, cls: t.Type[T]) -> None:
+        self._cls = cls
+        self.error_message = f"must be an instance of {self._cls.__name__}"
 
-    return value
+    def __call__(self, name: str, value: t.Any) -> T:
+        if not isinstance(value, self._cls):
+            _fail(self, name)
 
-
-def _null(value: t.Any) -> None:
-    if value is not None:
-        raise ValueError("Must be null")
-
-    return None
+        return value
 
 
-def _anyof(
-    validators: tuple[t.Callable[..., t.Any], ...],
-    description: str,
-) -> t.Callable[..., t.Any]:
-    def _anyof_validator(value: t.Any) -> t.Any:
-        for validator in validators:
+class _ListOfStrings(Validator[t.List[str]]):
+    error_message = "must be a list of strings"
+
+    def __call__(self, name: str, value: t.Any) -> t.List[str]:
+        if not (isinstance(value, list) and all(isinstance(v, str) for v in value)):
+            _fail(self, name)
+
+        return value
+
+
+ListOfStrings = _ListOfStrings()
+
+
+class _CommaDelimitedStrings(Validator[t.List[str]]):
+    error_message = "must be a comma-delimited of string"
+
+    def __call__(self, name: str, value: t.Any) -> t.List[str]:
+        if not isinstance(value, str):
+            _fail(self, name)
+
+        return value.split(",")
+
+
+CommaDelimitedStrings = _CommaDelimitedStrings()
+
+
+class _Boolean(Validator[bool]):
+    error_message = "must be a bool"
+
+    def __call__(self, name: str, value: t.Any) -> bool:
+        if not isinstance(value, bool):
+            _fail(self, name)
+
+        return value
+
+
+Boolean = _Boolean()
+
+
+class _Null(Validator[None]):
+    error_message = "must be null"
+
+    def __call__(self, name: str, value: t.Any) -> None:
+        if value is not None:
+            _fail(self, name)
+
+        return None
+
+
+Null = _Null()
+
+
+class _AnyOf(Validator[t.Any]):
+    def __init__(self, *validators: Validator[t.Any], description: str) -> None:
+        self._validators = validators
+        self.error_message = f"must be one {description}"
+
+    def __call__(self, name: str, value: t.Any) -> t.Any:
+        for validator in self._validators:
             with suppress(ValueError):
-                return validator(value)
+                return validator(name, value)
 
-        raise ValueError(f"Must be {description}")
-
-    return _anyof_validator
+        _fail(self, name)
 
 
-String: t.Callable[[t.Any], str] = _string
-StringLiteral: t.Callable[[str], t.Callable[[t.Any], str]] = _string_literal
-ClassInstance: t.Callable[[t.Any], t.Any] = _class_instance
-ListOfStrings: t.Callable[[t.Any], list[str]] = _list_of_strings
-CommaDelimitedStrings: t.Callable[[t.Any], list[str]] = _comma_delimited_strings
-Bool: t.Callable[[t.Any], bool] = _boolean
-Null: t.Callable[[t.Any], None] = _null
-OptionalString: t.Callable[[t.Any], str | None] = _anyof(
-    (_string, _null), description="a string or null"
+OptionalString: Validator[str | None] = _AnyOf(
+    String, Null, description="a string or null"
 )
-OptionalListOfStrings: t.Callable[[t.Any], list[str] | None] = _anyof(
-    (_list_of_strings, _null), description="a list of strings or null"
+OptionalListOfStrings: Validator[list[str] | None] = _AnyOf(
+    ListOfStrings, Null, description="a list of strings or null"
 )
-OptionalCommaDelimitedStrings: t.Callable[[t.Any], list[str] | None] = _anyof(
-    (_comma_delimited_strings, _null), description="a comma-delimited string or null"
+OptionalCommaDelimitedStrings: Validator[list[str] | None] = _AnyOf(
+    CommaDelimitedStrings, Null, description="a comma-delimited string or null"
 )
-OptionalListOfStringsOrCommaDelimitedStrings: t.Callable[
-    [t.Any], list[str] | None
-] = _anyof(
-    (_list_of_strings, _comma_delimited_strings, _null),
+OptionalListOfStringsOrCommaDelimitedStrings: Validator[list[str] | None] = _AnyOf(
+    ListOfStrings,
+    CommaDelimitedStrings,
+    Null,
     description="a list of strings, a comma-delimited string, or null",
 )
-OptionalBool: t.Callable[[t.Any], bool | None] = _anyof(
-    (_boolean, _null), description="a bool or null"
+OptionalBool: Validator[bool | None] = _AnyOf(
+    Boolean, Null, description="a bool or null"
 )
 
-# a sentinel used to indicate default validator lookup behavior
-DEFAULT = object()
-DEFAULT_TYPE_MAP = {
-    str: String,
-    t.Optional[str]: OptionalString,
-    t.Optional[t.List[str]]: OptionalListOfStrings,
-    t.Optional[bool]: OptionalBool,
-}
 
-
-def run_annotated_validators(o: object, require_at_least_one: bool = False) -> None:
-    found_non_null = False
-    validator_annotations = list(get_validator_annotations(o))
-
-    for attrname, value in validator_annotations:
-        try:
-            validator_result = value(getattr(o, attrname))
-        except ValueError as e:
-            raise ValueError(f"Error validating field '{attrname}': {e}") from e
-        setattr(o, attrname, validator_result)
-        if validator_result is not None:
-            found_non_null = True
-
-    if require_at_least_one and not found_non_null:
+def require_at_least_one_field(o: object, field_description: str) -> None:
+    one_of_fields = set(derive_supported_fields(o))
+    if all((getattr(o, field_name) is None) for field_name in one_of_fields):
         raise ValueError(
-            "Must include at least one supported parameter: "
-            + ", ".join([f for f, _ in validator_annotations])
+            f"Must include at least one {field_description}: "
+            + ", ".join(one_of_fields)
         )
 
 
-def get_supported_fields(o_or_cls: object | type) -> list[str]:
-    return [field_name for (field_name, _) in get_validator_annotations(o_or_cls)]
-
-
-def get_validator_annotations(
-    o_or_cls: object | type,
-) -> t.Iterator[tuple[str, t.Callable[..., t.Any]]]:
-    if isinstance(o_or_cls, type):
-        cls = o_or_cls
-    else:
-        cls = o_or_cls.__class__
-
-    for attrname, value in get_type_hints(cls, include_extras=True).items():
-        # an Annotated[...] annotation produces a special form "_AnnotatedAlias"
-        # rather than inspecting typing internals, check that the interface we want
-        # (`__metadata__` is present and is a tuple) is satisfied by the annotation
-        if not isinstance(getattr(value, "__metadata__", None), tuple):
-            continue
-
-        maybe_validator = value.__metadata__[0]
-        if maybe_validator is DEFAULT:
-            maybe_validator = DEFAULT_TYPE_MAP.get(value.__origin__, None)
-            if maybe_validator is None:
-                raise NotImplementedError(
-                    "Internal SDK Error! An unsupported validator type was requested "
-                    "via DEFAULT. DEFAULT should only be used for supported types."
-                )
-
-        if not callable(maybe_validator):
-            continue
-
-        yield (attrname, maybe_validator)
+def derive_supported_fields(o_or_cls: object | type) -> list[str]:
+    # mypy warns here about `__init__` access being potnetially unsound, but the check
+    # is a false negative in this case since we're operating on a closed set of classes
+    # which we control
+    signature = inspect.signature(o_or_cls.__init__)  # type: ignore[misc]
+    return [k for k in signature.parameters.keys() if k not in ("extra", "self")]

--- a/src/globus_sdk/experimental/auth_requirements_error/validators.py
+++ b/src/globus_sdk/experimental/auth_requirements_error/validators.py
@@ -39,9 +39,6 @@ class _String(Validator[str]):
         return value
 
 
-String = _String()
-
-
 class StringLiteral(Validator[T]):
     def __init__(self, literal: str) -> None:
         self._value = literal
@@ -76,9 +73,6 @@ class _ListOfStrings(Validator[t.List[str]]):
         return value
 
 
-ListOfStrings = _ListOfStrings()
-
-
 class _CommaDelimitedStrings(Validator[t.List[str]]):
     error_message = "must be a comma-delimited of string"
 
@@ -87,9 +81,6 @@ class _CommaDelimitedStrings(Validator[t.List[str]]):
             _fail(self, name)
 
         return value.split(",")
-
-
-CommaDelimitedStrings = _CommaDelimitedStrings()
 
 
 class _Boolean(Validator[bool]):
@@ -102,9 +93,6 @@ class _Boolean(Validator[bool]):
         return value
 
 
-Boolean = _Boolean()
-
-
 class _Null(Validator[None]):
     error_message = "must be null"
 
@@ -113,9 +101,6 @@ class _Null(Validator[None]):
             _fail(self, name)
 
         return None
-
-
-Null = _Null()
 
 
 class _AnyOf(Validator[t.Any]):
@@ -131,6 +116,11 @@ class _AnyOf(Validator[t.Any]):
         _fail(self, name)
 
 
+ListOfStrings = _ListOfStrings()
+String = _String()
+CommaDelimitedStrings = _CommaDelimitedStrings()
+Boolean = _Boolean()
+Null = _Null()
 OptionalString: Validator[str | None] = _AnyOf(
     String, Null, description="a string or null"
 )

--- a/src/globus_sdk/experimental/auth_requirements_error/validators.py
+++ b/src/globus_sdk/experimental/auth_requirements_error/validators.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import inspect
 import sys
 import typing as t
 from contextlib import suppress
@@ -141,18 +140,11 @@ OptionalBool: Validator[bool | None] = _AnyOf(
 )
 
 
-def require_at_least_one_field(o: object, field_description: str) -> None:
-    one_of_fields = set(derive_supported_fields(o))
+def require_at_least_one_field(
+    o: object, one_of_fields: list[str], field_description: str
+) -> None:
     if all((getattr(o, field_name) is None) for field_name in one_of_fields):
         raise ValueError(
             f"Must include at least one {field_description}: "
             + ", ".join(one_of_fields)
         )
-
-
-def derive_supported_fields(o_or_cls: object | type) -> list[str]:
-    # mypy warns here about `__init__` access being potnetially unsound, but the check
-    # is a false negative in this case since we're operating on a closed set of classes
-    # which we control
-    signature = inspect.signature(o_or_cls.__init__)  # type: ignore[misc]
-    return [k for k in signature.parameters.keys() if k not in ("extra", "self")]

--- a/tests/unit/experimental/test_auth_requirements_error.py
+++ b/tests/unit/experimental/test_auth_requirements_error.py
@@ -1,3 +1,5 @@
+import inspect
+
 import pytest
 
 from globus_sdk._testing import construct_error
@@ -10,9 +12,6 @@ from globus_sdk.experimental.auth_requirements_error import (
     is_auth_requirements_error,
     to_auth_requirements_error,
     to_auth_requirements_errors,
-)
-from globus_sdk.experimental.auth_requirements_error.validators import (
-    derive_supported_fields,
 )
 
 
@@ -419,12 +418,12 @@ def test_backward_compatibility_consent_required_error():
         _variants.LegacyConsentRequiredAPError,
     ],
 )
-def test_supported_fields_excludes_extra_and_self(target_class):
-    supported_fields = derive_supported_fields(target_class)
-    assert isinstance(supported_fields, list)
-    assert len(supported_fields) > 0
-    assert "self" not in supported_fields
-    assert "extra" not in supported_fields
+def test_supported_fields_matches_init(target_class):
+    signature = inspect.signature(target_class.__init__)
+    derived_supported = {
+        k for k in signature.parameters.keys() if k not in ("extra", "self")
+    }
+    assert derived_supported == target_class.SUPPORTED_FIELDS
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/experimental/test_auth_requirements_error.py
+++ b/tests/unit/experimental/test_auth_requirements_error.py
@@ -13,6 +13,9 @@ from globus_sdk.experimental.auth_requirements_error import (
     to_auth_requirements_error,
     to_auth_requirements_errors,
 )
+from globus_sdk.experimental.auth_requirements_error.validators import (
+    get_supported_fields,
+)
 
 
 @pytest.mark.parametrize(
@@ -410,8 +413,6 @@ def test_backward_compatibility_consent_required_error():
 @pytest.mark.parametrize(
     "target_class",
     [
-        GlobusAuthRequirementsError,
-        GlobusAuthorizationParameters,
         _variants.LegacyAuthorizationParameters,
         _variants.LegacyAuthorizationParametersError,
         _variants.LegacyConsentRequiredTransferError,
@@ -425,6 +426,24 @@ def test_constructors_include_all_supported_fields(target_class):
 
     method_sig = inspect.signature(target_class.__init__)
     for field_name in target_class.SUPPORTED_FIELDS:
+        # Make sure the constructor has a parameter for this field
+        assert field_name in method_sig.parameters
+
+
+@pytest.mark.parametrize(
+    "target_class",
+    [
+        GlobusAuthRequirementsError,
+        GlobusAuthorizationParameters,
+    ],
+)
+def test_constructors_include_all_annotated_supported_fields(target_class):
+    """
+    Test that all supported fields are included in the constructors.
+    """
+    method_sig = inspect.signature(target_class.__init__)
+    supported_fields = get_supported_fields(target_class)
+    for field_name in supported_fields:
         # Make sure the constructor has a parameter for this field
         assert field_name in method_sig.parameters
 
@@ -458,6 +477,4 @@ def test_authorization_parameters_from_dict_insufficient_input(target_class):
     with pytest.raises(ValueError) as exc_info:
         target_class.from_dict({})
 
-    assert "Must include at least one supported authorization parameter" in str(
-        exc_info.value
-    )
+    assert "Must include at least one supported parameter" in str(exc_info.value)


### PR DESCRIPTION
My interest in making some changes to the GARE work has shifted since I started on this.
Originally, my goal was surface-level simplicity and brevity, regardless of how much sophisticated plumbing was needed.
It seemed problematic to me that we had a situation like
```python
class Foo:
    code: str

    SUPPORTED_FIELDS = {
        "code": literal_validator("ConsentRequired"),
        ...,
    }

    def __init__(self, code: str | None, ...):
        ...
```
This would seem to declare a single field, `code`, three times. Each with subtly different apparent types -- `str`, `str | None`, and `Literal[...]`.

I thought I could combine two of these together into something which looked like
```python
class Foo:
    code: Annotated[Literal["ConsentRequired"], validators.AUTO]

    def __init__(self, code: str | None, ...):
        ...
```
and collapse away one of the redundancies.

A state approximating this _was_ achieved in the course of this work: all tests should pass on https://github.com/globus/globus-sdk-python/commit/2ba3166e0f218ac4b97f428b1682ce2ff40dbd53 .

However, this was really too complex for our needs. After a conversation in which we questioned the wisdom of annotation inspection (and `--keep-runtime-typing` is a red flag for this), I reconsidered what the end goal of my refactor should be, and came up with the following target:
- instance variables should be assigned explicitly, not via an implicit looping structure
- those assignments should have _values_ whose types are knowable to a type checker

The problem therefore was partly that the phrasing of the validator module as plain callables precluded passing the relevant and necessary type information around. Instead, converting all of the validators to implementers of a callable protocol allows us to express the idea that validators are generics which, upon invocation, return some "result type".
However we declare it, the correct type for the `code` validator above would be `Validator[Literal["ConsentRequired"]]`.  (See the end of `_variants.py` for the real definition. It is quite simple.)

For the most part, the changes are a great deal of tedious copy-paste and not terribly interesting.
However, certain cases illuminate the value of a refactor which is more typing-friendly. Consider `LegacyAuthorizationParameters`, where it is now clear from the types that an input of `str | list[str] | None` is narrowed by the validator to `list[str] | None`.

The move from brevity towards explicit-ness reaches its apex in https://github.com/globus/globus-sdk-python/commit/768922f8997b22ea40c11b942056db774965b082 , which reintroduces some of the original redundancy I was seeking to remove. The issue I seek to solve in this changeset is not that we are declaring 3x that `code` is a field, but rather that we have declared it with multiple types and the interplay between those types is not clear. Therefore, there is an argument against seeking brevity as one of our criteria.
Even so, the changeset at that point did not actually increase our LOC -- it ever so barely manages to decrease it. This is in spite of a more verbose paradigm for the validators I attribute it primarily to the fact that looping over fields to assign them dynamically is not shorter or simpler than the "apparent verbosity" of explicit assignments *if* that logic is combined with class-level instance variable type declarations.

However, I've since tried to see if I could regain some of the terseness that I destroyed.
In the very last commits here, some slightly suspect use of `inspect` creeps back in. In particular, any critical feedback about the extraction of the `f_locals` of the grandparent frame of a helper would be very understandable and welcome.

---

All that said, was the mission, set forth in this PR title, accomplished? Is validation simpler now than it was before?
It is debatable, but I would say yes.
Consider the before and after of `LegacyConsentRequiredTransferError` -- this is definitely improved.
The non-legacy module is also now shorter -- by 30 lines -- and although there's now _more_ magic involved in pulling out values (not just locals, but the parent frame's locals!), I would call it also more readable.

This is not necessarily our final iteration. I started to think about a descriptor for the validators with a clever `fset`, which might work well. But then I decided to open this PR and share what I've been working on.

<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--795.org.readthedocs.build/en/795/

<!-- readthedocs-preview globus-sdk-python end -->