### PR TITLE
Fix AuthClient.create_policy to make some fields optional in a backwards-compatible way

### DIFF
--- a/changelog.d/20231218_161848_sirosen_fix_create_policy.rst
+++ b/changelog.d/20231218_161848_sirosen_fix_create_policy.rst
@@ -1,0 +1,6 @@
+Changed
+~~~~~~~
+
+- The argument specification for ``AuthClient.create_policy`` was incorrect.
+  The corrected method will emit deprecation warnings if called with positional
+  arguments, as the corrected version uses keyword-only arguments. (:pr:`NUMBER`)

--- a/src/globus_sdk/_testing/data/auth/create_policy.py
+++ b/src/globus_sdk/_testing/data/auth/create_policy.py
@@ -7,8 +7,6 @@ from globus_sdk._testing.models import RegisteredResponse, ResponseSet
 
 POLICY_REQUEST_ARGS = {
     "project_id": str(uuid.uuid1()),
-    "high_assurance": False,
-    "authentication_assurance_timeout": 35,
     "display_name": "Policy of Foo",
     "description": "Controls access to Foo",
 }
@@ -45,6 +43,7 @@ def make_response_body(request_args: t.Dict[str, t.Any]) -> t.Dict[str, t.Any]:
 
 def register_response(
     args: t.Mapping[str, t.Any],
+    match: t.Any = None,
 ) -> RegisteredResponse:
     request_args = {**POLICY_REQUEST_ARGS, **args}
     request_body = make_request_body(request_args)
@@ -61,15 +60,19 @@ def register_response(
             # Test functions use 'response' to verify response
             "response": response_body,
         },
