### PR TITLE
Remove unnecessary internal dict-conversions

### DIFF
--- a/src/globus_sdk/services/gcs/data/collection.py
+++ b/src/globus_sdk/services/gcs/data/collection.py
@@ -301,7 +301,7 @@ class MappedCollectionDocument(CollectionDocument):
         allow_guest_collections: bool | None = None,
         disable_anonymous_writes: bool | None = None,
         # dicts
-        policies: (CollectionPolicies | dict[str, t.Any] | None) = None,
+        policies: CollectionPolicies | dict[str, t.Any] | None = None,
         # > specific args end <
         # additional fields
         additional_fields: dict[str, t.Any] | None = None,
@@ -348,7 +348,7 @@ class MappedCollectionDocument(CollectionDocument):
             disable_anonymous_writes=disable_anonymous_writes,
         )
         self._set_value("sharing_restrict_paths", sharing_restrict_paths)
-        self._set_value("policies", policies, callback=dict)
+        self._set_value("policies", policies)
         ensure_datatype(self)
 
 

--- a/src/globus_sdk/services/gcs/data/storage_gateway.py
+++ b/src/globus_sdk/services/gcs/data/storage_gateway.py
@@ -75,8 +75,8 @@ class StorageGatewayDocument(utils.PayloadWrapper):
         display_name: str | None = None,
         connector_id: UUIDLike | None = None,
         root: str | None = None,
-        identity_mappings: None | (t.Iterable[dict[str, t.Any]]) = None,
-        policies: (StorageGatewayPolicies | dict[str, t.Any] | None) = None,
+        identity_mappings: None | t.Iterable[dict[str, t.Any]] = None,
+        policies: StorageGatewayPolicies | dict[str, t.Any] | None = None,
         allowed_domains: t.Iterable[str] | None = None,
         high_assurance: bool | None = None,
         require_mfa: bool | None = None,
@@ -100,7 +100,7 @@ class StorageGatewayDocument(utils.PayloadWrapper):
         self._set_optbools(high_assurance=high_assurance, require_mfa=require_mfa)
         self._set_optints(authentication_timeout_mins=authentication_timeout_mins)
         self._set_value("identity_mappings", identity_mappings, callback=list)
-        self._set_value("policies", policies, callback=dict)
+        self._set_value("policies", policies)
         if additional_fields is not None:
             self.update(additional_fields)
         ensure_datatype(self)

--- a/src/globus_sdk/services/gcs/data/user_credential.py
+++ b/src/globus_sdk/services/gcs/data/user_credential.py
@@ -52,7 +52,7 @@ class UserCredentialDocument(utils.PayloadWrapper):
             display_name=display_name,
             storage_gateway_id=storage_gateway_id,
         )
-        self._set_value("policies", policies, callback=dict)
+        self._set_value("policies", policies)
 
         if additional_fields is not None:
             self.update(additional_fields)

--- a/src/globus_sdk/services/timer/client.py
+++ b/src/globus_sdk/services/timer/client.py
@@ -115,10 +115,7 @@ class TimerClient(client.BaseClient):
                 "Create a TransferTimer instead."
             )
         log.info("TimerClient.create_timer(...)")
-        return self.post(
-            "/v2/timer",
-            data={"timer": dict(timer) if isinstance(timer, TransferTimer) else timer},
-        )
+        return self.post("/v2/timer", data={"timer": timer})
 
     def create_job(
         self, data: dict[str, t.Any] | TimerJob

--- a/tests/unit/helpers/gcs/test_storage_gateway.py
+++ b/tests/unit/helpers/gcs/test_storage_gateway.py
@@ -16,6 +16,7 @@ from globus_sdk import (
     S3StoragePolicies,
     StorageGatewayDocument,
 )
+from globus_sdk.transport import JSONRequestEncoder
 
 
 @pytest.mark.parametrize(
@@ -37,8 +38,12 @@ def test_storage_gateway_policy_document_conversion():
     )
     sg = StorageGatewayDocument(policies=policies)
     assert "policies" in sg
-    assert isinstance(sg["policies"], dict)
-    assert sg["policies"] == {
+    assert isinstance(sg["policies"], POSIXStoragePolicies)
+
+    encoder = JSONRequestEncoder()
+    request_data = encoder.encode("POST", "bogus.url.example", {}, sg, {}).json
+
+    assert request_data["policies"] == {
         "DATA_TYPE": "posix_storage_policies#1.0.0",
         "groups_allow": ["jedi", "wookies"],
         "groups_deny": ["sith", "stormtroopers"],


### PR DESCRIPTION
The SDK had a number of locations in which it would convert a
PayloadWrapper class into a dict so that it could be used as an
internal component in a request payload.

Now that the request encoders handle this automatically, it's not
necesary to eagerly convert an input object into a dict in order for
it to be serialized correctly.
Defer the dict conversions until request sending by removing the
unnecessary eager calls to `dict(obj)`.

Tests which check on the results of encoding are refined to use an
encoder to build a dummy `Request` object, but are otherwise
unchanged.


<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--927.org.readthedocs.build/en/927/

<!-- readthedocs-preview globus-sdk-python end -->