### PR TITLE
Add `delete_protected` for mapped collections

### DIFF
--- a/changelog.d/20231211_160420_sirosen_support_delete_protected.rst
+++ b/changelog.d/20231211_160420_sirosen_support_delete_protected.rst
@@ -1,0 +1,4 @@
+Added
+~~~~~
+
+- Add the ``delete_protected`` field to ``MappedCollectionDocument``. (:pr:`NUMBER`)

--- a/src/globus_sdk/services/gcs/data/collection.py
+++ b/src/globus_sdk/services/gcs/data/collection.py
@@ -236,6 +236,10 @@ class MappedCollectionDocument(CollectionDocument):
         guest collections
     :type sharing_users_deny: iterable of str, optional
 
+    :param delete_protected: Enable or disable deletion protection on this collection.
+        Defaults to ``True`` during creation.
+    :type delete_protected: bool, optional
+
     :param allow_guest_collections: Enable or disable creation and use of Guest
         Collections on this Mapped Collection
     :type allow_guest_collections: bool, optional
@@ -292,6 +296,7 @@ class MappedCollectionDocument(CollectionDocument):
         sharing_users_deny: t.Iterable[str] | None = None,
         sharing_restrict_paths: dict[str, t.Any] | None = None,
         # bools
+        delete_protected: bool | None = None,
         allow_guest_collections: bool | None = None,
         disable_anonymous_writes: bool | None = None,
         # dicts
@@ -337,6 +342,7 @@ class MappedCollectionDocument(CollectionDocument):
             sharing_users_deny=sharing_users_deny,
         )
         self._set_optbools(
+            delete_protected=delete_protected,
             allow_guest_collections=allow_guest_collections,
             disable_anonymous_writes=disable_anonymous_writes,
         )

--- a/src/globus_sdk/services/gcs/data/collection.py
+++ b/src/globus_sdk/services/gcs/data/collection.py
@@ -126,6 +126,7 @@ class CollectionDocument(utils.PayloadWrapper, abc.ABC):
 
     DATATYPE_BASE: str = "collection"
     DATATYPE_VERSION_IMPLICATIONS: dict[str, tuple[int, int, int]] = {
+        "delete_protected": (1, 8, 0),
         "guest_auth_policy_id": (1, 6, 0),
         "disable_anonymous_writes": (1, 5, 0),
         "force_verify": (1, 4, 0),

--- a/tests/unit/helpers/gcs/test_collections.py
+++ b/tests/unit/helpers/gcs/test_collections.py
@@ -71,6 +71,17 @@ def test_datatype_version_deduction(use_kwargs, doc_version):
         ({"disable_anonymous_writes": True}, "1.5.0"),
         ({"disable_anonymous_writes": False}, "1.5.0"),
         ({"guest_auth_policy_id": str(uuid.uuid4())}, "1.6.0"),
+        ({"delete_protected": False}, "1.8.0"),
+        # combining a long user_message (which uses callback-based detection) with
+        # higher and lower bounding fields needs to apply correctly
+        (
+            {"force_verify": False, "user_message": "long message..." + "x" * 100},
+            "1.7.0",
+        ),
+        (
+            {"delete_protected": False, "user_message": "long message..." + "x" * 100},
+            "1.8.0",
+        ),
     ],
 )
 def test_datatype_version_deduction_mapped_specific_fields(use_kwargs, doc_version):


### PR DESCRIPTION
This is a new field in the MappedCollectionDocument definition.

As a bit of new testing art to try to validate the change, the unit
tests for the GCS helpers now include some signature-inspection tests
+ a test for optional bool settings. These are rather simplistic
tests which might not offer a ton of value, but they're also very
quick to execute.


<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--920.org.readthedocs.build/en/920/

<!-- readthedocs-preview globus-sdk-python end -->