### PR TITLE
Update 'freezedeps' to use '--strip-extras'

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -14,9 +14,9 @@ certifi==2023.7.22
     # via requests
 charset-normalizer==3.2.0
     # via requests
-docutils==0.19
+docutils==0.20.1
     # via sphinx
-furo==2023.5.20
+furo==2023.7.26
     # via -r docs.in
 idna==3.4
     # via requests
@@ -28,7 +28,7 @@ markupsafe==2.1.3
     # via jinja2
 packaging==23.1
     # via sphinx
-pygments==2.15.1
+pygments==2.16.1
     # via
     #   furo
     #   sphinx
@@ -38,13 +38,13 @@ requests==2.31.0
     # via
     #   responses
     #   sphinx
-responses==0.23.2
+responses==0.23.3
     # via -r docs.in
 snowballstemmer==2.2.0
     # via sphinx
 soupsieve==2.4.1
     # via beautifulsoup4
-sphinx==6.2.1
+sphinx==7.1.2
     # via
     #   -r docs.in
     #   furo
@@ -52,25 +52,30 @@ sphinx==6.2.1
     #   sphinx-copybutton
     #   sphinx-design
     #   sphinx-issues
+    #   sphinxcontrib-applehelp
+    #   sphinxcontrib-devhelp
+    #   sphinxcontrib-htmlhelp
+    #   sphinxcontrib-qthelp
+    #   sphinxcontrib-serializinghtml
 sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
     # via -r docs.in
-sphinx-design==0.4.1
+sphinx-design==0.5.0
     # via -r docs.in
 sphinx-issues==3.0.1
     # via -r docs.in
-sphinxcontrib-applehelp==1.0.4
+sphinxcontrib-applehelp==1.0.6
     # via sphinx
-sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-devhelp==1.0.4
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.1
+sphinxcontrib-htmlhelp==2.0.3
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.3
+sphinxcontrib-qthelp==1.0.5
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.5
+sphinxcontrib-serializinghtml==1.1.7
     # via sphinx
 types-pyyaml==6.0.12.11
     # via responses

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -30,7 +30,7 @@ pyyaml==6.0.1
     # via responses
 requests==2.31.0
     # via responses
-responses==0.23.2
+responses==0.23.3
     # via -r test.in
 types-pyyaml==6.0.12.11
     # via responses

--- a/requirements/typing-mindeps.txt
+++ b/requirements/typing-mindeps.txt
@@ -18,7 +18,7 @@ pyyaml==6.0.1
     # via responses
 requests==2.31.0
     # via responses
-responses==0.23.2
+responses==0.23.3
     # via -r typing.in
 types-cryptography==3.3.23.2
     # via types-jwt

--- a/requirements/typing.txt
+++ b/requirements/typing.txt
@@ -10,7 +10,7 @@ charset-normalizer==3.2.0
     # via requests
 idna==3.4
     # via requests
-mypy==1.4.1
+mypy==1.5.0
     # via -r typing.in
 mypy-extensions==1.0.0
     # via mypy
@@ -18,7 +18,7 @@ pyyaml==6.0.1
     # via responses
 requests==2.31.0
     # via responses
-responses==0.23.2
+responses==0.23.3
     # via -r typing.in
 types-cryptography==3.3.23.2
     # via types-jwt

--- a/scripts/freezedeps.py
+++ b/scripts/freezedeps.py
@@ -32,6 +32,7 @@ def main():
                 "-m",
                 "piptools",
                 "compile",
+                "--strip-extras",
                 "-q",
                 "--resolver=backtracking",
                 str(source),


### PR DESCRIPTION
This is becoming the default behavior in an upcoming pip-tools release, but currently warns.

Running and applying the result appears to make minimal changes to our requirements data. (i.e. only expected changes)

---

I ran into the warning when looking into testing on py3.12, and this is how I resolved it.

<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--800.org.readthedocs.build/en/800/

<!-- readthedocs-preview globus-sdk-python end -->