### PR TITLE
Fix missing docparams in _testing/

### DIFF
--- a/src/globus_sdk/_testing/registry.py
+++ b/src/globus_sdk/_testing/registry.py
@@ -63,6 +63,10 @@ def get_response_set(set_id: t.Any) -> ResponseSet:
     """
     Lookup a ``ResponseSet`` as in ``load_response_set``, but without
     activating it.
+
+    :param set_id: The ID used to retrieve the response set. Typically a string, but
+        could be any key used to register a response set.
+    :type set_id: any
     """
     # first priority: check the explicit registry
     if set_id in _RESPONSE_SET_REGISTRY:
@@ -99,6 +103,13 @@ def load_response_set(
     Optionally lookup a response set and activate all of its responses. If
     passed a ``ResponseSet``, activate it, otherwise the first argument is an
     ID used for lookup.
+
+    :param set_id: The ID used to retrieve the response set. Typically a string, but
+        could be any key used to register a response set.
+    :type set_id: any
+    :param requests_mock: A ``responses`` library mock to use for response mocking,
+        defaults to the ``responses`` default
+    :type requests_mock: ``responses.RequestsMock``, optional
     """
     if isinstance(set_id, ResponseSet):
         return set_id.activate_all(requests_mock=requests_mock)
@@ -118,6 +129,16 @@ def load_response(
     ``RegisteredResponse``, activate it, otherwise the first argument is an ID
     of a ``ResponseSet`` used for lookup. By default, looks for the response
     registered under ``case="default"``.
+
+    :param set_id: The ID used to retrieve the response set. Typically a string, but
+        could be any key used to register a response set.
+    :type set_id: any
+    :param case: The name of a case within the response set to load, ignoring all other
+        registered mocks in the response set
+    :type case: str, optional
+    :param requests_mock: A ``responses`` library mock to use for response mocking,
+        defaults to the ``responses`` default
+    :type requests_mock: ``responses.RequestsMock``, optional
     """
     if isinstance(set_id, RegisteredResponse):
         return set_id.add(requests_mock=requests_mock)


### PR DESCRIPTION


<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--845.org.readthedocs.build/en/845/

<!-- readthedocs-preview globus-sdk-python end -->