### PR TITLE
Improve the way that enum members get stringified

### DIFF
--- a/src/globus_sdk/services/groups/data.py
+++ b/src/globus_sdk/services/groups/data.py
@@ -112,7 +112,7 @@ class BatchMembershipActions(utils.PayloadWrapper):
         :type role: str or :class:`~.GroupRole`
         """
         self.setdefault("add", []).extend(
-            {"identity_id": identity_id, "role": utils.render_enums_for_api(role)}
+            {"identity_id": identity_id, "role": role}
             for identity_id in utils.safe_strseq_iter(identity_ids)
         )
         return self
@@ -162,7 +162,7 @@ class BatchMembershipActions(utils.PayloadWrapper):
         :type role: str or :class:`~.GroupRole`
         """
         self.setdefault("invite", []).extend(
-            {"identity_id": identity_id, "role": utils.render_enums_for_api(role)}
+            {"identity_id": identity_id, "role": role}
             for identity_id in utils.safe_strseq_iter(identity_ids)
         )
         return self
@@ -252,9 +252,6 @@ class GroupPolicies(utils.PayloadWrapper):
     <https://groups.api.globus.org/redoc#operation/update_policies_v2_groups__group_id__policies_put>`_
     """
 
-    def __setitem__(self, key: str, value: t.Any) -> None:
-        self.data[key] = utils.render_enums_for_api(value)
-
     def __init__(
         self,
         *,
@@ -269,10 +266,8 @@ class GroupPolicies(utils.PayloadWrapper):
     ):
         super().__init__()
         self["is_high_assurance"] = is_high_assurance
-        self["group_visibility"] = utils.render_enums_for_api(group_visibility)
-        self["group_members_visibility"] = utils.render_enums_for_api(
-            group_members_visibility
-        )
+        self["group_visibility"] = group_visibility
+        self["group_members_visibility"] = group_members_visibility
         self["join_requests"] = join_requests
-        self["signup_fields"] = utils.render_enums_for_api(signup_fields)
+        self["signup_fields"] = list(signup_fields)
         self["authentication_assurance_timeout"] = authentication_assurance_timeout

--- a/src/globus_sdk/transport/encoders.py
+++ b/src/globus_sdk/transport/encoders.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import enum
 import typing as t
 import uuid
 
@@ -46,10 +47,13 @@ class RequestEncoder:
         Transforms data as follows:
 
             x: UUID -> str(x)
+            x: Enum -> x.value
             x: _    -> x
         """
         if isinstance(value, uuid.UUID):
             return str(value)
+        if isinstance(value, enum.Enum):
+            return value.value
         return value
 
     def _prepare_params(

--- a/src/globus_sdk/utils.py
+++ b/src/globus_sdk/utils.py
@@ -8,7 +8,6 @@ import sys
 import typing as t
 import uuid
 from base64 import b64encode
-from enum import Enum
 
 from globus_sdk._types import UUIDLike
 
@@ -117,25 +116,6 @@ def safe_strseq_iter(
     else:
         for x in value:
             yield str(x)
-
-
-def render_enums_for_api(value: t.Any) -> t.Any:
-    """
-    Convert enum values to their underlying value.
-
-    :param value: The stringifiable value or values to convert.
-    :type value: str, enum member, or iterable of str or enum members
-
-    If a value is an iterable type, it will be converted to a list and the values will
-    also be converted if they are enum values.
-    """
-    # special-case: handle str and bytes because these types are technically iterable
-    # types (of bytes or str values) which could trip someone up
-    if isinstance(value, (str, bytes)):
-        return value
-    if isinstance(value, collections.abc.Iterable):
-        return [render_enums_for_api(x) for x in value]
-    return value.value if isinstance(value, Enum) else value
 
 
 def commajoin(val: UUIDLike | t.Iterable[UUIDLike]) -> str:


### PR DESCRIPTION
The GroupsClient and related helpers have a number of enums of strings which are accepted as inputs. Previously, rendering these enums to their `.value` attributes (their values) was done via explicit calls in all of the locations where they are used.

Under this change, the serialization of any `Enum` member as `x.value` is codified as one of the characteristics of the primitive-value processing done in the transport layer's encoders, alongside UUID stringification.

The end result is a minor but useful simplification to any code which handles these enums, as the enum value can be passed to the underlying transport without a prior transformation. A minor helper function is eliminated (in favor of the addition to the encoders).

One test, which evaluated the correct stringification of an enum, has been updated to use `responses` to check the sent request, rather than a payload object prior to sending.


<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--894.org.readthedocs.build/en/894/

<!-- readthedocs-preview globus-sdk-python end -->