### PR TITLE
Release v3.33.0.post0

### DIFF
--- a/changelog.d/20231205_114526_ada_remove_use_of_tutorial_endpoints_in_docs.rst
+++ b/changelog.d/20231205_114526_ada_remove_use_of_tutorial_endpoints_in_docs.rst
@@ -1,4 +1,0 @@
-Documentation
-~~~~~~~~~~~~~
-
-- Remove references to the Tutorial Endpoints from documentation. (:pr:`915`)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,16 @@ to a major new version of the SDK.
 
 .. scriv-insert-here
 
+.. _changelog-3.33.0.post0:
+
+v3.33.0.post0 (2023-12-05)
+--------------------------
+
+Documentation
+~~~~~~~~~~~~~
+
+- Remove references to the Tutorial Endpoints from documentation. (:pr:`915`)
+
 .. _changelog-3.33.0:
 
 v3.33.0 (2023-12-04)

--- a/src/globus_sdk/version.py
+++ b/src/globus_sdk/version.py
@@ -1,3 +1,3 @@
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "3.33.0"
+__version__ = "3.33.0.post0"


### PR DESCRIPTION
Documentation
-------------

- Remove references to the Tutorial Endpoints from documentation.
  (#915)

<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--916.org.readthedocs.build/en/916/

<!-- readthedocs-preview globus-sdk-python end -->