### PR TITLE
Add pylint to default envlist

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist =
     lint
     mypy
+    pylint
     test-lazy-imports
     coverage_clean
     py{312,311,310,39,38,37}


### PR DESCRIPTION


<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--847.org.readthedocs.build/en/847/

<!-- readthedocs-preview globus-sdk-python end -->