### PR TITLE
Fix the release creation command

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -53,5 +53,5 @@ Generate the release body by running
 or create the release via the GitHub CLI
 ```
 ./scripts/changelog2md.py | \
-  gh release create $SDK_VERSION --title "v$SDK_VERSION" --notes -
+  gh release create $SDK_VERSION --title "v$SDK_VERSION" --notes-file -
 ```


### PR DESCRIPTION
`--notes -` makes `"-"` the content. `--notes-file -` reads from
stdin.


<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--851.org.readthedocs.build/en/851/

<!-- readthedocs-preview globus-sdk-python end -->