### PR TITLE
Use Trusted Publishing

### DIFF
--- a/.github/workflows/publish_to_pypi.yaml
+++ b/.github/workflows/publish_to_pypi.yaml
@@ -7,6 +7,9 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: publish-pypi
+    permissions:
+      id-token: write
 
     steps:
       - uses: actions/checkout@v3
@@ -19,5 +22,3 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish_to_test_pypi.yaml
+++ b/.github/workflows/publish_to_test_pypi.yaml
@@ -7,6 +7,9 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: publish-test-pypi
+    permissions:
+      id-token: write
 
     steps:
       - uses: actions/checkout@v3
@@ -20,5 +23,4 @@ jobs:
       - name: Publish to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
This PR migrates the SDK GitHub workflows from PyPI token secrets to Trusted Publishing.

The projects on TestPyPI and PyPI have already been updated, and the GitHub environments have already been created.

In addition, this has been tested by creating a `3.27.1b1` tag on this branch and pushing it to GitHub to trigger the TestPyPI workflow.

<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--805.org.readthedocs.build/en/805/

<!-- readthedocs-preview globus-sdk-python end -->