### PR TITLE
Remove use of tutorial endpoints in docs

### DIFF
--- a/changelog.d/20231205_114526_ada_remove_use_of_tutorial_endpoints_in_docs.rst
+++ b/changelog.d/20231205_114526_ada_remove_use_of_tutorial_endpoints_in_docs.rst
@@ -1,0 +1,4 @@
+Documentation
+~~~~~~~~~~~~~
+
+- Remove references to the Tutorial Endpoints from documentation. (:pr:`NUMBER`)

--- a/docs/examples/minimal_transfer_script/index.rst
+++ b/docs/examples/minimal_transfer_script/index.rst
@@ -12,6 +12,10 @@ using the :class:`TransferClient <globus_sdk.TransferClient>`.
 It uses the tutorial client ID from the :ref:`tutorial <tutorial>`.
 For simplicity, the script will prompt for login on each use.
 
+.. note::
+    You will need to replace the values for ``source_collection_id`` and
+    ``dest_collection_id`` with UUIDs of collections that you have access to.
+
 .. literalinclude:: transfer_minimal.py
     :caption: ``transfer_minimal.py`` [:download:`download <transfer_minimal.py>`]
     :language: python

--- a/docs/examples/minimal_transfer_script/transfer_minimal.py
+++ b/docs/examples/minimal_transfer_script/transfer_minimal.py
@@ -20,14 +20,13 @@ transfer_client = globus_sdk.TransferClient(
     authorizer=globus_sdk.AccessTokenAuthorizer(transfer_tokens["access_token"])
 )
 
-# Globus Tutorial Endpoint 1
-source_endpoint_id = "ddb59aef-6d04-11e5-ba46-22000b92c6ec"
-# Globus Tutorial Endpoint 2
-dest_endpoint_id = "ddb59af0-6d04-11e5-ba46-22000b92c6ec"
+# Replace these with your own collection UUIDs
+source_collection_id = "..."
+dest_collection_id = "..."
 
 # create a Transfer task consisting of one or more items
 task_data = globus_sdk.TransferData(
-    source_endpoint=source_endpoint_id, destination_endpoint=dest_endpoint_id
+    source_endpoint=source_collection_id, destination_endpoint=dest_collection_id
 )
 task_data.add_item(
     "/share/godata/file1.txt",  # source

--- a/docs/examples/timer_operations.rst
+++ b/docs/examples/timer_operations.rst
@@ -4,6 +4,10 @@ Timer Operations Script
 This example demonstrates the usage of methods on the Timer client to
 schedule a recurring Transfer task.
 
+.. note::
+    You will need to replace the values for ``SOURCE_COLLECTION`` and ``DEST_COLLECTION``
+    with UUIDs of collections that you have access to.
+
 .. code-block:: python
 
     import os
@@ -23,8 +27,10 @@ schedule a recurring Transfer task.
         TransferScopes,
     )
 
-    GOEP1 = "ddb59aef-6d04-11e5-ba46-22000b92c6ec"
-    GOEP2 = "ddb59af0-6d04-11e5-ba46-22000b92c6ec"
+    # Replace these with UUIDs of collections that you have access to
+    SOURCE_COLLECTION = "..."
+    DEST_COLLECTION = "..."
+
     NATIVE_CLIENT_ID = "61338d24-54d5-408f-a10d-66c06b59f6d2"
     TIMER_CLIENT_ID = "524230d7-ea86-4a52-8312-86065a9e0417"
 
@@ -67,7 +73,9 @@ schedule a recurring Transfer task.
     timer_token = token_response.by_resource_server[TIMER_CLIENT_ID]["access_token"]
 
     # Create a `TransferData` object
-    data = TransferData(source_endpoint=GOEP1, destination_endpoint=GOEP2)
+    data = TransferData(
+        source_endpoint=SOURCE_COLLECTION, destination_endpoint=DEST_COLLECTION
+    )
     data.add_item("/share/godata/file1.txt", "/~/file1.txt")
 
     # Set up the Timer client


### PR DESCRIPTION


<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--915.org.readthedocs.build/en/915/

<!-- readthedocs-preview globus-sdk-python end -->