### PR TITLE
Fix failing docparams in tokenstorage/

### DIFF
--- a/src/globus_sdk/tokenstorage/base.py
+++ b/src/globus_sdk/tokenstorage/base.py
@@ -38,7 +38,7 @@ class StorageAdapter(metaclass=abc.ABCMeta):
         stores the token response.
 
         :param token_response: The token response received from the refresh
-        :type token_response: :class:`OAuthTokenResponse`
+        :type token_response: :class:`~.OAuthTokenResponse`
         """
         self.store(token_response)
 

--- a/src/globus_sdk/tokenstorage/base.py
+++ b/src/globus_sdk/tokenstorage/base.py
@@ -13,6 +13,9 @@ class StorageAdapter(metaclass=abc.ABCMeta):
     def store(self, token_response: OAuthTokenResponse) -> None:
         """
         Store an `OAuthTokenResponse` in the underlying storage for this adapter.
+
+        :param token_response: The token response to store
+        :type token_response: :class:`~.OAuthTokenResponse`
         """
 
     @abc.abstractmethod
@@ -23,12 +26,19 @@ class StorageAdapter(metaclass=abc.ABCMeta):
         Either returns a dict with the access token, refresh token (optional), and
         expiration time, or returns ``None``, indicating that there was no data for that
         resource server.
+
+        :param resource_server: The resource_server string which uniquely identifies the
+            token data to retriever from storage
+        :type resource_server: str
         """
 
     def on_refresh(self, token_response: OAuthTokenResponse) -> None:
         """
         By default, the on_refresh handler for a token storage adapter simply
         stores the token response.
+
+        :param token_response: The token response received from the refresh
+        :type token_response: :class:`OAuthTokenResponse`
         """
         self.store(token_response)
 

--- a/src/globus_sdk/tokenstorage/file_adapters.py
+++ b/src/globus_sdk/tokenstorage/file_adapters.py
@@ -87,6 +87,9 @@ class SimpleJSONFileAdapter(FileAdapter):
         Under the assumption that this may be running on a system with multiple
         local users, this sets the umask such that only the owner of the
         resulting file can read or write it.
+
+        :param token_response: The token data received from the refresh
+        :type token_response: :class:`~.OAuthTokenResponse`
         """
         to_write = self._load()
 


### PR DESCRIPTION


<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--835.org.readthedocs.build/en/835/

<!-- readthedocs-preview globus-sdk-python end -->