### PR TITLE
Support custom CA certificate bundles

### DIFF
--- a/changelog.d/20231115_101055_kurtmckee_custom_ca_bundles_sc_28404.rst
+++ b/changelog.d/20231115_101055_kurtmckee_custom_ca_bundles_sc_28404.rst
@@ -1,0 +1,11 @@
+Added
+~~~~~
+
+- Support custom CA certificate bundles. (:pr:`NUMBER`)
+
+  Previously, SSL/TLS verification allowed only a boolean ``True`` or ``False`` value.
+  It is now possible to specify a CA certificate bundle file
+  using the existing ``verify_ssl`` parameter
+  or ``GLOBUS_SDK_VERIFY_SSL`` environment variable.
+
+  This may be useful for interacting with Globus through certain proxy firewalls.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -23,9 +23,11 @@ created with ``verify_ssl=True``, the resulting client will have SSL
 verification turned on.
 
 ``GLOBUS_SDK_VERIFY_SSL``
-    Used to disable SSL verification, typically to handle SSL-intercepting
-    firewalls. By default, all connections to servers are verified. Set
-    ``GLOBUS_SDK_VERIFY_SSL="false"`` to disable verification.
+    Used to configure SSL/TLS verification, typically to handle SSL/TLS-intercepting firewalls.
+    By default, all connections to servers are verified.
+    Set ``GLOBUS_SDK_VERIFY_SSL="false"`` to disable verification,
+    or set ``GLOBUS_SDK_VERIFY_SSL="/path/to/ca-bundle.cert"``
+    to use an alternate certificate authority bundle file.
 
 ``GLOBUS_SDK_HTTP_TIMEOUT``
     Adjust the timeout when HTTP requests are made. By default, requests have a

