### PR TITLE
Support for v2 Timer Creation: client method + payload helpers

### DIFF
--- a/changelog.d/20231027_012754_sirosen_timers_v2.rst
+++ b/changelog.d/20231027_012754_sirosen_timers_v2.rst
@@ -1,0 +1,19 @@
+Added
+~~~~~
+
+- Add support for the new Transfer Timer creation method, in the form of a
+  client method, ``TimerClient.create_timer``, and a payload builder type,
+  ``TransferTimer`` (:pr:`NUMBER`)
+
+  - ``create_timer`` only supports dict data and ``TransferTimer``, not the
+    previous ``TimerJob`` type
+
+  - Additional helper classes, ``RecurringTimerSchedule`` and
+    ``OneceTimerSchedule``, are provided to help build the ``TransferTimer``
+    payload
+
+Deprecated
+~~~~~~~~~~
+
+- Creation of timers to run transfers using ``TimerJob`` is now
+  deprecated (:pr:`NUMBER`)

--- a/docs/services/timer.rst
+++ b/docs/services/timer.rst
@@ -12,13 +12,29 @@ Globus Timer
 Helper Objects
 --------------
 
-The :class:`TimerJob` class is used to set up request data to send to Timer for
-creating a recurring job. Currently only recurring transfers are supported.
-Thus, a :class:`TimerJob` should not be initialized directly; use the
-:meth:`TimerJob.from_transfer_data` method to construct one to start a Timer job to run a
-transfer. This will require having a :class:`TransferClient`
-nstantiated first -- see the Transfer service docs
-for details and examples.
+The main helper users should use is the one for constructing Transfer Timers:
+
+.. autoclass:: TransferTimer
+   :members:
+   :show-inheritance:
+
+In order to schedule a timer, pass a ``schedule`` with relevant parameters.
+This can be done using the two schedule helper classes
+
+.. autoclass:: OnceTimerSchedule
+   :members:
+   :show-inheritance:
+
+.. autoclass:: RecurringTimerSchedule
+   :members:
+   :show-inheritance:
+
+TimerJob (legacy)
+~~~~~~~~~~~~~~~~~
+
+The ``TimerJob`` class is still supported for creating timer, but it is
+not recommended.
+New users should prefer the ``TransferTimer`` class.
 
 .. autoclass:: TimerJob
    :members:

--- a/docs/services/timer.rst
+++ b/docs/services/timer.rst
@@ -12,7 +12,7 @@ Globus Timer
 Helper Objects
 --------------
 
-The main helper users should use is the one for constructing Transfer Timers:
+A helper is provided for constructing Transfer Timers:
 
 .. autoclass:: TransferTimer
    :members:
@@ -32,7 +32,7 @@ This can be done using the two schedule helper classes
 TimerJob (legacy)
 ~~~~~~~~~~~~~~~~~
 
-The ``TimerJob`` class is still supported for creating timer, but it is
+The ``TimerJob`` class is still supported for creating timers, but it is
 not recommended.
 New users should prefer the ``TransferTimer`` class.
 

