### PR TITLE
Add a `prompt` kwarg to `AuthClient.oauth2_get_authorize_url()`

### DIFF
--- a/changelog.d/20230818_072838_kurtmckee_surface_prompt_query_parameter.rst
+++ b/changelog.d/20230818_072838_kurtmckee_surface_prompt_query_parameter.rst
@@ -1,0 +1,12 @@
+Added
+~~~~~
+
+-   Add a ``prompt`` keyword parameter to ``AuthClient.oauth2_get_authorize_url()``. (:pr:`NUMBER`)
+
+    Setting this parameter requires users to authenticate with an identity provider,
+    even if they are already logged in. Doing so can help avoid errors caused by
+    unexpected session required policies, which would otherwise require a second,
+    follow-up login flow.
+
+    ``prompt`` could previously only be set via the ``query_params`` keyword parameter.
+    It is now more discoverable.

--- a/src/globus_sdk/services/auth/client/base.py
+++ b/src/globus_sdk/services/auth/client/base.py
@@ -541,6 +541,7 @@ class AuthClient(client.BaseClient):
         session_required_identities: UUIDLike | t.Iterable[UUIDLike] | None = None,
         session_required_single_domain: str | t.Iterable[str] | None = None,
         session_required_policies: UUIDLike | t.Iterable[UUIDLike] | None = None,
+        prompt: Literal["login"] | None = None,
         query_params: dict[str, t.Any] | None = None,
     ) -> str:
         """
@@ -557,6 +558,14 @@ class AuthClient(client.BaseClient):
         :param session_required_policies: A list of IDs for policies which must
             be satisfied by the user.
         :type session_required_policies: str or uuid or list of str or uuid, optional
+        :param prompt:
+            Control whether a user is required to log in before the authorization step.
+
+            If set to "login", the user must authenticate with an identity provider
+            even if they are already logged in. Setting this parameter can help ensure
+            that a user's session meets known or unknown session requirement policies
+            and avoid additional login flows.
+        :type prompt: ``"login"``, optional
         :param query_params: Additional query parameters to include in the
             authorize URL. Primarily for internal use
         :type query_params: dict, optional
@@ -583,6 +592,8 @@ class AuthClient(client.BaseClient):
             query_params["session_required_policies"] = _commasep(
                 session_required_policies
             )
+        if prompt is not None:
+            query_params["prompt"] = prompt
         auth_url = self.current_oauth2_flow_manager.get_authorize_url(
             query_params=query_params
         )


### PR DESCRIPTION
Added
-----

-   Add a ``prompt`` keyword parameter to ``AuthClient.oauth2_get_authorize_url()``.

    Setting this parameter requires users to authenticate with an identity provider,
    even if they are already logged in. Doing so can help avoid errors caused by
    unexpected session required policies, which would otherwise require a second,
    follow-up login flow.

    ``prompt`` could previously only be set via the ``query_params`` keyword parameter.
    It is now more discoverable.


<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--813.org.readthedocs.build/en/813/

<!-- readthedocs-preview globus-sdk-python end -->