### PR TITLE
Enhance docs for 'client_type'

### DIFF
--- a/src/globus_sdk/services/auth/client/confidential_client.py
+++ b/src/globus_sdk/services/auth/client/confidential_client.py
@@ -300,12 +300,6 @@ class ConfidentialAppAuthClient(AuthLoginClient):
         name: str,
         *,
         public_client: bool | utils.MissingType = utils.MISSING,
-        visibility: t.Literal["public", "private"] | utils.MissingType = utils.MISSING,
-        redirect_uris: t.Iterable[str] | utils.MissingType = utils.MISSING,
-        terms_and_conditions: str | utils.MissingType = utils.MISSING,
-        privacy_policy: str | utils.MissingType = utils.MISSING,
-        required_idp: UUIDLike | utils.MissingType = utils.MISSING,
-        preselect_idp: UUIDLike | utils.MissingType = utils.MISSING,
         client_type: (
             t.Literal[
                 "client_identity",
@@ -317,6 +311,12 @@ class ConfidentialAppAuthClient(AuthLoginClient):
             ]
             | utils.MissingType
         ) = utils.MISSING,
+        visibility: t.Literal["public", "private"] | utils.MissingType = utils.MISSING,
+        redirect_uris: t.Iterable[str] | utils.MissingType = utils.MISSING,
+        terms_and_conditions: str | utils.MissingType = utils.MISSING,
+        privacy_policy: str | utils.MissingType = utils.MISSING,
+        required_idp: UUIDLike | utils.MissingType = utils.MISSING,
+        preselect_idp: UUIDLike | utils.MissingType = utils.MISSING,
         additional_fields: dict[str, t.Any] | utils.MissingType = utils.MISSING,
     ) -> GlobusHTTPResponse:
         """
@@ -332,6 +332,39 @@ class ConfidentialAppAuthClient(AuthLoginClient):
             option is mutually exclusive with ``client_type``, exactly one must be
             given.
         :type public_client: bool, optional
+        :param client_type: Defines the type of client that will be created. This
+            option is mutually exclusive with ``public_client``, exactly one must
+            be given.
+
+            .. dropdown:: Values for ``client_type``
+
+                .. list-table::
+
+                    * - ``"confidential_client"``
+                      - Applications that are OAuth confidential clients, and can
+                        manage a client secret and requests for user consent.
+                    * - ``"public_installed_client"``
+                      - Applications that are OAuth public clients or native
+                        applications that are distributed to users, and thus cannot
+                        manage a client secret.
+                    * - ``"client_identity"``
+                      - Applications that authenticate and act as the application
+                        itself. These applications are used for automation and as
+                        service or community accounts, and do NOT act on behalf of
+                        other users. Also known as a "Service Account".
+                    * - ``"resource_server"``
+                      - An API (OAuth resource server) that uses Globus Auth tokens for
+                        authentication. Users accessing the service login via Globus and
+                        consent for the client to use your API.
+                    * - ``"globus_connect_server"``
+                      - Create a client that will service as a Globus Connect Server
+                        endpoint.
+                    * - ``"hybrid_confidential_client_resource_server"``
+                      - A client which can use any behavior with Globus Auth - an
+                        application (confidential or public client), service account,
+                        or API.
+
+        :type client_type: str, optional
         :param visibility: If set to "public", any authenticated entity can view it.
             When set to "private", only entities in the same project as the client can
             view it.
@@ -351,36 +384,6 @@ class ConfidentialAppAuthClient(AuthLoginClient):
         :type preselect_idp: str or uuid, optional
         :param additional_fields: Any additional parameters to be passed through.
         :type additional_fields: dict, optional
-        :param client_type: Defines the type of client that will be created. This
-            option is mutually exclusive with ``public_client``, exactly one must
-            be given.
-        :type client_type: str, optional
-
-        ``client_type`` must be one of the following values:
-
-        "confidential_client": Applications that are OAuth confidential clients, and can
-        manage a client secret and requests for user consent.
-
-        "public_installed_client" : Applications that are OAuth public clients or native
-        applications that are distributed to users, and thus cannot manage a client
-        secret.
-
-        "client_identity": Applications that authenticate and act as the application
-        itself. These applications are used for automation and as service or community
-        accounts, and do NOT act on behalf of other users. Also known as a "Service
-        Account".
-
-        "resource_server":  A RESTful API (OAuth resource server) that uses Globus Auth
-        tokens for authentication. Users accessing the service login via Globus and
-        consent for the client to use your API.
-
-        "globus_connect_server": Create a client that will service as a Globus Connect
-        Server endpoint.
-
-        "hybrid_confidential_client_resource_server": Register any client with Globus
-        Auth - an application (confidential or public client), service account, or
-        service API.
-
 
         .. tab-set::
 

--- a/src/globus_sdk/services/auth/client/service_client.py
+++ b/src/globus_sdk/services/auth/client/service_client.py
@@ -1108,12 +1108,6 @@ class AuthClient(client.BaseClient):
         project: UUIDLike,
         *,
         public_client: bool | utils.MissingType = utils.MISSING,
-        visibility: t.Literal["public", "private"] | utils.MissingType = utils.MISSING,
-        redirect_uris: t.Iterable[str] | utils.MissingType = utils.MISSING,
-        terms_and_conditions: str | utils.MissingType = utils.MISSING,
-        privacy_policy: str | utils.MissingType = utils.MISSING,
-        required_idp: UUIDLike | utils.MissingType = utils.MISSING,
-        preselect_idp: UUIDLike | utils.MissingType = utils.MISSING,
         client_type: (
             t.Literal[
                 "client_identity",
@@ -1125,6 +1119,12 @@ class AuthClient(client.BaseClient):
             ]
             | utils.MissingType
         ) = utils.MISSING,
+        visibility: t.Literal["public", "private"] | utils.MissingType = utils.MISSING,
+        redirect_uris: t.Iterable[str] | utils.MissingType = utils.MISSING,
+        terms_and_conditions: str | utils.MissingType = utils.MISSING,
+        privacy_policy: str | utils.MissingType = utils.MISSING,
+        required_idp: UUIDLike | utils.MissingType = utils.MISSING,
+        preselect_idp: UUIDLike | utils.MissingType = utils.MISSING,
         additional_fields: dict[str, t.Any] | utils.MissingType = utils.MISSING,
     ) -> GlobusHTTPResponse:
         """
