### PR TITLE
Release v3.30.0

### DIFF
--- a/changelog.d/20231016_114115_sirosen_add_ls_params.rst
+++ b/changelog.d/20231016_114115_sirosen_add_ls_params.rst
@@ -1,5 +1,0 @@
-Added
-~~~~~
-
-- ``TransferClient.operation_ls`` now supports the ``limit`` and ``offset``
-  parameters (:pr:`868`)

--- a/changelog.d/20231025_122826_sirosen_introduce_missingtype.rst
+++ b/changelog.d/20231025_122826_sirosen_introduce_missingtype.rst
@@ -1,9 +1,0 @@
-Added
-~~~~~
-
-- A new sentinel value, ``globus_sdk.MISSING``, has been introduced.
-  It is used for method calls which need to distinguish missing parameters from
-  an explicit ``None`` used to signify ``null`` (:pr:`885`)
-
-  - ``globus_sdk.MISSING`` is now supported in payload data for all methods, and
-    will be automatically removed from the payload before sending to the server

--- a/changelog.d/20231025_125551_sirosen_introduce_missingtype.rst
+++ b/changelog.d/20231025_125551_sirosen_introduce_missingtype.rst
@@ -1,5 +1,0 @@
-Changed
-~~~~~~~
-
-- ``GroupPolicies`` objects now treat an explicit instantiation with
-  ``high_assurance_timeout=None`` as setting the timeout to ``null`` (:pr:`885`)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,30 @@ to a major new version of the SDK.
 
 .. scriv-insert-here
 
+.. _changelog-3.30.0:
+
+v3.30.0 (2023-10-27)
+--------------------
+
+Added
+~~~~~
+
+- ``TransferClient.operation_ls`` now supports the ``limit`` and ``offset``
+  parameters (:pr:`868`)
+
+- A new sentinel value, ``globus_sdk.MISSING``, has been introduced.
+  It is used for method calls which need to distinguish missing parameters from
+  an explicit ``None`` used to signify ``null`` (:pr:`885`)
+
+  - ``globus_sdk.MISSING`` is now supported in payload data for all methods, and
+    will be automatically removed from the payload before sending to the server
+
+Changed
+~~~~~~~
+
+- ``GroupPolicies`` objects now treat an explicit instantiation with
+  ``high_assurance_timeout=None`` as setting the timeout to ``null`` (:pr:`885`)
+
 .. _changelog-3.29.0:
 
 v3.29.0 (2023-10-12)

--- a/src/globus_sdk/utils.py
+++ b/src/globus_sdk/utils.py
@@ -53,7 +53,7 @@ class MissingType:
 # users should typically not use this value directly, but it is part of the public SDK
 # interfaces along with its type for annotation purposes
 #
-# *new after v3.29.0*
+# *new in version 3.30.0*
 MISSING = MissingType()
 
 

--- a/src/globus_sdk/version.py
+++ b/src/globus_sdk/version.py
@@ -1,3 +1,3 @@
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "3.29.0"
+__version__ = "3.30.0"


### PR DESCRIPTION
Standard release updates, e.g. changelog.
Also make a minor tweak to the "new in version" comment on the `MISSING` sentinel.

---

# Changelog

## Added

- `TransferClient.operation_ls` now supports the `limit` and `offset`
  parameters (#868)

- A new sentinel value, `globus_sdk.MISSING`, has been introduced.
  It is used for method calls which need to distinguish missing parameters from
  an explicit `None` used to signify `null` (#885)

  - `globus_sdk.MISSING` is now supported in payload data for all methods, and
    will be automatically removed from the payload before sending to the server

## Changed

- `GroupPolicies` objects now treat an explicit instantiation with
  `high_assurance_timeout=None` as setting the timeout to `null` (#885)


<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--889.org.readthedocs.build/en/889/

<!-- readthedocs-preview globus-sdk-python end -->