### PR TITLE
Fix stale version pin in example doc

### DIFF
--- a/docs/examples/three_legged_oauth.rst
+++ b/docs/examples/three_legged_oauth.rst
@@ -63,7 +63,7 @@ Assuming you want to do so into a fresh virtualenv:
     $ virtualenv example-venv
     ...
     $ source example-venv/bin/activate
-    $ pip install Flask==0.11.1 globus-sdk
+    $ pip install flask globus-sdk
     ...
 
 You'll also want a shared function for loading the SDK ``AuthClient`` which


### PR DESCRIPTION
Simply remove the pin. It's only an example anyway.

---

I also grepped for `pip install` and `==` in the examples.
Nothing else was flagged.


<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--891.org.readthedocs.build/en/891/

<!-- readthedocs-preview globus-sdk-python end -->