### PR TITLE
Add a `README.rst` content type to resolve a warning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,7 @@ author = Globus Team
 author_email = support@globus.org
 description = Globus SDK for Python
 long_description = file: README.rst
+long_description_content_type = text/x-rst
 url = https://github.com/globus/globus-sdk-python
 keywords= globus
 license = Apache-2.0


### PR DESCRIPTION
This resolves a warning thrown while a GitHub workflow publishes to PyPI. [[recent example](https://github.com/globus/globus-sdk-python/actions/runs/5857734295/job/15880231600#step:7:24)]

> WARNING  `long_description_content_type` missing. defaulting to `text/x-rst`.

Development
-----------

- Add a ``README.rst`` content type to resolve a warning during publication to PyPI.

<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--804.org.readthedocs.build/en/804/

<!-- readthedocs-preview globus-sdk-python end -->