### PR TITLE
Use a monthly update schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     groups:
       github-actions:
         patterns:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+ci:
+  autoupdate_schedule: "monthly"
+
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks.git
   rev: v4.5.0


### PR DESCRIPTION

This PR introduces the following changes:

*   Configure Dependabot and pre-commit.ci to use a monthly update schedule.

<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>