### PR TITLE
Fix AuthClient.create_policy signature

### DIFF
--- a/changelog.d/20231218_161848_sirosen_fix_create_policy.rst
+++ b/changelog.d/20231218_161848_sirosen_fix_create_policy.rst
@@ -1,0 +1,6 @@
+Changed
+~~~~~~~
+
+- The argument specification for ``AuthClient.create_policy`` was incorrect.
+  Fixing this required a breaking change to the signature, and all arguments
+  to that method are now specified as keyword-only. (:pr:`NUMBER`)

--- a/src/globus_sdk/_testing/data/auth/create_policy.py
+++ b/src/globus_sdk/_testing/data/auth/create_policy.py
@@ -7,8 +7,6 @@ from globus_sdk._testing.models import RegisteredResponse, ResponseSet
 
 POLICY_REQUEST_ARGS = {
     "project_id": str(uuid.uuid1()),
-    "high_assurance": False,
-    "authentication_assurance_timeout": 35,
     "display_name": "Policy of Foo",
     "description": "Controls access to Foo",
 }
@@ -69,7 +67,9 @@ RESPONSES = ResponseSet(
     default=register_response({}),
     project_id_str=register_response({"project_id": str(uuid.uuid1())}),
     project_id_uuid=register_response({"project_id": uuid.uuid1()}),
-    high_assurance=register_response({"high_assurance": True}),
+    high_assurance=register_response(
+        {"high_assurance": True, "authentication_assurance_timeout": 35}
+    ),
     not_high_assurance=register_response({"high_assurance": False}),
     authentication_assurance_timeout=register_response(
         {"authentication_assurance_timeout": 23}

--- a/src/globus_sdk/services/auth/client/service_client.py
+++ b/src/globus_sdk/services/auth/client/service_client.py
@@ -778,12 +778,12 @@ class AuthClient(client.BaseClient):
 
     def create_policy(
         self,
+        *,
         project_id: UUIDLike,
-        high_assurance: bool,
-        authentication_assurance_timeout: int,
         display_name: str,
         description: str,
-        *,
+        high_assurance: bool | utils.MissingType = utils.MISSING,
+        authentication_assurance_timeout: int | utils.MissingType = utils.MISSING,
         domain_constraints_include: (
             t.Iterable[str] | None | utils.MissingType
         ) = utils.MISSING,


### PR DESCRIPTION
Fixing the signature is an inherently breaking change. Therefore, move to keyword-only arguments as a progressive upgrade which makes this easier to manage into the future.

---

Per our team discussion, although this is a violation of the semver backwards compatibility policy (and not in a marginal way, but very clearly we are breaking an API which we had previously declared), doing this does more good than harm.
The API is relatively newly released, and any fix here either has to encode these as optional positional args or else has to handle things in an awkward way.

Given the short lifetime to-date of the SDK version with this method available, we are making the decision that breaking the compatibility policy is better than strict adherence in this case.


<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--925.org.readthedocs.build/en/925/

<!-- readthedocs-preview globus-sdk-python end -->