### PR TITLE
Add `IterableRunLogsResponse`

### DIFF
--- a/changelog.d/20230808_111757_ada_add_iterable_run_logs_response.rst
+++ b/changelog.d/20230808_111757_ada_add_iterable_run_logs_response.rst
@@ -1,0 +1,4 @@
+Changed
+~~~~~~~
+
+- ``FlowsClient.get_run_logs()`` now uses an ``IterableRunLogsResponse``. (:pr:`NUMBER`)

--- a/src/globus_sdk/services/flows/client.py
+++ b/src/globus_sdk/services/flows/client.py
@@ -9,7 +9,11 @@ from globus_sdk.authorizers import GlobusAuthorizer
 from globus_sdk.scopes import ScopeBuilder
 
 from .errors import FlowsAPIError
-from .response import IterableFlowsResponse, IterableRunsResponse
+from .response import (
+    IterableFlowsResponse,
+    IterableRunLogsResponse,
+    IterableRunsResponse,
+)
 from .scopes import SpecificFlowScopesClassStub
 
 log = logging.getLogger(__name__)
@@ -545,7 +549,7 @@ class FlowsClient(client.BaseClient):
         reverse_order: bool | None = None,
         marker: str | None = None,
         query_params: dict[str, t.Any] | None = None,
-    ) -> IterableFlowsResponse:
+    ) -> IterableRunLogsResponse:
         """
         Retrieve the execution logs associated with a run
 
@@ -589,7 +593,7 @@ class FlowsClient(client.BaseClient):
         }
         # Filter out request keys with None values to allow server defaults
         query_params = {k: v for k, v in query_params.items() if v is not None}
-        return IterableFlowsResponse(
+        return IterableRunLogsResponse(
             self.get(f"/runs/{run_id}/log", query_params=query_params)
         )
 

--- a/src/globus_sdk/services/flows/response.py
+++ b/src/globus_sdk/services/flows/response.py
@@ -15,3 +15,11 @@ class IterableRunsResponse(response.IterableResponse):
     """
 
     default_iter_key = "runs"
+
+
+class IterableRunLogsResponse(response.IterableResponse):
+    """
+    An iterable response containing an "entries" array.
+    """
+
+    default_iter_key = "entries"


### PR DESCRIPTION
Discovered in the course of working on the `globus flows run get-logs` command that the existing iterator doesn't point to the "entries" key, ~causing issues when using `Paginator.wrap()` which relies on the value of the `default_iter_key`.~

Update: Subsequently discovered the issue I was encountering arose due to a different issue. I still believe this is correct, but I am reverting to draft while I sort it out.

Update 2: Okay, I can see this is being overridden by the `paging.has_paginator` setting. I think this is still a _very_ modest improvement to correctness but don't expect a meaningful functional change either. Promoting back to PR.

<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--797.org.readthedocs.build/en/797/

<!-- readthedocs-preview globus-sdk-python end -->