### PR TITLE
Preserve tzinfo if it is set in Timer payloads

### DIFF
--- a/changelog.d/20231103_143420_sirosen_fix_timers_tz_handling.rst
+++ b/changelog.d/20231103_143420_sirosen_fix_timers_tz_handling.rst
@@ -1,0 +1,5 @@
+Fixed
+~~~~~
+
+- When serializing ``TransferTimer`` data, do not convert to UTC if the input
+  was a valid datetime with an offset. (:pr:`NUMBER`)

--- a/src/globus_sdk/services/timer/data.py
+++ b/src/globus_sdk/services/timer/data.py
@@ -353,6 +353,8 @@ class TimerJob(PayloadWrapper):
 
 def _format_date(date: str | dt.datetime | MissingType) -> str | MissingType:
     if isinstance(date, dt.datetime):
-        return date.astimezone(dt.timezone.utc).replace(microsecond=0).isoformat()
+        if date.tzinfo is None:
+            date = date.astimezone(dt.timezone.utc)
+        return date.isoformat(timespec="seconds")
     else:
         return date

--- a/tests/unit/helpers/test_timer.py
+++ b/tests/unit/helpers/test_timer.py
@@ -65,8 +65,13 @@ def test_transfer_timer_removes_disallowed_fields():
         # even though this string is "obviously" not a valid datetime, we don't
         # translate it when we create the schedule
         ("tomorrow", "tomorrow"),
-        # use a fixed (known) timestamp and check how it's formatted
+        # use a fixed (known) timestamp and check how it's formatted as UTC
         (datetime.datetime.fromtimestamp(1698385129.7044), "2023-10-27T05:38:49+00:00"),
+        # use a non-UTC datetime and confirm that it is sent as non-UTC
+        (
+            datetime.datetime.fromisoformat("2023-10-27T05:38:49.999+01:00"),
+            "2023-10-27T05:38:49+01:00",
+        ),
     ),
 )
 def test_once_timer_schedule_formats_datetime(input_time, expected):


### PR DESCRIPTION
When converting/cleaning datetime objects, don't always force the conversion. Doing so leaves users unable to express times with non-UTC timezones.


<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--900.org.readthedocs.build/en/900/

<!-- readthedocs-preview globus-sdk-python end -->