### PR TITLE
Fix failing docparams in scopes/

### DIFF
--- a/src/globus_sdk/scopes/scope_definition.py
+++ b/src/globus_sdk/scopes/scope_definition.py
@@ -117,5 +117,8 @@ class MutableScope:
         Given a scope string, a collection of scope strings, a MutableScope object, a
         collection of MutableScope objects, or a mixed collection of strings and
         Scopes, convert to a string which can be used in a request.
+
+        :param obj: The object or collection to convert to a string
+        :type obj: str, MutableScope, iterable of str or MutableScope
         """
         return " ".join(_iter_scope_collection(obj))


### PR DESCRIPTION


<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--834.org.readthedocs.build/en/834/

<!-- readthedocs-preview globus-sdk-python end -->