### PR TITLE
Fix an always-raising code example

### DIFF
--- a/docs/examples/auth_manage_projects/manage_projects.py
+++ b/docs/examples/auth_manage_projects/manage_projects.py
@@ -92,37 +92,38 @@ def main():
     try:
         execute(parser, args)
     except globus_sdk.GlobusAPIError as err:
-        if err.info.authorization_parameters:
-            err_params = err.info.authorization_parameters
-            session_params = {}
-            if err_params.session_required_identities:
-                print("session required identities detected")
-                session_params[
-                    "session_required_identities"
-                ] = err_params.session_required_identities
-            if err_params.session_required_single_domain:
-                print("session required single domain detected")
-                session_params[
-                    "session_required_single_domain"
-                ] = err_params.session_required_single_domain
-            if err_params.session_required_policies:
-                print("session required policies detected")
-                session_params[
-                    "session_required_policies"
-                ] = err_params.session_required_policies
-            print(session_params)
-            print(err_params)
-            response = do_login_flow(session_params=session_params)
-            # now store the tokens
-            MY_FILE_ADAPTER.store(response)
-            print(
-                "Reauthenticated successfully to satisfy "
-                "session requirements. Will now try again.\n"
-            )
+        if not err.info.authorization_parameters:
+            raise
 
-            # try the action again
-            execute(parser, args)
-        raise
+        err_params = err.info.authorization_parameters
+        session_params = {}
+        if err_params.session_required_identities:
+            print("session required identities detected")
+            session_params[
+                "session_required_identities"
+            ] = err_params.session_required_identities
+        if err_params.session_required_single_domain:
+            print("session required single domain detected")
+            session_params[
+                "session_required_single_domain"
+            ] = err_params.session_required_single_domain
+        if err_params.session_required_policies:
+            print("session required policies detected")
+            session_params[
+                "session_required_policies"
+            ] = err_params.session_required_policies
+        print(session_params)
+        print(err_params)
+        response = do_login_flow(session_params=session_params)
+        # now store the tokens
+        MY_FILE_ADAPTER.store(response)
+        print(
+            "Reauthenticated successfully to satisfy "
+            "session requirements. Will now try again.\n"
+        )
+
+        # try the action again
+        execute(parser, args)
 
 
 def execute(parser, args):


### PR DESCRIPTION
We shouldn't raise an exception after successfully handling it.

<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--807.org.readthedocs.build/en/807/

<!-- readthedocs-preview globus-sdk-python end -->