### PR TITLE
Address flaky scope parsing test

### DIFF
--- a/requirements/py3.10/test.txt
+++ b/requirements/py3.10/test.txt
@@ -4,17 +4,19 @@
 #
 #    tox p -m freezedeps
 #
-certifi==2023.7.22
+certifi==2023.11.17
     # via requests
-charset-normalizer==3.3.0
+charset-normalizer==3.3.2
     # via requests
 coverage==7.3.2
     # via -r test.in
-exceptiongroup==1.1.3
+exceptiongroup==1.2.0
     # via pytest
 execnet==2.0.2
     # via pytest-xdist
-idna==3.4
+flaky==3.7.0
+    # via -r test.in
+idna==3.6
     # via requests
 iniconfig==2.0.0
     # via pytest
@@ -22,23 +24,21 @@ packaging==23.2
     # via pytest
 pluggy==1.3.0
     # via pytest
-pytest==7.4.2
+pytest==7.4.3
     # via
     #   -r test.in
     #   pytest-xdist
-pytest-xdist==3.3.1
+pytest-xdist==3.5.0
     # via -r test.in
 pyyaml==6.0.1
     # via responses
 requests==2.31.0
     # via responses
-responses==0.23.3
+responses==0.24.1
     # via -r test.in
 tomli==2.0.1
     # via pytest
-types-pyyaml==6.0.12.12
-    # via responses
-urllib3==2.0.7
+urllib3==2.1.0
     # via
     #   requests
     #   responses

--- a/requirements/py3.10/typing.txt
+++ b/requirements/py3.10/typing.txt
@@ -4,13 +4,13 @@
 #
 #    tox p -m freezedeps
 #
-certifi==2023.7.22
+certifi==2023.11.17
     # via requests
-charset-normalizer==3.3.0
+charset-normalizer==3.3.2
     # via requests
-idna==3.4
+idna==3.6
     # via requests
-mypy==1.6.1
+mypy==1.7.1
     # via -r typing.in
 mypy-extensions==1.0.0
     # via mypy
@@ -18,7 +18,7 @@ pyyaml==6.0.1
     # via responses
 requests==2.31.0
     # via responses
-responses==0.23.3
+responses==0.24.1
     # via -r typing.in
 tomli==2.0.1
     # via mypy
@@ -28,15 +28,13 @@ types-docutils==0.20.0.3
     # via -r typing.in
 types-jwt==0.1.3
     # via -r typing.in
-types-pyyaml==6.0.12.12
-    # via responses
 types-requests==2.31.0.10
     # via -r typing.in
 typing-extensions==4.8.0
     # via
     #   -r typing.in
     #   mypy
-urllib3==2.0.7
+urllib3==2.1.0
     # via
     #   requests
     #   responses

--- a/requirements/py3.11/docs.txt
+++ b/requirements/py3.11/docs.txt
@@ -6,19 +6,19 @@
 #
 alabaster==0.7.13
     # via sphinx
-babel==2.13.0
+babel==2.13.1
     # via sphinx
 beautifulsoup4==4.12.2
     # via furo
-certifi==2023.7.22
+certifi==2023.11.17
     # via requests
-charset-normalizer==3.3.0
+charset-normalizer==3.3.2
     # via requests
 docutils==0.20.1
     # via sphinx
 furo==2023.9.10
     # via -r docs.in
-idna==3.4
+idna==3.6
     # via requests
 imagesize==1.4.1
     # via sphinx
@@ -28,7 +28,7 @@ markupsafe==2.1.3
     # via jinja2
 packaging==23.2
     # via sphinx
-pygments==2.16.1
+pygments==2.17.2
     # via
     #   furo
     #   sphinx
@@ -38,7 +38,7 @@ requests==2.31.0
     # via
     #   responses
     #   sphinx
-responses==0.23.3
+responses==0.24.1
     # via -r docs.in
 snowballstemmer==2.2.0
     # via sphinx
@@ -77,9 +77,7 @@ sphinxcontrib-qthelp==1.0.6
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.9
     # via sphinx
-types-pyyaml==6.0.12.12
-    # via responses
-urllib3==2.0.7
+urllib3==2.1.0
     # via
     #   requests
     #   responses