--- a/src/globus_sdk/__init__.py
+++ b/src/globus_sdk/__init__.py
@@ -118,6 +118,8 @@ _LAZY_IMPORT_TABLE = {
         "TimerClient",
         "TransferTimer",
         "TimerJob",
+        "OnceTimerSchedule",
+        "RecurringTimerSchedule",
     },
     "services.transfer": {
         "ActivationRequirementsResponse",
@@ -211,6 +213,8 @@ if t.TYPE_CHECKING:
     from .services.timer import TimerClient
     from .services.timer import TransferTimer
     from .services.timer import TimerJob
+    from .services.timer import OnceTimerSchedule
+    from .services.timer import RecurringTimerSchedule
     from .services.transfer import ActivationRequirementsResponse
     from .services.transfer import DeleteData
     from .services.transfer import IterableTransferResponse
@@ -313,11 +317,13 @@ __all__ = (
     "NullAuthorizer",
     "OAuthDependentTokenResponse",
     "OAuthTokenResponse",
+    "OnceTimerSchedule",
     "OneDriveStoragePolicies",
     "POSIXCollectionPolicies",
     "POSIXStagingCollectionPolicies",
     "POSIXStagingStoragePolicies",
     "POSIXStoragePolicies",
+    "RecurringTimerSchedule",
     "RefreshTokenAuthorizer",
     "RemovedInV4Warning",
     "S3StoragePolicies",

--- a/src/globus_sdk/__init__.py
+++ b/src/globus_sdk/__init__.py
@@ -116,6 +116,7 @@ _LAZY_IMPORT_TABLE = {
     "services.timer": {
         "TimerAPIError",
         "TimerClient",
+        "TransferTimer",
         "TimerJob",
     },
     "services.transfer": {
@@ -208,6 +209,7 @@ if t.TYPE_CHECKING:
     from .services.search import SearchScrollQuery
     from .services.timer import TimerAPIError
     from .services.timer import TimerClient
+    from .services.timer import TransferTimer
     from .services.timer import TimerJob
     from .services.transfer import ActivationRequirementsResponse
     from .services.transfer import DeleteData
@@ -332,6 +334,7 @@ __all__ = (
     "TransferAPIError",
     "TransferClient",
     "TransferData",
+    "TransferTimer",
     "UserCredentialDocument",
 )
 

--- a/src/globus_sdk/_generate_init.py
+++ b/src/globus_sdk/_generate_init.py
@@ -188,7 +188,17 @@ _LAZY_IMPORT_TABLE: list[tuple[str, tuple[str, ...]]] = [
             "SearchScrollQuery",
         ),
     ),
-    ("services.timer", ("TimerAPIError", "TimerClient", "TransferTimer", "TimerJob")),
+    (
+        "services.timer",
+        (
+            "TimerAPIError",
+            "TimerClient",
+            "TransferTimer",
+            "TimerJob",
+            "OnceTimerSchedule",
+            "RecurringTimerSchedule",
+        ),
+    ),
     (
         "services.transfer",
         (

--- a/src/globus_sdk/_generate_init.py
+++ b/src/globus_sdk/_generate_init.py
@@ -188,7 +188,7 @@ _LAZY_IMPORT_TABLE: list[tuple[str, tuple[str, ...]]] = [
             "SearchScrollQuery",
         ),
     ),
-    ("services.timer", ("TimerAPIError", "TimerClient", "TimerJob")),
+    ("services.timer", ("TimerAPIError", "TimerClient", "TransferTimer", "TimerJob")),
     (
         "services.transfer",
         (

--- a/src/globus_sdk/_testing/data/timer/_common.py
+++ b/src/globus_sdk/_testing/data/timer/_common.py
@@ -37,6 +37,7 @@ V2_TRANSFER_TIMER = {
     "number_of_errors": 0,
     "number_of_runs": 0,
     "schedule": {
+        "type": "recurring",
         "end": {"count": 2},
         "interval_seconds": 604800,
         "start": "2023-10-27T05:00:00+00:00",

--- a/src/globus_sdk/_testing/data/timer/_common.py
+++ b/src/globus_sdk/_testing/data/timer/_common.py
@@ -1,0 +1,157 @@
+import uuid
+
+TIMER_ID = str(uuid.uuid1())
+
+DEST_EP_ID = str(uuid.uuid1())
+SOURCE_EP_ID = str(uuid.uuid1())
+
+
+V2_TRANSFER_TIMER = {
+    "body": {
+        "DATA": [
+            {
+                "DATA_TYPE": "transfer_item",
+                "destination_path": "/~/dst.txt",
+                "source_path": "/share/godata/file1.txt",
+            }
+        ],
+        "DATA_TYPE": "transfer",
+        "delete_destination_extra": False,
+        "destination_endpoint": DEST_EP_ID,
+        "encrypt_data": False,
+        "fail_on_quota_errors": False,
+        "notify_on_failed": True,
+        "notify_on_inactive": True,
+        "notify_on_succeeded": True,
+        "preserve_timestamp": False,
+        "skip_source_errors": False,
+        "source_endpoint": SOURCE_EP_ID,
+        "store_base_path_info": False,
+        "verify_checksum": True,
+    },
+    "inactive_reason": None,
+    "job_id": TIMER_ID,
+    "last_ran_at": None,
+    "name": "Very Cool Timer",
+    "next_run": "2023-10-27T05:00:00+00:00",
+    "number_of_errors": 0,
+    "number_of_runs": 0,
+    "schedule": {
+        "end": {"count": 2},
+        "interval_seconds": 604800,
+        "start": "2023-10-27T05:00:00+00:00",
+    },
+    "status": "new",
+    "submitted_at": "2023-10-26T20:31:09+00:00",
+}
+
+
+# V1 API data
+
+_transfer_data = {
+    "data": {
+        "action_id": "15jfdBESgveZQ",
+        "completion_time": "2022-04-01T19:30:05.973261+00:00",
+        "creator_id": "urn:globus:auth:identity:5276fa05-eedf-46c5-919f-ad2d0160d1a9",
+        "details": {
+            "DATA_TYPE": "task",
+            "bytes_checksummed": 0,
+            "bytes_transferred": 0,
+            "canceled_by_admin": None,
+            "canceled_by_admin_message": None,
+            "command": "API 0.10",
+            "completion_time": None,
+            "deadline": "2022-04-02T19:30:07+00:00",
+            "delete_destination_extra": False,
+            "destination_endpoint": "globus#dest_ep",
+            "destination_endpoint_display_name": "Some Dest Endpoint",
+            "destination_endpoint_id": DEST_EP_ID,
+            "directories": 0,
+            "effective_bytes_per_second": 0,
+            "encrypt_data": False,
+            "event_list": [],
+            "fail_on_quota_errors": False,
+            "fatal_error": None,
+            "faults": 0,
+            "files": 0,
+            "files_skipped": 0,
+            "files_transferred": 0,
+            "filter_rules": None,
+            "history_deleted": False,
+            "is_ok": True,
+            "is_paused": False,
+            "label": "example timer, run 1",
+            "nice_status": "Queued",
+            "nice_status_details": None,
+            "nice_status_expires_in": -1,
+            "nice_status_short_description": "Queued",
+            "owner_id": "5276fa05-eedf-46c5-919f-ad2d0160d1a9",
+            "preserve_timestamp": False,
+            "recursive_symlinks": "ignore",
+            "request_time": "2022-04-01T19:30:07+00:00",
+            "skip_source_errors": True,
+            "source_endpoint": "globus#src_ep",
+            "source_endpoint_display_name": "Some Source Endpoint",
+            "source_endpoint_id": SOURCE_EP_ID,
+            "status": "ACTIVE",
+            "subtasks_canceled": 0,
+            "subtasks_expired": 0,
+            "subtasks_failed": 0,
+            "subtasks_pending": 1,
+            "subtasks_retrying": 0,
+            "subtasks_skipped_errors": 0,
+            "subtasks_succeeded": 0,
+            "subtasks_total": 1,
+            "symlinks": 0,
+            "sync_level": 3,
+            "task_id": "22f0148c-b1f2-11ec-b87e-3912f602f346",
+            "type": "TRANSFER",
+            "username": "u_kj3pubpo35dmlem7vuwqcygrve",
+            "verify_checksum": True,
+        },
+        "display_status": "ACTIVE",
+        "label": None,
+        "manage_by": [],
+        "monitor_by": [],
+        "release_after": "P30D",
+        "start_time": "2022-04-01T19:30:05.973232+00:00",
+        "status": "ACTIVE",
+    },
+    "errors": None,
+    "status": 202,
+    "ran_at": "2022-04-01T19:30:07.103090",
+}
+V1_TIMER = {
+    "name": "example timer",
+    "start": "2022-04-01T19:30:00+00:00",
+    "stop_after": None,
+    "interval": 864000.0,
+    "callback_url": "https://actions.automate.globus.org/transfer/transfer/run",
+    "callback_body": {
+        "body": {
+            "label": "example timer",
+            "skip_source_errors": True,
+            "sync_level": 3,
+            "verify_checksum": True,
+            "source_endpoint_id": "ddb59aef-6d04-11e5-ba46-22000b92c6ec",
+            "destination_endpoint_id": "ddb59af0-6d04-11e5-ba46-22000b92c6ec",
+            "transfer_items": [
+                {
+                    "source_path": "/share/godata/file1.txt",
+                    "destination_path": "/~/file1.txt",
+                    "recursive": False,
+                }
+            ],
+        }
+    },
+    "inactive_reason": None,
+    "scope": None,
+    "job_id": TIMER_ID,
+    "status": "loaded",
+    "submitted_at": "2022-04-01T19:29:55.942546+00:00",
+    "last_ran_at": "2022-04-01T19:30:07.103090+00:00",
+    "next_run": "2022-04-11T19:30:00+00:00",
+    "n_runs": 1,
+    "n_errors": 0,
+    "results": {"data": [_transfer_data], "page_next": None},
+}

--- a/src/globus_sdk/_testing/data/timer/create_job.py
+++ b/src/globus_sdk/_testing/data/timer/create_job.py
@@ -1,14 +1,14 @@
 from globus_sdk._testing.models import RegisteredResponse, ResponseSet
 
-from .get_job import JOB_ID, JOB_JSON
+from ._common import TIMER_ID, V1_TIMER
 
 RESPONSES = ResponseSet(
-    metadata={"job_id": JOB_ID},
+    metadata={"job_id": TIMER_ID},
     default=RegisteredResponse(
         service="timer",
         path="/jobs/",
         method="POST",
-        json=JOB_JSON,
+        json=V1_TIMER,
         status=201,
     ),
     validation_error=RegisteredResponse(
@@ -30,7 +30,7 @@ RESPONSES = ResponseSet(
             ]
         },
         metadata={
-            "job_id": JOB_ID,
+            "job_id": TIMER_ID,
             "expect_messages": [
                 "field required: body.start",
                 "field required: body.callback_url",

--- a/src/globus_sdk/_testing/data/timer/create_timer.py
+++ b/src/globus_sdk/_testing/data/timer/create_timer.py
@@ -1,0 +1,20 @@
+from globus_sdk._testing.models import RegisteredResponse, ResponseSet
+
+from ._common import DEST_EP_ID, SOURCE_EP_ID, TIMER_ID, V2_TRANSFER_TIMER
+
+RESPONSES = ResponseSet(
+    default=RegisteredResponse(
+        service="timer",
+        path="/jobs/",
+        method="POST",
+        json={
+            "timer": V2_TRANSFER_TIMER,
+        },
+        status=201,
+        metadata={
+            "timer_id": TIMER_ID,
+            "source_endpoint": SOURCE_EP_ID,
+            "destination_endpoint": DEST_EP_ID,
+        },
+    ),
+)

--- a/src/globus_sdk/_testing/data/timer/create_timer.py
+++ b/src/globus_sdk/_testing/data/timer/create_timer.py
@@ -5,7 +5,7 @@ from ._common import DEST_EP_ID, SOURCE_EP_ID, TIMER_ID, V2_TRANSFER_TIMER
 RESPONSES = ResponseSet(
     default=RegisteredResponse(
         service="timer",
-        path="/jobs/",
+        path="/v2/timer",
         method="POST",
         json={
             "timer": V2_TRANSFER_TIMER,

--- a/src/globus_sdk/_testing/data/timer/delete_job.py
+++ b/src/globus_sdk/_testing/data/timer/delete_job.py
@@ -1,13 +1,13 @@
 from globus_sdk._testing.models import RegisteredResponse, ResponseSet
 
-from .get_job import JOB_ID, JOB_JSON
+from ._common import TIMER_ID, V1_TIMER
 
 RESPONSES = ResponseSet(
-    metadata={"job_id": JOB_ID},
+    metadata={"job_id": TIMER_ID},
     default=RegisteredResponse(
         service="timer",
-        path=f"/jobs/{JOB_ID}",
+        path=f"/jobs/{TIMER_ID}",
         method="DELETE",
-        json=JOB_JSON,
+        json=V1_TIMER,
     ),
 )

--- a/src/globus_sdk/_testing/data/timer/get_job.py
+++ b/src/globus_sdk/_testing/data/timer/get_job.py
@@ -1,123 +1,15 @@
 from globus_sdk._testing.models import RegisteredResponse, ResponseSet
 
-transfer_data = {
-    "data": {
-        "action_id": "15jfdBESgveZQ",
-        "completion_time": "2022-04-01T19:30:05.973261+00:00",
-        "creator_id": "urn:globus:auth:identity:5276fa05-eedf-46c5-919f-ad2d0160d1a9",
-        "details": {
-            "DATA_TYPE": "task",
-            "bytes_checksummed": 0,
-            "bytes_transferred": 0,
-            "canceled_by_admin": None,
-            "canceled_by_admin_message": None,
-            "command": "API 0.10",
-            "completion_time": None,
-            "deadline": "2022-04-02T19:30:07+00:00",
-            "delete_destination_extra": False,
-            "destination_endpoint": "go#ep2",
-            "destination_endpoint_display_name": "Globus Tutorial Endpoint 2",
-            "destination_endpoint_id": "ddb59af0-6d04-11e5-ba46-22000b92c6ec",
-            "directories": 0,
-            "effective_bytes_per_second": 0,
-            "encrypt_data": False,
-            "event_list": [],
-            "fail_on_quota_errors": False,
-            "fatal_error": None,
-            "faults": 0,
-            "files": 0,
-            "files_skipped": 0,
-            "files_transferred": 0,
-            "filter_rules": None,
-            "history_deleted": False,
-            "is_ok": True,
-            "is_paused": False,
-            "label": "example timer, run 1",
-            "nice_status": "Queued",
-            "nice_status_details": None,
-            "nice_status_expires_in": -1,
-            "nice_status_short_description": "Queued",
-            "owner_id": "5276fa05-eedf-46c5-919f-ad2d0160d1a9",
-            "preserve_timestamp": False,
-            "recursive_symlinks": "ignore",
-            "request_time": "2022-04-01T19:30:07+00:00",
-            "skip_source_errors": True,
-            "source_endpoint": "go#ep1",
-            "source_endpoint_display_name": "Globus Tutorial Endpoint 1",
-            "source_endpoint_id": "ddb59aef-6d04-11e5-ba46-22000b92c6ec",
-            "status": "ACTIVE",
-            "subtasks_canceled": 0,
-            "subtasks_expired": 0,
-            "subtasks_failed": 0,
-            "subtasks_pending": 1,
-            "subtasks_retrying": 0,
-            "subtasks_skipped_errors": 0,
-            "subtasks_succeeded": 0,
-            "subtasks_total": 1,
-            "symlinks": 0,
-            "sync_level": 3,
-            "task_id": "22f0148c-b1f2-11ec-b87e-3912f602f346",
-            "type": "TRANSFER",
-            "username": "u_kj3pubpo35dmlem7vuwqcygrve",
-            "verify_checksum": True,
-        },
-        "display_status": "ACTIVE",
-        "label": None,
-        "manage_by": [],
-        "monitor_by": [],
-        "release_after": "P30D",
-        "start_time": "2022-04-01T19:30:05.973232+00:00",
-        "status": "ACTIVE",
-    },
-    "errors": None,
-    "status": 202,
-    "ran_at": "2022-04-01T19:30:07.103090",
-}
+from ._common import TIMER_ID, V1_TIMER
 
-JOB_ID = "c59d942e-cd54-4711-93dd-4515de55a5f9"
-JOB_JSON = {
-    "name": "example timer",
-    "start": "2022-04-01T19:30:00+00:00",
-    "stop_after": None,
-    "interval": 864000.0,
-    "callback_url": "https://actions.automate.globus.org/transfer/transfer/run",
-    "callback_body": {
-        "body": {
-            "label": "example timer",
-            "skip_source_errors": True,
-            "sync_level": 3,
-            "verify_checksum": True,
-            "source_endpoint_id": "ddb59aef-6d04-11e5-ba46-22000b92c6ec",
-            "destination_endpoint_id": "ddb59af0-6d04-11e5-ba46-22000b92c6ec",
-            "transfer_items": [
-                {
-                    "source_path": "/share/godata/file1.txt",
-                    "destination_path": "/~/file1.txt",
-                    "recursive": False,
-                }
-            ],
-        }
-    },
-    "inactive_reason": None,
-    "scope": None,
-    "job_id": JOB_ID,
-    "status": "loaded",
-    "submitted_at": "2022-04-01T19:29:55.942546+00:00",
-    "last_ran_at": "2022-04-01T19:30:07.103090+00:00",
-    "next_run": "2022-04-11T19:30:00+00:00",
-    "n_runs": 1,
-    "n_errors": 0,
-    "results": {"data": [transfer_data], "page_next": None},
-}
-
-JOB_JSON_INACTIVE_USER = {
-    **JOB_JSON,
+TIMER_INACTIVE_USER = {
+    **V1_TIMER,
     "status": "inactive",
     "inactive_reason": {"cause": "user", "detail": None},
 }
 
-JOB_JSON_INACTIVE_GARE = {
-    **JOB_JSON,
+TIMER_INACTIVE_GARE = {
+    **V1_TIMER,
     "status": "inactive",
     "inactive_reason": {
         "cause": "globus_auth_requirements",
@@ -141,28 +33,28 @@ JOB_JSON_INACTIVE_GARE = {
 
 
 RESPONSES = ResponseSet(
-    metadata={"job_id": JOB_ID},
+    metadata={"job_id": TIMER_ID},
     default=RegisteredResponse(
         service="timer",
-        path=f"/jobs/{JOB_ID}",
+        path=f"/jobs/{TIMER_ID}",
         method="GET",
-        json=JOB_JSON,
+        json=V1_TIMER,
     ),
     inactive_gare=RegisteredResponse(
         service="timer",
-        path=f"/jobs/{JOB_ID}",
+        path=f"/jobs/{TIMER_ID}",
         method="GET",
-        json=JOB_JSON_INACTIVE_GARE,
+        json=TIMER_INACTIVE_GARE,
     ),
     inactive_user=RegisteredResponse(
         service="timer",
-        path=f"/jobs/{JOB_ID}",
+        path=f"/jobs/{TIMER_ID}",
         method="GET",
-        json=JOB_JSON_INACTIVE_USER,
+        json=TIMER_INACTIVE_USER,
     ),
     simple_500_error=RegisteredResponse(
         service="timer",
-        path=f"/jobs/{JOB_ID}",
+        path=f"/jobs/{TIMER_ID}",
         method="GET",
         status=500,
         json={

--- a/src/globus_sdk/_testing/data/timer/list_jobs.py
+++ b/src/globus_sdk/_testing/data/timer/list_jobs.py
@@ -1,13 +1,13 @@
 from globus_sdk._testing.models import RegisteredResponse, ResponseSet
 
-from .get_job import JOB_ID, JOB_JSON
+from ._common import TIMER_ID, V1_TIMER
 
 RESPONSES = ResponseSet(
-    metadata={"job_ids": [JOB_ID]},
+    metadata={"job_ids": [TIMER_ID]},
     default=RegisteredResponse(
         service="timer",
         path="/jobs/",
         method="GET",
-        json={"jobs": [JOB_JSON]},
+        json={"jobs": [V1_TIMER]},
     ),
 )

--- a/src/globus_sdk/_testing/data/timer/pause_job.py
+++ b/src/globus_sdk/_testing/data/timer/pause_job.py
@@ -1,13 +1,13 @@
 from globus_sdk._testing.models import RegisteredResponse, ResponseSet
 
-from .get_job import JOB_ID
+from ._common import TIMER_ID
 
 RESPONSES = ResponseSet(
-    metadata={"job_id": JOB_ID},
+    metadata={"job_id": TIMER_ID},
     default=RegisteredResponse(
         service="timer",
-        path=f"/jobs/{JOB_ID}/pause",
+        path=f"/jobs/{TIMER_ID}/pause",
         method="POST",
-        json={"message": f"Successfully paused job {JOB_ID}."},
+        json={"message": f"Successfully paused job {TIMER_ID}."},
     ),
 )

--- a/src/globus_sdk/_testing/data/timer/resume_job.py
+++ b/src/globus_sdk/_testing/data/timer/resume_job.py
@@ -1,13 +1,13 @@
 from globus_sdk._testing.models import RegisteredResponse, ResponseSet
 
-from .get_job import JOB_ID
+from ._common import TIMER_ID
 
 RESPONSES = ResponseSet(
-    metadata={"job_id": JOB_ID},
+    metadata={"job_id": TIMER_ID},
     default=RegisteredResponse(
         service="timer",
-        path=f"/jobs/{JOB_ID}/resume",
+        path=f"/jobs/{TIMER_ID}/resume",
         method="POST",
-        json={"message": f"Successfully resumed job {JOB_ID}."},
+        json={"message": f"Successfully resumed job {TIMER_ID}."},
     ),
 )

--- a/src/globus_sdk/_testing/data/timer/update_job.py
+++ b/src/globus_sdk/_testing/data/timer/update_job.py
@@ -1,17 +1,17 @@
 from globus_sdk._testing.models import RegisteredResponse, ResponseSet
 
-from .get_job import JOB_ID, JOB_JSON
+from ._common import TIMER_ID, V1_TIMER
 
 UPDATED_NAME = "updated name"
-UPDATED_JSON = dict(JOB_JSON)
-UPDATED_JSON["name"] = UPDATED_NAME  # mypy complains if this is onelinerized
+UPDATED_TIMER = dict(V1_TIMER)
+UPDATED_TIMER["name"] = UPDATED_NAME  # mypy complains if this is onelinerized
 
 RESPONSES = ResponseSet(
-    metadata={"job_id": JOB_ID, "name": UPDATED_NAME},
+    metadata={"job_id": TIMER_ID, "name": UPDATED_NAME},
     default=RegisteredResponse(
         service="timer",
-        path=f"/jobs/{JOB_ID}",
+        path=f"/jobs/{TIMER_ID}",
         method="PATCH",
-        json=UPDATED_JSON,
+        json=UPDATED_TIMER,
     ),
 )

--- a/src/globus_sdk/services/timer/__init__.py
+++ b/src/globus_sdk/services/timer/__init__.py
@@ -1,9 +1,10 @@
 from .client import TimerClient
-from .data import TimerJob
+from .data import TimerJob, TransferTimer
 from .errors import TimerAPIError
 
 __all__ = (
     "TimerAPIError",
     "TimerClient",
     "TimerJob",
+    "TransferTimer",
 )

--- a/src/globus_sdk/services/timer/__init__.py
+++ b/src/globus_sdk/services/timer/__init__.py
@@ -1,10 +1,12 @@
 from .client import TimerClient
-from .data import TimerJob, TransferTimer
+from .data import OnceTimerSchedule, RecurringTimerSchedule, TimerJob, TransferTimer
 from .errors import TimerAPIError
 
 __all__ = (
     "TimerAPIError",
     "TimerClient",
+    "OnceTimerSchedule",
+    "RecurringTimerSchedule",
     "TimerJob",
     "TransferTimer",
 )

--- a/src/globus_sdk/services/timer/client.py
+++ b/src/globus_sdk/services/timer/client.py
@@ -81,7 +81,7 @@ class TimerClient(client.BaseClient):
         :type timer: dict or :class:`~.TransferTimer`
 
         A ``TransferTimer`` object can be constructed from a ``TransferData`` object,
-        which is the recommended way to create a Timer for data transfers.
+        which is the recommended way to create a timer for data transfers.
 
         **Examples**
 

--- a/src/globus_sdk/services/timer/client.py
+++ b/src/globus_sdk/services/timer/client.py
@@ -7,7 +7,7 @@ from globus_sdk import client, response
 from globus_sdk._types import UUIDLike
 from globus_sdk.scopes import TimerScopes
 
-from .data import TimerJob
+from .data import TimerJob, TransferTimer
 from .errors import TimerAPIError
 
 log = logging.getLogger(__name__)
@@ -72,6 +72,48 @@ class TimerClient(client.BaseClient):
         """
         log.info(f"TimerClient.get_job({job_id})")
         return self.get(f"/jobs/{job_id}", query_params=query_params)
+
+    def create_timer(
+        self, timer: dict[str, t.Any] | TransferTimer
+    ) -> response.GlobusHTTPResponse:
+        """
+        :param timer: a document defining the new timer
+        :type timer: dict or :class:`~.TransferTimer`
+
+        A ``TransferTimer`` object can be constructed from a ``TransferData`` object,
+        which is the recommended way to create a Timer for data transfers.
+
+        **Examples**
+
+        .. tab-set::
+
+            .. tab-item:: Example Usage
+
+                .. code-block:: pycon
+
+                    >>> transfer_client = TransferClient(...)
+                    >>> transfer_data = TransferData(transfer_client, ...)
+                    >>> timer_client = globus_sdk.TimerClient(...)
+                    >>> create_doc = globus_sdk.TransferTimer(
+                    ...     name="my-timer",
+                    ...     schedule={"type": "recurring", "interval": 1800},
+                    ...     body=transfer_data,
+                    ... )
+                    >>> response = timer_client.create_timer(timer=create_doc)
+
+            .. tab-item:: Example Response Data
+
+                .. expandtestfixture:: timers.create_timer
+
+            .. tab-item:: API Info
+
+                ``POST /v2/timer``
+        """
+        log.info("TimerClient.create_timer(...)")
+        return self.post(
+            "/v2/timer",
+            data={"timer": dict(timer) if isinstance(timer, TransferTimer) else timer},
+        )
 
     def create_job(
         self, data: TimerJob | dict[str, t.Any]

--- a/src/globus_sdk/services/timer/client.py
+++ b/src/globus_sdk/services/timer/client.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import typing as t
 
-from globus_sdk import client, response
+from globus_sdk import client, exc, response
 from globus_sdk._types import UUIDLike
 from globus_sdk.scopes import TimerScopes
 
@@ -109,6 +109,11 @@ class TimerClient(client.BaseClient):
 
                 ``POST /v2/timer``
         """
+        if isinstance(timer, TimerJob):
+            raise exc.GlobusSDKUsageError(
+                "Cannot pass a TimerJob to create_timer(). "
+                "Create a TransferTimer instead."
+            )
         log.info("TimerClient.create_timer(...)")
         return self.post(
             "/v2/timer",
@@ -116,7 +121,7 @@ class TimerClient(client.BaseClient):
         )
 
     def create_job(
-        self, data: TimerJob | dict[str, t.Any]
+        self, data: dict[str, t.Any] | TimerJob
     ) -> response.GlobusHTTPResponse:
         """
         ``POST /jobs/``
@@ -138,6 +143,11 @@ class TimerClient(client.BaseClient):
         ... )
         >>> timer_result = timer_client.create_job(job)
         """
+        if isinstance(data, TransferTimer):
+            raise exc.GlobusSDKUsageError(
+                "Cannot pass a TransferTimer to create_job(). Use create_timer() "
+                "instead."
+            )
         log.info(f"TimerClient.create_job({data})")
         return self.post("/jobs/", data=data)
 

--- a/src/globus_sdk/services/timer/client.py
+++ b/src/globus_sdk/services/timer/client.py
@@ -103,7 +103,7 @@ class TimerClient(client.BaseClient):
 
             .. tab-item:: Example Response Data
 
-                .. expandtestfixture:: timers.create_timer
+                .. expandtestfixture:: timer.create_timer
 
             .. tab-item:: API Info
 

--- a/src/globus_sdk/services/timer/data.py
+++ b/src/globus_sdk/services/timer/data.py
@@ -139,6 +139,7 @@ class RecurringTimerSchedule(PayloadWrapper):
         start: str | dt.datetime | MissingType = MISSING,
         end: dict[str, t.Any] | MissingType = MISSING,
     ) -> None:
+        super().__init__()
         self["type"] = "recurring"
         self["interval_seconds"] = interval_seconds
         self["end"] = end
@@ -157,6 +158,7 @@ class OnceTimerSchedule(PayloadWrapper):
         self,
         datetime: str | dt.datetime | MissingType = MISSING,
     ) -> None:
+        super().__init__()
         self["type"] = "once"
         self["datetime"] = _format_date(datetime)
 

--- a/src/globus_sdk/services/timer/data.py
+++ b/src/globus_sdk/services/timer/data.py
@@ -308,6 +308,6 @@ class TimerJob(PayloadWrapper):
 
 def _format_date(date: str | dt.datetime | MISSING) -> str | MISSING:
     if isinstance(date, dt.datetime):
-        return date.astimezone(dt.timezone.utc).isoformat()
+        return date.astimezone(dt.timezone.utc).replace(microsecond=0).isoformat()
     else:
         return date

--- a/src/globus_sdk/services/timer/data.py
+++ b/src/globus_sdk/services/timer/data.py
@@ -350,7 +350,7 @@ class TimerJob(PayloadWrapper):
         )
 
 
-def _format_date(date: str | dt.datetime | MISSING) -> str | MISSING:
+def _format_date(date: str | dt.datetime | MissingType) -> str | MissingType:
     if isinstance(date, dt.datetime):
         return date.astimezone(dt.timezone.utc).replace(microsecond=0).isoformat()
     else:

--- a/src/globus_sdk/services/timer/data.py
+++ b/src/globus_sdk/services/timer/data.py
@@ -16,7 +16,7 @@ log = logging.getLogger(__name__)
 
 class TransferTimer(PayloadWrapper):
     """
-    A helper for specifying the payload for Transfer Timer creation.
+    A helper for defining a payload for Transfer Timer creation.
     Use this along with :meth:`create_timer <globus_sdk.TimerClient.create_timer>` to
     create a timer.
 
@@ -38,12 +38,13 @@ class TransferTimer(PayloadWrapper):
         removed, as they are not supported in timers.
     :type body: dict or :class:`~.TransferData`
 
-    The Schedule field encodes data which determines when the Timer will run.
+    The ``schedule`` field determines when the timer will run.
     Timers may be "run once" or "recurring", and "recurring" timers may specify an end
     date or a number of executions after which the timer will stop. A ``schedule`` is
     specified as a dict, but the SDK provides two useful helpers for constructing these
     data.
-    Example schedules:
+
+    **Example Schedules**
 
     .. tab-set::
 
@@ -127,7 +128,7 @@ class TransferTimer(PayloadWrapper):
 
 class RecurringTimerSchedule(PayloadWrapper):
     """
-    A helper used as part of a *timer* to define the "schedule" for the *timer*.
+    A helper used as part of a *timer* to define when the *timer* will run.
 
     A ``RecurringTimerSchedule`` is used to describe a *timer* which runs repeatedly
     until some end condition is reached.
@@ -188,7 +189,7 @@ class RecurringTimerSchedule(PayloadWrapper):
 
 class OnceTimerSchedule(PayloadWrapper):
     """
-    A helper used as part of a *timer* to define the "schedule" for the *timer*.
+    A helper used as part of a *timer* to define when the *timer* will run.
 
     A ``OnceTimerSchedule`` is used to describe a *timer* which runs exactly once.
     It may be scheduled for a time in the future.
@@ -216,7 +217,7 @@ class TimerJob(PayloadWrapper):
 
         ``TimerJob`` is still supported for non-transfer use-cases.
 
-    Helper for specifying a timer in the Timer service. Used as the ``data``
+    Helper for creating a timer in the Timer service. Used as the ``data``
     argument in :meth:`create_job <globus_sdk.TimerClient.create_job>`.
 
     The ``callback_url`` parameter should always be the URL used to run an

--- a/src/globus_sdk/services/timer/data.py
+++ b/src/globus_sdk/services/timer/data.py
@@ -39,6 +39,7 @@ class TransferTimer(PayloadWrapper):
     The Schedule field encodes data which determines when the Timer will run.
     Timers may be "run once" or "recurring", and "recurring" timers may specify an end
     date or a number of executions after which the timer will stop.
+
     Example schedules:
 
     .. tab-set::
@@ -75,11 +76,27 @@ class TransferTimer(PayloadWrapper):
                     "end": {"condition": "iterations", "iterations": 10},
                 }
 
-        .. tab-item:: Run Every 10 Minutes, Indefinitedly
+        .. tab-item:: Run Every 10 Minutes, Indefinitely
 
             .. code-block:: python
 
                 schedule = {"type": "recurring", "interval_seconds": 600}
+
+    Using these schedules, you can create a timer from a ``TransferData`` object:
+
+    .. code-block:: pycon
+
+        >>> from globus_sdk import TransferData, TransferTimer
+        >>> schedule = ...
+        >>> transfer_data = TransferData(...)
+        >>> timer = TransferTimer(
+        ...     name="my timer",
+        ...     schedule=schedule,
+        ...     body=transfer_data,
+        ... )
+
+    Submit the timer to the Timers service with
+    :meth:`create_timer <globus_sdk.TimerClient.create_timer>`.
     """
 
     def __init__(

--- a/tests/functional/services/timer/conftest.py
+++ b/tests/functional/services/timer/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+
+import globus_sdk
+
+
+@pytest.fixture
+def client():
+    return globus_sdk.TimerClient()

--- a/tests/functional/services/timer/test_create_timer.py
+++ b/tests/functional/services/timer/test_create_timer.py
@@ -4,7 +4,22 @@ import globus_sdk
 from globus_sdk._testing import get_last_request, load_response
 
 
-def test_simple_transfer_timer_creation(client):
+def test_dummy_timer_creation(client):
+    # create a timer with a dummy payload and validate how it gets wrapped by the
+    # sending method
+    meta = load_response(client.create_timer).metadata
+
+    timer = client.create_timer(timer={"foo": "bar"})
+    assert timer["timer"]["job_id"] == meta["timer_id"]
+
+    req = get_last_request()
+    sent = json.loads(req.body)
+    assert sent == {"timer": {"foo": "bar"}}
+
+
+def test_transfer_timer_creation(client):
+    # create a timer using the payload helpers and confirm that it is serialized as
+    # desired
     meta = load_response(client.create_timer).metadata
     body = globus_sdk.TransferData(
         source_endpoint=meta["source_endpoint"],

--- a/tests/functional/services/timer/test_create_timer.py
+++ b/tests/functional/services/timer/test_create_timer.py
@@ -1,0 +1,33 @@
+import json
+
+import globus_sdk
+from globus_sdk._testing import get_last_request, load_response
+
+
+def test_simple_transfer_timer_creation(client):
+    meta = load_response(client.create_timer).metadata
+    body = globus_sdk.TransferData(
+        source_endpoint=meta["source_endpoint"],
+        destination_endpoint=meta["destination_endpoint"],
+    )
+    body.add_item("/share/godata/file1.txt", "/~/file1.txt")
+
+    schedule = globus_sdk.RecurringTimerSchedule(
+        interval_seconds=60, end={"condition": "iterations", "iterations": 3}
+    )
+
+    timer = client.create_timer(
+        timer=globus_sdk.TransferTimer(body=body, schedule=schedule)
+    )
+    assert timer["timer"]["job_id"] == meta["timer_id"]
+
+    req = get_last_request()
+    sent = json.loads(req.body)
+    assert sent["timer"]["schedule"] == {
+        "type": "recurring",
+        "interval_seconds": 60,
+        "end": {"condition": "iterations", "iterations": 3},
+    }
+    assert sent["timer"]["body"] == {
+        k: v for k, v in body.items() if k != "skip_activation_check"
+    }

--- a/tests/functional/services/timer/test_jobs.py
+++ b/tests/functional/services/timer/test_jobs.py
@@ -3,42 +3,29 @@ import json
 
 import pytest
 
-from globus_sdk import (
-    TimerAPIError,
-    TimerClient,
-    TimerJob,
-    TransferData,
-    config,
-    exc,
-    utils,
-)
+from globus_sdk import TimerAPIError, TimerJob, TransferData, config, exc, utils
 from globus_sdk._testing import get_last_request, load_response
 from tests.common import GO_EP1_ID, GO_EP2_ID
 
 
-@pytest.fixture
-def timer_client():
-    return TimerClient()
-
-
-def test_list_jobs(timer_client):
-    meta = load_response(timer_client.list_jobs).metadata
-    response = timer_client.list_jobs()
+def test_list_jobs(client):
+    meta = load_response(client.list_jobs).metadata
+    response = client.list_jobs()
     assert response.http_status == 200
     assert set(meta["job_ids"]) == {job["job_id"] for job in response.data["jobs"]}
 
 
-def test_get_job(timer_client):
-    meta = load_response(timer_client.get_job).metadata
-    response = timer_client.get_job(meta["job_id"])
+def test_get_job(client):
+    meta = load_response(client.get_job).metadata
+    response = client.get_job(meta["job_id"])
     assert response.http_status == 200
     assert response.data.get("job_id") == meta["job_id"]
 
 
-def test_get_job_errors(timer_client):
-    meta = load_response(timer_client.get_job, case="simple_500_error").metadata
+def test_get_job_errors(client):
+    meta = load_response(client.get_job, case="simple_500_error").metadata
     with pytest.raises(TimerAPIError) as excinfo:
-        timer_client.get_job(meta["job_id"])
+        client.get_job(meta["job_id"])
     err = excinfo.value
     assert err.http_status == 500
     assert err.code == "ERROR"
@@ -49,19 +36,19 @@ def test_get_job_errors(timer_client):
 @pytest.mark.parametrize(
     "interval", [datetime.timedelta(days=1), datetime.timedelta(minutes=60), 600, None]
 )
-def test_create_job(timer_client, start, interval):
-    meta = load_response(timer_client.create_job).metadata
+def test_create_job(client, start, interval):
+    meta = load_response(client.create_job).metadata
     transfer_data = TransferData(
         source_endpoint=GO_EP1_ID, destination_endpoint=GO_EP2_ID
     )
     with pytest.warns(exc.RemovedInV4Warning, match="Prefer TransferTimer"):
         timer_job = TimerJob.from_transfer_data(transfer_data, start, interval)
-    response = timer_client.create_job(timer_job)
+    response = client.create_job(timer_job)
     assert response.http_status == 201
     assert response.data["job_id"] == meta["job_id"]
     with pytest.warns(exc.RemovedInV4Warning, match="Prefer TransferTimer"):
         timer_job = TimerJob.from_transfer_data(dict(transfer_data), start, interval)
-    response = timer_client.create_job(timer_job)
+    response = client.create_job(timer_job)
     assert response.http_status == 201
     assert response.data["job_id"] == meta["job_id"]
     req_body = json.loads(get_last_request().body)
@@ -78,8 +65,8 @@ def test_create_job(timer_client, start, interval):
     )
 
 
-def test_create_job_validation_error(timer_client):
-    meta = load_response(timer_client.create_job, case="validation_error").metadata
+def test_create_job_validation_error(client):
+    meta = load_response(client.create_job, case="validation_error").metadata
     transfer_data = TransferData(
         source_endpoint=GO_EP1_ID, destination_endpoint=GO_EP2_ID
     )
@@ -89,7 +76,7 @@ def test_create_job_validation_error(timer_client):
         )
 
     with pytest.raises(TimerAPIError) as excinfo:
-        timer_client.create_job(timer_job)
+        client.create_job(timer_job)
 
     err = excinfo.value
     assert err.http_status == 422
@@ -97,37 +84,37 @@ def test_create_job_validation_error(timer_client):
     assert err.messages == meta["expect_messages"]
 
 
-def test_update_job(timer_client):
-    meta = load_response(timer_client.update_job).metadata
-    response = timer_client.update_job(meta["job_id"], {"name": meta["name"]})
+def test_update_job(client):
+    meta = load_response(client.update_job).metadata
+    response = client.update_job(meta["job_id"], {"name": meta["name"]})
     assert response.http_status == 200
     assert response.data["job_id"] == meta["job_id"]
     assert response.data["name"] == meta["name"]
 
 
-def test_delete_job(timer_client):
-    meta = load_response(timer_client.delete_job).metadata
-    response = timer_client.delete_job(meta["job_id"])
+def test_delete_job(client):
+    meta = load_response(client.delete_job).metadata
+    response = client.delete_job(meta["job_id"])
     assert response.http_status == 200
     assert response.data["job_id"] == meta["job_id"]
 
 
-def test_pause_job(timer_client):
-    meta = load_response(timer_client.pause_job).metadata
-    response = timer_client.pause_job(meta["job_id"])
+def test_pause_job(client):
+    meta = load_response(client.pause_job).metadata
+    response = client.pause_job(meta["job_id"])
     assert response.http_status == 200
     assert "Successfully paused" in response.data["message"]
 
 
 @pytest.mark.parametrize("update_credentials", [True, False, None])
-def test_resume_job(update_credentials, timer_client):
-    meta = load_response(timer_client.resume_job).metadata
+def test_resume_job(update_credentials, client):
+    meta = load_response(client.resume_job).metadata
 
     kwargs = {}
     if update_credentials is not None:
         kwargs["update_credentials"] = update_credentials
 
-    response = timer_client.resume_job(meta["job_id"], **kwargs)
+    response = client.resume_job(meta["job_id"], **kwargs)
     assert response.http_status == 200
     assert json.loads(response._raw_response.request.body) == kwargs
     assert "Successfully resumed" in response.data["message"]

--- a/tests/unit/helpers/test_timer.py
+++ b/tests/unit/helpers/test_timer.py
@@ -1,12 +1,13 @@
 import pytest
 
-from globus_sdk import TimerJob, TransferData
+from globus_sdk import TimerJob, TransferData, TransferTimer, exc
 from tests.common import GO_EP1_ID, GO_EP2_ID
 
 
 def test_timer_from_transfer_data_ok():
     tdata = TransferData(None, GO_EP1_ID, GO_EP2_ID)
-    job = TimerJob.from_transfer_data(tdata, "2022-01-01T00:00:00Z", 600)
+    with pytest.warns(exc.RemovedInV4Warning, match="Prefer TransferTimer"):
+        job = TimerJob.from_transfer_data(tdata, "2022-01-01T00:00:00Z", 600)
     assert "callback_body" in job
     assert "body" in job["callback_body"]
     assert "source_endpoint" in job["callback_body"]["body"]
@@ -21,4 +22,28 @@ def test_timer_from_transfer_data_ok():
 def test_timer_from_transfer_data_rejects_forbidden_keys(badkey, value):
     tdata = TransferData(None, GO_EP1_ID, GO_EP2_ID, **{badkey: value})
     with pytest.raises(ValueError):
-        TimerJob.from_transfer_data(tdata, "2022-01-01T00:00:00Z", 600)
+        with pytest.warns(exc.RemovedInV4Warning, match="Prefer TransferTimer"):
+            TimerJob.from_transfer_data(tdata, "2022-01-01T00:00:00Z", 600)
+
+
+def test_transfer_timer_ok():
+    tdata = TransferData(source_endpoint=GO_EP1_ID, destination_endpoint=GO_EP2_ID)
+    timer = TransferTimer(body=tdata, name="foo timer", schedule={"type": "once"})
+    assert timer["name"] == "foo timer"
+    assert timer["schedule"]["type"] == "once"
+    assert {"source_endpoint", "destination_endpoint"} < timer["body"].keys()
+    assert timer["body"]["source_endpoint"] == GO_EP1_ID
+    assert timer["body"]["destination_endpoint"] == GO_EP2_ID
+
+
+def test_transfer_timer_removes_disallowed_fields():
+    # set transfer-data-like body with disallowed fields
+    tdata = {"submission_id": "foo", "skip_activation_check": False, "foo": "bar"}
+    timer = TransferTimer(body=tdata, name="foo timer", schedule={"type": "once"})
+    assert timer["name"] == "foo timer"
+    assert timer["schedule"]["type"] == "once"
+
+    # confirm that disallowed fields are stripped in the timer,
+    # but the original dict is unchanged
+    assert timer["body"] == {"foo": "bar"}
+    assert set(tdata.keys()) == {"submission_id", "skip_activation_check", "foo"}

--- a/tests/unit/helpers/test_timer.py
+++ b/tests/unit/helpers/test_timer.py
@@ -99,3 +99,16 @@ def test_recurring_timer_schedule_formats_start(input_time, expected):
         "interval_seconds": 600,
         "start": expected,
     }
+
+
+def test_recurring_timer_schedule_formats_datetime_for_end():
+    # use a fixed (known) timestamp and check how it's formatted
+    end_time = datetime.datetime.fromtimestamp(1698385129.7044)
+    schedule = RecurringTimerSchedule(
+        interval_seconds=600, end={"condition": "time", "datetime": end_time}
+    )
+    assert utils.filter_missing(schedule) == {
+        "type": "recurring",
+        "interval_seconds": 600,
+        "end": {"condition": "time", "datetime": "2023-10-27T05:38:49+00:00"},
+    }

--- a/tests/unit/test_timers_client.py
+++ b/tests/unit/test_timers_client.py
@@ -1,0 +1,25 @@
+import pytest
+
+import globus_sdk
+
+
+def test_create_job_rejects_transfer_timer():
+    client = globus_sdk.TimerClient()
+    payload = globus_sdk.TransferTimer(schedule={"type": "once"}, body={})
+
+    with pytest.raises(
+        globus_sdk.GlobusSDKUsageError,
+        match=r"Cannot pass a TransferTimer to create_job\(\)\.",
+    ):
+        client.create_job(payload)
+
+
+def test_create_timer_rejects_timer_job():
+    client = globus_sdk.TimerClient()
+    payload = globus_sdk.TimerJob("https://bogus", {}, "2021-01-01T00:00:00Z", 300)
+
+    with pytest.raises(
+        globus_sdk.GlobusSDKUsageError,
+        match=r"Cannot pass a TimerJob to create_timer\(\)\.",
+    ):
+        client.create_timer(payload)


### PR DESCRIPTION
This puts in place a method:
- `TimerClient.create_timer`
- It calls `POST /v2/timer`
- It accepts a single argument, `timer`, which is passed as `{"timer": timer}` in the payload (enveloped)

The following three payload helpers are added:
- TransferTimer
- RecurringTimerSchedule
- OnceTimerSchedule

These three express the new valid payload types.

Explicit checks forbid the use of a TransferTimer with the older create_job method or the use of an older TimerJob payload helper with the new create_timer method.

`globus_sdk.MISSING` is used as a default throughout, where `None` would have been used in the past.

<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--887.org.readthedocs.build/en/887/

<!-- readthedocs-preview globus-sdk-python end -->