--- a/src/globus_sdk/config/env_vars.py
+++ b/src/globus_sdk/config/env_vars.py
@@ -76,9 +76,8 @@ def _ssl_verify_cast(
             return False
         if os.path.isfile(value):
             return value
-    if isinstance(value, pathlib.Path):
-        if value.is_file():
-            return str(value.absolute())
+    if isinstance(value, pathlib.Path) and value.is_file():
+        return str(value.absolute())
     raise ValueError(
         "SSL verification value must be a valid boolean value "
         f"or a path to a file that exists (got {value})"

--- a/src/globus_sdk/config/env_vars.py
+++ b/src/globus_sdk/config/env_vars.py
@@ -80,8 +80,8 @@ def _ssl_verify_cast(
         if value.is_file():
             return str(value.absolute())
     raise ValueError(
-        f"SSL verification {value} is not a valid boolean value "
-        "nor a path to a file that exists"
+        "SSL verification value must be a valid boolean value "
+        f"or a path to a file that exists (got {value})"
     )
 
 

--- a/src/globus_sdk/transport/requests.py
+++ b/src/globus_sdk/transport/requests.py
@@ -65,11 +65,9 @@ class RequestsTransport:
     If the maximum number of retries is reached, the final response or exception will
     be returned or raised.
 
-    :param verify_ssl: Explicitly enable or disable SSL verification. This parameter
-        defaults to True, but can be set via the ``GLOBUS_SDK_VERIFY_SSL`` environment
-        variable. Any non-``None`` setting via this parameter takes precedence over the
-        environment variable.
-    :type verify_ssl: bool, optional
+    :param verify_ssl: Explicitly enable or disable SSL verification,
+        or configure the path to a CA certificate bundle to use for SSL verification
+    :type verify_ssl: bool, str, or pathlib.Path, optional
     :param http_timeout: Explicitly set an HTTP timeout value in seconds. This parameter
         defaults to 60s but can be set via the ``GLOBUS_SDK_HTTP_TIMEOUT`` environment
         variable. Any value set via this parameter takes precedence over the environment

--- a/src/globus_sdk/transport/requests.py
+++ b/src/globus_sdk/transport/requests.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import logging
+import pathlib
 import random
 import time
 import typing as t
@@ -110,7 +111,7 @@ class RequestsTransport:
 
     def __init__(
         self,
-        verify_ssl: bool | None = None,
+        verify_ssl: bool | str | pathlib.Path | None = None,
         http_timeout: float | None = None,
         retry_backoff: t.Callable[[RetryContext], float] = _exponential_backoff,
         retry_checks: list[RetryCheck] | None = None,
@@ -148,7 +149,7 @@ class RequestsTransport:
     def tune(
         self,
         *,
-        verify_ssl: bool | None = None,
+        verify_ssl: bool | str | pathlib.Path | None = None,
         http_timeout: float | None = None,
         retry_backoff: t.Callable[[RetryContext], float] | None = None,
         max_sleep: float | int | None = None,
@@ -162,8 +163,9 @@ class RequestsTransport:
         In particular, this can be used to temporarily adjust request-sending minutiae
         like the ``http_timeout`` used.
 
-        :param verify_ssl: Explicitly enable or disable SSL verification
-        :type verify_ssl: bool, optional
+        :param verify_ssl: Explicitly enable or disable SSL verification,
+            or configure the path to a CA certificate bundle to use for SSL verification
+        :type verify_ssl: bool, str, or pathlib.Path, optional
         :param http_timeout: Explicitly set an HTTP timeout value in seconds
         :type http_timeout: float, optional
         :param retry_backoff: A function which determines how long to sleep between
@@ -201,7 +203,10 @@ class RequestsTransport:
             self.max_retries,
         )
         if verify_ssl is not None:
-            self.verify_ssl = verify_ssl
+            if isinstance(verify_ssl, bool):
+                self.verify_ssl = verify_ssl
+            else:
+                self.verify_ssl = str(verify_ssl)
         if http_timeout is not None:
             self.http_timeout = http_timeout
         if retry_backoff is not None:

--- a/tests/unit/CA-Bundle.cert
+++ b/tests/unit/CA-Bundle.cert
@@ -1,0 +1,2 @@
+This file exists to ensure that custom CA bundle files can be used.
+You can find references to this file by name in the test suite.

--- a/tests/unit/transport/test_transport.py
+++ b/tests/unit/transport/test_transport.py
@@ -1,3 +1,5 @@
+import pathlib
+
 import pytest
 
 from globus_sdk.transport import RequestsTransport, RetryContext
@@ -10,11 +12,22 @@ def _linear_backoff(ctx: RetryContext) -> float:
     return 0.5 * (2**ctx.attempt)
 
 
+ca_bundle_file = pathlib.Path(__file__).parent.parent.absolute() / "CA-Bundle.cert"
+ca_bundle_directory = ca_bundle_file.parent
+ca_bundle_non_existent = ca_bundle_directory / "bogus.bogus"
+
+
 @pytest.mark.parametrize(
     "param_name, init_value, tune_value",
     [
         ("verify_ssl", True, True),
         ("verify_ssl", True, False),
+        ("verify_ssl", True, ca_bundle_file),
+        ("verify_ssl", True, str(ca_bundle_file)),
+        ("verify_ssl", True, ca_bundle_directory),
+        ("verify_ssl", True, str(ca_bundle_directory)),
+        ("verify_ssl", True, ca_bundle_non_existent),
+        ("verify_ssl", True, str(ca_bundle_non_existent)),
         ("http_timeout", 60, 120),
         ("retry_backoff", _exponential_backoff, _linear_backoff),
         ("max_sleep", 10, 10),
@@ -24,6 +37,9 @@ def _linear_backoff(ctx: RetryContext) -> float:
     ],
 )
 def test_transport_tuning(param_name, init_value, tune_value):
+    expected_value = (
+        str(tune_value) if isinstance(tune_value, pathlib.Path) else tune_value
+    )
     init_kwargs = {param_name: init_value}
     transport = RequestsTransport(**init_kwargs)
 
@@ -31,6 +47,6 @@ def test_transport_tuning(param_name, init_value, tune_value):
 
     tune_kwargs = {param_name: tune_value}
     with transport.tune(**tune_kwargs):
-        assert getattr(transport, param_name) == tune_value
+        assert getattr(transport, param_name) == expected_value
 
     assert getattr(transport, param_name) == init_value


### PR DESCRIPTION
Added
-----

* Support custom CA certificate bundles.

  Previously, SSL/TLS verification allowed only a boolean ``True`` or ``False`` value.
  It is now possible to specify a CA certificate bundle file
  using the existing ``verify_ssl`` parameter
  or ``GLOBUS_SDK_VERIFY_SSL`` environment variable.

  This may be useful for interacting with Globus through certain proxy firewalls.


<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--903.org.readthedocs.build/en/903/

<!-- readthedocs-preview globus-sdk-python end -->