### PR TITLE
Release SDK 3.27.0

### DIFF
--- a/changelog.d/20230808_111757_ada_add_iterable_run_logs_response.rst
+++ b/changelog.d/20230808_111757_ada_add_iterable_run_logs_response.rst
@@ -1,4 +1,0 @@
-Changed
-~~~~~~~
-
-- ``FlowsClient.get_run_logs()`` now uses an ``IterableRunLogsResponse``. (:pr:`797`)

--- a/changelog.d/20230809_125026_kurtmckee_get_run_definitions_sc_25840.rst
+++ b/changelog.d/20230809_125026_kurtmckee_get_run_definitions_sc_25840.rst
@@ -1,4 +1,0 @@
-Added
-~~~~~
-
-- Add a ``FlowsClient.get_run_definition()`` method. (:pr:`799`)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,21 @@ to a major new version of the SDK.
 
 .. scriv-insert-here
 
+.. _changelog-3.27.0:
+
+v3.27.0 (2023-08-11)
+--------------------
+
+Added
+~~~~~
+
+- Add a ``FlowsClient.get_run_definition()`` method. (:pr:`799`)
+
+Changed
+~~~~~~~
+
+- ``FlowsClient.get_run_logs()`` now uses an ``IterableRunLogsResponse``. (:pr:`797`)
+
 .. _changelog-3.26.0:
 
 v3.26.0 (2023-08-07)

--- a/src/globus_sdk/version.py
+++ b/src/globus_sdk/version.py
@@ -1,3 +1,3 @@
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "3.26.0"
+__version__ = "3.27.0"


### PR DESCRIPTION
Added
-----

- Add a ``FlowsClient.get_run_definition()`` method. (#799)

Changed
-------

- ``FlowsClient.get_run_logs()`` now uses an ``IterableRunLogsResponse``. (#797)


<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--801.org.readthedocs.build/en/801/

<!-- readthedocs-preview globus-sdk-python end -->