--- a/requirements/py3.11/test.txt
+++ b/requirements/py3.11/test.txt
@@ -4,15 +4,17 @@
 #
 #    tox p -m freezedeps
 #
-certifi==2023.7.22
+certifi==2023.11.17
     # via requests
-charset-normalizer==3.3.0
+charset-normalizer==3.3.2
     # via requests
 coverage==7.3.2
     # via -r test.in
 execnet==2.0.2
     # via pytest-xdist
-idna==3.4
+flaky==3.7.0
+    # via -r test.in
+idna==3.6
     # via requests
 iniconfig==2.0.0
     # via pytest
@@ -20,21 +22,19 @@ packaging==23.2
     # via pytest
 pluggy==1.3.0
     # via pytest
-pytest==7.4.2
+pytest==7.4.3
     # via
     #   -r test.in
     #   pytest-xdist
-pytest-xdist==3.3.1
+pytest-xdist==3.5.0
     # via -r test.in
 pyyaml==6.0.1
     # via responses
 requests==2.31.0
     # via responses
-responses==0.23.3
+responses==0.24.1
     # via -r test.in
-types-pyyaml==6.0.12.12
-    # via responses
-urllib3==2.0.7
+urllib3==2.1.0
     # via
     #   requests
     #   responses

--- a/requirements/py3.11/typing.txt
+++ b/requirements/py3.11/typing.txt
@@ -4,13 +4,13 @@
 #
 #    tox p -m freezedeps
 #
-certifi==2023.7.22
+certifi==2023.11.17
     # via requests
-charset-normalizer==3.3.0
+charset-normalizer==3.3.2
     # via requests
-idna==3.4
+idna==3.6
     # via requests
-mypy==1.6.1
+mypy==1.7.1
     # via -r typing.in
 mypy-extensions==1.0.0
     # via mypy
@@ -18,7 +18,7 @@ pyyaml==6.0.1
     # via responses
 requests==2.31.0
     # via responses
-responses==0.23.3
+responses==0.24.1
     # via -r typing.in
 types-cryptography==3.3.23.2
     # via types-jwt
@@ -26,15 +26,13 @@ types-docutils==0.20.0.3
     # via -r typing.in
 types-jwt==0.1.3
     # via -r typing.in
-types-pyyaml==6.0.12.12
-    # via responses
 types-requests==2.31.0.10
     # via -r typing.in
 typing-extensions==4.8.0
     # via
     #   -r typing.in
     #   mypy
-urllib3==2.0.7
+urllib3==2.1.0
     # via
     #   requests
     #   responses

--- a/requirements/py3.12/test.txt
+++ b/requirements/py3.12/test.txt
@@ -4,15 +4,17 @@
 #
 #    tox p -m freezedeps
 #
-certifi==2023.7.22
+certifi==2023.11.17
     # via requests
-charset-normalizer==3.3.0
+charset-normalizer==3.3.2
     # via requests
 coverage==7.3.2
     # via -r test.in
 execnet==2.0.2
     # via pytest-xdist
-idna==3.4
+flaky==3.7.0
+    # via -r test.in
+idna==3.6
     # via requests
 iniconfig==2.0.0
     # via pytest
@@ -20,21 +22,19 @@ packaging==23.2
     # via pytest
 pluggy==1.3.0
     # via pytest
-pytest==7.4.2
+pytest==7.4.3
     # via
     #   -r test.in
     #   pytest-xdist
-pytest-xdist==3.3.1
+pytest-xdist==3.5.0
     # via -r test.in
 pyyaml==6.0.1
     # via responses
 requests==2.31.0
     # via responses
-responses==0.23.3
+responses==0.24.1
     # via -r test.in
-types-pyyaml==6.0.12.12
-    # via responses
-urllib3==2.0.7
+urllib3==2.1.0
     # via
     #   requests
     #   responses

--- a/requirements/py3.12/typing.txt
+++ b/requirements/py3.12/typing.txt
@@ -4,13 +4,13 @@
 #
 #    tox p -m freezedeps
 #
-certifi==2023.7.22
+certifi==2023.11.17
     # via requests
