### PR TITLE
Update slyp to 0.1.2 and fix what it finds

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
     - id: isort
       name: "Sort python imports"
 - repo: https://github.com/sirosen/slyp
-  rev: 0.1.1
+  rev: 0.1.2
   hooks:
     - id: slyp
 - repo: https://github.com/codespell-project/codespell

--- a/src/globus_sdk/services/transfer/data/transfer_data.py
+++ b/src/globus_sdk/services/transfer/data/transfer_data.py
@@ -365,8 +365,9 @@ class TransferData(utils.PayloadWrapper):
         name: str,
         *,
         method: Literal["include", "exclude"] = "exclude",
-        type: None  # pylint: disable=redefined-builtin
-        | (Literal["file", "dir"]) = None,
+        type: (  # pylint: disable=redefined-builtin
+            None | Literal["file", "dir"]
+        ) = None,
     ) -> None:
         """
         Add a filter rule to the transfer document.


### PR DESCRIPTION
slyp v0.1.2 adds W120 for multiline `|`-style unions in parameter annotations without enclosing parentheses.

---

This PR is the result of my test of the `slyp` check I just added to see if it works for us.
It looks to me like a success.


<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--886.org.readthedocs.build/en/886/

<!-- readthedocs-preview globus-sdk-python end -->