@@ -1133,6 +1133,9 @@ class AuthClient(client.BaseClient):
         :param name: The display name shown to users on consents. May not contain
             linebreaks.
         :type name: str
+        :param project: ID representing the project this client belongs to.
+        :type project: str or uuid
+
         :param public_client: This is used to infer which OAuth grant_types the client
             will be able to use. Should be false if the client is capable of keeping
             secret credentials (such as clients running on a server) and true if it is
@@ -1140,8 +1143,40 @@ class AuthClient(client.BaseClient):
             option is mutually exclusive with ``client_type``, exactly one must be
             given.
         :type public_client: bool, optional
-        :param project: ID representing the project this client belongs to.
-        :type project: str or uuid
+        :param client_type: Defines the type of client that will be created. This
+            option is mutually exclusive with ``public_client``, exactly one must
+            be given.
+
+            .. dropdown:: Values for ``client_type``
+
+                .. list-table::
+
+                    * - ``"confidential_client"``
+                      - Applications that are OAuth confidential clients, and can
+                        manage a client secret and requests for user consent.
+                    * - ``"public_installed_client"``
+                      - Applications that are OAuth public clients or native
+                        applications that are distributed to users, and thus cannot
+                        manage a client secret.
+                    * - ``"client_identity"``
+                      - Applications that authenticate and act as the application
+                        itself. These applications are used for automation and as
+                        service or community accounts, and do NOT act on behalf of
+                        other users. Also known as a "Service Account".
+                    * - ``"resource_server"``
+                      - An API (OAuth resource server) that uses Globus Auth tokens for
+                        authentication. Users accessing the service login via Globus and
+                        consent for the client to use your API.
+                    * - ``"globus_connect_server"``
+                      - Create a client that will service as a Globus Connect Server
+                        endpoint.
+                    * - ``"hybrid_confidential_client_resource_server"``
+                      - A client which can use any behavior with Globus Auth - an
+                        application (confidential or public client), service account,
+                        or API.
+
+        :type client_type: str, optional
+
         :param visibility: If set to "public", any authenticated entity can view it.
             When set to "private", only entities in the same project as the client can
             view it.
@@ -1161,36 +1196,6 @@ class AuthClient(client.BaseClient):
         :type preselect_idp: str or uuid, optional
         :param additional_fields: Any additional parameters to be passed through.
         :type additional_fields: dict, optional
-        :param client_type: Defines the type of client that will be created. This
-            option is mutually exclusive with ``public_client``, exactly one must
-            be given.
-        :type client_type: str, optional
-
-        ``client_type`` must be one of the following values:
-
-        "confidential_client": Applications that are OAuth confidential clients, and can
-        manage a client secret and requests for user consent.
-
-        "public_installed_client" : Applications that are OAuth public clients or native
-        applications that are distributed to users, and thus cannot manage a client
-        secret.
-
-        "client_identity": Applications that authenticate and act as the application
-        itself. These applications are used for automation and as service or community
-        accounts, and do NOT act on behalf of other users. Also known as a "Service
-        Account".
-
-        "resource_server":  A RESTful API (OAuth resource server) that uses Globus Auth
-        tokens for authentication. Users accessing the service login via Globus and
-        consent for the client to use your API.
-
-        "globus_connect_server": Create a client that will service as a Globus Connect
-        Server endpoint.
-
-        "hybrid_confidential_client_resource_server": Register any client with Globus
-        Auth - an application (confidential or public client), service account, or
-        service API.
-
 
         .. tab-set::
 


### PR DESCRIPTION
1. Reorder the keyword-only parameters for client creation to put `client_type` adjacent to `public_client`

This has no semantic impact. It's done only to make the parameter order in code match the order in doc.

2. Reorder parameter docs to make sure `client_type` is adjacent to `public_client`

These are mutex and one is required, which makes me want them near each other and at the top of the parameter list.

3. Convert doc of `client_type` values to a list-table under a dropdown

I find this to be a good balance of information, vertical density for scrolling, and easy authorship. `list-table` is pretty simple and requires minimal clever ASCII-art arrangements (vs many other table systems for markup languages).

---

Doc preview:
expanded | collapsed
--- | ---
![image](https://github.com/globus/globus-sdk-python/assets/1300022/a44168d1-eed3-4f4d-b65d-0d8b703a2fce) | ![image](https://github.com/globus/globus-sdk-python/assets/1300022/2485b119-fa8a-460b-8f2a-9a953a32de8a)

<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--898.org.readthedocs.build/en/898/

<!-- readthedocs-preview globus-sdk-python end -->