### PR TITLE
Remove the built-in ``/v2`` API route prefix from `GroupsClient`

### DIFF
--- a/changelog.d/20231128_104558_kurtmckee_fix_groups_api.rst
+++ b/changelog.d/20231128_104558_kurtmckee_fix_groups_api.rst
@@ -1,0 +1,6 @@
+Changed
+~~~~~~~
+
+-   Remove the built-in ``/v2`` API route prefix from the Groups client. (:pr:`NUMBER`)
+
+    This allows copying-and-pasting of Groups API routes directly from the documentation.

--- a/src/globus_sdk/_testing/data/groups/create_group.py
+++ b/src/globus_sdk/_testing/data/groups/create_group.py
@@ -6,7 +6,7 @@ RESPONSES = ResponseSet(
     metadata={"group_id": GROUP_ID},
     default=RegisteredResponse(
         service="groups",
-        path="/groups",
+        path="/v2/groups",
         method="POST",
         json=BASE_GROUP_DOC,
     ),

--- a/src/globus_sdk/_testing/data/groups/delete_group.py
+++ b/src/globus_sdk/_testing/data/groups/delete_group.py
@@ -6,7 +6,7 @@ RESPONSES = ResponseSet(
     metadata={"group_id": GROUP_ID},
     default=RegisteredResponse(
         service="groups",
-        path=f"/groups/{GROUP_ID}",
+        path=f"/v2/groups/{GROUP_ID}",
         method="DELETE",
         json=BASE_GROUP_DOC,
     ),

--- a/src/globus_sdk/_testing/data/groups/get_group.py
+++ b/src/globus_sdk/_testing/data/groups/get_group.py
@@ -6,7 +6,7 @@ RESPONSES = ResponseSet(
     metadata={"group_id": GROUP_ID},
     default=RegisteredResponse(
         service="groups",
-        path=f"/groups/{GROUP_ID}",
+        path=f"/v2/groups/{GROUP_ID}",
         json=BASE_GROUP_DOC,
     ),
 )

--- a/src/globus_sdk/_testing/data/groups/get_my_groups.py
+++ b/src/globus_sdk/_testing/data/groups/get_my_groups.py
@@ -175,7 +175,7 @@ RESPONSES = ResponseSet(
     },
     default=RegisteredResponse(
         service="groups",
-        path="/groups/my_groups",
+        path="/v2/groups/my_groups",
         json=raw_data,
     ),
 )

--- a/src/globus_sdk/_testing/data/groups/set_group_policies.py
+++ b/src/globus_sdk/_testing/data/groups/set_group_policies.py
@@ -6,7 +6,7 @@ RESPONSES = ResponseSet(
     metadata={"group_id": GROUP_ID},
     default=RegisteredResponse(
         service="groups",
-        path=f"/groups/{GROUP_ID}/policies",
+        path=f"/v2/groups/{GROUP_ID}/policies",
         method="PUT",
         json={
             "is_high_assurance": False,

--- a/src/globus_sdk/_testing/models.py
+++ b/src/globus_sdk/_testing/models.py
@@ -27,7 +27,7 @@ class RegisteredResponse:
         "transfer": "https://transfer.api.globus.org/v0.10",
         "search": "https://search.api.globus.org/",
         "gcs": "https://abc.xyz.data.globus.org/api",
-        "groups": "https://groups.api.globus.org/v2/",
+        "groups": "https://groups.api.globus.org/",
         "timer": "https://timer.automate.globus.org/",
         "flows": "https://flows.automate.globus.org/",
     }

--- a/src/globus_sdk/services/groups/client.py
+++ b/src/globus_sdk/services/groups/client.py
@@ -22,7 +22,6 @@ class GroupsClient(client.BaseClient):
     .. automethodlist:: globus_sdk.GroupsClient
     """
 
-    base_path = "/v2/"
     error_class = GroupsAPIError
     service_name = "groups"
     scopes = GroupsScopes
@@ -47,7 +46,7 @@ class GroupsClient(client.BaseClient):
                     :ref: get_my_groups_and_memberships_v2_groups_my_groups_get
         """
         return response.ArrayResponse(
-            self.get("/groups/my_groups", query_params=query_params)
+            self.get("/v2/groups/my_groups", query_params=query_params)
         )
 
     def get_group(
@@ -83,7 +82,7 @@ class GroupsClient(client.BaseClient):
             query_params = {}
         if include is not None:
             query_params["include"] = ",".join(utils.safe_strseq_iter(include))
-        return self.get(f"/groups/{group_id}", query_params=query_params)
+        return self.get(f"/v2/groups/{group_id}", query_params=query_params)
 
     def delete_group(
         self,
@@ -109,7 +108,7 @@ class GroupsClient(client.BaseClient):
                     :service: groups
                     :ref: delete_group_v2_groups__group_id__delete
         """
-        return self.delete(f"/groups/{group_id}", query_params=query_params)
+        return self.delete(f"/v2/groups/{group_id}", query_params=query_params)
 
     def create_group(
         self,
@@ -135,7 +134,7 @@ class GroupsClient(client.BaseClient):
                     :service: groups
                     :ref: create_group_v2_groups_post
         """
-        return self.post("/groups", data=data, query_params=query_params)
+        return self.post("/v2/groups", data=data, query_params=query_params)
 
     def update_group(
         self,
@@ -164,7 +163,7 @@ class GroupsClient(client.BaseClient):
                     :service: groups
                     :ref: update_group_v2_groups__group_id__put
         """
-        return self.put(f"/groups/{group_id}", data=data, query_params=query_params)
+        return self.put(f"/v2/groups/{group_id}", data=data, query_params=query_params)
 
     def get_group_policies(
         self,
@@ -190,7 +189,7 @@ class GroupsClient(client.BaseClient):
                     :service: groups
                     :ref: get_policies_v2_groups__group_id__policies_get
         """
-        return self.get(f"/groups/{group_id}/policies", query_params=query_params)
+        return self.get(f"/v2/groups/{group_id}/policies", query_params=query_params)
 
     def set_group_policies(
         self,
@@ -220,7 +219,7 @@ class GroupsClient(client.BaseClient):
                     :ref: update_policies_v2_groups__group_id__policies_put
         """
         return self.put(
-            f"/groups/{group_id}/policies", data=data, query_params=query_params
+            f"/v2/groups/{group_id}/policies", data=data, query_params=query_params
         )
 
     def get_identity_preferences(
@@ -304,7 +303,7 @@ class GroupsClient(client.BaseClient):
                     :ref: get_membership_fields_v2_groups__group_id__membership_fields_get
         """  # noqa: E501
         return self.get(
-            f"/groups/{group_id}/membership_fields", query_params=query_params
+            f"/v2/groups/{group_id}/membership_fields", query_params=query_params
         )
 
     def set_membership_fields(
@@ -335,7 +334,7 @@ class GroupsClient(client.BaseClient):
                     :ref: put_membership_fields_v2_groups__group_id__membership_fields_put
         """  # noqa: E501
         return self.put(
-            f"/groups/{group_id}/membership_fields",
+            f"/v2/groups/{group_id}/membership_fields",
             data=data,
             query_params=query_params,
         )
@@ -379,4 +378,6 @@ class GroupsClient(client.BaseClient):
                     :service: groups
                     :ref: group_membership_post_actions_v2_groups__group_id__post
         """
-        return self.post(f"/groups/{group_id}", data=actions, query_params=query_params)
+        return self.post(
+            f"/v2/groups/{group_id}", data=actions, query_params=query_params
+        )

--- a/tests/functional/services/groups/test_group_memberships.py
+++ b/tests/functional/services/groups/test_group_memberships.py
@@ -63,7 +63,7 @@ def test_batch_action_payload(groups_client, role):
     group_id = str(uuid.uuid1())
     load_response(
         RegisteredResponse(
-            service="groups", method="POST", path=f"/groups/{group_id}", json={}
+            service="groups", method="POST", path=f"/v2/groups/{group_id}", json={}
         )
     )
     rolestr = role if isinstance(role, str) else role.value


### PR DESCRIPTION
Changed
-------

-   Remove the built-in ``/v2`` API route prefix from the Groups client. (:pr:`NUMBER`)

    This allows copying-and-pasting of Groups API routes directly from the documentation.
