### PR TITLE
Fix annotation for `IdentityMap.__init__` to allow `ConfidentialAppAuthClient`

### DIFF
--- a/changelog.d/20231204_112410_sirosen_fix_annotation.rst
+++ b/changelog.d/20231204_112410_sirosen_fix_annotation.rst
@@ -1,0 +1,5 @@
+Fixed
+~~~~~
+
+- Fix the type annotation for ``globus_sdk.IdentityMap`` init, which
+  incorrectly rejected ``ConfidentialAppAuthClient`` (:pr:`NUMBER`)

--- a/src/globus_sdk/services/auth/identity_map.py
+++ b/src/globus_sdk/services/auth/identity_map.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import typing as t
 import uuid
 
-from .client import AuthClient
+from .client import AuthClient, ConfidentialAppAuthClient
 
 
 def is_username(val: str) -> bool:
@@ -114,7 +114,8 @@ class IdentityMap:
         username = record["username"] if record is not None else "NO_SUCH_IDENTITY"
 
     :param auth_client: The client object which will be used for lookups against Globus Auth
-    :type auth_client: :class:`AuthClient <globus_sdk.AuthClient>`
+    :type auth_client: :class:`AuthClient <globus_sdk.AuthClient>` or
+        :class:`ConfidentialAppAuthClient <globus_sdk.ConfidentialAppAuthClient>`
     :param identity_ids: A list or other iterable of usernames or identity IDs (potentially
         mixed together) which will be used to seed the ``IdentityMap`` 's tracking of
         unresolved Identities.
@@ -135,7 +136,7 @@ class IdentityMap:
 
     def __init__(
         self,
-        auth_client: AuthClient,
+        auth_client: AuthClient | ConfidentialAppAuthClient,
         identity_ids: t.Iterable[str] | None = None,
         *,
         id_batch_size: int | None = None,

--- a/tests/non-pytest/mypy-ignore-tests/identity_map.py
+++ b/tests/non-pytest/mypy-ignore-tests/identity_map.py
@@ -1,0 +1,18 @@
+# check IdentityMap usages
+import globus_sdk
+
+# create clients for later usage
+ac = globus_sdk.AuthClient()
+nc = globus_sdk.NativeAppAuthClient("foo_client_id")
+cc = globus_sdk.ConfidentialAppAuthClient("foo_client_id", "foo_client_secret")
+
+# check init allows CC, but not NC
+im = globus_sdk.IdentityMap(ac)
+im = globus_sdk.IdentityMap(cc)
+im = globus_sdk.IdentityMap(nc)  # type: ignore[arg-type]
+
+# getitem and delitem work, but setitem and contains do not
+foo = im["foo"]
+del im["foo"]
+im["foo"] = "bar"  # type: ignore[index]
+somebool = "foo" in im  # type: ignore[operator]


### PR DESCRIPTION
The annotation should allow `ConfidentialAppAuthClient`, as that client type supports `get_identities`.

Includes a typing-test for `IdentityMap`.


<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--912.org.readthedocs.build/en/912/

<!-- readthedocs-preview globus-sdk-python end -->