### PR TITLE
Fix failing docparams in services/gcs/

### DIFF
--- a/src/globus_sdk/services/gcs/client.py
+++ b/src/globus_sdk/services/gcs/client.py
@@ -101,6 +101,9 @@ class GCSClient(client.BaseClient):
 
         Note that it is possible for valid connector_ids to be unrecognized
         due to differing SDK and GCS versions.
+
+        :param connector_id: The ID of the connector
+        :type connector_id: UUID or str
         """
         connector_dict = {
             "7c100eae-40fe-11e9-95a3-9cb6d0d9fd63": "Box",


### PR DESCRIPTION


<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--841.org.readthedocs.build/en/841/

<!-- readthedocs-preview globus-sdk-python end -->