### PR TITLE
Fix failing docparams in config/

### DIFF
--- a/src/globus_sdk/config/environments.py
+++ b/src/globus_sdk/config/environments.py
@@ -67,8 +67,12 @@ def get_service_url(service: str, environment: str | None = None) -> str:
     >>> get_service_url("search", environment="production")
     'https://search.api.globus.org/'
 
-    If no ``environment`` is specified, this will use the ``GLOBUS_SDK_ENVIRONMENT``
-    environment variable.
+
+    :param service: The short name of the service to get the URL for
+    :type service: str
+    :param environment: The name of the environment to use. If unspecified, this will
+        use the ``GLOBUS_SDK_ENVIRONMENT`` environment variable.
+    :type environment: str, optional
     """
     log.debug(f'Service URL Lookup for "{service}" under env "{environment}"')
     environment = environment or get_environment_name()
@@ -94,6 +98,10 @@ def get_webapp_url(environment: str | None = None) -> str:
 
     >>> get_webapp_url("preview")
     'https://app.preview.globus.org/'
+
+    :param environment: The name of the environment to use. If unspecified, this will
+        use the ``GLOBUS_SDK_ENVIRONMENT`` environment variable.
+    :type environment: str, optional
     """
     environment = environment or get_environment_name()
     return get_service_url("app", environment=environment)


### PR DESCRIPTION


<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--837.org.readthedocs.build/en/837/

<!-- readthedocs-preview globus-sdk-python end -->