### PR TITLE
Resolve a GitHub workflow warning

### DIFF
--- a/.github/workflows/publish_to_test_pypi.yaml
+++ b/.github/workflows/publish_to_test_pypi.yaml
@@ -21,4 +21,4 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-          repository_url: https://test.pypi.org/legacy/
+          repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
This resolves a warning that pops up when a GitHub workflow publishes to Test PyPI. [[recent example](https://github.com/globus/globus-sdk-python/actions/runs/5857734295)]

> :warning: publish
>
> Input 'repository_url' has been deprecated with message: The inputs have been normalized to use kebab-case. Use `repository-url` instead.


Development
-----------

- Resolve a GitHub workflow warning caused by using a deprecated ``repository_url`` key.


<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--803.org.readthedocs.build/en/803/

<!-- readthedocs-preview globus-sdk-python end -->