### PR TITLE
Disable Dependabot updates to requirements files used for testing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,11 @@ updates:
       github-actions:
         patterns:
           - "*"
+
+  # Prevent updates of requirements files used only for testing.
+  - package-ecosystem: "pip"
+    directory: "/requirements/"
+    schedule:
+      interval: "monthly"
+    ignore:
+      - dependency-name: "*"


### PR DESCRIPTION
I don't _know_ that this will fix the issue we're seeing, but I _hope_ it will.

This is PR 9-1-1, so I guess it's trying to address an emergency situation.

Example PRs that we don't want to see anymore, trying to update our minimum dependency tests:

* [cryptography](https://github.com/globus/globus-sdk-python/pull/908)
* [urllib3](https://github.com/globus/globus-sdk-python/pull/888)


<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--911.org.readthedocs.build/en/911/

<!-- readthedocs-preview globus-sdk-python end -->