-        match=[json_params_matcher({"policy": request_body})],
+        match=(
+            [json_params_matcher({"policy": request_body})] if match is None else match
+        ),
     )
 
 
 RESPONSES = ResponseSet(
-    default=register_response({}),
+    default=register_response({}, match=[]),
     project_id_str=register_response({"project_id": str(uuid.uuid1())}),
     project_id_uuid=register_response({"project_id": uuid.uuid1()}),
-    high_assurance=register_response({"high_assurance": True}),
+    high_assurance=register_response(
+        {"high_assurance": True, "authentication_assurance_timeout": 35}
+    ),
     not_high_assurance=register_response({"high_assurance": False}),
     authentication_assurance_timeout=register_response(
         {"authentication_assurance_timeout": 23}

--- a/src/globus_sdk/services/auth/client/service_client.py
+++ b/src/globus_sdk/services/auth/client/service_client.py
@@ -808,7 +808,7 @@ class AuthClient(client.BaseClient):
 
     # coerce the type of this method to be "correct"
     @_coerce_create_policy
-    def create_policy(
+    def create_policy(  # pylint: disable=missing-param-doc
         self,
         *args: t.Any,
         project_id: UUIDLike | utils.MissingType = utils.MISSING,
@@ -829,10 +829,10 @@ class AuthClient(client.BaseClient):
         :param project_id: ID of the project for the new policy
         :type project_id: str or uuid
         :param high_assurance: Whether or not this policy is applied to sessions.
-        :type high_assurance: bool
+        :type high_assurance: bool, optional
         :param authentication_assurance_timeout: Number of seconds within which someone
             must have authenticated to satisfy the policy
-        :type authentication_assurance_timeout: int
+        :type authentication_assurance_timeout: int, optional
         :param display_name: A user-friendly name for the policy
         :type display_name: str
         :param description: A user-friendly description to explain the purpose of the
@@ -843,6 +843,14 @@ class AuthClient(client.BaseClient):
         :param domain_constraints_exclude: A list of domains that cannot satisfy the
             policy
         :type domain_constraints_exclude: iterable of str or None
+
+        .. note:
+
+            ``project_id``, ``display_name``, and ``description`` are all required
+            arguments, although they are not declared as required in the function
+            signature. This is due to a backwards compatible behavior with earlier
+            versions of globus-sdk, and will be changed in a future release which
+            removes the compatible behavior.
 
         .. tab-set::
 
@@ -885,7 +893,7 @@ class AuthClient(client.BaseClient):
                 "Use only keyword arguments instead."
             )
 
-            (
+            (  # pylint: disable=unbalanced-tuple-unpacking
                 project_id,
                 high_assurance,
                 authentication_assurance_timeout,

--- a/tests/functional/services/auth/service_client/test_create_policy.py
+++ b/tests/functional/services/auth/service_client/test_create_policy.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import json
+
 import pytest
 
-from globus_sdk._testing import load_response
+from globus_sdk import exc
+from globus_sdk._testing import get_last_request, load_response
 
 
 @pytest.mark.parametrize(
@@ -32,3 +35,206 @@ def test_create_policy(
     res = service_client.create_policy(**meta["args"])
     for k, v in meta["response"].items():
         assert res["policy"][k] == v
+
+
+def test_compatible_create_policy_usage_rejects_too_many_positionals(service_client):
+    load_response(service_client.create_policy)
+    with pytest.raises(
+        TypeError,
+        match=r"create_policy\(\) takes 5 positional arguments but 6 were given",
+    ):
+        service_client.create_policy(1, 2, 3, 4, 5, 6)
+
+
+@pytest.mark.parametrize(
+    "posargs, keyword_args, expect_data",
+    [
+        pytest.param(
+            ["my_project_id"],
+            {
+                "display_name": "my_display_name",
+                "description": "my_description",
+            },
+            {
+                "project_id": "my_project_id",
+                "display_name": "my_display_name",
+                "description": "my_description",
+            },
+            id="one_arg",
+        ),
+        pytest.param(
+            [
+                "my_project_id",
+                True,
+            ],
+            {
+                "display_name": "my_display_name",
+                "description": "my_description",
+            },
+            {
+                "project_id": "my_project_id",
+                "high_assurance": True,
+                "display_name": "my_display_name",
+                "description": "my_description",
+            },
+            id="two_arg",
+        ),
+        pytest.param(
+            [
+                "my_project_id",
+                True,
+                101,
+            ],
+            {
+                "display_name": "my_display_name",
+                "description": "my_description",
+            },
+            {
+                "project_id": "my_project_id",
+                "high_assurance": True,
+                "authentication_assurance_timeout": 101,
+                "display_name": "my_display_name",
+                "description": "my_description",
+            },
+            id="three_arg",
+        ),
+        pytest.param(
+            [
+                "my_project_id",
+                True,
+                101,
+                "my_display_name",
+            ],
+            {
+                "description": "my_description",
+            },
+            {
+                "project_id": "my_project_id",
+                "high_assurance": True,
+                "authentication_assurance_timeout": 101,
+                "display_name": "my_display_name",
+                "description": "my_description",
+            },
+            id="four_arg",
+        ),
+        pytest.param(
+            [
+                "my_project_id",
+                True,
+                101,
+                "my_display_name",
+                "my_description",
+            ],
+            {},
+            {
+                "project_id": "my_project_id",
+                "high_assurance": True,
+                "authentication_assurance_timeout": 101,
+                "display_name": "my_display_name",
+                "description": "my_description",
+            },
+            id="five_arg",
+        ),
+    ],
+)
+def test_valid_compatible_policy_usage_emits_warning(
+    service_client, posargs, keyword_args, expect_data
+):
+    load_response(service_client.create_policy)
+    with pytest.warns(
+        exc.RemovedInV4Warning,
+        match=r"'AuthClient\.create_policy' received positional arguments",
+    ):
+        service_client.create_policy(*posargs, **keyword_args)
+
+    lastreq = get_last_request()
+    sent_data = json.loads(lastreq.body)
+    assert sent_data["policy"] == expect_data
+
+
+@pytest.mark.parametrize(
+    "posargs, keyword_args, missing_arg_count, missing_arg_strlist",
+    [
+        pytest.param(
+            [],
+            {"project_id": "my_project_id", "description": "my_description"},
+            1,
+            "'display_name'",
+            id="missing_display_name",
+        ),
+        pytest.param(
+            ["my_project_id"],
+            {"description": "my_description"},
+            1,
+            "'display_name'",
+            id="missing_display_name_with_posarg",
+        ),
+        pytest.param(
+            [],
+            {"project_id": "my_project_id"},
+            2,
+            "'display_name' and 'description'",
+            id="missing_display_name_and_description",
+        ),
+        pytest.param(
+            ["my_project_id"],
+            {},
+            2,
+            "'display_name' and 'description'",
+            id="missing_display_name_and_description_with_posarg",
+        ),
+        pytest.param(
+            [],
+            {},
+            3,
+            "'project_id', 'display_name', and 'description'",
+            id="no_args",
+        ),
+    ],
+)
+def test_policy_usage_warns_and_errors_when_required_args_are_missing(
+    service_client, posargs, keyword_args, missing_arg_count, missing_arg_strlist
+):
+    with pytest.raises(
+        TypeError,
+        match=(
+            f"missing {missing_arg_count} "
+            f"required keyword-only arguments?: {missing_arg_strlist}"
+        ),
+    ):
+        # warning is emitted if posargs is nonempty
+        if posargs:
+            with pytest.warns(
+                exc.RemovedInV4Warning,
+                match="'AuthClient.create_policy()' received positional arguments",
+            ):
+                service_client.create_policy(*posargs, **keyword_args)
+        else:
+            service_client.create_policy(*posargs, **keyword_args)
+
+
+@pytest.mark.parametrize(
+    "posargs, keyword_args",
+    (
+        (["my_project_id"], {"project_id": "my_project_id2"}),
+        (["my_project_id", False], {"high_assurance": True}),
+        (["my_project_id", False, 101], {"authentication_assurance_timeout": 102}),
+        (["my_project_id", False, 101, "foo"], {"display_name": "bar"}),
+        (["my_project_id", False, 101, "foo", "my_description"], {"description": "hi"}),
+    ),
+)
+def test_policy_usage_warns_and_errors_when_argument_is_supplied_twice(
+    service_client, posargs, keyword_args
+):
+    assert len(keyword_args) == 1
+    argname = next(iter(keyword_args))
+
+    with pytest.raises(
+        TypeError,
+        match=f"create_policy\\(\\) got multiple values for argument '{argname}'",
+    ):
+        with pytest.warns(
+            exc.RemovedInV4Warning,
+            match="'AuthClient.create_policy()' received positional arguments",
+        ):
+            service_client.create_policy(*posargs, **keyword_args)

--- a/tests/non-pytest/mypy-ignore-tests/auth_client_create_policy.py
+++ b/tests/non-pytest/mypy-ignore-tests/auth_client_create_policy.py
@@ -1,0 +1,19 @@
+import globus_sdk
+
+ac = globus_sdk.AuthClient()
+
+# create new policy with keyword-only args, as supported
+ac.create_policy(
+    project_id="foo",
+    display_name="My Policy",
+    description="This is a policy",
+)
+
+# create using positional args (deprecated/unsupported)
+ac.create_policy(  # type: ignore[misc]
+    "foo",
+    True,  # type: ignore[arg-type]
+    101,  # type: ignore[arg-type]
+    "My Policy",  # type: ignore[arg-type]
+    "This is a policy",  # type: ignore[arg-type]
+)


### PR DESCRIPTION
This is done in a very carefully backwards-compatible way, and also introduces new helpers which make it easier to apply this sort of fix to other methods in the future (if necessary).

In the fixed implementation -- which makes the HA fields optional -- backwards compatibility shims ensure that positional argument usage with all 5 expected positional arguments works as expected. When some subset of those positional arguments are used, the remainder may be specified as keyword arguments.

The following cases are carefully handled and treated as errors:
- too many positional arguments
- same argument multiple times (positional and keyword)
- required argument omitted (now harder to detect)
- too few arguments when only positionals were used

The arguments are checked in the order in which they are passed, one at a time. This is done so that they can be compared against provided keyword argument values.
This allows easy enforcement of errors on usages which repeat a parameter, as in `ac.create_policy("foo", project_id="bar")`.

In order to implement these checks, new helpers have been added to `utils` which examine the locals in their calling context and provide a relatively simple-to-apply compatibility shim. They are tested relatively exhaustively in the context of the changes to `create_policy`, but they also have dedicated unit tests so that they can be maintained independently from this usage site.

Using a protocol to declare the desired type for the method + a decorator to cast to that type (without name-related issues), the type of `create_policy` is declared to type checkers as distinct from the runtime type. As a result, type checkers can treat non-keyword argument usage as erroneous while still allowing for the positional argument usage at runtime.

As an end result, `*args` are unpacked, TypeErrors are emitted at runtime in all of the appropriate cases, type checkers enforce correct calling conventions, and in any case in which `*args` is unpacked, a deprecation warning is emitted.


<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--926.org.readthedocs.build/en/926/

<!-- readthedocs-preview globus-sdk-python end -->