### PR TITLE
Make 'experimental' more lazy-import friendly

### DIFF
--- a/src/globus_sdk/experimental/auth_requirements_error/_functional_api.py
+++ b/src/globus_sdk/experimental/auth_requirements_error/_functional_api.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import logging
 import typing as t
 
-from globus_sdk.exc import ErrorSubdocument, GlobusAPIError
-
 from . import _validators
 from ._auth_requirements_error import GlobusAuthRequirementsError
 from ._variants import (
@@ -13,6 +11,9 @@ from ._variants import (
     LegacyConsentRequiredAPError,
     LegacyConsentRequiredTransferError,
 )
+
+if t.TYPE_CHECKING:
+    from globus_sdk.exc import ErrorSubdocument, GlobusAPIError
 
 log = logging.getLogger(__name__)
 

--- a/src/globus_sdk/experimental/auth_requirements_error/_functional_api.py
+++ b/src/globus_sdk/experimental/auth_requirements_error/_functional_api.py
@@ -38,6 +38,7 @@ def to_auth_requirements_error(
     :param error: The error to convert.
     :type error: a GlobusAPIError, ErrorSubdocument, or dict
     """
+    from globus_sdk.exc import ErrorSubdocument, GlobusAPIError
 
     # GlobusAPIErrors may contain more than one error, so we consider all of them
     # even though we only return the first.
@@ -93,6 +94,8 @@ def to_auth_requirements_errors(
     :param errors: The errors to convert.
     :type errors: a list of GlobusAPIErrors, ErrorSubdocuments, or dicts
     """
+    from globus_sdk.exc import GlobusAPIError
+
     candidate_errors: list[ErrorSubdocument | dict[str, t.Any]] = []
     for error in errors:
         if isinstance(error, GlobusAPIError):

--- a/tests/non-pytest/lazy-imports/test_modules_do_not_require_requests.py
+++ b/tests/non-pytest/lazy-imports/test_modules_do_not_require_requests.py
@@ -1,0 +1,47 @@
+"""
+Test that various modules do not rely on `requests` at import-time.
+
+This means that these modules are safe to import in highly latency-sensitive
+applications like globus-cli.
+"""
+import os
+import subprocess
+import sys
+
+import pytest
+
+PYTHON_BINARY = os.environ.get("GLOBUS_TEST_PY", sys.executable)
+
+
+@pytest.mark.parametrize(
+    "module_name",
+    (
+        # experimental modules
+        "experimental",
+        "experimental.auth_requirements_error",
+        "experimental.scope_parser",
+        # parts which are expected to be standalone
+        "scopes",
+        "config",
+        # internal bits and bobs
+        "_guards",
+        "_types",
+        "utils",
+        "version",
+    ),
+)
+def test_module_does_not_require_requests(module_name):
+    command = (
+        f"import globus_sdk.{module_name}; "
+        "import sys; assert 'requests' not in sys.modules"
+    )
+    proc = subprocess.Popen(
+        f'{PYTHON_BINARY} -c "{command}"',
+        shell=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    status = proc.wait()
+    assert status == 0, str(proc.communicate())
+    proc.stdout.close()
+    proc.stderr.close()

--- a/tox.ini
+++ b/tox.ini
@@ -54,7 +54,7 @@ commands =
 [testenv:test-lazy-imports]
 deps = -r requirements/py{py_dot_ver}/test.txt
 commands =
-    pytest -n auto tests/non-pytest/lazy-imports/test_for_import_cycles.py
+    pytest -n auto tests/non-pytest/lazy-imports/
     pytest tests/unit/test_lazy_imports.py
 
 [testenv:pylint]


### PR DESCRIPTION
Modules under 'experimental' are now tested -- as part of the lazy-import dedicated tests -- to confirm that they do not have any import-time dependency on 'requests'. This helps ensure that these modules are safe to use in an application like globus-cli which is extremely latency-sensitive for slow imports, without accidentally incurring the large import-time costs of the `requests`, `urllib3`, etc dependency chain.

In order to pass the test, one import is moved to be TYPE_CHECKING-deferred in the GARE modules.

---

I discovered this of necessity in globus-cli work, and although I won't be able to take advantage right away, it will help us to have this guarantee out of the SDK.

It's not documented (yet), as I don't want the details of lazy-import behavior to be part of the external contract of the SDK.


<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--890.org.readthedocs.build/en/890/

<!-- readthedocs-preview globus-sdk-python end -->