### PR TITLE
Add slyp as a pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,10 @@ repos:
   hooks:
     - id: isort
       name: "Sort python imports"
+- repo: https://github.com/sirosen/slyp
+  rev: 0.1.1
+  hooks:
+    - id: slyp
 - repo: https://github.com/codespell-project/codespell
   rev: v2.2.6
   hooks:

--- a/tests/unit/experimental/test_auth_requirements_error.py
+++ b/tests/unit/experimental/test_auth_requirements_error.py
@@ -416,8 +416,10 @@ def test_backward_compatibility_consent_required_error():
         (  # missing 'authorization_parameters'
             _variants.LegacyAuthorizationParametersError,
             {},
-            "'authorization_parameters' must be a 'LegacyAuthorizationParameters' "
-            "object or a dictionary",
+            (
+                "'authorization_parameters' must be a 'LegacyAuthorizationParameters' "
+                "object or a dictionary"
+            ),
         ),
         (  # missing 'code'
             _variants.LegacyConsentRequiredTransferError,


### PR DESCRIPTION

This PR adds slyp as a pre-commit hook.

For some affected repos, the isort hook repo was updated as well.

## How this change was made

I added slyp as a pre-commit hook, then manually resolved all reported errors.

<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>

<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--872.org.readthedocs.build/en/872/

<!-- readthedocs-preview globus-sdk-python end -->