### PR TITLE
Group all Dependabot updates for GitHub actions together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,10 @@
 version: 2
-# check for python package and github-actions updates weekly
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION

This PR introduces the following changes:

*   _(For some repos)_ Introduce a Dependabot config
*   Configure Dependabot to group all GitHub action version updates together.

<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>

<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--880.org.readthedocs.build/en/880/

<!-- readthedocs-preview globus-sdk-python end -->