-charset-normalizer==3.3.0
+charset-normalizer==3.3.2
     # via requests
-idna==3.4
+idna==3.6
     # via requests
-mypy==1.6.1
+mypy==1.7.1
     # via -r typing.in
 mypy-extensions==1.0.0
     # via mypy
@@ -18,7 +18,7 @@ pyyaml==6.0.1
     # via responses
 requests==2.31.0
     # via responses
-responses==0.23.3
+responses==0.24.1
     # via -r typing.in
 types-cryptography==3.3.23.2
     # via types-jwt
@@ -26,15 +26,13 @@ types-docutils==0.20.0.3
     # via -r typing.in
 types-jwt==0.1.3
     # via -r typing.in
-types-pyyaml==6.0.12.12
-    # via responses
 types-requests==2.31.0.10
     # via -r typing.in
 typing-extensions==4.8.0
     # via
     #   -r typing.in
     #   mypy
-urllib3==2.0.7
+urllib3==2.1.0
     # via
     #   requests
     #   responses

--- a/requirements/py3.7/test-mindeps.txt
+++ b/requirements/py3.7/test-mindeps.txt
@@ -4,7 +4,7 @@
 #
 #    tox p -m freezedeps
 #
-certifi==2023.7.22
+certifi==2023.11.17
     # via requests
 cffi==1.15.1
     # via cryptography
@@ -14,10 +14,12 @@ coverage==7.2.7
     # via -r test.in
 cryptography==3.3.1
     # via -r test-mindeps.in
-exceptiongroup==1.1.3
+exceptiongroup==1.2.0
     # via pytest
 execnet==2.0.2
     # via pytest-xdist
+flaky==3.7.0
+    # via -r test.in
 idna==2.8
     # via requests
 importlib-metadata==6.7.0
@@ -34,11 +36,11 @@ pycparser==2.21
     # via cffi
 pyjwt==2.0.0
     # via -r test-mindeps.in
-pytest==7.4.2
+pytest==7.4.3
     # via
     #   -r test.in
     #   pytest-xdist
-pytest-xdist==3.3.1
+pytest-xdist==3.5.0
     # via -r test.in
 pyyaml==6.0.1
     # via responses

--- a/requirements/py3.7/test.txt
+++ b/requirements/py3.7/test.txt
@@ -4,17 +4,19 @@
 #
 #    tox p -m freezedeps
 #
-certifi==2023.7.22
+certifi==2023.11.17
     # via requests
-charset-normalizer==3.3.0
+charset-normalizer==3.3.2
     # via requests
 coverage==7.2.7
     # via -r test.in
-exceptiongroup==1.1.3
+exceptiongroup==1.2.0
     # via pytest
 execnet==2.0.2
     # via pytest-xdist
-idna==3.4
+flaky==3.7.0
+    # via -r test.in
+idna==3.6
     # via requests
 importlib-metadata==6.7.0
     # via
@@ -26,11 +28,11 @@ packaging==23.2
     # via pytest
 pluggy==1.2.0
     # via pytest
-pytest==7.4.2
+pytest==7.4.3
     # via
     #   -r test.in
     #   pytest-xdist
-pytest-xdist==3.3.1
+pytest-xdist==3.5.0
     # via -r test.in
 pyyaml==6.0.1
     # via responses

--- a/requirements/py3.7/typing.txt
+++ b/requirements/py3.7/typing.txt
@@ -4,11 +4,11 @@
 #
 #    tox p -m freezedeps
 #
-certifi==2023.7.22
+certifi==2023.11.17
     # via requests
-charset-normalizer==3.3.0
+charset-normalizer==3.3.2
     # via requests
-idna==3.4
+idna==3.6
     # via requests
 mypy==1.4.1
     # via -r typing.in

--- a/requirements/py3.8/test.txt
+++ b/requirements/py3.8/test.txt
@@ -4,17 +4,19 @@
 #
 #    tox p -m freezedeps
 #
-certifi==2023.7.22
+certifi==2023.11.17
     # via requests
-charset-normalizer==3.3.0
+charset-normalizer==3.3.2
     # via requests
 coverage==7.3.2
     # via -r test.in
