### PR TITLE
Fix failing docparams in response.py

### DIFF
--- a/src/globus_sdk/response.py
+++ b/src/globus_sdk/response.py
@@ -135,6 +135,9 @@ class GlobusHTTPResponse:
         """
         ``get`` is just an alias for ``data.get(key, default)``, but with the added
         checks that if ``data`` is ``None`` or a list, it returns the default.
+
+        :param key: The string key to lookup in the response if it is a dict
+        :param default: The default value to be used if the data is null or a list
         """
         if _guards.is_optional(self.data, list):
             return default


### PR DESCRIPTION


<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--831.org.readthedocs.build/en/831/

<!-- readthedocs-preview globus-sdk-python end -->