### PR TITLE
Update pre-commit hooks and configurations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,14 +18,14 @@ repos:
   rev: 1.16.0
   hooks:
     - id: blacken-docs
-      additional_dependencies: ['black==23.7.0']
+      additional_dependencies: ['black==23.9.1']
 - repo: https://github.com/PyCQA/flake8
   rev: 6.1.0
   hooks:
     - id: flake8
       name: "Lint python files"
       additional_dependencies:
-        - 'flake8-bugbear==23.7.10'
+        - 'flake8-bugbear==23.9.16'
         - 'flake8-comprehensions==3.14.0'
         - 'flake8-typing-as-t==0.0.3'
 - repo: https://github.com/PyCQA/isort

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,11 @@ repos:
   hooks:
     - id: check-github-workflows
     - id: check-readthedocs
+- repo: https://github.com/asottile/pyupgrade
+  rev: v3.15.0
+  hooks:
+    - id: pyupgrade
+      args: ["--py37-plus"]
 - repo: https://github.com/psf/black
   rev: 23.9.1
   hooks:
@@ -33,11 +38,6 @@ repos:
   hooks:
     - id: isort
       name: "Sort python imports"
-- repo: https://github.com/asottile/pyupgrade
-  rev: v3.15.0
-  hooks:
-    - id: pyupgrade
-      args: ["--py37-plus"]
 - repo: https://github.com/codespell-project/codespell
   rev: v2.2.6
   hooks:


### PR DESCRIPTION

This PR introduces the following changes:

* Run `pre-commit autoupdate`.
* Run `upadup`.
* (If applicable) resolve any new issues uncovered by updated hooks.
* (If applicable) remove pre-commit hooks that don't apply to any files in the repo.
* (If applicable) reorders and/or otherwise standardizes the pre-commit hooks.

<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>

<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--871.org.readthedocs.build/en/871/

<!-- readthedocs-preview globus-sdk-python end -->