-exceptiongroup==1.1.3
+exceptiongroup==1.2.0
     # via pytest
 execnet==2.0.2
     # via pytest-xdist
-idna==3.4
+flaky==3.7.0
+    # via -r test.in
+idna==3.6
     # via requests
 iniconfig==2.0.0
     # via pytest
@@ -22,23 +24,21 @@ packaging==23.2
     # via pytest
 pluggy==1.3.0
     # via pytest
-pytest==7.4.2
+pytest==7.4.3
     # via
     #   -r test.in
     #   pytest-xdist
-pytest-xdist==3.3.1
+pytest-xdist==3.5.0
     # via -r test.in
 pyyaml==6.0.1
     # via responses
 requests==2.31.0
     # via responses
-responses==0.23.3
+responses==0.24.1
     # via -r test.in
 tomli==2.0.1
     # via pytest
-types-pyyaml==6.0.12.12
-    # via responses
-urllib3==2.0.7
+urllib3==2.1.0
     # via
     #   requests
     #   responses

--- a/requirements/py3.8/typing.txt
+++ b/requirements/py3.8/typing.txt
@@ -4,13 +4,13 @@
 #
 #    tox p -m freezedeps
 #
-certifi==2023.7.22
+certifi==2023.11.17
     # via requests
-charset-normalizer==3.3.0
+charset-normalizer==3.3.2
     # via requests
-idna==3.4
+idna==3.6
     # via requests
-mypy==1.6.1
+mypy==1.7.1
     # via -r typing.in
 mypy-extensions==1.0.0
     # via mypy
@@ -18,7 +18,7 @@ pyyaml==6.0.1
     # via responses
 requests==2.31.0
     # via responses
-responses==0.23.3
+responses==0.24.1
     # via -r typing.in
 tomli==2.0.1
     # via mypy
@@ -28,15 +28,13 @@ types-docutils==0.20.0.3
     # via -r typing.in
 types-jwt==0.1.3
     # via -r typing.in
-types-pyyaml==6.0.12.12
-    # via responses
 types-requests==2.31.0.10
     # via -r typing.in
 typing-extensions==4.8.0
     # via
     #   -r typing.in
     #   mypy
-urllib3==2.0.7
+urllib3==2.1.0
     # via
     #   requests
     #   responses

--- a/requirements/py3.9/test.txt
+++ b/requirements/py3.9/test.txt
@@ -4,17 +4,19 @@
 #
 #    tox p -m freezedeps
 #
-certifi==2023.7.22
+certifi==2023.11.17
     # via requests
-charset-normalizer==3.3.0
+charset-normalizer==3.3.2
     # via requests
 coverage==7.3.2
     # via -r test.in
-exceptiongroup==1.1.3
+exceptiongroup==1.2.0
     # via pytest
 execnet==2.0.2
     # via pytest-xdist
-idna==3.4
+flaky==3.7.0
+    # via -r test.in
+idna==3.6
     # via requests
 iniconfig==2.0.0
     # via pytest
@@ -22,23 +24,21 @@ packaging==23.2
     # via pytest
 pluggy==1.3.0
     # via pytest
-pytest==7.4.2
+pytest==7.4.3
     # via
     #   -r test.in
     #   pytest-xdist
-pytest-xdist==3.3.1
+pytest-xdist==3.5.0
     # via -r test.in
 pyyaml==6.0.1
     # via responses
 requests==2.31.0
     # via responses
-responses==0.23.3
+responses==0.24.1
     # via -r test.in
 tomli==2.0.1
     # via pytest
-types-pyyaml==6.0.12.12
-    # via responses
-urllib3==2.0.7
+urllib3==2.1.0
     # via
     #   requests
     #   responses

--- a/requirements/py3.9/typing.txt
+++ b/requirements/py3.9/typing.txt
@@ -4,13 +4,13 @@
 #
 #    tox p -m freezedeps
 #
-certifi==2023.7.22
+certifi==2023.11.17
     # via requests
-charset-normalizer==3.3.0
+charset-normalizer==3.3.2
     # via requests
-idna==3.4
+idna==3.6
     # via requests
