### PR TITLE
Improve URL handling in BaseClient and GCSClient

### DIFF
--- a/changelog.d/20231213_111925_sirosen_improved_url_handling.rst
+++ b/changelog.d/20231213_111925_sirosen_improved_url_handling.rst
@@ -1,0 +1,12 @@
+Changed
+~~~~~~~
+
+- Minor improvements to handling of paths and URLs. (:pr:`NUMBER`)
+
+  - Request paths which start with the ``base_path`` of a client are now
+    normalized to avoid duplicating the ``base_path``.
+
+  - When a ``GCSClient`` is initialized with an HTTPS URL, if the URL does not
+    end with the ``/api`` suffix, that suffix will automatically be appended.
+    This allows the ``gcs_manager_url`` field from Globus Transfer to be used
+    verbatim as the address for a ``GCSClient``.

--- a/src/globus_sdk/_testing/models.py
+++ b/src/globus_sdk/_testing/models.py
@@ -31,6 +31,10 @@ class RegisteredResponse:
         "timer": "https://timer.automate.globus.org/",
         "flows": "https://flows.automate.globus.org/",
     }
+    _base_path_map = {
+        "transfer": "/v0.10/",
+        "groups": "/v2/",
+    }
 
     def __init__(
         self,
@@ -45,11 +49,20 @@ class RegisteredResponse:
         **kwargs: t.Any,
     ) -> None:
         self.service = service
-        self.path = path
+
         if service:
+            # strip base_paths to match the behavior of clients
+            # this allows a registered response to use a path like `/v2/groups` with
+            # the GroupsClient, rather than *requiring* that it use `/groups`
+            base_path = self._base_path_map.get(service)
+            if base_path and path.startswith(base_path):
+                path = path[len(base_path) :]
+
             self.full_url = slash_join(self._url_map[service], path)
         else:
             self.full_url = path
+
+        self.path = path
 
         # convert the method to uppercase so that specifying `method="post"` will match
         # correctly -- method matching is case sensitive but we don't need to expose the

--- a/src/globus_sdk/client.py
+++ b/src/globus_sdk/client.py
@@ -296,6 +296,11 @@ class BaseClient:
         if path.startswith("https://") or path.startswith("http://"):
             url = path
         else:
+            # if passed a path which has a prefix matching the base_path, strip it
+            # this means that if a client has a base path of `/v1/`, a request for
+            # `/v1/foo` will hit `/v1/foo` rather than `/v1/v1/foo`
+            if path.startswith(self.base_path):
+                path = path[len(self.base_path) :]
             url = utils.slash_join(self.base_url, urllib.parse.quote(path))
 
         # make the request

--- a/src/globus_sdk/services/gcs/client.py
+++ b/src/globus_sdk/services/gcs/client.py
@@ -50,11 +50,14 @@ class GCSClient(client.BaseClient):
         transport_params: dict[str, t.Any] | None = None,
     ):
         # check if the provided address was a DNS name or an HTTPS URL
-        # if it was a URL, do not modify, but if it's a DNS name format it accordingly
-        # as a heuristic for this: just check if string starts with "https://" (this is
-        # sufficient to distinguish between the two for valid inputs)
         if not gcs_address.startswith("https://"):
+            # if it's a DNS name format it accordingly
             gcs_address = f"https://{gcs_address}/api/"
+        # if it was an HTTPS URL, check that it ends with /api/
+        elif not gcs_address.endswith(("/api/", "/api")):
+            # if it doesn't, add it
+            gcs_address = utils.slash_join(gcs_address, "/api/")
+
         super().__init__(
             base_url=gcs_address,
             environment=environment,

--- a/tests/unit/test_gcs_client.py
+++ b/tests/unit/test_gcs_client.py
@@ -2,14 +2,28 @@ from globus_sdk import GCSClient
 
 
 def test_client_address_handling():
-    # check on address parsing abilities
+    # variants of the same location
     c1 = GCSClient("foo.data.globus.org")
     c2 = GCSClient("https://foo.data.globus.org")
     c3 = GCSClient("https://foo.data.globus.org/api")
+    c4 = GCSClient("https://foo.data.globus.org/api/")
+    # explicit subpath of /api/
+    c5 = GCSClient("https://foo.data.globus.org/api/bar")
+    # explicit construction can point at the root (rather than /api/)
+    c6 = GCSClient("foo.data.globus.org")
+    c6.base_url = "https://foo.data.globus.org/"
 
+    # 1, 2, 3, and 4 are all the same
+    assert c1.base_url == c2.base_url
     assert c1.base_url == c3.base_url
-    assert c2.base_url != c1.base_url
-    assert c1.base_url.startswith(c2.base_url)
+    assert c1.base_url == c4.base_url
+
+    # 5 and 6 are different from the rest
+    assert c5.base_url != c1.base_url
+    assert c6.base_url != c1.base_url
+
+    # 6 is the root of 1
+    assert c1.base_url.startswith(c6.base_url)
 
 
 def test_gcs_client_has_no_resource_server():


### PR DESCRIPTION
BaseClient now strips any duplicate ``base_path`` from request paths. So a
client class can be used with a request path which matches the full documented
path for a service, regardless of whether or not a ``base_path`` is set.

The BaseClient behavior is matched in ``globus_sdk._testing`` for Transfer and
Groups, meaning that fixture construction for those services is also liberated
from the requirement to *omit* part of the path.
(It is not matched for GCS, as that behavior is harder to justify; see below.)

GCSClient handling of an input address has also been enhanced. GCS uses,
practically speaking, a base path of ``/api/`` for all API requests. This is
encoded directly in the ``base_url`` field, however, not ``base_path``.
Therefore, there is no clear need to do special ``base_path`` handling or
matching there. Instead, the client class has been enhanced to append ``/api``
when it is missing from the input URL. This is common when the
``gcs_manager_url`` field is taken from Transfer and used as an input.
Testing verifies that including the ``/api`` suffix is unharmed by this
improvement.

---

- Implement base_path normalization
- GCSClient appends `/api` to the address if missing
- Add URL handling changelog


<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--922.org.readthedocs.build/en/922/

<!-- readthedocs-preview globus-sdk-python end -->