### PR TITLE
Fix failing docparams in services/transfer/

### DIFF
--- a/src/globus_sdk/services/transfer/data/delete_data.py
+++ b/src/globus_sdk/services/transfer/data/delete_data.py
@@ -170,6 +170,11 @@ class DeleteData(utils.PayloadWrapper):
 
         Appends a delete_item document to the DATA key of the delete
         document.
+
+        :param path: Path to the directory or file to be deleted
+        :type path: str
+        :param additional_fields: additional fields to be added to the delete item
+        :type additional_fields: dict, optional
         """
         item_data = {"DATA_TYPE": "delete_item", "path": path}
         if additional_fields is not None:

--- a/src/globus_sdk/services/transfer/transport.py
+++ b/src/globus_sdk/services/transfer/transport.py
@@ -11,6 +11,10 @@ class TransferRequestsTransport(RequestsTransport):
         check for transient error status codes which could be resolved by
         retrying the request. Does not retry ExternalErrors or EndpointErrors
         as those are unlikely to actually be transient.
+
+        :param ctx: The context object which describes the state of the request and the
+            retries which may already have been attempted
+        :type ctx: RetryContext
         """
         if ctx.response is not None and (
             ctx.response.status_code in self.TRANSIENT_ERROR_STATUS_CODES


### PR DESCRIPTION


<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--840.org.readthedocs.build/en/840/

<!-- readthedocs-preview globus-sdk-python end -->