-mypy==1.6.1
+mypy==1.7.1
     # via -r typing.in
 mypy-extensions==1.0.0
     # via mypy
@@ -18,7 +18,7 @@ pyyaml==6.0.1
     # via responses
 requests==2.31.0
     # via responses
-responses==0.23.3
+responses==0.24.1
     # via -r typing.in
 tomli==2.0.1
     # via mypy
@@ -28,15 +28,13 @@ types-docutils==0.20.0.3
     # via -r typing.in
 types-jwt==0.1.3
     # via -r typing.in
-types-pyyaml==6.0.12.12
-    # via responses
 types-requests==2.31.0.10
     # via -r typing.in
 typing-extensions==4.8.0
     # via
     #   -r typing.in
     #   mypy
-urllib3==2.0.7
+urllib3==2.1.0
     # via
     #   requests
     #   responses

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -1,4 +1,5 @@
 pytest
 coverage
+flaky
 pytest-xdist
 responses

--- a/setup.cfg
+++ b/setup.cfg
@@ -85,6 +85,7 @@ warn_no_return = true
 
 
 [tool:pytest]
+addopts = --no-success-flaky-report
 testpaths = tests
 norecursedirs = tests/non-pytest
 filterwarnings =

--- a/src/globus_sdk/_testing/data/auth/delete_client.py
+++ b/src/globus_sdk/_testing/data/auth/delete_client.py
@@ -19,7 +19,7 @@ CLIENT = {
     "userinfo_from_effective_identity": True,
     "preselect_idp": None,
     "public_client": False,
-}  # type: ignore [var-annotated]
+}
 
 RESPONSES = ResponseSet(
     default=RegisteredResponse(

--- a/src/globus_sdk/_testing/data/auth/get_client.py
+++ b/src/globus_sdk/_testing/data/auth/get_client.py
@@ -21,7 +21,7 @@ CLIENT = {
     "userinfo_from_effective_identity": True,
     "preselect_idp": None,
     "public_client": False,
-}  # type: ignore [var-annotated]
+}
 
 RESPONSES = ResponseSet(
     default=RegisteredResponse(

--- a/src/globus_sdk/_testing/data/auth/get_clients.py
+++ b/src/globus_sdk/_testing/data/auth/get_clients.py
@@ -19,7 +19,7 @@ FOO_CLIENT = {
     "userinfo_from_effective_identity": True,
     "preselect_idp": None,
     "public_client": False,
-}  # type: ignore [var-annotated]
+}
 
 BAR_CLIENT = {
     "required_idp": None,
@@ -38,7 +38,7 @@ BAR_CLIENT = {
     "userinfo_from_effective_identity": True,
     "preselect_idp": None,
     "public_client": False,
-}  # type: ignore [var-annotated]
+}
 
 RESPONSES = ResponseSet(
     default=RegisteredResponse(

--- a/src/globus_sdk/_testing/helpers.py
+++ b/src/globus_sdk/_testing/helpers.py
@@ -26,7 +26,7 @@ def get_last_request(
         last_call = calls[-1]
     except IndexError:
         return None
-    return t.cast(requests.PreparedRequest, last_call.request)
+    return last_call.request
 
 
 @t.overload

--- a/tests/unit/experimental/test_scope_parser.py
+++ b/tests/unit/experimental/test_scope_parser.py
@@ -144,6 +144,7 @@ def test_scope_parsing_catches_and_rejects_cycles(scopestring):
         Scope.parse(scopestring)
 
 
+@pytest.mark.flaky
 def test_scope_parsing_catches_and_rejects_very_large_cycles_quickly():
     """
     WARNING: this test is hardware speed dependent and could fail on slow systems.


### PR DESCRIPTION
This PR introduces the following changes:

* Add the `flaky` pytest plugin to mark the scope parsing timing test as flaky.
  This has the effect that it will be re-run once if it fails ([and it does](https://github.com/globus/globus-sdk-python/actions/runs/7060037397/job/19218803435#step:5:320)).

* Disable the flaky report for successes.

* Run `tox -m freezedeps` to pick up the flaky pytest plugin.
  This had the effect that mypy was upgraded, too.

* Resolve newly-triggered mypy lint failures caught by mypy 1.7.1.