### PR TITLE
Improve sphinx documentation rendering to use autodoc type hints for params and not in signatures

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,6 +26,9 @@ intersphinx_mapping = {
 # pull signature docs from type hints, into body
 # and keep the signatures concise
 autodoc_typehints = "description"
+# do not generate doc stubs for inherited parameters from a superclass,
+# merely because they are type annotated
+autodoc_typehints_description_target = "documented_params"
 
 
 # sphinx extensions (minimally, we want autodoc and viewcode to build the site)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,6 +23,10 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
 }
 
+# pull signature docs from type hints, into body
+# and keep the signatures concise
+autodoc_typehints = "description"
+
 
 # sphinx extensions (minimally, we want autodoc and viewcode to build the site)
 # plus, we have our own custom extension in the SDK to include

--- a/docs/core/responses.rst
+++ b/docs/core/responses.rst
@@ -14,3 +14,7 @@ To customize client methods with additional detail, the SDK uses subclasses of
 .. autoclass:: globus_sdk.response.IterableResponse
    :members:
    :show-inheritance:
+
+.. autoclass:: globus_sdk.response.ArrayResponse
+   :members:
+   :show-inheritance:

--- a/docs/core/utils.rst
+++ b/docs/core/utils.rst
@@ -20,3 +20,22 @@ payload datatypes to provide nicer interfaces for payload construction.
 The objects are a type of ``UserDict`` with no special methods.
 
 .. autoclass:: globus_sdk.utils.PayloadWrapper
+
+
+MissingType and MISSING
+-----------------------
+
+The ``MISSING`` sentinel value is used as an alternative to ``None`` in APIs
+which accept ``null`` as a valid value. Whenever ``MISSING`` is included in a
+request, it will be removed before the request is sent to the service.
+
+As a result, where ``MISSING`` is used as the default for a value, ``None`` can
+be used to explicitly pass the value ``null``.
+
+.. autoclass:: globus_sdk.MissingType
+
+    This is the type of ``MISSING``.
+
+.. py:data:: globus_sdk.MISSING
+
+    The ``MISSING`` sentinel value. It is a singleton.

--- a/docs/core/utils.rst
+++ b/docs/core/utils.rst
@@ -32,7 +32,8 @@ request, it will be removed before the request is sent to the service.
 As a result, where ``MISSING`` is used as the default for a value, ``None`` can
 be used to explicitly pass the value ``null``.
 
-.. autoclass:: globus_sdk.MissingType
+.. class:: globus_sdk.MissingType
+    :canonical: globus_sdk.utils.MissingType
 
     This is the type of ``MISSING``.
 

--- a/src/globus_sdk/_sphinxext.py
+++ b/src/globus_sdk/_sphinxext.py
@@ -310,6 +310,16 @@ class PaginatedUsage(AddContentDirective):
         yield ":ref:`how to make paginated calls <making_paginated_calls>`."
 
 
+def after_autodoc_signature_replace_MISSING_repr(
+    app, what, name, obj, options, signature, return_annotation
+):
+    if signature is not None:
+        signature = signature.replace("<globus_sdk.MISSING>", "MISSING")
+    if return_annotation is not None:
+        return_annotation = return_annotation.replace("<globus_sdk.MISSING>", "MISSING")
+    return signature, return_annotation
+
+
 def setup(app):
     app.add_directive("automethodlist", AutoMethodList)
     app.add_directive("listknownscopes", ListKnownScopes)
@@ -317,6 +327,11 @@ def setup(app):
     app.add_directive("expandtestfixture", ExpandTestingFixture)
     app.add_directive("extdoclink", ExternalDocLink)
     app.add_directive("paginatedusage", PaginatedUsage)
+
+    app.connect(
+        "autodoc-process-signature", after_autodoc_signature_replace_MISSING_repr
+    )
+
     return {
         "parallel_read_safe": True,
         "parallel_write_safe": True,

--- a/src/globus_sdk/_sphinxext.py
+++ b/src/globus_sdk/_sphinxext.py
@@ -313,6 +313,7 @@ class PaginatedUsage(AddContentDirective):
 def after_autodoc_signature_replace_MISSING_repr(
     app, what, name, obj, options, signature, return_annotation
 ):
+    """convert <globus_sdk.MISSING> to MISSING in autodoc signatures"""
     if signature is not None:
         signature = signature.replace("<globus_sdk.MISSING>", "MISSING")
     if return_annotation is not None:

--- a/src/globus_sdk/_sphinxext.py
+++ b/src/globus_sdk/_sphinxext.py
@@ -310,10 +310,22 @@ class PaginatedUsage(AddContentDirective):
         yield ":ref:`how to make paginated calls <making_paginated_calls>`."
 
 
-def after_autodoc_signature_replace_MISSING_repr(
-    app, what, name, obj, options, signature, return_annotation
+def after_autodoc_signature_replace_MISSING_repr(  # pylint: disable=missing-param-doc,missing-type-doc  # noqa: E501
+    app,  # pylint: disable=unused-argument
+    what,  # pylint: disable=unused-argument
+    name,  # pylint: disable=unused-argument
+    obj,  # pylint: disable=unused-argument
+    options,  # pylint: disable=unused-argument
+    signature: str,
+    return_annotation: str,
 ):
-    """convert <globus_sdk.MISSING> to MISSING in autodoc signatures"""
+    """
+    convert <globus_sdk.MISSING> to MISSING in autodoc signatures
+
+    :param signature: the signature after autodoc parsing/rendering
+    :param return_annotation: the return type annotation, including the leading `->`,
+        after autodoc parsing/rendering
+    """
     if signature is not None:
         signature = signature.replace("<globus_sdk.MISSING>", "MISSING")
     if return_annotation is not None:

--- a/src/globus_sdk/_testing/helpers.py
+++ b/src/globus_sdk/_testing/helpers.py
@@ -19,7 +19,6 @@ def get_last_request(
     Get the last request which was received, or None if there were no requests.
 
     :param requests_mock: A non-default ``RequestsMock`` object to use.
-    :type requests_mock: responses.RequestsMock
     """
     calls = requests_mock.calls if requests_mock is not None else responses.calls
     try:
@@ -74,21 +73,13 @@ def construct_error(
 
     :param error_class: The class of the error to construct. Defaults to
         GlobusAPIError.
-    :type error_class: type[GlobusAPIError]
     :param http_status: The HTTP status code to use in the response.
-    :type http_status: int
     :param body: The body of the response. If a dict, will be JSON-encoded.
-    :type body: bytes | str | dict
     :param method: The HTTP method to set on the underlying request.
-    :type method: str, optional
     :param response_headers: The headers of the response.
-    :type response_headers: dict, optional
     :param request_headers: The headers of the request.
-    :type request_headers: dict, optional
     :param response_encoding: The encoding to use for the response body.
-    :type response_encoding: str, optional
     :param url: The URL to set on the underlying request.
-    :type url: str, optional
     """
     raw_response = requests.Response()
     raw_response.status_code = http_status

--- a/src/globus_sdk/_testing/models.py
+++ b/src/globus_sdk/_testing/models.py
@@ -120,7 +120,6 @@ class RegisteredResponse:
 
         :param requests_mock: The mocked requests object to use. Defaults to the default
             provided by the ``responses`` library
-        :type requests_mock: responses.RequestsMock, optional
         """
         return self._add_or_replace("add", requests_mock=requests_mock)
 
@@ -133,7 +132,6 @@ class RegisteredResponse:
 
         :param requests_mock: The mocked requests object to use. Defaults to the default
             provided by the ``responses`` library
-        :type requests_mock: responses.RequestsMock, optional
         """
         return self._add_or_replace("replace", requests_mock=requests_mock)
 

--- a/src/globus_sdk/_testing/registry.py
+++ b/src/globus_sdk/_testing/registry.py
@@ -23,12 +23,9 @@ def register_response_set(
     The response set may be specified as a dict or a ResponseSet object.
 
     :param set_id: The ID used to retrieve the response set later
-    :type set_id: any
     :param rset: The response set to register
-    :type rset: dict or ResponseSet
     :param metadata: Metadata dict to assign to the response set when it is specified
         as a dict. If the response set is an object, this argument is ignored.
-    :type metadata: dict, optional
     """
     if isinstance(rset, dict):
         rset = ResponseSet.from_dict(rset, metadata=metadata)
@@ -66,7 +63,6 @@ def get_response_set(set_id: t.Any) -> ResponseSet:
 
     :param set_id: The ID used to retrieve the response set. Typically a string, but
         could be any key used to register a response set.
-    :type set_id: any
     """
     # first priority: check the explicit registry
     if set_id in _RESPONSE_SET_REGISTRY:
@@ -106,10 +102,8 @@ def load_response_set(
 
     :param set_id: The ID used to retrieve the response set. Typically a string, but
         could be any key used to register a response set.
-    :type set_id: any
     :param requests_mock: A ``responses`` library mock to use for response mocking,
         defaults to the ``responses`` default
-    :type requests_mock: ``responses.RequestsMock``, optional
     """
     if isinstance(set_id, ResponseSet):
         return set_id.activate_all(requests_mock=requests_mock)
@@ -132,13 +126,10 @@ def load_response(
 
     :param set_id: The ID used to retrieve the response set. Typically a string, but
         could be any key used to register a response set.
-    :type set_id: any
     :param case: The name of a case within the response set to load, ignoring all other
         registered mocks in the response set
-    :type case: str, optional
     :param requests_mock: A ``responses`` library mock to use for response mocking,
         defaults to the ``responses`` default
-    :type requests_mock: ``responses.RequestsMock``, optional
     """
     if isinstance(set_id, RegisteredResponse):
         return set_id.add(requests_mock=requests_mock)

--- a/src/globus_sdk/_types.py
+++ b/src/globus_sdk/_types.py
@@ -5,13 +5,13 @@ import sys
 import typing as t
 import uuid
 
+from globus_sdk.scopes import MutableScope
+
 if sys.version_info < (3, 8):
     from typing_extensions import Protocol
 else:
     from typing import Protocol
 
-if t.TYPE_CHECKING:
-    from globus_sdk.scopes import MutableScope
 
 # these types are aliases meant for internal use
 IntLike = t.Union[int, str]
@@ -20,10 +20,8 @@ DateLike = t.Union[str, datetime.datetime]
 
 ScopeCollectionType = t.Union[
     str,
-    "MutableScope",
-    t.Iterable[str],
-    t.Iterable["MutableScope"],
-    t.Iterable[t.Union[str, "MutableScope"]],
+    MutableScope,
+    t.Iterable[t.Union[str, MutableScope]],
 ]
 
 

--- a/src/globus_sdk/authorizers/access_token.py
+++ b/src/globus_sdk/authorizers/access_token.py
@@ -14,7 +14,6 @@ class AccessTokenAuthorizer(StaticGlobusAuthorizer):
     unadorned.
 
     :param access_token: An access token for Globus Auth
-    :type access_token: str
     """
 
     def __init__(self, access_token: str):

--- a/src/globus_sdk/authorizers/basic.py
+++ b/src/globus_sdk/authorizers/basic.py
@@ -14,9 +14,7 @@ class BasicAuthorizer(StaticGlobusAuthorizer):
     header.
 
     :param username: Username component for Basic Auth
-    :type username: str
     :param password: Password component for Basic Auth
-    :type password: str
     """
 
     def __init__(self, username: str, password: str) -> None:

--- a/src/globus_sdk/authorizers/client_credentials.py
+++ b/src/globus_sdk/authorizers/client_credentials.py
@@ -36,20 +36,15 @@ class ClientCredentialsAuthorizer(RenewingAuthorizer):
     the client itself.
 
     :param confidential_client: client object with a valid id and client secret
-    :type confidential_client: :class:`ConfidentialAppAuthClient\
-        <globus_sdk.ConfidentialAppAuthClient>`
     :param scopes: A string of space-separated scope names being requested for the
         access tokens that will be used for the Authorization header. These scopes must
         all be for the same resource server, or else the token response will have
         multiple access tokens.
-    :type scopes: str, MutableScope, or iterable of str or MutableScope
     :param access_token: Initial Access Token to use, only used if ``expires_at`` is
         also set. Must be requested with the same set of scopes passed to this
         authorizer.
-    :type access_token: str
     :param expires_at: Expiration time for the starting ``access_token`` expressed as a
         POSIX timestamp (i.e. seconds since the epoch)
-    :type expires_at: int, optional
     :param on_refresh: A callback which is triggered any time this authorizer fetches a
         new access_token. The ``on_refresh`` callable is invoked on the
         :class:`OAuthTokenResponse <globus_sdk.OAuthTokenResponse>`
@@ -58,7 +53,6 @@ class ClientCredentialsAuthorizer(RenewingAuthorizer):
         This is useful for implementing storage for Access Tokens, as the
         ``on_refresh`` callback can be used to update the Access Tokens and
         their expiration times.
-    :type on_refresh: callable, optional
     """
 
     def __init__(

--- a/src/globus_sdk/authorizers/refresh_token.py
+++ b/src/globus_sdk/authorizers/refresh_token.py
@@ -32,15 +32,11 @@ class RefreshTokenAuthorizer(RenewingAuthorizer):
     will automatically support usage of the ``RefreshTokenAuthorizer``.
 
     :param refresh_token: Refresh Token for Globus Auth
-    :type refresh_token: str
     :param auth_client: ``AuthClient`` capable of using the ``refresh_token``
-    :type auth_client: :class:`AuthClient <globus_sdk.AuthClient>`
     :param access_token: Initial Access Token to use, only used if ``expires_at`` is
         also set
-    :type access_token: str, optional
     :param expires_at: Expiration time for the starting ``access_token`` expressed as a
         POSIX timestamp (i.e. seconds since the epoch)
-    :type expires_at: int, optional
     :param on_refresh: A callback which is triggered any time this authorizer fetches a
         new access_token. The ``on_refresh`` callable is invoked on the
         :class:`OAuthTokenResponse <globus_sdk.OAuthTokenResponse>`
@@ -49,7 +45,6 @@ class RefreshTokenAuthorizer(RenewingAuthorizer):
         This is useful for implementing storage for Access Tokens, as the
         ``on_refresh`` callback can be used to update the Access Tokens and
         their expiration times.
-    :type on_refresh: callable, optional
     """  # noqa: E501
 
     def __init__(

--- a/src/globus_sdk/authorizers/renewing.py
+++ b/src/globus_sdk/authorizers/renewing.py
@@ -35,10 +35,8 @@ class RenewingAuthorizer(GlobusAuthorizer, metaclass=abc.ABCMeta):
 
     :param access_token: Initial Access Token to use, only used if ``expires_at`` is
         also set
-    :type access_token: str, optional
     :param expires_at: Expiration time for the starting ``access_token`` expressed as a
         POSIX timestamp (i.e. seconds since the epoch)
-    :type expires_at: int, optional
     :param on_refresh: A callback which is triggered any time this authorizer fetches a
         new access_token. The ``on_refresh`` callable is invoked on the
         :class:`OAuthTokenResponse <globus_sdk.OAuthTokenResponse>`
@@ -47,7 +45,6 @@ class RenewingAuthorizer(GlobusAuthorizer, metaclass=abc.ABCMeta):
         This is useful for implementing storage for Access Tokens, as the
         ``on_refresh`` callback can be used to update the Access Tokens and
         their expiration times.
-    :type on_refresh: callable, optional
     """
 
     def __init__(

--- a/src/globus_sdk/client.py
+++ b/src/globus_sdk/client.py
@@ -21,18 +21,13 @@ class BaseClient:
     Abstract base class for clients with error handling for Globus APIs.
 
     :param authorizer: A ``GlobusAuthorizer`` which will generate Authorization headers
-    :type authorizer: :class:`GlobusAuthorizer\
-        <globus_sdk.authorizers.base.GlobusAuthorizer>`
     :param app_name: Optional "nice name" for the application. Has no bearing on the
         semantics of client actions. It is just passed as part of the User-Agent
         string, and may be useful when debugging issues with the Globus Team
-    :type app_name: str
     :param base_url: The URL for the service. Most client types initialize this value
         intelligently by default. Set it when inheriting from BaseClient or
         communicating through a proxy.
-    :type base_url: str
     :param transport_params: Options to pass to the transport for this client
-    :type transport_params: dict
 
     All other parameters are for internal use and should be ignored.
     """
@@ -138,9 +133,6 @@ class BaseClient:
         Make a GET request to the specified path.
 
         See :py:meth:`~.BaseClient.request` for details on the various parameters.
-
-        :return: :class:`GlobusHTTPResponse \
-        <globus_sdk.response.GlobusHTTPResponse>` object
         """
         log.debug(f"GET to {path} with query_params {query_params}")
         return self.request("GET", path, query_params=query_params, headers=headers)
@@ -158,9 +150,6 @@ class BaseClient:
         Make a POST request to the specified path.
 
         See :py:meth:`~.BaseClient.request` for details on the various parameters.
-
-        :return: :class:`GlobusHTTPResponse \
-        <globus_sdk.response.GlobusHTTPResponse>` object
         """
         log.debug(f"POST to {path} with query_params {query_params}")
         return self.request(
@@ -183,9 +172,6 @@ class BaseClient:
         Make a DELETE request to the specified path.
 
         See :py:meth:`~.BaseClient.request` for details on the various parameters.
-
-        :return: :class:`GlobusHTTPResponse \
-        <globus_sdk.response.GlobusHTTPResponse>` object
         """
         log.debug(f"DELETE to {path} with query_params {query_params}")
         return self.request("DELETE", path, query_params=query_params, headers=headers)
@@ -203,9 +189,6 @@ class BaseClient:
         Make a PUT request to the specified path.
 
         See :py:meth:`~.BaseClient.request` for details on the various parameters.
-
-        :return: :class:`GlobusHTTPResponse \
-        <globus_sdk.response.GlobusHTTPResponse>` object
         """
         log.debug(f"PUT to {path} with query_params {query_params}")
         return self.request(
@@ -230,9 +213,6 @@ class BaseClient:
         Make a PATCH request to the specified path.
 
         See :py:meth:`~.BaseClient.request` for details on the various parameters.
-
-        :return: :class:`GlobusHTTPResponse \
-        <globus_sdk.response.GlobusHTTPResponse>` object
         """
         log.debug(f"PATCH to {path} with query_params {query_params}")
         return self.request(
@@ -260,29 +240,18 @@ class BaseClient:
         Send an HTTP request
 
         :param method: HTTP request method, as an all caps string
-        :type method: str
         :param path: Path for the request, with or without leading slash
-        :type path: str
         :param query_params: Parameters to be encoded as a query string
-        :type query_params: dict, optional
         :param headers: HTTP headers to add to the request
-        :type headers: dict
         :param data: Data to send as the request body. May pass through encoding.
-        :type data: dict or str
         :param encoding: A way to encode request data. "json", "form", and "text"
             are all valid values. Custom encodings can be used only if they are
             registered with the transport. By default, strings get "text" behavior and
             all other objects get "json".
-        :type encoding: str
         :param allow_redirects: Follow Location headers on redirect response
             automatically. Defaults to ``True``
-        :type allow_redirects: bool
         :param stream: Do not immediately download the response content. Defaults to
             ``False``
-        :type stream: bool
-
-        :return: :class:`GlobusHTTPResponse \
-        <globus_sdk.response.GlobusHTTPResponse>` object
 
         :raises GlobusAPIError: a `GlobusAPIError` will be raised if the response to the
             request is received and has a status code in the 4xx or 5xx categories

--- a/src/globus_sdk/config/environments.py
+++ b/src/globus_sdk/config/environments.py
@@ -69,10 +69,8 @@ def get_service_url(service: str, environment: str | None = None) -> str:
 
 
     :param service: The short name of the service to get the URL for
-    :type service: str
     :param environment: The name of the environment to use. If unspecified, this will
         use the ``GLOBUS_SDK_ENVIRONMENT`` environment variable.
-    :type environment: str, optional
     """
     log.debug(f'Service URL Lookup for "{service}" under env "{environment}"')
     environment = environment or get_environment_name()
@@ -101,7 +99,6 @@ def get_webapp_url(environment: str | None = None) -> str:
 
     :param environment: The name of the environment to use. If unspecified, this will
         use the ``GLOBUS_SDK_ENVIRONMENT`` environment variable.
-    :type environment: str, optional
     """
     environment = environment or get_environment_name()
     return get_service_url("app", environment=environment)

--- a/src/globus_sdk/experimental/auth_requirements_error/_functional_api.py
+++ b/src/globus_sdk/experimental/auth_requirements_error/_functional_api.py
@@ -36,7 +36,6 @@ def to_auth_requirements_error(
     If the provided error does not match a known format, None is returned.
 
     :param error: The error to convert.
-    :type error: a GlobusAPIError, ErrorSubdocument, or dict
     """
     from globus_sdk.exc import ErrorSubdocument, GlobusAPIError
 
@@ -92,7 +91,6 @@ def to_auth_requirements_errors(
     If no errors match any known formats, an empty list is returned.
 
     :param errors: The errors to convert.
-    :type errors: a list of GlobusAPIErrors, ErrorSubdocuments, or dicts
     """
     from globus_sdk.exc import GlobusAPIError
 
@@ -119,7 +117,6 @@ def is_auth_requirements_error(
     Globus Auth Requirements Error format.
 
     :param error: The error to check.
-    :type error: a GlobusAPIError, ErrorSubdocument, or dict
     """
     return to_auth_requirements_error(error) is not None
 
@@ -132,6 +129,5 @@ def has_auth_requirements_errors(
     Globus Auth Requirements Error format.
 
     :param errors: The errors to check.
-    :type errors: a list of GlobusAPIErrors, ErrorSubdocuments, or dicts
     """
     return any(is_auth_requirements_error(error) for error in errors)

--- a/src/globus_sdk/experimental/auth_requirements_error/_serializable.py
+++ b/src/globus_sdk/experimental/auth_requirements_error/_serializable.py
@@ -25,7 +25,6 @@ class Serializable:
         Instantiate from a dictionary.
 
         :param data: The dictionary to create the error from.
-        :type data: dict
         """
 
         # Extract any extra fields
@@ -43,7 +42,6 @@ class Serializable:
 
         :param include_extra: Whether to include stored extra (non-standard) fields in
             the returned dictionary.
-        :type include_extra: bool
         """
         result = {}
 

--- a/src/globus_sdk/experimental/scope_parser/scope_definition.py
+++ b/src/globus_sdk/experimental/scope_parser/scope_definition.py
@@ -15,10 +15,8 @@ class Scope:
     `str(Scope(...))` produces a valid scope string for use in various methods.
 
     :param scope_string: The string which will be used as the basis for this Scope
-    :type scope_string: str
     :param optional: The scope may be marked as optional. This means that the scope can
         be declined by the user without declining consent for other scopes
-    :type optional: bool
     """
 
     def __init__(
@@ -55,7 +53,6 @@ class Scope:
             multiple parts of the tree.
 
         :param scope_string: The string to parse
-        :type scope_string: str
         """
         scope_graph = parse_scope_graph(scope_string)
 
@@ -86,7 +83,6 @@ class Scope:
         will be raised.
 
         :param scope_string: The string to parse
-        :type scope_string: str
         """
         data = Scope.parse(scope_string)
         if len(data) != 1:
@@ -112,11 +108,9 @@ class Scope:
         Scope and will be evident in its string representation.
 
         :param scope: The scope upon which the current scope depends
-        :type scope: str
         :param optional: Mark the dependency an optional one. By default it is not. An
             optional scope dependency can be declined by the user without declining
             consent for the primary scope
-        :type optional: bool, optional
         """
         if optional is not None:
             if isinstance(scope, Scope):

--- a/src/globus_sdk/local_endpoint/personal/endpoint.py
+++ b/src/globus_sdk/local_endpoint/personal/endpoint.py
@@ -31,7 +31,6 @@ class LocalGlobusConnectPersonal:
     :param config_dir: Path to a non-default configuration directory. On Linux, this is
         the same as the value passed to Globus Connect Personal's `-dir` flag
         (i.e. the default value is ``~/.globusonline``).
-    :type config_dir: str, optional
     """
 
     def __init__(self, *, config_dir: str | None = None) -> None:
@@ -110,7 +109,6 @@ class LocalGlobusConnectPersonal:
 
         :param auth_client: An AuthClient to use to lookup the full identity information
             for the GCP owner
-        :type auth_client: globus_sdk.AuthClient
 
         **Examples**
 
@@ -164,8 +162,6 @@ class LocalGlobusConnectPersonal:
     @property
     def endpoint_id(self) -> str | None:
         """
-        :type: str
-
         The endpoint ID of the local Globus Connect Personal endpoint
         installation.
 

--- a/src/globus_sdk/local_endpoint/personal/owner_info.py
+++ b/src/globus_sdk/local_endpoint/personal/owner_info.py
@@ -55,7 +55,6 @@ class GlobusConnectPersonalOwnerInfo:
     :vartype username: str or None
     :param config_dn: A DN value from GCP configuration, which will be parsed into
         username or ID
-    :type config_dn: str
     """
 
     _GRIDMAP_DN_START = '"/C=US/O=Globus Consortium/OU=Globus Connect User/CN='

--- a/src/globus_sdk/local_endpoint/server/endpoint.py
+++ b/src/globus_sdk/local_endpoint/server/endpoint.py
@@ -15,7 +15,6 @@ class LocalGlobusConnectServer:
     for interacting with any Globus Service APIs.
 
     :param info_path: The path to the info file used to inspect the local system
-    :type info_path: str, optional
     """
 
     def __init__(
@@ -36,8 +35,6 @@ class LocalGlobusConnectServer:
         one, it cannot be used or examined by the SDK. For example, containerized
         applications using the SDK may not be able to interact with Globus Connect
         Server on the container host.
-
-        :type: dict or None
         """
         if self._loaded_info is None:
             if self.info_path.is_file():
@@ -60,8 +57,6 @@ class LocalGlobusConnectServer:
         """
         The endpoint ID of the local Globus Connect Server endpoint.
         None if the data cannot be loaded or is malformed.
-
-        :type: str or None
         """
         if self.info_dict is not None:
             epid = self.info_dict.get("endpoint_id")
@@ -74,8 +69,6 @@ class LocalGlobusConnectServer:
         """
         The domain name of the local Globus Connect Server endpoint.
         None if the data cannot be loaded or is malformed.
-
-        :type: str or None
         """
         if self.info_dict is not None:
             domain = self.info_dict.get("domain_name")

--- a/src/globus_sdk/paging/base.py
+++ b/src/globus_sdk/paging/base.py
@@ -35,18 +35,14 @@ class Paginator(t.Iterable[PageT], metaclass=abc.ABCMeta):
     Iterating on a Paginator is equivalent to iterating on its ``pages``.
 
     :param method: A bound method of an SDK client, used to generate a paginated variant
-    :type method: callable
     :param items_key: The key to use within pages of results to get an array of items
-    :type items_key: str
     :param client_args: Arguments to the underlying method which are passed when the
         paginator is instantiated. i.e. given ``client.paginated.foo(a, b, c=1)``, this
         will be ``(a, b)``. The paginator will pass these arguments to each call of the
         bound method as it pages.
-    :type client_args: tuple
     :param client_kwargs: Keyword arguments to the underlying method, like
         ``client_args`` above. ``client.paginated.foo(a, b, c=1)`` will pass this as
         ``{"c": 1}``. As with ``client_args``, it's passed to each paginated call.
-    :type client_kwargs: dict
     """
 
     def __init__(
@@ -54,7 +50,7 @@ class Paginator(t.Iterable[PageT], metaclass=abc.ABCMeta):
         method: t.Callable[..., t.Any],
         *,
         items_key: str | None = None,
-        client_args: list[t.Any],
+        client_args: tuple[t.Any, ...],
         client_kwargs: dict[str, t.Any],
         # the Base paginator must accept arbitrary additional kwargs to indicate that
         # its child classes could define and use additional kwargs
@@ -112,7 +108,6 @@ class Paginator(t.Iterable[PageT], metaclass=abc.ABCMeta):
         checkers to more accurately infer the type of the paginator.
 
         :param method: The method to convert to a paginator
-        :type method: callable
         """
         if not inspect.ismethod(method):
             raise TypeError(f"Paginator.wrap can only be used on methods, not {method}")
@@ -128,7 +123,7 @@ class Paginator(t.Iterable[PageT], metaclass=abc.ABCMeta):
         def paginated_method(*args: t.Any, **kwargs: t.Any) -> Paginator[PageT]:
             return paginator_class(
                 method,
-                client_args=list(args),
+                client_args=tuple(args),
                 client_kwargs=kwargs,
                 items_key=paginator_items_key,
                 **paginator_params,
@@ -157,11 +152,8 @@ def has_paginator(
     >>> paginator = c.paginated.foo()
 
     :param paginator_class: The type of paginator used by this method
-    :type paginator_class: Paginator subclass
     :param items_key: The key to use within pages of results to get an array of items
-    :type items_key: str, optional
     :param paginator_params: Additional parameters to pass to the paginator constructor
-    :type paginator_params: any
     """
 
     def decorate(func: C) -> C:

--- a/src/globus_sdk/paging/last_key.py
+++ b/src/globus_sdk/paging/last_key.py
@@ -11,7 +11,7 @@ class LastKeyPaginator(Paginator[PageT]):
         method: t.Callable[..., t.Any],
         *,
         items_key: str | None = None,
-        client_args: list[t.Any],
+        client_args: tuple[t.Any, ...],
         client_kwargs: dict[str, t.Any],
     ):
         super().__init__(

--- a/src/globus_sdk/paging/limit_offset.py
+++ b/src/globus_sdk/paging/limit_offset.py
@@ -14,7 +14,7 @@ class _LimitOffsetBasedPaginator(Paginator[PageT]):  # pylint: disable=abstract-
         get_page_size: t.Callable[[dict[str, t.Any]], int],
         max_total_results: int,
         page_size: int,
-        client_args: list[t.Any],
+        client_args: tuple[t.Any, ...],
         client_kwargs: dict[str, t.Any],
     ):
         super().__init__(

--- a/src/globus_sdk/paging/marker.py
+++ b/src/globus_sdk/paging/marker.py
@@ -19,7 +19,7 @@ class MarkerPaginator(Paginator[PageT]):
         *,
         items_key: str | None = None,
         marker_key: str = "marker",
-        client_args: list[t.Any],
+        client_args: tuple[t.Any, ...],
         client_kwargs: dict[str, t.Any],
     ):
         super().__init__(

--- a/src/globus_sdk/paging/next_token.py
+++ b/src/globus_sdk/paging/next_token.py
@@ -19,7 +19,7 @@ class NextTokenPaginator(Paginator[PageT]):
         method: t.Callable[..., t.Any],
         *,
         items_key: str | None = None,
-        client_args: list[t.Any],
+        client_args: tuple[t.Any, ...],
         client_kwargs: dict[str, t.Any],
     ):
         super().__init__(

--- a/src/globus_sdk/scopes/builder.py
+++ b/src/globus_sdk/scopes/builder.py
@@ -18,13 +18,10 @@ class ScopeBuilder:
 
     :param resource_server: The identifier, usually a domain name or a UUID, for the
         resource server to return scopes for.
-    :type resource_server: str
     :param known_scopes: A list of scope names to pre-populate on this instance. This
         will set attributes on the instance using the URN scope format.
-    :type known_scopes: list of str, optional
     :param known_url_scopes: A list of scope names to pre-populate on this instance.
         This will set attributes on the instance using the URL scope format.
-    :type known_url_scopes: list of str, optional
     """
 
     _classattr_scope_names: list[str] = []
@@ -111,7 +108,6 @@ class ScopeBuilder:
         "urn:globus:auth:scope:transfer.api.globus.org:all"
 
         :param scope_name: The short name for the scope involved.
-        :type scope_name: str
         """
         return f"urn:globus:auth:scope:{self.resource_server}:{scope_name}"
 
@@ -127,7 +123,6 @@ class ScopeBuilder:
         "https://auth.globus.org/scopes/actions.globus.org/hello_world"
 
         :param scope_name: The short name for the scope involved.
-        :type scope_name: str
         """
         return f"https://auth.globus.org/scopes/{self.resource_server}/{scope_name}"
 
@@ -154,10 +149,8 @@ class ScopeBuilder:
         Scope('urn:globus:auth:scope:transfer.api.globus.org:all')
 
         :param scope: The name of the scope to convert to a MutableScope
-        :type scope: str
         :param optional: If true, the created MutableScope object will be marked
             optional
-        :type optional: bool
         """
         return MutableScope(getattr(self, scope), optional=optional)
 

--- a/src/globus_sdk/scopes/scope_definition.py
+++ b/src/globus_sdk/scopes/scope_definition.py
@@ -8,7 +8,8 @@ from __future__ import annotations
 import typing as t
 import warnings
 
-from globus_sdk._types import ScopeCollectionType
+if t.TYPE_CHECKING:
+    from globus_sdk._types import ScopeCollectionType
 
 
 def _iter_scope_collection(obj: ScopeCollectionType) -> t.Iterator[str]:

--- a/src/globus_sdk/scopes/scope_definition.py
+++ b/src/globus_sdk/scopes/scope_definition.py
@@ -32,10 +32,8 @@ class MutableScope:
     `str(MutableScope(...))` produces a valid scope string for use in various methods.
 
     :param scope_string: The string which will be used as the basis for this Scope
-    :type scope_string: str
     :param optional: The scope may be marked as optional. This means that the scope can
         be declined by the user without declining consent for other scopes
-    :type optional: bool
     """
 
     def __init__(
@@ -74,11 +72,9 @@ class MutableScope:
         Scope and will be evident in its string representation.
 
         :param scope: The scope upon which the current scope depends
-        :type scope: str
         :param optional: Mark the dependency an optional one. By default it is not. An
             optional scope dependency can be declined by the user without declining
             consent for the primary scope
-        :type optional: bool, optional
         """
         if optional is not None:
             if isinstance(scope, MutableScope):
@@ -120,6 +116,5 @@ class MutableScope:
         Scopes, convert to a string which can be used in a request.
 
         :param obj: The object or collection to convert to a string
-        :type obj: str, MutableScope, iterable of str or MutableScope
         """
         return " ".join(_iter_scope_collection(obj))

--- a/src/globus_sdk/services/auth/client/base_login_client.py
+++ b/src/globus_sdk/services/auth/client/base_login_client.py
@@ -35,7 +35,6 @@ class AuthLoginClient(client.BaseClient):
 
     :param client_id: The ID of the application provided by registration with
         Globus Auth.
-    :type client_id: str or UUID
 
     All other initialization parameters are passed through to ``BaseClient``.
 
@@ -126,9 +125,7 @@ class AuthLoginClient(client.BaseClient):
 
         :param openid_configuration: The OIDC config as a GlobusHTTPResponse or dict.
             When not provided, it will be fetched automatically.
-        :type openid_configuration: dict or GlobusHTTPResponse
         :param as_pem: Decode the JWK to an RSA PEM key, typically for JWT decoding
-        :type as_pem: bool
         """
         if openid_configuration is None:
             log.debug("No OIDC Config provided, autofetching...")
@@ -154,13 +151,10 @@ class AuthLoginClient(client.BaseClient):
 
         :param session_required_identities: A list of identities must be
             added to the session.
-        :type session_required_identities: str or uuid or list of str or uuid, optional
         :param session_required_single_domain: A list of domain requirements
             which must be satisfied by identities added to the session.
-        :type session_required_single_domain: str or list of str, optional
         :param session_required_policies: A list of IDs for policies which must
             be satisfied by the user.
-        :type session_required_policies: str or uuid or list of str or uuid, optional
         :param prompt:
             Control whether a user is required to log in before the authorization step.
 
@@ -168,11 +162,8 @@ class AuthLoginClient(client.BaseClient):
             even if they are already logged in. Setting this parameter can help ensure
             that a user's session meets known or unknown session requirement policies
             and avoid additional login flows.
-        :type prompt: ``"login"``, optional
         :param query_params: Additional query parameters to include in the
             authorize URL. Primarily for internal use
-        :type query_params: dict, optional
-        :rtype: ``string``
         """
         if not self.current_oauth2_flow_manager:
             log.error("OutOfOrderOperations(get_authorize_url before start_flow)")
@@ -207,13 +198,10 @@ class AuthLoginClient(client.BaseClient):
         """
         Exchange an authorization code for a token or tokens.
 
-        :rtype: :class:`OAuthTokenResponse <.OAuthTokenResponse>`
-
         :param auth_code: An auth code typically obtained by sending the user to the
             authorize URL. The code is a very short-lived credential which this method
             is exchanging for tokens. Tokens are the credentials used to authenticate
             against Globus APIs.
-        :type auth_code: str
         """
         log.info(
             "Final Step of 3-legged OAuth2 Flows: "
@@ -250,10 +238,7 @@ class AuthLoginClient(client.BaseClient):
         plus any additional parameters you may specify.
 
         :param refresh_token: A Globus Refresh Token as a string
-        :type refresh_token: str
-
         :param body_params: A dict of extra params to encode in the refresh call.
-        :type body_params: dict, optional
         """
         log.info("Executing token refresh; typically requires client credentials")
         form_data = {"refresh_token": refresh_token, "grant_type": "refresh_token"}
@@ -273,10 +258,8 @@ class AuthLoginClient(client.BaseClient):
 
         :param token: The token which should be validated. Can be a refresh token or an
             access token
-        :type token: str
         :param body_params: Additional parameters to include in the validation
             body. Primarily for internal use
-        :type body_params: dict, optional
         """
         exc.warn_deprecated(
             f"{self.__class__.__name__}.oauth2_validate_token() is deprecated. "
@@ -317,11 +300,9 @@ class AuthLoginClient(client.BaseClient):
         want to confirm that it was revoked.
 
         :param token: The token which should be revoked
-        :type token: str
         :param body_params: Additional parameters to include in the revocation
             body, which can help speed the revocation process. Primarily for
             internal use
-        :type body_params: dict, optional
 
         **Examples**
 
@@ -385,7 +366,7 @@ class AuthLoginClient(client.BaseClient):
         form_data: dict[str, t.Any] | utils.PayloadWrapper,
         *,
         body_params: dict[str, t.Any] | None = None,
-        response_class: (type[OAuthTokenResponse] | type[RT]) = OAuthTokenResponse,
+        response_class: type[OAuthTokenResponse] | type[RT] = OAuthTokenResponse,
     ) -> OAuthTokenResponse | RT:
         """
         This is the generic form of calling the OAuth2 Token endpoint.
@@ -401,13 +382,11 @@ class AuthLoginClient(client.BaseClient):
             <globus_sdk.ConfidentialAppAuthClient.oauth2_get_dependent_tokens>`
             requires a specialize response class to handle the dramatically different
             format of the Dependent Token Grant response
-        :type response_class: class, optional
         :param form_data: The main body of the request
-        :type form_data: dict or `utils.PayloadWrapper`
         :param body_params: Any additional parameters to be passed through
             as body parameters.
-        :type body_params: dict, optional
-        :rtype: ``response_class``
+        :rtype: ``response_class`` if set, defaults to
+            :py:attr:`~globus_sdk.OAuthTokenResponse`
         """
         log.info("Fetching new token from Globus Auth")
         # use the fact that requests implicitly encodes the `data` parameter as

--- a/src/globus_sdk/services/auth/client/confidential_client.py
+++ b/src/globus_sdk/services/auth/client/confidential_client.py
@@ -34,10 +34,8 @@ class ConfidentialAppAuthClient(AuthLoginClient):
 
     :param client_id: The ID of the application provided by registration with
         Globus Auth.
-    :type client_id: str or UUID
     :param client_secret: The secret string to use for authentication. Secrets can be
         generated via the Globus developers interface.
-    :type client_secret: str
 
     All other initialization parameters are passed through to ``BaseClient``.
 
@@ -80,16 +78,12 @@ class ConfidentialAppAuthClient(AuthLoginClient):
 
         :param usernames: A username or list of usernames to lookup. Mutually exclusive
             with ``ids``
-        :type usernames: str or iterable of str, optional
         :param ids: An identity ID or list of IDs to lookup. Mutually exclusive
             with ``usernames``
-        :type ids: str, UUID, or iterable of str or UUID, optional
         :param provision: Create identities if they do not exist, allowing clients to
             get username-to-identity mappings prior to the identity being used
-        :type provision: bool
         :param query_params: Any additional parameters to be passed through
             as query params.
-        :type query_params: dict, optional
         """
         exc.warn_deprecated(
             "ConfidentialAuthClient.get_identities() is deprecated. "
@@ -125,9 +119,6 @@ class ConfidentialAppAuthClient(AuthLoginClient):
 
         :param requested_scopes: The scopes on the token(s) being requested. Defaults to
             ``openid profile email urn:globus:auth:scope:transfer.api.globus.org:all``
-        :type requested_scopes: str, MutableScope, or iterable of str or MutableScope,
-            optional
-        :rtype: :class:`OAuthTokenResponse <.OAuthTokenResponse>`
 
         For example, with a Client ID of "CID1001" and a Client Secret of
         "RAND2002", you could use this grant type like so:
@@ -161,20 +152,14 @@ class ConfidentialAppAuthClient(AuthLoginClient):
 
         :param redirect_uri: The page that users should be directed to after
             authenticating at the authorize URL.
-        :type redirect_uri: str
-            ``redirect_uri`` (*string*)
         :param requested_scopes: The scopes on the token(s) being requested. Defaults to
             ``openid profile email urn:globus:auth:scope:transfer.api.globus.org:all``
-        :type requested_scopes: str, MutableScope, or iterable of str or MutableScope,
-            optional
         :param state: This string allows an application to pass information back to
             itself in the course of the OAuth flow. Because the user will navigate away
             from the application to complete the flow, this parameter lets the app pass
             an arbitrary string from the starting page to the ``redirect_uri``
-        :type state: str, optional
         :param refresh_tokens: When True, request refresh tokens in addition to access
             tokens. [Default: ``False``]
-        :type refresh_tokens: bool, optional
 
         .. tab-set::
 
@@ -227,13 +212,9 @@ class ConfidentialAppAuthClient(AuthLoginClient):
         this Grant to get those "Dependent" or "Downstream" tokens for Service B.
 
         :param token: A Globus Access Token as a string
-        :type token: str
         :param refresh_tokens: When True, request dependent refresh tokens in addition
             to access tokens. [Default: ``False``]
-        :type refresh_tokens: bool, optional
         :param additional_params: Additional parameters to include in the request body
-        :type additional_params: dict, optional
-        :rtype: :class:`OAuthDependentTokenResponse <.OAuthDependentTokenResponse>`
         """
         log.info("Getting dependent tokens from access token")
         log.debug(f"additional_params={additional_params}")
@@ -258,10 +239,8 @@ class ConfidentialAppAuthClient(AuthLoginClient):
         Get information about a Globus Auth token.
 
         :param token: An Access Token as a raw string, being evaluated
-        :type token: str
         :param include: A value for the ``include`` parameter in the request body.
             Default is to omit the parameter.
-        :type include: str, optional
 
         .. tab-set::
 
@@ -324,14 +303,12 @@ class ConfidentialAppAuthClient(AuthLoginClient):
 
         :param name: The display name shown to users on consents. May not contain
             linebreaks.
-        :type name: str
         :param public_client: This is used to infer which OAuth grant_types the client
             will be able to use. Should be false if the client is capable of keeping
             secret credentials (such as clients running on a server) and true if it is
             not (such as native apps). After creation this value is immutable. This
             option is mutually exclusive with ``client_type``, exactly one must be
             given.
-        :type public_client: bool, optional
         :param client_type: Defines the type of client that will be created. This
             option is mutually exclusive with ``public_client``, exactly one must
             be given.
@@ -364,26 +341,18 @@ class ConfidentialAppAuthClient(AuthLoginClient):
                         application (confidential or public client), service account,
                         or API.
 
-        :type client_type: str, optional
         :param visibility: If set to "public", any authenticated entity can view it.
             When set to "private", only entities in the same project as the client can
             view it.
-        :type visibility: str, optional
         :param redirect_uris: list of URIs that may be used in OAuth authorization
             flows.
-        :type redirect_uris: iterable of str, optional
         :param terms_and_conditions: URL of client's terms and conditions.
-        :type terms_and_conditions: str, optional
         :param privacy_policy: URL of client's privacy policy.
-        :type privacy_policy: str, optional
         :param required_idp: In order to use this client a user must have an identity
             from this IdP in their identity set.
-        :type required_idp: str or uuid, optional
         :param preselect_idp: This pre-selects the given IdP on the Globus Auth login
             page if the user is not already authenticated.
-        :type preselect_idp: str or uuid, optional
         :param additional_fields: Any additional parameters to be passed through.
-        :type additional_fields: dict, optional
 
         .. tab-set::
 

--- a/src/globus_sdk/services/auth/client/native_client.py
+++ b/src/globus_sdk/services/auth/client/native_client.py
@@ -69,8 +69,6 @@ class NativeAppAuthClient(AuthLoginClient):
 
         :param requested_scopes: The scopes on the token(s) being requested. Defaults to
             ``openid profile email urn:globus:auth:scope:transfer.api.globus.org:all``
-        :type requested_scopes: str, MutableScope, or iterable of str or MutableScope,
-            optional
         :param redirect_uri: The page that users should be directed to after
             authenticating at the authorize URL. Defaults to
             'https://auth.globus.org/v2/web/auth-code', which displays the resulting
@@ -79,16 +77,12 @@ class NativeAppAuthClient(AuthLoginClient):
         :param state: The ``redirect_uri`` page will have this included in a query
             parameter, so you can use it to pass information to that page if you use a
             custom page. It defaults to the string '_default'
-        :type state: str, optional
         :param verifier: A secret used for the Native App flow. It will by default be a
             freshly generated random string, known only to this
             ``GlobusNativeAppFlowManager`` instance
-        :type verifier: str, optional
         :param refresh_tokens: When True, request refresh tokens in addition to access
             tokens. [Default: ``False``]
-        :type refresh_tokens: bool, optional
         :param prefill_named_grant: Prefill the named grant label on the consent page
-        :type prefill_named_grant: str, optional
 
         .. tab-set::
 
@@ -129,9 +123,7 @@ class NativeAppAuthClient(AuthLoginClient):
         grant call with client credentials, as is normal.
 
         :param refresh_token: The refresh token to use to get a new access token
-        :type refresh_token: str
         :param body_params: Extra parameters to include in the POST body
-        :type body_params: dict, optional
         """
         log.info("Executing token refresh without client credentials")
         form_data = {
@@ -150,9 +142,7 @@ class NativeAppAuthClient(AuthLoginClient):
          Create a new native app instance. The new instance is a confidential client.
 
          :param template_id: The client ID of the calling native app
-         :type template_id: str or uuid
          :param name: The name given to the new app instance
-         :type name: str
 
         .. tab-set::
 

--- a/src/globus_sdk/services/auth/client/service_client.py
+++ b/src/globus_sdk/services/auth/client/service_client.py
@@ -1072,7 +1072,8 @@ class AuthClient(client.BaseClient):
         *,
         public_client: bool | utils.MissingType = utils.MISSING,
         client_type: (
-            t.Literal[
+            utils.MissingType
+            | t.Literal[
                 "client_identity",
                 "confidential_client",
                 "globus_connect_server",
@@ -1080,9 +1081,8 @@ class AuthClient(client.BaseClient):
                 "hybrid_confidential_client_resource_server",
                 "resource_server",
             ]
-            | utils.MissingType
         ) = utils.MISSING,
-        visibility: t.Literal["public", "private"] | utils.MissingType = utils.MISSING,
+        visibility: utils.MissingType | t.Literal["public", "private"] = utils.MISSING,
         redirect_uris: t.Iterable[str] | utils.MissingType = utils.MISSING,
         terms_and_conditions: str | utils.MissingType = utils.MISSING,
         privacy_policy: str | utils.MissingType = utils.MISSING,
@@ -1219,7 +1219,7 @@ class AuthClient(client.BaseClient):
         client_id: UUIDLike,
         *,
         name: str | utils.MissingType = utils.MISSING,
-        visibility: t.Literal["public", "private"] | utils.MissingType = utils.MISSING,
+        visibility: utils.MissingType | t.Literal["public", "private"] = utils.MISSING,
         redirect_uris: t.Iterable[str] | utils.MissingType = utils.MISSING,
         terms_and_conditions: str | None | utils.MissingType = utils.MISSING,
         privacy_policy: str | None | utils.MissingType = utils.MISSING,

--- a/src/globus_sdk/services/auth/client/service_client.py
+++ b/src/globus_sdk/services/auth/client/service_client.py
@@ -154,7 +154,7 @@ class AuthClient(client.BaseClient):
 
         :param openid_configuration: The OIDC config as a GlobusHTTPResponse or dict.
             When not provided, it will be fetched automatically.
-        :type openid_configuration: dict or GlobusHTTPResponse
+        :type openid_configuration: None | GlobusHTTPResponse | dict[str, typing.Any]
         :param as_pem: Decode the JWK to an RSA PEM key, typically for JWT decoding
         :type as_pem: bool
         """
@@ -232,16 +232,12 @@ class AuthClient(client.BaseClient):
 
         :param usernames: A username or list of usernames to lookup. Mutually exclusive
             with ``ids``
-        :type usernames: str or iterable of str, optional
         :param ids: An identity ID or list of IDs to lookup. Mutually exclusive
             with ``usernames``
-        :type ids: str, UUID, or iterable of str or UUID, optional
         :param provision: Create identities if they do not exist, allowing clients to
             get username-to-identity mappings prior to the identity being used
-        :type provision: bool
         :param query_params: Any additional parameters to be passed through
             as query params.
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -338,13 +334,10 @@ class AuthClient(client.BaseClient):
 
         :param domains: A domain or iterable of domains to lookup. Mutually exclusive
             with ``ids``.
-        :type domains: str or iterable of str, optional
         :param ids: An identity provider ID or iterable of IDs to lookup. Mutually exclusive
             with ``domains``.
-        :type ids: str, UUID, or iterable of str or UUID, optional
         :param query_params: Any additional parameters to be passed through
             as query params.
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -434,7 +427,6 @@ class AuthClient(client.BaseClient):
         Look up a project. Requires the ``manage_projects`` scope.
 
         :param project_id: The ID of the project to lookup
-        :type project_id: str or uuid
 
         .. tab-set::
 
@@ -540,13 +532,9 @@ class AuthClient(client.BaseClient):
         At least one of ``admin_ids`` or ``admin_group_ids`` must be provided.
 
         :param display_name: The name of the project
-        :type display_name: str
         :param contact_email: The email address of the project's point of contact
-        :type contact_email: str
         :param admin_ids: A list of user IDs to be added as admins of the project
-        :type admin_ids: str or uuid or iterable of str or uuid, optional
         :param admin_group_ids: A list of group IDs to be added as admins of the project
-        :type admin_group_ids: str or uuid or iterable of str or uuid, optional
 
         .. tab-set::
 
@@ -604,15 +592,10 @@ class AuthClient(client.BaseClient):
         Update a project. Requires the ``manage_projects`` scope.
 
         :param project_id: The ID of the project to update
-        :type project_id: str or uuid
         :param display_name: The name of the project
-        :type display_name: str
         :param contact_email: The email address of the project's point of contact
-        :type contact_email: str
         :param admin_ids: A list of user IDs to be set as admins of the project
-        :type admin_ids: str or uuid or iterable of str or uuid, optional
         :param admin_group_ids: A list of group IDs to be set as admins of the project
-        :type admin_group_ids: str or uuid or iterable of str or uuid, optional
 
         .. tab-set::
 
@@ -657,7 +640,6 @@ class AuthClient(client.BaseClient):
         Delete a project. Requires the ``manage_projects`` scope.
 
         :param project_id: The ID of the project to delete
-        :type project_id: str or uuid
 
         .. tab-set::
 
@@ -687,7 +669,6 @@ class AuthClient(client.BaseClient):
         Look up a policy. Requires the ``manage_projects`` scope.
 
         :param policy_id: The ID of the policy to lookup
-        :type policy_id: str or uuid
 
         .. tab-set::
 
@@ -795,22 +776,15 @@ class AuthClient(client.BaseClient):
         Create a new Auth policy. Requires the ``manage_projects`` scope.
 
         :param project_id: ID of the project for the new policy
-        :type project_id: str or uuid
         :param high_assurance: Whether or not this policy is applied to sessions.
-        :type high_assurance: bool
         :param authentication_assurance_timeout: Number of seconds within which someone
             must have authenticated to satisfy the policy
-        :type authentication_assurance_timeout: int
         :param display_name: A user-friendly name for the policy
-        :type display_name: str
         :param description: A user-friendly description to explain the purpose of the
             policy
-        :type description: str
         :param domain_constraints_include: A list of domains that can satisfy the policy
-        :type domain_constraints_include: iterable of str or None
         :param domain_constraints_exclude: A list of domains that cannot satisfy the
             policy
-        :type domain_constraints_exclude: iterable of str or None
 
         .. tab-set::
 
@@ -872,23 +846,15 @@ class AuthClient(client.BaseClient):
         Update a policy. Requires the ``manage_projects`` scope.
 
         :param policy_id: ID of the policy to update
-        :type policy_id: str or uuid
-
         :param project_id: ID of the project for the new policy
-        :type project_id: str or uuid
         :param authentication_assurance_timeout: Number of seconds within which someone
             must have authenticated to satisfy the policy
-        :type authentication_assurance_timeout: int
         :param display_name: A user-friendly name for the policy
-        :type display_name: str
         :param description: A user-friendly description to explain the purpose of the
             policy
-        :type description: str
         :param domain_constraints_include: A list of domains that can satisfy the policy
-        :type domain_constraints_include: iterable of str or None
         :param domain_constraints_exclude: A list of domains that can not satisfy the
             policy
-        :type domain_constraints_exclude: iterable of str or None
 
         .. tab-set::
 
@@ -926,7 +892,6 @@ class AuthClient(client.BaseClient):
         Delete a policy. Requires the ``manage_projects`` scope.
 
         :param policy_id: The ID of the policy to delete
-        :type policy_id: str or uuid
 
         .. tab-set::
 
@@ -962,9 +927,7 @@ class AuthClient(client.BaseClient):
         Requires the ``manage_projects`` scope.
 
         :param client_id: The ID of the client to look up
-        :type client_id: str or uuid
         :param fqdn: The fully-qualified domain name of the client to look up
-        :type fqdn: str
 
         .. tab-set::
 
@@ -1132,9 +1095,7 @@ class AuthClient(client.BaseClient):
 
         :param name: The display name shown to users on consents. May not contain
             linebreaks.
-        :type name: str
         :param project: ID representing the project this client belongs to.
-        :type project: str or uuid
 
         :param public_client: This is used to infer which OAuth grant_types the client
             will be able to use. Should be false if the client is capable of keeping
@@ -1142,7 +1103,6 @@ class AuthClient(client.BaseClient):
             not (such as native apps). After creation this value is immutable. This
             option is mutually exclusive with ``client_type``, exactly one must be
             given.
-        :type public_client: bool, optional
         :param client_type: Defines the type of client that will be created. This
             option is mutually exclusive with ``public_client``, exactly one must
             be given.
@@ -1175,27 +1135,18 @@ class AuthClient(client.BaseClient):
                         application (confidential or public client), service account,
                         or API.
 
-        :type client_type: str, optional
-
         :param visibility: If set to "public", any authenticated entity can view it.
             When set to "private", only entities in the same project as the client can
             view it.
-        :type visibility: str, optional
         :param redirect_uris: list of URIs that may be used in OAuth authorization
             flows.
-        :type redirect_uris: iterable of str, optional
         :param terms_and_conditions: URL of client's terms and conditions.
-        :type terms_and_conditions: str, optional
         :param privacy_policy: URL of client's privacy policy.
-        :type privacy_policy: str, optional
         :param required_idp: In order to use this client a user must have an identity
             from this IdP in their identity set.
-        :type required_idp: str or uuid, optional
         :param preselect_idp: This pre-selects the given IdP on the Globus Auth login
             page if the user is not already authenticated.
-        :type preselect_idp: str or uuid, optional
         :param additional_fields: Any additional parameters to be passed through.
-        :type additional_fields: dict, optional
 
         .. tab-set::
 
@@ -1280,29 +1231,20 @@ class AuthClient(client.BaseClient):
         Update a client. Requires the ``manage_projects`` scope.
 
         :param client_id: ID of the client to update
-        :type client_id: str or uuid
         :param name: The display name shown to users on consents. May not contain
             linebreaks.
-        :type name: str
         :param visibility: If set to "public", any authenticated entity can view it.
             When set to "private", only entities in the same project as the client can
             view it.
-        :type visibility: str
         :param redirect_uris: list of URIs that may be used in OAuth authorization
             flows.
-        :type redirect_uris: iterable of str
         :param terms_and_conditions: URL of client's terms and conditions.
-        :type terms_and_conditions: str
         :param privacy_policy: URL of client's privacy policy.
-        :type privacy_policy: str
         :param required_idp: In order to use this client a user must have an identity
             from this IdP in their identity set.
-        :type required_idp: str or uuid
         :param preselect_idp: This pre-selects the given IdP on the Globus Auth login
             page if the user is not already authenticated.
-        :type preselect_idp: str or uuid
         :param additional_fields: Any additional parameters to be passed through.
-        :type additional_fields: dict
 
 
         .. tab-set::
@@ -1368,7 +1310,6 @@ class AuthClient(client.BaseClient):
         Delete a client. Requires the ``manage_projects`` scope.
 
         :param client_id: The ID of the client to delete
-        :type client_id: str or uuid
 
         .. tab-set::
 
@@ -1399,7 +1340,6 @@ class AuthClient(client.BaseClient):
         ``manage_projects`` scope.
 
         :param client_id: The ID of the client that owns the credentials
-        :type client_id: str or uuid
 
         .. tab-set::
 
@@ -1444,9 +1384,7 @@ class AuthClient(client.BaseClient):
         Create a new client credential. Requires the ``manage_projects`` scope.
 
         :param client_id: ID for the client
-        :type client_id: str or uuid
         :param name: The display name of the new credential.
-        :type name: str
 
         .. tab-set::
 
@@ -1495,9 +1433,7 @@ class AuthClient(client.BaseClient):
         Delete a credential. Requires the ``manage_projects`` scope.
 
         :param client_id: The ID of the client that owns the credential to delete
-        :type client_id: str or uuid
         :param credential_id: The ID of the credential to delete
-        :type credential_id: str or uuid
 
         .. tab-set::
 
@@ -1528,7 +1464,6 @@ class AuthClient(client.BaseClient):
         Look up a scope by ``scope_id``.  Requires the ``manage_projects`` scope.
 
         :param scope_id: The ID of the scope to look up
-        :type scope_id: str or uuid
 
         .. tab-set::
 
@@ -1579,12 +1514,9 @@ class AuthClient(client.BaseClient):
         ``ids``.  Requires the ``manage_projects`` scope.
 
         :param scope_strings: The scope_strings of the scopes to look up
-        :type scope_strings: iterable of str
         :param ids: The ID of the scopes to look up
-        :type ids: iterable of str or uuid
         :param query_params: Any additional parameters to be passed through
             as query params.
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -1678,27 +1610,19 @@ class AuthClient(client.BaseClient):
         Create a new scope. Requires the ``manage_projects`` scope.
 
         :param client_id: ID of the client for the new scope
-        :type client_id: str or uuid
         :param name: A display name used to display consents to users,
             along with description
-        :type name: str
         :param description: A description used to display consents to users, along with
             name
-        :type description: str
         :param scope_suffix: String consisting of lowercase letters, number, and
             underscores. This will be the final part of the scope_string
-        :type scope_suffix: str
         :param required_domains: Domains the user must have linked identities in in
             order to make use of the scope
-        :type required_domains: iterable of str
         :param dependent_scopes: Scopes included in the consent for this new scope
-        :type dependent_scopes: iterable of DependentScopeSpec
         :param advertised: If True, scope is visible to anyone regardless of client
             visibility, otherwise, scope visibility is based on client visibility.
-        :type advertised: bool
         :param allows_refresh_token: Whether or not the scope allows refresh tokens
             to be issued.
-        :type allows_refresh_token: bool
 
         .. tab-set::
 
@@ -1757,27 +1681,19 @@ class AuthClient(client.BaseClient):
         Update a scope. Requires the ``manage_projects`` scope.
 
         :param scope_id: ID of the scope to update
-        :type scope_id: str or uuid
         :param name: A display name used to display consents to users,
             along with description
-        :type name: str
         :param description: A description used to display consents to users, along with
             name
-        :type description: str
         :param scope_suffix: String consisting of lowercase letters, number, and
             underscores. This will be the final part of the scope_string
-        :type scope_suffix: str
         :param required_domains: Domains the user must have linked identities in in
             order to make use of the scope
-        :type required_domains: iterable of str
         :param dependent_scopes: Scopes included in the consent for this new scope
-        :type dependent_scopes: iterable of DependentScope
         :param advertised: If True, scope is visible to anyone regardless of client
             visibility, otherwise, scope visibility is based on client visibility.
-        :type advertised: bool
         :param allows_refresh_token: Whether or not the scope allows refresh tokens
             to be issued.
-        :type allows_refresh_token: bool
 
         .. tab-set::
 
@@ -1817,7 +1733,6 @@ class AuthClient(client.BaseClient):
         Delete a scope. Requires the ``manage_projects`` scope.
 
         :param scope_id: The ID of the scope to delete
-        :type scope_id: str or uuid
 
         .. tab-set::
 

--- a/src/globus_sdk/services/auth/data.py
+++ b/src/globus_sdk/services/auth/data.py
@@ -10,13 +10,10 @@ class DependentScopeSpec(utils.PayloadWrapper):
     :meth:`AuthClient.update_scope <globus_sdk.AuthClient.update_scope>`.
 
     :param scope: The ID of the dependent scope
-    :type scope: str or uuid
     :param optional: Whether or not the user can decline this specific scope without
         declining the whole consent.
-    :type optional: bool
     :param requires_refresh_token: Whether or not the dependency requires a refresh
         token.
-    :type requires_refresh_token: bool
     """
 
     def __init__(

--- a/src/globus_sdk/services/auth/flow_managers/authorization_code.py
+++ b/src/globus_sdk/services/auth/flow_managers/authorization_code.py
@@ -34,23 +34,16 @@ class GlobusAuthorizationCodeFlowManager(GlobusOAuthFlowManager):
 
     :param auth_client: The client used to extract default values for the flow,
         and also to make calls to the Auth service.
-    :type auth_client: :class:`ConfidentialAppAuthClient \
-        <globus_sdk.ConfidentialAppAuthClient>`
     :param redirect_uri: The page that users should be directed to after authenticating
         at the authorize URL.
-    :type redirect_uri: str
     :param requested_scopes: The scopes on the token(s) being requested. Defaults to
         ``openid profile email urn:globus:auth:scope:transfer.api.globus.org:all``
-    :type requested_scopes: str, MutableScope, or iterable of str or MutableScope,
-        optional
     :param state: This string allows an application to pass information back to itself
         in the course of the OAuth flow. Because the user will navigate away from the
         application to complete the flow, this parameter lets the app pass an arbitrary
         string from the starting page to the ``redirect_uri``
-    :type state: str, optional
     :param refresh_tokens: When True, request refresh tokens in addition to access
         tokens. [Default: ``False``]
-    :type refresh_tokens: bool, optional
     """
 
     def __init__(
@@ -86,8 +79,6 @@ class GlobusAuthorizationCodeFlowManager(GlobusOAuthFlowManager):
 
         :param query_params: Additional parameters to include in the authorize URL.
             Primarily for internal use
-        :type query_params: dict, optional
-        :rtype: ``string``
 
         The returned URL string is encoded to be suitable to display to users
         in a link or to copy into their browser. Users will be redirected
@@ -120,9 +111,6 @@ class GlobusAuthorizationCodeFlowManager(GlobusOAuthFlowManager):
         authorization code for access tokens (and refresh tokens if specified)
 
         :param auth_code: The short-lived code to exchange for tokens
-        :type auth_code: str
-
-        :rtype: :class:`OAuthTokenResponse <.OAuthTokenResponse>`
         """
         logger.debug(
             "Performing Authorization Code auth_code exchange. "

--- a/src/globus_sdk/services/auth/flow_managers/base.py
+++ b/src/globus_sdk/services/auth/flow_managers/base.py
@@ -38,9 +38,6 @@ class GlobusOAuthFlowManager(abc.ABC):
 
         :param query_params: Any additional parameters to be passed through
             as query params on the URL.
-        :type query_params: dict, optional
-
-        :rtype: ``string``
         """
 
     @abc.abstractmethod
@@ -56,7 +53,4 @@ class GlobusOAuthFlowManager(abc.ABC):
 
         :param auth_code: The authorization code which was produced from the
             authorization flow
-        :type auth_code: str
-
-        :rtype: :class:`OAuthTokenResponse <globus_sdk.OAuthTokenResponse>`
         """

--- a/src/globus_sdk/services/auth/flow_managers/native_app.py
+++ b/src/globus_sdk/services/auth/flow_managers/native_app.py
@@ -39,7 +39,6 @@ def make_native_app_challenge(
     :param verifier: The code verifier string used to construct the code challenge. Must
         be at least 43 characters long and not longer than 128 characters. Must only
         contain the following characters: [a-zA-Z0-9~_.-].
-    :type verifier: str, optional
     """
 
     if verifier:
@@ -81,30 +80,22 @@ class GlobusNativeAppFlowManager(GlobusOAuthFlowManager):
     :param auth_client: The client object on which this flow is based.
         It is used to extract default values for the flow, and also to make calls to the
         Auth service.
-    :type auth_client: :class:`NativeAppAuthClient <globus_sdk.NativeAppAuthClient>`
     :param requested_scopes: The scopes on the token(s) being requested. Defaults to
         ``openid profile email urn:globus:auth:scope:transfer.api.globus.org:all``
-    :type requested_scopes: str, MutableScope, or iterable of str or MutableScope,
-        optional
     :param redirect_uri: The page that users should be directed to after authenticating
         at the authorize URL. Defaults to 'https://auth.globus.org/v2/web/auth-code',
         which displays the resulting ``auth_code`` for users to copy-paste back into
         your application (and thereby be passed back to the
         ``GlobusNativeAppFlowManager``)
-    :type redirect_uri: str, optional
     :param state: The ``redirect_uri`` page will have this included in a query
         parameter, so you can use it to pass information to that page if you use a
         custom page. It defaults to the string '_default'
-    :type state: str, optional
     :param verifier: A secret used for the Native App flow. It will by default be a
         freshly generated random string, known only to this
         ``GlobusNativeAppFlowManager`` instance
-    :type verifier: str, optional
     :param refresh_tokens: When True, request refresh tokens in addition to access
         tokens. [Default: ``False``]
-    :type refresh_tokens: bool, optional
     :param prefill_named_grant: Prefill the named grant label on the consent page
-    :type prefill_named_grant: str, optional
     """
 
     def __init__(
@@ -169,8 +160,6 @@ class GlobusNativeAppFlowManager(GlobusOAuthFlowManager):
 
         :param query_params: Additional query parameters to include in the
             authorize URL. Primarily for internal use
-        :type query_params: dict, optional
-        :rtype: ``string``
 
         The returned URL string is encoded to be suitable to display to users
         in a link or to copy into their browser. Users will be redirected
@@ -207,9 +196,6 @@ class GlobusNativeAppFlowManager(GlobusOAuthFlowManager):
         for access tokens (and refresh tokens if specified).
 
         :param auth_code: The short-lived code to exchange for tokens
-        :type auth_code: str
-
-        :rtype: :class:`OAuthTokenResponse <.OAuthTokenResponse>`
         """
         logger.debug(
             "Performing Native App auth_code exchange. "

--- a/src/globus_sdk/services/auth/identity_map.py
+++ b/src/globus_sdk/services/auth/identity_map.py
@@ -114,19 +114,14 @@ class IdentityMap:
         username = record["username"] if record is not None else "NO_SUCH_IDENTITY"
 
     :param auth_client: The client object which will be used for lookups against Globus Auth
-    :type auth_client: :class:`AuthClient <globus_sdk.AuthClient>` or
-        :class:`ConfidentialAppAuthClient <globus_sdk.ConfidentialAppAuthClient>`
     :param identity_ids: A list or other iterable of usernames or identity IDs (potentially
         mixed together) which will be used to seed the ``IdentityMap`` 's tracking of
         unresolved Identities.
-    :type identity_ids: iterable of str, optional
     :param id_batch_size: A non-default batch size to use when communicating with Globus
         Auth. Leaving this set to the default is strongly recommended.
-    :type id_batch_size: int, optional
     :param cache:  A dict or other mapping object which will be used to cache results.
         The default is that results are cached once per IdentityMap object. If you want
         multiple IdentityMaps to share data, explicitly pass the same ``cache`` to both.
-    :type cache: MutableMapping, optional
 
     .. automethodlist:: globus_sdk.IdentityMap
         :include_methods: __getitem__,__delitem__
@@ -140,7 +135,7 @@ class IdentityMap:
         identity_ids: t.Iterable[str] | None = None,
         *,
         id_batch_size: int | None = None,
-        cache: None | (t.MutableMapping[str, dict[str, t.Any]]) = None,
+        cache: None | t.MutableMapping[str, dict[str, t.Any]] = None,
     ):
         self.auth_client = auth_client
         self.id_batch_size = id_batch_size or self._default_id_batch_size
@@ -213,7 +208,6 @@ class IdentityMap:
 
         :param identity_id: A string Identity ID or Identity Name (a.k.a. "username") to
             add
-        :type identity_id: str
         """
         if identity_id in self._cache:
             return False
@@ -233,9 +227,7 @@ class IdentityMap:
         A dict-like get() method which accepts a default value.
 
         :param key: The username or ID to look up
-        :type key: str
         :param default: The default value to return if the key is not found
-        :type default: any, optional
         """
         try:
             return self[key]

--- a/src/globus_sdk/services/auth/response/oauth.py
+++ b/src/globus_sdk/services/auth/response/oauth.py
@@ -185,14 +185,11 @@ class OAuthTokenResponse(GlobusHTTPResponse):
 
         :param openid_configuration: The OIDC config as a GlobusHTTPResponse or dict.
             When not provided, it will be fetched automatically.
-        :type openid_configuration: dict or GlobusHTTPResponse
         :param jwk: The JWK as a cryptography public key object. When not provided, it
             will be fetched and parsed automatically.
-        :type jwk: RSAPublicKey
         :param jwt_params: An optional dict of parameters to pass to the jwt decode
             step. If ``"leeway"`` is included, it will be passed as the ``leeway``
             parameter, and all other values are passed as ``options``.
-        :type jwt_params: dict
         """
         logger.info('Decoding ID Token "%s"', self["id_token"])
         if not isinstance(self.client, SupportsJWKMethods):

--- a/src/globus_sdk/services/flows/client.py
+++ b/src/globus_sdk/services/flows/client.py
@@ -46,19 +46,14 @@ class FlowsClient(client.BaseClient):
         Create a Flow
 
         :param title: A non-unique, human-friendly name used for displaying the
-            flow to end users.
-        :type title: str (1 - 128 characters)
+            flow to end users. (1 - 128 characters)
         :param definition: JSON object specifying flows states and execution order. For
             a more detailed explanation of the flow definition, see
             `Authoring Flows <https://docs.globus.org/api/flows/authoring-flows>`_
-        :type definition: dict
         :param input_schema: A JSON Schema to which Flow Invocation input must conform
-        :type input_schema: dict
-        :param subtitle: A concise summary of the flow’s purpose.
-        :type subtitle: str (0 - 128 characters), optional
+        :param subtitle: A concise summary of the flow’s purpose. (0 - 128 characters)
         :param description: A detailed description of the flow's purpose for end user
-            display.
-        :type description: str (0 - 4096 characters), optional
+            display. (0 - 4096 characters)
         :param flow_viewers: A set of Principal URN values, or the value "public",
             indicating entities who can view the flow
 
@@ -76,7 +71,6 @@ class FlowsClient(client.BaseClient):
                     ]
 
 
-        :type flow_viewers: list[str], optional
         :param flow_starters: A set of Principal URN values, or the value
             "all_authenticated_users", indicating entities who can initiate a *Run* of
             the flow
@@ -95,7 +89,6 @@ class FlowsClient(client.BaseClient):
                         "urn:globus:groups:id:c1dcd951-3f35-4ea3-9f28-a7cdeaf8b68f"
                     ]
 
-        :type flow_starters: list[str], optional
         :param flow_administrators: A set of Principal URN values indicating entities
             who can perform administrative operations on the flow (create, delete,
             update)
@@ -109,12 +102,9 @@ class FlowsClient(client.BaseClient):
                         "urn:globus:groups:id:c1dcd951-3f35-4ea3-9f28-a7cdeaf8b68f"
                     ]
 
-        :type flow_administrators: list[str], optional
         :param keywords: A set of terms used to categorize the flow used in query and
-            discovery operations
-        :type keywords: list[str] (0 - 1024 items), optional
+            discovery operations (0 - 1024 items)
         :param additional_fields: Additional Key/Value pairs sent to the create API
-        :type additional_fields: dict of str -> any, optional
 
         .. tab-set::
 
@@ -181,10 +171,8 @@ class FlowsClient(client.BaseClient):
         """Retrieve a Flow by ID
 
         :param flow_id: The ID of the Flow to fetch
-        :type flow_id: str or UUID
         :param query_params: Any additional parameters to be passed through
             as query params.
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -215,16 +203,11 @@ class FlowsClient(client.BaseClient):
 
         :param filter_role: A role name specifying the minimum permissions required for
             a Flow to be included in the response.
-        :type filter_role: str, optional
         :param filter_fulltext: A string to use in a full-text search to filter results
-        :type filter_fulltext: str, optional
         :param orderby: A criterion for ordering flows in the listing
-        :type orderby: str, optional
         :param marker: A marker for pagination
-        :type marker: str, optional
         :param query_params: Any additional parameters to be passed through
             as query params.
-        :type query_params: dict, optional
 
         **Role Values**
 
@@ -345,24 +328,17 @@ class FlowsClient(client.BaseClient):
         Any fields omitted from the request will be unchanged
 
         :param flow_id: The ID of the Flow to fetch
-        :type flow_id: str or UUID
         :param title: A non-unique, human-friendly name used for displaying the
-            flow to end users.
-        :type title: str (1 - 128 characters), optional
+            flow to end users. (1 - 128 characters)
         :param definition: JSON object specifying flows states and execution order. For
             a more detailed explanation of the flow definition, see
             `Authoring Flows <https://docs.globus.org/api/flows/authoring-flows>`_
-        :type definition: dict, optional
         :param input_schema: A JSON Schema to which Flow Invocation input must conform
-        :type input_schema: dict, optional
-        :param subtitle: A concise summary of the flow’s purpose.
-        :type subtitle: str (0 - 128 characters), optional
+        :param subtitle: A concise summary of the flow’s purpose. (0 - 128 characters)
         :param description: A detailed description of the flow's purpose for end user
-            display.
-        :type description: str (0 - 4096 characters), optional
+            display. (0 - 4096 characters)
         :param flow_owner: An Auth Identity URN to set as flow owner; this must match
             the Identity URN of the entity calling `update_flow`
-        :type flow_owner: str, optional
         :param flow_viewers: A set of Principal URN values, or the value "public",
             indicating entities who can view the flow
 
@@ -379,7 +355,6 @@ class FlowsClient(client.BaseClient):
                         "urn:globus:groups:id:c1dcd951-3f35-4ea3-9f28-a7cdeaf8b68f"
                     ]
 
-        :type flow_viewers: list[str], optional
         :param flow_starters: A set of Principal URN values, or the value
             "all_authenticated_users", indicating entities who can initiate a *Run* of
             the flow
@@ -398,7 +373,6 @@ class FlowsClient(client.BaseClient):
                         "urn:globus:groups:id:c1dcd951-3f35-4ea3-9f28-a7cdeaf8b68f"
                     ]
 
-        :type flow_starters: list[str], optional
         :param flow_administrators: A set of Principal URN values indicating entities
             who can perform administrative operations on the flow (create, delete,
             update)
@@ -412,12 +386,9 @@ class FlowsClient(client.BaseClient):
                         "urn:globus:groups:id:c1dcd951-3f35-4ea3-9f28-a7cdeaf8b68f"
                     ]
 
-        :type flow_administrators: list[str], optional
         :param keywords: A set of terms used to categorize the flow used in query and
-            discovery operations
-        :type keywords: list[str] (0 - 1024 items), optional
+            discovery operations (0 - 1024 items)
         :param additional_fields: Additional Key/Value pairs sent to the create API
-        :type additional_fields: dict of str -> any, optional
 
         .. tab-set::
 
@@ -473,10 +444,8 @@ class FlowsClient(client.BaseClient):
         """Delete a Flow
 
         :param flow_id: The ID of the flow to delete
-        :type flow_id: str or UUID, optional
         :param query_params: Any additional parameters to be passed through
             as query params.
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -504,11 +473,8 @@ class FlowsClient(client.BaseClient):
         List all runs.
 
         :param filter_flow_id: One or more Flow IDs used to filter the results
-        :type filter_flow_id: str, UUID, or iterable of str or UUID, optional
         :param marker: A pagination marker, used to get the next page of results.
-        :type marker: str, optional
         :param query_params: Any additional parameters to be passed through
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -556,17 +522,12 @@ class FlowsClient(client.BaseClient):
         These logs describe state transitions and associated payloads for a run
 
         :param run_id: Run ID to retrieve logs for
-        :type run_id: str or UUID, optional
         :param limit: Maximum number of log entries to return (server default: 10)
              (value between 1 and 100 inclusive)
-        :type limit: int, optional
         :param reverse_order: Return results in reverse chronological order (server
             default: false)
-        :type reverse_order: bool
         :param marker: Marker for the next page of results (provided by the server)
-        :type marker: str, optional
         :param query_params: Any additional parameters to be passed through
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -608,13 +569,10 @@ class FlowsClient(client.BaseClient):
         Retrieve information about a particular Run of a Flow
 
         :param run_id: The ID of the run to get
-        :type run_id: str or UUID
         :param include_flow_description: If set to true, the lookup will attempt to
            attach metadata about the flow to the run to the run response under the key
            "flow_description" (default: False)
-        :type include_flow_description: bool, optional
         :param query_params: Any additional parameters to be passed through
-        :type query_params: dict, optional
 
 
         .. tab-set::
@@ -653,7 +611,6 @@ class FlowsClient(client.BaseClient):
         Get the flow definition and input schema at the time the run was started.
 
         :param run_id: The ID of the run to get
-        :type run_id: str or UUID
 
         .. tab-set::
 
@@ -684,7 +641,6 @@ class FlowsClient(client.BaseClient):
         Cancel a run.
 
         :param run_id: The ID of the run to cancel
-        :type run_id: str or UUID
 
 
         .. tab-set::
@@ -725,22 +681,16 @@ class FlowsClient(client.BaseClient):
         Update the metadata of a specific run.
 
         :param run_id: The ID of the run to update
-        :type run_id: str or UUID
-        :param label: A short human-readable title
-        :type label: Optional string (1 - 64 chars)
+        :param label: A short human-readable title (1 - 64 chars)
         :param tags: A collection of searchable tags associated with the run.
             Tags are normalized by stripping leading and trailing whitespace,
             and replacing all whitespace with a single space.
-        :type tags: Optional list of strings
         :param run_monitors: A list of authenticated entities (identified by URN)
             authorized to view this run in addition to the run owner
-        :type run_monitors: Optional list of strings
         :param run_managers: A list of authenticated entities (identified by URN)
             authorized to view & cancel this run in addition to the run owner
-        :type run_managers: Optional list of strings
         :param additional_fields: Additional Key/Value pairs sent to the run API
             (this parameter is used to bypass local sdk key validation helping)
-        :type additional_fields: Optional dictionary
 
 
         .. tab-set::
@@ -787,7 +737,6 @@ class FlowsClient(client.BaseClient):
         Delete a run.
 
         :param run_id: The ID of the run to delete
-        :type run_id: str or UUID
 
 
         .. tab-set::
@@ -823,7 +772,6 @@ class SpecificFlowClient(client.BaseClient):
         arguments are the same as those for :class:`~globus_sdk.BaseClient`.
 
     :param flow_id: The generated UUID associated with a flow
-    :type flow_id: str or uuid
 
     .. automethodlist:: globus_sdk.SpecificFlowClient
     """
@@ -867,22 +815,16 @@ class SpecificFlowClient(client.BaseClient):
         """
         :param body: The input json object handed to the first flow state. The flows
             service will validate this object against the flow's supplied input schema.
-        :type body: json dict
-        :param label: A short human-readable title
-        :type label: Optional string (1 - 64 chars)
+        :param label: A short human-readable title (1 - 64 chars)
         :param tags: A collection of searchable tags associated with the run. Tags are
             normalized by stripping leading and trailing whitespace, and replacing all
             whitespace with a single space.
-        :type tags: Optional list of strings
         :param run_monitors: A list of authenticated entities (identified by URN)
             authorized to view this run in addition to the run owner
-        :type run_monitors: Optional list of strings
         :param run_managers: A list of authenticated entities (identified by URN)
             authorized to view & cancel this run in addition to the run owner
-        :type run_managers: Optional list of strings
         :param additional_fields: Additional Key/Value pairs sent to the run API
             (this parameter is used to bypass local sdk key validation helping)
-        :type additional_fields: Optional dictionary
 
         .. tab-set::
 
@@ -910,7 +852,6 @@ class SpecificFlowClient(client.BaseClient):
     def resume_run(self, run_id: UUIDLike) -> GlobusHTTPResponse:
         """
         :param run_id: The ID of the run to resume
-        :type run_id: str or UUID
 
         .. tab-set::
 

--- a/src/globus_sdk/services/gcs/client.py
+++ b/src/globus_sdk/services/gcs/client.py
@@ -31,7 +31,6 @@ class GCSClient(client.BaseClient):
     :class:`~globus_sdk.BaseClient`.
 
     :param gcs_address: The FQDN (DNS name) or HTTPS URL for the GCS Manager API.
-    :type gcs_address: str
 
     .. automethodlist:: globus_sdk.GCSClient
     """
@@ -74,7 +73,6 @@ class GCSClient(client.BaseClient):
         scopes for that Endpoint.
 
         :param endpoint_id: The ID of the Endpoint
-        :type endpoint_id: UUID or str
 
         See documentation for :class:`globus_sdk.scopes.GCSEndpointScopeBuilder` for
         more information.
@@ -89,7 +87,6 @@ class GCSClient(client.BaseClient):
         scopes for that Collection.
 
         :param collection_id: The ID of the Collection
-        :type collection_id: UUID or str
 
         See documentation for :class:`globus_sdk.scopes.GCSCollectionScopeBuilder` for
         more information.
@@ -106,7 +103,6 @@ class GCSClient(client.BaseClient):
         due to differing SDK and GCS versions.
 
         :param connector_id: The ID of the connector
-        :type connector_id: UUID or str
         """
         connector_dict = {
             "7c100eae-40fe-11e9-95a3-9cb6d0d9fd63": "Box",
@@ -144,20 +140,14 @@ class GCSClient(client.BaseClient):
 
         :param mapped_collection_id: Filter collections which were created using this
             mapped collection ID.
-        :type mapped_collection_id: str or UUID
         :param filter: Filter the returned set to any combination of the following:
             ``mapped_collections``, ``guest_collections``, ``managed_by_me``,
             ``created_by_me``.
-        :type filter: str or iterable of str, optional
         :param include: Names of additional documents to include in the response
-        :type include: str or iterable of str, optional
         :param page_size: Number of results to return per page
-        :type page_size: int, optional
         :param marker: Pagination marker supplied by previous API calls in the event
             a request returns more values than the page size
-        :type marker: str, optional
         :param query_params: Additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -195,9 +185,7 @@ class GCSClient(client.BaseClient):
         Lookup a Collection on an Endpoint
 
         :param collection_id: The ID of the collection to lookup
-        :type collection_id: str or UUID
         :param query_params: Additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -230,7 +218,6 @@ class GCSClient(client.BaseClient):
         ``endpoint:administrator`` or ``endpoint:owner`` role.
 
         :param collection_data: The collection document for the new collection
-        :type collection_data: dict or CollectionDocument
 
         .. tab-set::
 
@@ -257,11 +244,8 @@ class GCSClient(client.BaseClient):
         Update a Collection
 
         :param collection_id: The ID of the collection to update
-        :type collection_id: str or UUID
         :param collection_data: The collection document for the modified collection
-        :type collection_data: dict or CollectionDocument
         :param query_params: Additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -292,9 +276,7 @@ class GCSClient(client.BaseClient):
         Delete a Collection
 
         :param collection_id: The ID of the collection to delete
-        :type collection_id: str or UUID
         :param query_params: Additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -331,14 +313,10 @@ class GCSClient(client.BaseClient):
             'private_policies' is included, then include private storage gateway
             policies in the attached storage_gateways document. This requires an
             ``administrator`` role on the Endpoint.
-        :type include: str or iterable of str, optional
         :param page_size: Number of results to return per page
-        :type page_size: int, optional
         :param marker: Pagination marker supplied by previous API calls in the event
             a request returns more values than the page size
-        :type marker: str, optional
         :param query_params: Additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -377,9 +355,7 @@ class GCSClient(client.BaseClient):
 
         :param data: Data in the format of a Storage Gateway document, it is recommended
             to use the ``StorageGatewayDocument`` class to construct this data.
-        :type data: dict or StorageGatewayDocument
         :param query_params: Additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -407,14 +383,11 @@ class GCSClient(client.BaseClient):
         Lookup a Storage Gateway by ID
 
         :param storage_gateway_id: UUID for the Storage Gateway to be gotten
-        :type storage_gateway_id: str or UUID
         :param include: Optional document types to include in the response. If
             'private_policies' is included, then include private storage gateway
             policies in the attached storage_gateways document. This requires an
             ``administrator`` role on the Endpoint.
-        :type include: str or iterable of str, optional
         :param query_params: Additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -450,12 +423,9 @@ class GCSClient(client.BaseClient):
         Update a Storage Gateway
 
         :param storage_gateway_id: UUID for the Storage Gateway to be updated
-        :type storage_gateway_id: str or UUID
         :param data: Data in the format of a Storage Gateway document, it is recommended
             to use the ``StorageGatewayDocument`` class to construct this data.
-        :type data: dict or StorageGatewayDocument
         :param query_params: Additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -483,9 +453,7 @@ class GCSClient(client.BaseClient):
         Delete a Storage Gateway
 
         :param storage_gateway_id: UUID for the Storage Gateway to be deleted
-        :type storage_gateway_id: str or UUID
         :param query_params: Additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -523,18 +491,13 @@ class GCSClient(client.BaseClient):
         :param collection_id: UUID of a Collection. If given then only roles
             related to that Collection are returned, otherwise only Endpoint
             roles are returned.
-        :type collection_id: str or UUID, optional
         :param include: Pass "all_roles" to request all roles all roles
             relevant to the resource instead of only those the caller has on
             the resource
         :param page_size: Number of results to return per page
-        :type page_size: int, optional
         :param marker: Pagination marker supplied by previous API calls in the event
             a request returns more values than the page size
-        :type marker: str, optional
-        :type include: str, optional
         :param query_params: Additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -570,9 +533,7 @@ class GCSClient(client.BaseClient):
 
         :param data: Data in the format of a Role document, it is recommended
             to use the `GCSRoleDocument` class to construct this data.
-        :type data: dict
         :param query_params: Additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -599,9 +560,7 @@ class GCSClient(client.BaseClient):
         Get a Role by ID
 
         :param role_id: UUID for the Role to be gotten
-        :type role_id: str or UUID
         :param query_params: Additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -625,9 +584,7 @@ class GCSClient(client.BaseClient):
         Delete a Role
 
         :param role_id: UUID for the Role to be deleted
-        :type role_id: str or UUID
         :param query_params: Additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -657,14 +614,10 @@ class GCSClient(client.BaseClient):
         List User Credentials
 
         :param storage_gateway: UUID of a storage gateway to limit results to
-        :type storage_gateway: str or UUID, optional
         :param query_params: Additional passthrough query parameters
-        :type query_params: dict, optional
         :param page_size: Number of results to return per page
-        :type page_size: int, optional
         :param marker: Pagination marker supplied by previous API calls in the event
             a request returns more values than the page size
-        :type marker: str, optional
 
         .. tab-set::
 
@@ -698,9 +651,7 @@ class GCSClient(client.BaseClient):
 
         :param data: Data in the format of a UserCredential document, it is
             recommended to use the `UserCredential` class to construct this
-        :type data: dict
         :param query_params: Additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -727,9 +678,7 @@ class GCSClient(client.BaseClient):
         Get a User Credential by ID
 
         :param user_credential_id: UUID for the UserCredential to be gotten
-        :type user_credential_id: str or UUID
         :param query_params: Additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -756,12 +705,9 @@ class GCSClient(client.BaseClient):
         Update a User Credential
 
         :param user_credential_id: UUID for the UserCredential to be updated
-        :type user_credential_id: str or UUID
         :param data: Data in the format of a UserCredential document, it is
             recommended to use the `UserCredential` class to construct this
-        :type data: dict
         :param query_params: Additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -787,9 +733,7 @@ class GCSClient(client.BaseClient):
         Delete a User Credential
 
         :param user_credential_id: UUID for the UserCredential to be deleted
-        :type user_credential_id: str or UUID
         :param query_params: Additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 

--- a/src/globus_sdk/services/gcs/data/collection.py
+++ b/src/globus_sdk/services/gcs/data/collection.py
@@ -67,7 +67,6 @@ class CollectionDocument(utils.PayloadWrapper, abc.ABC):
         Normally ``DATA_TYPE`` is deduced from the provided parameters and should not be
         set. To maximize compatibility with different versions of GCS, only set this
         value when necessary.
-    :type data_type: str, optional
 
     :param collection_base_path: The location of the collection on its underlying
         storage. For a mapped collection, this is an absolute path on the storage system
@@ -75,53 +74,34 @@ class CollectionDocument(utils.PayloadWrapper, abc.ABC):
         relative to the value of the ``root_path`` attribute on the mapped collection
         identified by the ``mapped_collection_id``. This parameter is optional for
         updates but required when creating a new collection.
-    :type collection_base_path: str, optional
     :param contact_email: Email address of the support contact for the collection
-    :type contact_email: str, optional
     :param contact_info: Other contact information for the collection, e.g. phone number
         or mailing address
-    :type contact_info: str, optional
     :param default_directory: Default directory when using the collection
-    :type default_directory: str, optional
     :param department: The department which operates the collection
-    :type department: str, optional
     :param description: A text description of the collection
-    :type description: str, optional
     :param display_name: Friendly name for the collection
-    :type display_name: str, optional
     :param identity_id: The Globus Auth identity which acts as the owner of the
         collection
-    :type identity_id: str or UUID, optional
     :param info_link: Link for more info about the collection
-    :type info_link: str, optional
     :param organization: The organization which maintains the collection
-    :type organization: str, optional
     :param user_message: A message to display to users when interacting with this
         collection
-    :type user_message: str, optional
     :param user_message_link: A link to additional messaging for users when interacting
         with this collection
-    :type user_message_link: str, optional
 
     :param keywords: A list of keywords used to help searches for the collection
-    :type keywords: iterable of str, optional
 
     :param disable_verify: Disable verification checksums on transfers to and from this
         collection
-    :type disable_verify: bool, optional
     :param enable_https: Enable or disable HTTPS support (requires a managed endpoint)
-    :type enable_https: bool, optional
     :param force_encryption: When set to True, all transfers to and from the collection
         are always encrypted
-    :type force_encryption: bool, optional
     :param force_verify: Force verification checksums on transfers to and from this
         collection
-    :type force_verify: bool, optional
     :param public: If True, the collection will be visible to other Globus users
-    :type public: bool, optional
 
     :param additional_fields: Additional data for inclusion in the collection document
-    :type additional_fields: dict, optional
     """
 
     DATATYPE_BASE: str = "collection"
@@ -222,37 +202,27 @@ class MappedCollectionDocument(CollectionDocument):
 
     :param storage_gateway_id: The ID of the storage gateway which hosts this mapped
         collection. This parameter is required when creating a collection.
-    :type storage_gateway_id: str or UUID, optional
 
     :param domain_name: DNS name of the virtual host serving this collection
-    :type domain_name: str, optional
     :param guest_auth_policy_id: Globus Auth policy ID to set on a mapped collection
         which is then inherited by its guest collections.
-    :type guest_auth_policy_id: UUID or str, optional
 
     :param sharing_users_allow: Connector-specific usernames allowed to create guest
         collections
-    :type sharing_users_allow: iterable of str, optional
     :param sharing_users_deny: Connector-specific usernames forbidden from creating
         guest collections
-    :type sharing_users_deny: iterable of str, optional
 
     :param delete_protected: Enable or disable deletion protection on this collection.
         Defaults to ``True`` during creation.
-    :type delete_protected: bool, optional
 
     :param allow_guest_collections: Enable or disable creation and use of Guest
         Collections on this Mapped Collection
-    :type allow_guest_collections: bool, optional
     :param disable_anonymous_writes: Allow anonymous write ACLs on Guest Collections
         attached to this Mapped Collection. This option is only usable on non
         high-assurance collections
-    :type disable_anonymous_writes: bool, optional
 
     :param policies: Connector-specific collection policies
-    :type policies: dict, optional
     :param sharing_restrict_paths: A PathRestrictions document
-    :type sharing_restrict_paths: dict, optional
     """
 
     @property
@@ -370,11 +340,9 @@ class GuestCollectionDocument(CollectionDocument):
 
     :param mapped_collection_id: The ID of the mapped collection which hosts this guest
         collection
-    :type mapped_collection_id: str or UUID
     :param user_credential_id: The ID of the User Credential which is used to access
         data on this collection. This credential must be owned by the collection’s
         ``identity_id``.
-    :type user_credential_id: str or UUID
     """
 
     @property
@@ -465,15 +433,11 @@ class POSIXCollectionPolicies(CollectionPolicies):
 
     :param DATA_TYPE: Versioned document type. Defaults to the appropriate type for
         this class.
-    :type DATA_TYPE: str, optional
     :param sharing_groups_allow: POSIX groups which are allowed to create guest
         collections.
-    :type sharing_groups_allow: iterable of str, optional
     :param sharing_groups_deny: POSIX groups which are not allowed to create guest
         collections.
-    :type sharing_groups_deny: iterable of str, optional
     :param additional_fields: Additional data for inclusion in the policy document
-    :type additional_fields: dict, optional
     """
 
     def __init__(
@@ -501,15 +465,11 @@ class POSIXStagingCollectionPolicies(CollectionPolicies):
 
     :param DATA_TYPE: Versioned document type. Defaults to the appropriate type for
         this class.
-    :type DATA_TYPE: str, optional
     :param sharing_groups_allow: POSIX groups which are allowed to create guest
         collections.
-    :type sharing_groups_allow: iterable of str, optional
     :param sharing_groups_deny: POSIX groups which are not allowed to create guest
         collections.
-    :type sharing_groups_deny: iterable of str, optional
     :param additional_fields: Additional data for inclusion in the policy document
-    :type additional_fields: dict, optional
     """
 
     def __init__(
@@ -536,11 +496,8 @@ class GoogleCloudStorageCollectionPolicies(CollectionPolicies):
 
     :param DATA_TYPE: Versioned document type. Defaults to the appropriate type for
         this class.
-    :type DATA_TYPE: str, optional
     :param project: Google Cloud Platform project ID that is used by this collection
-    :type project: str, optional
     :param additional_fields: Additional data for inclusion in the policy document
-    :type additional_fields: dict, optional
     """
 
     def __init__(

--- a/src/globus_sdk/services/gcs/data/role.py
+++ b/src/globus_sdk/services/gcs/data/role.py
@@ -12,17 +12,13 @@ class GCSRoleDocument(utils.PayloadWrapper):
     to use as the `data` parameter to `create_role`
 
     :param DATA_TYPE: Versioned document type.
-    :type DATA_TYPE: str
     :param collection: Collection ID for the collection the role will apply to.
         This value is omitted when creating an endpoint
         role or when creating role definitions when creating collections.
-    :type collection: str or UUID, optional
     :param principal: Auth identity or group id URN. Should be in the format
         urn:globus:auth:[identity|group]:{uuid of identity or group}
-    :type principal: str, optional
     :param role: Role assigned to the principal. Known values are owner,
         administrator, access_manager, activity_manager, and activity_monitor
-    :type role: str, optional
     """
 
     def __init__(

--- a/src/globus_sdk/services/gcs/data/storage_gateway.py
+++ b/src/globus_sdk/services/gcs/data/storage_gateway.py
@@ -17,50 +17,35 @@ class StorageGatewayDocument(utils.PayloadWrapper):
 
     :param DATA_TYPE: Versioned document type. Defaults to the appropriate type for
         this class.
-    :type DATA_TYPE: str, optional
     :param display_name: Name of the Storage Gateway
-    :type display_name: str, optional
     :param connector_id: UUID of the connector type that this Storage Gateway interacts
         with.
-    :type connector_id: str, optional
     :param identity_mappings: A list of IdentityMapping objects which are applied to
         user identities to attempt to determine what accounts are available for access.
-    :type identity_mappings: iterable of dict, optional
     :param policies: Connector specific storage policies. It is recommended that
         you use one of the policy helper classes (e.g. `POSIXStoragePolicies`
         if you are using the POSIX connector) to create these.
-    :type policies: dict or StorageGatewayPolicy, optional
     :param allowed_domains: List of allowed domains. Users creating credentials or
         collections on this Storage Gateway must have an identity in one of these
         domains.
-    :type allowed_domains: iterable of string
     :param restrict_paths: Path restrictions within this Storage Gateway. Private.
-    :type restrict_paths: dict, optional
     :param high_assurance: Flag indicating if the Storage Gateway requires high
         assurance features.
-    :type high_assurance: bool, optional
     :param authentication_timeout_mins: Timeout (in minutes) during which a user is
         required to have authenticated in a session to access this storage gateway.
-    :type authentication_timeout_mins: int, optional
     :param users_allow:  List of connector-specific usernames allowed to access this
         Storage Gateway. Private.
-    :type users_allow: iterable of str, optional
     :param users_deny: List of connector-specific usernames denied access to this
         Storage Gateway. Private.
-    :type users_deny: iterable of str, optional
     :param process_user: Local POSIX user the GridFTP server should run as when
         accessing this Storage Gateway.
-    :type process_user: str, optional
     :param load_dsi_module: Name of the DSI module to load by the GridFTP server when
         accessing this Storage Gateway.
-    :type load_dsi_module: str, optional
     :param require_mfa: Flag indicating that the Storage Gateway requires multi-factor
         authentication. Only usable on high assurance Storage Gateways.
-    :type require_mfa: bool, optional
 
     :param additional_fields: Additional data for inclusion in the Storage Gateway
         document
-    :type additional_fields: dict, optional
     """
 
     DATATYPE_BASE: str = "storage_gateway"
@@ -123,15 +108,11 @@ class POSIXStoragePolicies(StorageGatewayPolicies):
 
     :param DATA_TYPE: Versioned document type. Defaults to the appropriate type for
         this class.
-    :type DATA_TYPE: str, optional
     :param groups_allow: List of POSIX group IDs allowed to access this Storage
         Gateway. Private.
-    :type groups_allow: iterable of str, optional
     :param groups_deny: List of POSIX group IDs denied access this Storage
         Gateway. Private.
-    :type groups_deny: iterable of str, optional
     :param additional_fields: Additional data for inclusion in the policy document
-    :type additional_fields: dict, optional
     """
 
     def __init__(
@@ -155,20 +136,14 @@ class POSIXStagingStoragePolicies(StorageGatewayPolicies):
 
     :param DATA_TYPE: Versioned document type. Defaults to the appropriate type for
         this class.
-    :type DATA_TYPE: str, optional
     :param groups_allow: List of POSIX group IDs allowed to access this Storage
         Gateway. Private.
-    :type groups_allow: iterable of str, optional
     :param groups_deny: List of POSIX group IDs denied access this Storage
         Gateway. Private.
-    :type groups_deny: iterable of str, optional
     :param stage_app: Path to the stage app. Private.
-    :type stage_app: str, optional
     :param environment: A mapping of variable names to values to set in the environment
         when executing the ``stage_app``. Private.
-    :type environment: iterable of dict, optional
     :param additional_fields: Additional data for inclusion in the policy document
-    :type additional_fields: dict, optional
     """
 
     def __init__(
@@ -199,16 +174,12 @@ class BlackPearlStoragePolicies(StorageGatewayPolicies):
 
     :param DATA_TYPE: Versioned document type. Defaults to the appropriate type for
         this class.
-    :type DATA_TYPE: str, optional
     :param s3_endpoint: The URL of the S3 endpoint of the BlackPearl appliance to use to
         access collections on this Storage Gateway.
-    :type s3_endpoint: str
     :param bp_access_id_file: Path to the file which provides mappings from usernames
         within the configured identity domain to the ID and secret associated with the
         user's BlackPearl account
-    :type bp_access_id_file: str
     :param additional_fields: Additional data for inclusion in the policy document
-    :type additional_fields: dict, optional
     """
 
     def __init__(
@@ -235,15 +206,11 @@ class BoxStoragePolicies(StorageGatewayPolicies):
 
     :param DATA_TYPE: Versioned document type. Defaults to the appropriate type for
         this class.
-    :type DATA_TYPE: str, optional
     :param enterpriseID: Identifies which Box Enterprise this Storage Gateway is
         authorized to access. Private.
-    :type enterpriseID: str
     :param boxAppSettings: Values that the Storage Gateway uses to identify and
         authenticate with the Box API. Private.
-    :type boxAppSettings: dict
     :param additional_fields: Additional data for inclusion in the policy document
-    :type additional_fields: dict, optional
     """
 
     def __init__(
@@ -267,20 +234,14 @@ class CephStoragePolicies(StorageGatewayPolicies):
 
     :param DATA_TYPE: Versioned document type. Defaults to the appropriate type for
         this class.
-    :type DATA_TYPE: str, optional
     :param s3_endpoint: URL of the S3 API endpoint
-    :type s3_endpoint: str
     :param s3_buckets: List of buckets not owned by the collection owner that will be
         shown in the root of collections created at the base of this Storage Gateway.
-    :type s3_buckets: iterable of str
     :param ceph_admin_key_id: Administrator key id used to authenticate with the ceph
         admin service to obtain user credentials. Private.
-    :type ceph_admin_key_id: str
     :param ceph_admin_secret_key: Administrator secret key used to authenticate with the
         ceph admin service to obtain user credentials. Private.
-    :type ceph_admin_secret_key: str
     :param additional_fields: Additional data for inclusion in the policy document
-    :type additional_fields: dict, optional
     """
 
     def __init__(
@@ -311,17 +272,12 @@ class GoogleDriveStoragePolicies(StorageGatewayPolicies):
 
     :param DATA_TYPE: Versioned document type. Defaults to the appropriate type for
         this class.
-    :type DATA_TYPE: str, optional
     :param client_id: Client ID registered with the Google Application console to access
         Google Drive. Private.
-    :type client_id: str
     :param secret: Secret created to access access Google Drive with the client_id in
         this policy. Private.
-    :type secret: str
     :param user_api_rate_quota: User API Rate quota associated with this client ID.
-    :type user_api_rate_quota: int
     :param additional_fields: Additional data for inclusion in the policy document
-    :type additional_fields: dict, optional
     """
 
     def __init__(
@@ -346,29 +302,22 @@ class GoogleCloudStoragePolicies(StorageGatewayPolicies):
 
     :param DATA_TYPE: Versioned document type. Defaults to the appropriate type for
         this class.
-    :type DATA_TYPE: str, optional
     :param client_id: Client ID registered with the Google Application console to
         access Google Drive. Private.
-    :type client_id: str
     :param secret: Secret created to access access Google Drive with the client_id in
         this policy. Private.
-    :type secret: str
     :param service_account_key: Credentials for use with service account auth, read
         from a Google-provided json file. Private.
-    :type service_account_key: dict
     :param buckets: The list of Google Cloud Storage buckets which the Storage
         Gateway is allowed to access, as well as the list of buckets that will be
         shown in root level directory listings. If this list is unset, bucket
         access is unrestricted and all non public credential accessible buckets
         will be shown in root level directory listings. The value is a list of
         bucket names.
-    :type buckets: iterable of str
     :param projects: The list of Google Cloud Storage projects which the
         Storage Gateway is allowed to access. If this list is unset, project access
         is unrestricted.  The value is a list of project id strings.
-    :type projects: iterable of str
     :param additional_fields: Additional data for inclusion in the policy document
-    :type additional_fields: dict, optional
     """
 
     def __init__(
@@ -396,19 +345,13 @@ class OneDriveStoragePolicies(StorageGatewayPolicies):
 
     :param DATA_TYPE: Versioned document type. Defaults to the appropriate type for
         this class.
-    :type DATA_TYPE: str, optional
     :param client_id: Client ID registered with the MS Application console to
         access OneDrive. Private.
-    :type client_id: str
     :param secret: Secret created to access access MS with the client_id in
         this policy. Private.
-    :type secret: str
     :param tenant: MS Tenant ID from which to allow user logins. Private.
-    :type tenant: str or None
     :param user_api_rate_limit: User API Rate limit associated with this client ID.
-    :type user_api_rate_limit: int
     :param additional_fields: Additional data for inclusion in the policy document
-    :type additional_fields: dict, optional
     """
 
     def __init__(
@@ -436,23 +379,15 @@ class AzureBlobStoragePolicies(StorageGatewayPolicies):
 
     :param DATA_TYPE: Versioned document type. Defaults to the appropriate type for
         this class.
-    :type DATA_TYPE: str, optional
     :param client_id: Client ID registered with the MS Application console to
         access Azure Blob Private.
-    :type client_id: str
     :param secret: Secret created to access access MS with the client_id in
         this policy. Private.
-    :type secret: str
     :param tenant: MS Tenant ID from which to allow user logins. Private.
-    :type tenant: str
     :param account: Azure Storage account. Private.
-    :type account: str
     :param auth_type: Auth type: user, service_principal or user_service_principal
-    :type auth_type: str
     :param adls: ADLS support enabled or not. Private.
-    :type adls: bool
     :param additional_fields: Additional data for inclusion in the policy document
-    :type additional_fields: dict, optional
     """
 
     def __init__(
@@ -487,19 +422,14 @@ class S3StoragePolicies(StorageGatewayPolicies):
 
     :param DATA_TYPE: Versioned document type. Defaults to the appropriate type for
         this class.
-    :type DATA_TYPE: str, optional
     :param s3_endpoint: URL of the S3 API endpoint
-    :type s3_endpoint: str
     :param s3_buckets: List of buckets not owned by the collection owner that
         will be shown in the root of collections created at the base of this
         Storage Gateway.
-    :type s3_buckets: iterable of str
     :param s3_user_credential_required: Flag indicating if a Globus User must
         register a user credential in order to create a Guest Collection on this
         Storage Gateway.
-    :type s3_user_credential_required: str
     :param additional_fields: Additional data for inclusion in the policy document
-    :type additional_fields: dict, optional
     """
 
     def __init__(
@@ -532,13 +462,9 @@ class IrodsStoragePolicies(StorageGatewayPolicies):
 
     :param DATA_TYPE: Versioned document type. Defaults to the appropriate type for
         this class.
-    :type DATA_TYPE: str, optional
     :param irods_environment_file: Path to iRODS environment file on the endpoint
-    :type irods_environment_file: str
     :param irods_authentication_file: Path to iRODS authentication file on the endpoint
-    :type irods_authentication_file: str
     :param additional_fields: Additional data for inclusion in the policy document
-    :type additional_fields: dict, optional
     """
 
     def __init__(
@@ -565,16 +491,11 @@ class HPSSStoragePolicies(StorageGatewayPolicies):
 
     :param DATA_TYPE: Versioned document type. Defaults to the appropriate type for
         this class.
-    :type DATA_TYPE: str, optional
     :param authentication_mech: Authentication mechanism to use with HPSS.
-    :type authentication_mech: str
     :param authenticator: Authentication credentials to use with HPSS.
-    :type authenticator: str
     :param uda_checksum_support: Flag indicating whether checksums should be
         stored in metadata.
-    :type uda_checksum_support: bool
     :param additional_fields: Additional data for inclusion in the policy document
-    :type additional_fields: dict, optional
     """
 
     def __init__(

--- a/src/globus_sdk/services/gcs/data/user_credential.py
+++ b/src/globus_sdk/services/gcs/data/user_credential.py
@@ -13,23 +13,15 @@ class UserCredentialDocument(utils.PayloadWrapper):
     `update_user_credential`
 
     :param DATA_TYPE: Versioned document type.
-    :type DATA_TYPE: str
     :param identity_id: UUID of the Globus identity this credential will
         provide access for
-    :type identity_id: UUID or str, optional
     :param connector_id: UUID of the connector this credential is for
-    :type connector_id: UUID or str, optional
     :param username: Username of the local account this credential will provide
         access to, format is connector specific
-    :type username: str, optional
     :param display_name: Display name for this credential
-    :type display_name: str, optional
     :param storage_gateway_id: UUID of the storage gateway this credential is for
-    :type storage_gateway_id: UUID or str, optional
     :param policies: Connector specific policies for this credential
-    :type policies: dict, optional
     :param additional_fields: Additional data for inclusion in the document
-    :type additional_fields: dict, optional
     """
 
     def __init__(

--- a/src/globus_sdk/services/gcs/response.py
+++ b/src/globus_sdk/services/gcs/response.py
@@ -35,7 +35,6 @@ class UnpackingGCSResponse(GlobusHTTPResponse):
 
     :param match: Either a string containing a DATA_TYPE prefix, or an arbitrary
         callable which does the matching
-    :type match: str or callable
     """
 
     def _default_unpacking_match(

--- a/src/globus_sdk/services/groups/client.py
+++ b/src/globus_sdk/services/groups/client.py
@@ -34,7 +34,6 @@ class GroupsClient(client.BaseClient):
         Return a list of groups your identity belongs to.
 
         :param query_params: Additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -61,13 +60,10 @@ class GroupsClient(client.BaseClient):
         Get details about a specific group
 
         :param group_id: the ID of the group
-        :type group_id: str or UUID
         :param include: list of additional fields to include (allowed fields are
             ``memberships``, ``my_memberships``, ``policies``, ``allowed_actions``, and
             ``child_ids``)
-        :type include: str or iterable of str, optional
         :param query_params: additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -95,9 +91,7 @@ class GroupsClient(client.BaseClient):
         Delete a group.
 
         :param group_id: the ID of the group
-        :type group_id: str or UUID
         :param query_params: additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -121,9 +115,7 @@ class GroupsClient(client.BaseClient):
         Create a group.
 
         :param data: the group document to create
-        :type data: dict
         :param query_params: additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -148,11 +140,8 @@ class GroupsClient(client.BaseClient):
         Update a given group.
 
         :param group_id: the ID of the group
-        :type group_id: str or UUID
         :param data: the group document to use for update
-        :type data: dict
         :param query_params: additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -176,9 +165,7 @@ class GroupsClient(client.BaseClient):
         Get policies for the given group
 
         :param group_id: the ID of the group
-        :type group_id: str or UUID
         :param query_params: additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -203,11 +190,8 @@ class GroupsClient(client.BaseClient):
         Set policies for the group.
 
         :param group_id: the ID of the group
-        :type group_id: str or UUID
         :param data: the group policy document to set
-        :type data: dict or ``GroupPolicies``
         :param query_params: additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -231,7 +215,6 @@ class GroupsClient(client.BaseClient):
         user allows themselves to be added to groups.
 
         :param query_params: additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -256,9 +239,7 @@ class GroupsClient(client.BaseClient):
         user allows themselves to be added to groups.
 
         :param data: the identity set preferences document
-        :type data: dict
         :param query_params: additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -289,9 +270,7 @@ class GroupsClient(client.BaseClient):
         Get membership fields for your identities.
 
         :param group_id: the ID of the group
-        :type group_id: str or UUID
         :param query_params: additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -318,11 +297,8 @@ class GroupsClient(client.BaseClient):
         Set membership fields for your identities.
 
         :param group_id: the ID of the group
-        :type group_id: str or UUID
         :param data: the membership fields document
-        :type data: dict
         :param query_params: additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -351,12 +327,9 @@ class GroupsClient(client.BaseClient):
         Execute a batch of actions against several group memberships.
 
         :param group_id: the ID of the group
-        :type group_id: str or UUID
         :param actions: the batch of membership actions to perform, modifying, creating,
             and removing memberships in the group
-        :type actions: dict or BatchMembershipActions
         :param query_params: additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 

--- a/src/globus_sdk/services/groups/manager.py
+++ b/src/globus_sdk/services/groups/manager.py
@@ -39,11 +39,8 @@ class GroupsManager:
         group will be a subgroup of the given parent group.
 
         :param name: The name of the group
-        :type name: str
         :param description: A description of the group
-        :type description: str
         :param parent_id: The ID of the parent group, if there is one
-        :type parent_id: str or UUID, optional
         """
         data = {
             "name": name,
@@ -67,21 +64,14 @@ class GroupsManager:
         Set the group policies for the given group.
 
         :param group_id: The ID of the group on which to set policies
-        :type group_id: str or UUID
         :param is_high_assurance: Whether the group can provide a High Assurance
             guarantee when used for access controls
-        :type is_high_assurance: bool
         :param group_visibility: The visibility of the group
-        :type group_visibility: str or :class:`~.GroupVisibility`
         :param group_members_visibility: The visibility of memberships within the group
-        :type group_members_visibility: str or :class:`~.GroupMemberVisibility`
         :param join_requests: Whether the group allows users to request to join
-        :type join_requests: bool
         :param signup_fields: The required fields for a user to sign up for the group
-        :type signup_fields: iterable of str or :class:`~.GroupRequiredSignupFields`
         :param authentication_assurance_timeout: The timeout used when this group is
             used to apply a High Assurance authentication guarantee
-        :type authentication_assurance_timeout: int, optional
         """
         data = GroupPolicies(
             is_high_assurance=is_high_assurance,
@@ -101,9 +91,7 @@ class GroupsManager:
         the identity set of the authenticated user.
 
         :param group_id: The ID of the group
-        :type group_id: str or UUID
         :param identity_id: The identity for whom to accept the invite
-        :type identity_id: str or UUID
         """
         actions = BatchMembershipActions().accept_invites([identity_id])
         return self.client.batch_membership_action(group_id, actions)
@@ -119,11 +107,8 @@ class GroupsManager:
         Add an identity to a group with the given role.
 
         :param group_id: The ID of the group
-        :type group_id: str or UUID
         :param identity_id: The identity to add to the group
-        :type identity_id: str or UUID
         :param role: The role for the new group member
-        :type role: str or :class:`~.GroupRole`
         """
         actions = BatchMembershipActions().add_members([identity_id], role=role)
         return self.client.batch_membership_action(group_id, actions)
@@ -135,9 +120,7 @@ class GroupsManager:
         Approve an identity with a pending join request.
 
         :param group_id: The ID of the group
-        :type group_id: str or UUID
         :param identity_id: The identity to approve as a member of the group
-        :type identity_id: str or UUID
         """
         actions = BatchMembershipActions().approve_pending([identity_id])
         return self.client.batch_membership_action(group_id, actions)
@@ -149,9 +132,7 @@ class GroupsManager:
         Decline an invitation for a given identity.
 
         :param group_id: The ID of the group
-        :type group_id: str or UUID
         :param identity_id: The identity for whom to decline the invitation
-        :type identity_id: str or UUID
         """
         actions = BatchMembershipActions().decline_invites([identity_id])
         return self.client.batch_membership_action(group_id, actions)
@@ -167,11 +148,8 @@ class GroupsManager:
         Invite an identity to a group with the given role.
 
         :param group_id: The ID of the group
-        :type group_id: str or UUID
         :param identity_id: The identity to invite as a new group member
-        :type identity_id: str or UUID
         :param role: The role for the invited group member
-        :type role: str or :class:`~.GroupRole`
         """
         actions = BatchMembershipActions().invite_members([identity_id], role=role)
         return self.client.batch_membership_action(group_id, actions)
@@ -184,9 +162,7 @@ class GroupsManager:
         authenticated users identity set.
 
         :param group_id: The ID of the group
-        :type group_id: str or UUID
         :param identity_id: The identity to use to join the group
-        :type identity_id: str or UUID
         """
         actions = BatchMembershipActions().join([identity_id])
         return self.client.batch_membership_action(group_id, actions)
@@ -199,9 +175,7 @@ class GroupsManager:
         identity set is a member of.
 
         :param group_id: The ID of the group
-        :type group_id: str or UUID
         :param identity_id: The identity to remove from the group
-        :type identity_id: str or UUID
         """
         actions = BatchMembershipActions().leave([identity_id])
         return self.client.batch_membership_action(group_id, actions)
@@ -213,9 +187,7 @@ class GroupsManager:
         Reject a member that has requested to join the group.
 
         :param group_id: The ID of the group
-        :type group_id: str or UUID
         :param identity_id: The identity to reject from the group
-        :type identity_id: str or UUID
         """
         actions = BatchMembershipActions().reject_join_requests([identity_id])
         return self.client.batch_membership_action(group_id, actions)
@@ -228,9 +200,7 @@ class GroupsManager:
         of the group.
 
         :param group_id: The ID of the group
-        :type group_id: str or UUID
         :param identity_id: The identity to remove from the group
-        :type identity_id: str or UUID
         """
         actions = BatchMembershipActions().remove_members([identity_id])
         return self.client.batch_membership_action(group_id, actions)
@@ -242,9 +212,7 @@ class GroupsManager:
         Request to join a group.
 
         :param group_id: The ID of the group
-        :type group_id: str or UUID
         :param identity_id: The identity to use to request membership in the group
-        :type identity_id: str or UUID
         """
         actions = BatchMembershipActions().request_join([identity_id])
         return self.client.batch_membership_action(group_id, actions)

--- a/src/globus_sdk/services/search/client.py
+++ b/src/globus_sdk/services/search/client.py
@@ -22,11 +22,6 @@ class SearchClient(client.BaseClient):
     API, and basic ``get``, ``put``, ``post``, and ``delete`` methods
     from the base client that can be used to access any API resource.
 
-    :param authorizer: An authorizer instance used for all calls to
-                       Globus Search
-    :type authorizer: :class:`GlobusAuthorizer \
-                      <globus_sdk.authorizers.base.GlobusAuthorizer>`
-
     **Methods**
 
     .. automethodlist:: globus_sdk.SearchClient
@@ -46,9 +41,7 @@ class SearchClient(client.BaseClient):
         Create a new index.
 
         :param display_name: the name of the index
-        :type display_name: str
         :param description: a description of the index
-        :type description: str
 
         New indices default to trial status. For subscribers with a subscription ID,
         indices can be converted to non-trial by sending a request to support@globus.org
@@ -97,7 +90,6 @@ class SearchClient(client.BaseClient):
         use with the ``reopen`` API (see :meth:`~.reopen_index`) during that time.
 
         :param index_id: the ID of the index
-        :type index_id: str or UUID
 
         .. tab-set::
 
@@ -127,7 +119,6 @@ class SearchClient(client.BaseClient):
         Reopen an index that has been marked for deletion, cancelling the deletion.
 
         :param index_id: the ID of the index
-        :type index_id: str or UUID
 
         .. tab-set::
 
@@ -163,9 +154,7 @@ class SearchClient(client.BaseClient):
         and how much data it contains.
 
         :param index_id: the ID of the index
-        :type index_id: str or UUID
         :param query_params: additional parameters to pass as query params
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -213,18 +202,12 @@ class SearchClient(client.BaseClient):
         Execute a simple Search Query, described by the query string ``q``.
 
         :param index_id: the ID of the index
-        :type index_id: str or UUID
         :param q: the query string
-        :type q: str
         :param offset: an offset for pagination
-        :type offset: int
         :param limit: the size of a page of results
-        :type limit: int
         :param advanced: enable 'advanced' query mode, which has sophisticated syntax
             but may result in BadRequest errors when used if the query is invalid
-        :type advanced: bool
         :param query_params: additional parameters to pass as query params
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -285,13 +268,9 @@ class SearchClient(client.BaseClient):
         facets, sorting, field boostring, and other behaviors.
 
         :param index_id: The index on which to search
-        :type index_id: str or UUID
         :param data: A Search Query document containing the query and any other fields
-        :type data: dict or SearchQuery
         :param offset: offset used in paging (overwrites any offset in ``data``)
-        :type offset: int, optional
         :param limit: limit the number of results (overwrites any limit in ``data``)
-        :type limit: int, optional
 
         .. tab-set::
 
@@ -358,11 +337,8 @@ class SearchClient(client.BaseClient):
         scrolling to not include results or show other unexpected behaviors.
 
         :param index_id: The index on which to search
-        :type index_id: str or UUID
         :param data: A Search Scroll Query document
-        :type data: dict or SearchScrollQuery
         :param marker: marker used in paging (overwrites any marker in ``data``)
-        :type marker: str, optional
 
         .. tab-set::
 
@@ -405,9 +381,7 @@ class SearchClient(client.BaseClient):
         ``task_id`` value will be included in the response.
 
         :param index_id: The index into which to write data
-        :type index_id: str or UUID
         :param data: an ingest document
-        :type data: dict
 
         .. tab-set::
 
@@ -477,9 +451,7 @@ class SearchClient(client.BaseClient):
         A ``task_id`` value will be included in the response.
 
         :param index_id: The index in which to delete data
-        :type index_id: str or UUID
         :param data: a query document for documents to delete
-        :type data: dict
 
         .. tab-set::
 
@@ -523,11 +495,8 @@ class SearchClient(client.BaseClient):
         A ``task_id`` value will be included in the response.
 
         :param index_id: The index in which to delete data
-        :type index_id: str or UUID
         :param subjects: The subjects to delete, as an iterable of strings
-        :type subjects: iterable of str
         :param additional_params: Additional parameters to include in the request body
-        :type additional_params: dict, optional
 
         .. tab-set::
 
@@ -580,11 +549,8 @@ class SearchClient(client.BaseClient):
         Fetch exactly one Subject document from Search, containing one or more Entries.
 
         :param index_id: the index containing this Subject
-        :type index_id: str or UUID
         :param subject: the subject string to fetch
-        :type subject: str
         :param query_params: additional parameters to pass as query params
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -625,11 +591,8 @@ class SearchClient(client.BaseClient):
         A ``task_id`` value will be included in the response.
 
         :param index_id: the index in which data will be deleted
-        :type index_id: str or UUID
         :param subject: the subject string for the Subject document to delete
-        :type subject: str
         :param query_params: additional parameters to pass as query params
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -675,14 +638,10 @@ class SearchClient(client.BaseClient):
         ``subject`` string and ``entry_id``, which defaults to ``null``.
 
         :param index_id: the index containing this Entry
-        :type index_id: str or UUID
         :param subject: the subject string for the Subject document containing this
             Entry
-        :type subject: str
         :param entry_id: the entry_id for this Entry, which defaults to ``null``
-        :type entry_id: str, optional
         :param query_params: additional parameters to pass as query params
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -737,9 +696,7 @@ class SearchClient(client.BaseClient):
         any existing data.
 
         :param index_id: the index containing this Entry
-        :type index_id: str or UUID
         :param data: the entry document to write
-        :type data: dict
 
         .. tab-set::
 
@@ -802,9 +759,7 @@ class SearchClient(client.BaseClient):
         This does not do a partial update, but replaces the existing document.
 
         :param index_id: the index containing this Entry
-        :type index_id: str or UUID
         :param data: the entry document to write
-        :type data: dict
 
         .. tab-set::
 
@@ -853,13 +808,9 @@ class SearchClient(client.BaseClient):
         A ``task_id`` value will be included in the response.
 
         :param index_id: the index in which data will be deleted
-        :type index_id: str or UUID
         :param subject: the subject string for the Subject of the document to delete
-        :type subject: str
         :param entry_id: the ID string for the Entry to delete
-        :type entry_id: str
         :param query_params: additional parameters to pass as query params
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -914,9 +865,7 @@ class SearchClient(client.BaseClient):
         Fetch a Task document by ID, getting task details and status.
 
         :param task_id: the task ID from the original task submission
-        :type task_id: str or UUID
         :param query_params: additional parameters to pass as query params
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -950,9 +899,7 @@ class SearchClient(client.BaseClient):
         status.
 
         :param index_id: the index to query
-        :type index_id: str or UUID
         :param query_params: additional parameters to pass as query params
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -995,11 +942,8 @@ class SearchClient(client.BaseClient):
         <https://docs.globus.org/api/search/overview/#principal_urns>`_.
 
         :param index_id: The index on which to create the role
-        :type index_id: uuid or str
         :param data: The partial role document to use for creation
-        :type data: dict
         :param query_params: Any additional query params to pass
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -1037,9 +981,7 @@ class SearchClient(client.BaseClient):
         role on an index to list roles.
 
         :param index_id: The index on which to list roles
-        :type index_id: uuid or str
         :param query_params: Any additional query params to pass
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -1066,11 +1008,8 @@ class SearchClient(client.BaseClient):
         index.
 
         :param index_id: The index from which to delete a role
-        :type index_id: uuid or str
         :param role_id: The role to delete
-        :type role_id: str
         :param query_params: Any additional query params to pass
-        :type query_params: dict, optional
 
         .. tab-set::
 

--- a/src/globus_sdk/services/search/data.py
+++ b/src/globus_sdk/services/search/data.py
@@ -31,7 +31,6 @@ class SearchQueryBase(utils.PayloadWrapper):
         Set the query string for the query document.
 
         :param query: the new query string
-        :type query: str
         """
         self["q"] = query
         return self
@@ -41,7 +40,6 @@ class SearchQueryBase(utils.PayloadWrapper):
         Set the limit for the query document.
 
         :param limit: a limit on the number of results returned in a single page
-        :type limit: int
         """
         self["limit"] = limit
         return self
@@ -51,7 +49,6 @@ class SearchQueryBase(utils.PayloadWrapper):
         Enable or disable advanced query string processing.
 
         :param advanced: whether to enable (``True``) or not (``False``)
-        :type advanced: bool
         """
         self["advanced"] = advanced
         return self
@@ -69,13 +66,9 @@ class SearchQueryBase(utils.PayloadWrapper):
         Add a filter subdocument to the query.
 
         :param field_name: the field on which to filter
-        :type field_name: str
         :param values: the values to use in the filter
-        :type values: list of str
         :param type: the type of filter to apply, defaults to "match_all"
-        :type type: str
         :param additional_fields: additional data to include in the filter document
-        :type additional_fields: dict, optional
         """
         self["filters"] = self.get("filters", [])
         new_filter = {
@@ -94,17 +87,12 @@ class SearchQuery(SearchQueryBase):
     Query document.
 
     :param q: The query string. Required unless filters are used.
-    :type q: str, optional
     :param limit: A limit on the number of results returned in a single page
-    :type limit: int
     :param offset: An offset into the set of all results for the query
-    :type offset: int
     :param advanced: Whether to enable (``True``) or not to enable (``False``) advanced
         parsing of query strings. The default of ``False`` is robust and guarantees that
         the query will not error with "bad query string" errors
-    :type advanced: bool, optional
     :param additional_fields: additional data to include in the query document
-    :type additional_fields: dict, optional
 
     Example usage:
 
@@ -143,7 +131,6 @@ class SearchQuery(SearchQueryBase):
         Set the offset for the query document.
 
         :param offset: an offset into the set of all results for the query
-        :type offset: int
         """
         self["offset"] = offset
         return self
@@ -164,19 +151,12 @@ class SearchQuery(SearchQueryBase):
         Add a facet subdocument to the query.
 
         :param name: the name for the facet in the result
-        :type name: str
         :param field_name: the field on which to build the facet
-        :type field_name: str
         :param type: the type of facet to apply, defaults to "terms"
-        :type type: str
         :param size: the size parameter for the facet
-        :type size: int, optional
         :param date_interval: the date interval for a date histogram facet
-        :type date_interval: str, optional
         :param histogram_range: a low and high bound for a numeric histogram facet
-        :type histogram_range: tuple, optional
         :param additional_fields: additional data to include in the facet document
-        :type additional_fields: dict, optional
         """
         self["facets"] = self.get("facets", [])
         facet: dict[str, t.Any] = {
@@ -206,12 +186,9 @@ class SearchQuery(SearchQueryBase):
         Add a boost subdocument to the query.
 
         :param field_name: the field to boost in result weighting
-        :type field_name: str
         :param factor: the factor by which to adjust the field weight (where ``1.0`` is
             the default weight)
-        :type factor: str, int, or float
         :param additional_fields: additional data to include in the boost document
-        :type additional_fields: dict, optional
         """
         self["boosts"] = self.get("boosts", [])
         boost = {
@@ -233,11 +210,8 @@ class SearchQuery(SearchQueryBase):
         Add a sort subdocument to the query.
 
         :param field_name: the field on which to sort
-        :type field_name: str
         :param order: ascending or descending order, given as ``"asc"`` or ``"desc"``
-        :type order: str, optional
         :param additional_fields: additional data to include in the sort document
-        :type additional_fields: dict, optional
         """
         self["sort"] = self.get("sort", [])
         sort = {"field_name": field_name, **(additional_fields or {})}
@@ -259,17 +233,12 @@ class SearchScrollQuery(SearchQueryBase):
     used to paginate results.
 
     :param q: The query string
-    :type q: str, optional
     :param limit: A limit on the number of results returned in a single page
-    :type limit: int
     :param advanced: Whether to enable (``True``) or not to enable (``False``) advanced
         parsing of query strings. The default of ``False`` is robust and guarantees that
         the query will not error with "bad query string" errors
-    :type advanced: bool, optional
     :param marker: the marker value
-    :type marker: str, optional
     :param additional_fields: additional data to include in the query document
-    :type additional_fields: dict, optional
     """
 
     def __init__(
@@ -298,7 +267,6 @@ class SearchScrollQuery(SearchQueryBase):
         Set the marker on a scroll query.
 
         :param marker: the marker value
-        :type marker: str
         """
         self["marker"] = marker
         return self

--- a/src/globus_sdk/services/timer/client.py
+++ b/src/globus_sdk/services/timer/client.py
@@ -17,16 +17,6 @@ class TimerClient(client.BaseClient):
     r"""
     Client for the Globus Timer API.
 
-    :param authorizer: An authorizer instance used for all calls to Timer
-    :type authorizer: :class:`GlobusAuthorizer\
-                      <globus_sdk.authorizers.base.GlobusAuthorizer>`
-    :param app_name: Optional "nice name" for the application. Has no bearing on the
-        semantics of client actions. It is just passed as part of the User-Agent
-        string, and may be useful when debugging issues with the Globus team
-    :type app_name: str
-    :param transport_params: Options to pass to the transport for this client
-    :type transport_params: dict
-
     .. automethodlist:: globus_sdk.TimerClient
     """
     error_class = TimerAPIError
@@ -40,7 +30,6 @@ class TimerClient(client.BaseClient):
         ``GET /jobs/``
 
         :param query_params: additional parameters to pass as query params
-        :type query_params: dict, optional
 
         **Examples**
 
@@ -60,9 +49,7 @@ class TimerClient(client.BaseClient):
         ``GET /jobs/<job_id>``
 
         :param job_id: the ID of the timer ("job")
-        :type job_id: str or UUID
         :param query_params: additional parameters to pass as query params
-        :type query_params: dict, optional
 
         **Examples**
 
@@ -78,7 +65,6 @@ class TimerClient(client.BaseClient):
     ) -> response.GlobusHTTPResponse:
         """
         :param timer: a document defining the new timer
-        :type timer: dict or :class:`~.TransferTimer`
 
         A ``TransferTimer`` object can be constructed from a ``TransferData`` object,
         which is the recommended way to create a timer for data transfers.
@@ -127,7 +113,6 @@ class TimerClient(client.BaseClient):
         ``POST /jobs/``
 
         :param data: a timer document used to create the new timer ("job")
-        :type data: dict or :class:`~.TimerJob`
 
         **Examples**
 
@@ -158,9 +143,7 @@ class TimerClient(client.BaseClient):
         ``PATCH /jobs/<job_id>``
 
         :param job_id: the ID of the timer ("job")
-        :type job_id: str or UUID
         :param data: a partial timer document used to update the job
-        :type data: dict
 
         **Examples**
 
@@ -178,7 +161,6 @@ class TimerClient(client.BaseClient):
         ``DELETE /jobs/<job_id>``
 
         :param job_id: the ID of the timer ("job")
-        :type job_id: str or UUID
 
         **Examples**
 
@@ -196,7 +178,6 @@ class TimerClient(client.BaseClient):
         Make a timer job inactive, preventing it from running until it is resumed.
 
         :param job_id: The ID of the timer to pause
-        :type job_id: str or UUID
 
         **Examples**
 
@@ -217,7 +198,6 @@ class TimerClient(client.BaseClient):
         issues with insufficient authorization.
 
         :param job_id: The ID of the timer to resume
-        :type job_id: str or UUID
         :param update_credentials: When true, replace the credentials for the timer
             using the credentials for this resume call. This can be used to resolve
             authorization errors (such as session and consent errors), but it also
@@ -226,7 +206,6 @@ class TimerClient(client.BaseClient):
             replacing. If not supplied, the Timers service will determine whether to
             replace credentials according to the reason why the timer job
             became inactive.
-        :type update_credentials: bool, optional
 
         **Examples**
 

--- a/src/globus_sdk/services/timer/data.py
+++ b/src/globus_sdk/services/timer/data.py
@@ -30,13 +30,10 @@ class TransferTimer(PayloadWrapper):
         timer creation.
 
     :param name: A name to identify this timer
-    :type name: str, optional
     :param schedule: The schedule on which the timer runs
-    :type schedule: dict
     :param body: A transfer payload for the timer to use. If it includes
         ``submission_id`` or ``skip_activation_check``, these parameters will be
         removed, as they are not supported in timers.
-    :type body: dict or :class:`~.TransferData`
 
     The ``schedule`` field determines when the timer will run.
     Timers may be "run once" or "recurring", and "recurring" timers may specify an end
@@ -134,13 +131,10 @@ class RecurringTimerSchedule(PayloadWrapper):
     until some end condition is reached.
 
     :param interval_seconds: The number of seconds between each run of the timer.
-    :type interval_seconds: int
     :param start: The time at which to start the timer, either as an ISO 8601 string
         with timezone information, or as a ``datetime.datetime`` object.
-    :type start: str or datetime.datetime, optional
     :param end: The end condition for the timer, as a dict. This either expresses a
         number of iterations for the timer or an end date.
-    :type end: dict, optional
 
     Example ``end`` conditions:
 
@@ -196,7 +190,6 @@ class OnceTimerSchedule(PayloadWrapper):
 
     :param datetime: The time at which to run the timer, either as an ISO 8601
         string with timezone information, or as a ``datetime.datetime`` object.
-    :type datetime: str or datetime.datetime, optional
     """
 
     def __init__(
@@ -224,25 +217,17 @@ class TimerJob(PayloadWrapper):
     action provider.
 
     :param callback_url: URL for the action which the Timer job will use.
-    :type callback_url: str
     :param callback_body: JSON data which Timer will send to the Action Provider on
         each invocation
-    :type callback_body: dict
     :param start: The datetime at which to start the Timer job.
-    :type start: datetime.datetime or str
     :param interval: The interval at which the Timer job should recur. Interpreted as
         seconds if specified as an integer. If ``stop_after_n == 1``, i.e. the job is
         set to run only a single time, then interval *must* be None.
-    :type interval: datetime.timedelta or int
     :param name: A (not necessarily unique) name to identify this job in Timer
-    :type name: str, optional
     :param stop_after: A date after which the Timer job will stop running
-    :type stop_after: datetime.datetime, optional
     :param stop_after_n: A number of executions after which the Timer job will stop
-    :type stop_after_n: int
     :param scope: Timer defaults to the Transfer 'all' scope. Use this parameter to
         change the scope used by Timer when calling the Transfer Action Provider.
-    :type scope: str, optional
 
     .. automethodlist:: globus_sdk.TimerJob
     """
@@ -300,26 +285,18 @@ class TimerJob(PayloadWrapper):
         :param transfer_data: A :class:`TransferData <globus_sdk.TransferData>` object.
             Construct this object exactly as you would normally; Timer will use this to
             run the recurring transfer.
-        :type transfer_data: globus_sdk.TransferData
         :param start: The datetime at which to start the Timer job.
-        :type start: datetime.datetime or str
         :param interval: The interval at which the Timer job should recur. Interpreted
             as seconds if specified as an integer. If ``stop_after_n == 1``, i.e. the
             job is set to run only a single time, then interval *must* be None.
-        :type interval: datetime.timedelta or int
         :param name: A (not necessarily unique) name to identify this job in Timer
-        :type name: str, optional
         :param stop_after: A date after which the Timer job will stop running
-        :type stop_after: datetime.datetime, optional
         :param stop_after_n: A number of executions after which the Timer job will stop
-        :type stop_after_n: int
         :param scope: Timer defaults to the Transfer 'all' scope. Use this parameter to
             change the scope used by Timer when calling the Transfer Action Provider.
-        :type scope: str, optional
         :param environment: For internal use: because this method needs to generate a
             URL for the Transfer Action Provider, this argument can control which
             environment the Timer job is sent to.
-        :type environment: str, optional
         """
         warn_deprecated(
             "TimerJob.from_transfer_data(X, ...) is deprecated. "

--- a/src/globus_sdk/services/transfer/client.py
+++ b/src/globus_sdk/services/transfer/client.py
@@ -54,11 +54,6 @@ class TransferClient(client.BaseClient):
     that allow arbitrary keyword arguments will pass the extra arguments as
     query parameters.
 
-    :param authorizer: An authorizer instance used for all calls to
-                       Globus Transfer
-    :type authorizer: :class:`GlobusAuthorizer\
-                      <globus_sdk.authorizers.base.GlobusAuthorizer>`
-
     .. _transfer_filter_formatting:
 
     **Filter Formatting**
@@ -70,6 +65,7 @@ class TransferClient(client.BaseClient):
     list, each item of the list is parsed and passed as separate params.
 
     dict parsing rules:
+
     - each (key, value) pair in the dict is a clause in the resulting filter string
     - clauses are each formatted to ``key:value``
     - when the value is a list, it is comma-separated, as in ``key:value1,value2``
@@ -123,10 +119,8 @@ class TransferClient(client.BaseClient):
     ) -> response.GlobusHTTPResponse:
         """
         :param endpoint_id: ID of endpoint to lookup
-        :type endpoint_id: str or UUID
         :param query_params: Any additional parameters will be passed through
             as query params.
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -157,12 +151,9 @@ class TransferClient(client.BaseClient):
     ) -> response.GlobusHTTPResponse:
         """
         :param endpoint_id: ID of endpoint to lookup
-        :type endpoint_id: str or UUID
         :param data: A partial endpoint document with fields to update
-        :type data: dict
         :param query_params: Any additional parameters will be passed through
             as query params.
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -202,7 +193,6 @@ class TransferClient(client.BaseClient):
     def create_endpoint(self, data: dict[str, t.Any]) -> response.GlobusHTTPResponse:
         """
         :param data: An endpoint document with fields for the new endpoint
-        :type data: dict
 
         .. tab-set::
 
@@ -244,7 +234,6 @@ class TransferClient(client.BaseClient):
     def delete_endpoint(self, endpoint_id: UUIDLike) -> response.GlobusHTTPResponse:
         """
         :param endpoint_id: ID of endpoint to delete
-        :type endpoint_id: str or UUID
 
         .. tab-set::
 
@@ -288,30 +277,22 @@ class TransferClient(client.BaseClient):
         :param filter_fulltext: The string to use in a full text search on endpoints.
             Effectively, the "search query" which is being requested. May be omitted
             with specific ``filter_scope`` values.
-        :type filter_fulltext: str, optional
         :param filter_scope: A "scope" within which to search for endpoints. This must
             be one of the limited and known names known to the service, which can be
             found documented in the **External Documentation** below. Defaults to
             searching all endpoints (in which case ``filter_fulltext`` is required)
-        :type filter_scope: str, optional
         :param filter_owner_id: Limit search to endpoints owned by the specified Globus
             Auth identity. Conflicts with scopes 'my-endpoints', 'my-gcp-endpoints', and
             'shared-by-me'.
-        :type filter_owner_id: str, optional
         :param filter_host_endpoint: Limit search to endpoints hosted by the specified
             endpoint. May cause BadRequest or PermissionDenied errors if the endpoint ID
             given is not valid for this operation.
-        :type filter_host_endpoint: str, optional
         :param filter_non_functional: Limit search to endpoints which have the
             'non_functional' flag set to True or False.
-        :type filter_non_functional: bool, optional
         :param limit: limit the number of results
-        :type limit: int, optional
         :param offset: offset used in paging
-        :type offset: int, optional
         :param query_params: Any additional parameters will be passed through
             as query params.
-        :type query_params: dict, optional
 
         It is important to be aware that the Endpoint Search API limits
         you to 1000 results for any search query.
@@ -379,14 +360,11 @@ class TransferClient(client.BaseClient):
     ) -> response.GlobusHTTPResponse:
         r"""
         :param endpoint_id: The ID of the endpoint to autoactivate
-        :type endpoint_id: str or UUID
         :param if_expires_in: A number of seconds. Autoactivation will only be attempted
             if the current activation expires within this timeframe. Otherwise,
             autoactivation will succeed with a code of 'AlreadyActivated'
-        :type if_expires_in: int, optional
         :param query_params: Any additional parameters will be passed through
             as query params.
-        :type query_params: dict, optional
 
         The following example will try to "auto" activate the endpoint
         using a credential available from another endpoint or sign in by
@@ -460,10 +438,8 @@ class TransferClient(client.BaseClient):
     ) -> response.GlobusHTTPResponse:
         """
         :param endpoint_id: The ID of the endpoint to deactivate
-        :type endpoint_id: str or UUID
         :param query_params: Any additional parameters will be passed through
             as query params.
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -488,16 +464,12 @@ class TransferClient(client.BaseClient):
     ) -> response.GlobusHTTPResponse:
         """
         :param endpoint_id: The ID of the endpoint to activate
-        :type endpoint_id: str or UUID
         :pram requirements_data: Filled in activation requirements data, as can be
             fetched from :meth:`~endpoint_get_activation_requirements`. Only the fields
             for the activation type being used need to be filled in.
-        :type requirements_data: dict
         :param requirements_data: An optional body for the request
-        :type requirements_data: dict, optional
         :param query_params: Any additional parameters will be passed through
             as query params.
-        :type query_params: dict, optional
 
         Consider using autoactivate and web activation instead, described
         in the example for :meth:`~endpoint_autoactivate`.
@@ -527,10 +499,8 @@ class TransferClient(client.BaseClient):
         """
         :param endpoint_id: The ID of the endpoint whose activation requirements data is
             being looked up
-        :type endpoint_id: str or UUID
         :param query_params: Any additional parameters will be passed through
             as query params.
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -557,9 +527,7 @@ class TransferClient(client.BaseClient):
         """
         :param endpoint_id: the endpoint on which the current user's effective pause
             rules are fetched
-        :type endpoint_id: str or UUID
         :param query_params: Additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -588,9 +556,7 @@ class TransferClient(client.BaseClient):
     ) -> IterableTransferResponse:
         """
         :param endpoint_id: the host endpoint whose shares are listed
-        :type endpoint_id: str or UUID
         :param query_params: Additional passthrough query parameters
-        :type query_params: dict, optional
 
         Get a list of shared endpoints for which the user has ``administrator`` or
         ``access_manager`` on a given host endpoint.
@@ -623,14 +589,10 @@ class TransferClient(client.BaseClient):
     ) -> IterableTransferResponse:
         """
         :param endpoint_id: the host endpoint whose shares are listed
-        :type endpoint_id: str or UUID
         :param max_results: cap to the number of results
-        :type max_results: int, optional
         :param next_token: token used for paging
-        :type next_token: str, optional
         :param query_params: Any additional parameters to be passed through
             as query params.
-        :type query_params: dict, optional
 
         Get a list of all shared endpoints on a given host endpoint.
 
@@ -667,7 +629,6 @@ class TransferClient(client.BaseClient):
     ) -> response.GlobusHTTPResponse:
         """
         :param data: A python dict representation of a ``shared_endpoint`` document
-        :type data: dict
 
         .. tab-set::
 
@@ -707,10 +668,8 @@ class TransferClient(client.BaseClient):
     ) -> IterableTransferResponse:
         """
         :param endpoint_id: The endpoint whose servers are being listed
-        :type endpoint_id: str or UUID
         :param query_params: Any additional parameters to be passed through
             as query params.
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -735,11 +694,8 @@ class TransferClient(client.BaseClient):
     ) -> response.GlobusHTTPResponse:
         """
         :param endpoint_id: The endpoint under which the server is registered
-        :type endpoint_id: str or UUID
         :param server_id: The ID of the server
-        :type server_id: str or int
         :param query_params: Additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -762,9 +718,7 @@ class TransferClient(client.BaseClient):
     ) -> response.GlobusHTTPResponse:
         """
         :param endpoint_id: The endpoint under which the server is being registered
-        :type endpoint_id: str or UUID
         :param server_data: Fields for the new server, as a server document
-        :type server_data: dict
 
         .. tab-set::
 
@@ -786,11 +740,8 @@ class TransferClient(client.BaseClient):
     ) -> response.GlobusHTTPResponse:
         """
         :param endpoint_id: The endpoint under which the server is registered
-        :type endpoint_id: str or UUID
         :param server_id: The ID of the server to update
-        :type server_id: str or int
         :param server_data: Fields on the server to update, as a partial server document
-        :type server_data: dict
 
         .. tab-set::
 
@@ -813,9 +764,7 @@ class TransferClient(client.BaseClient):
     ) -> response.GlobusHTTPResponse:
         """
         :param endpoint_id: The endpoint under which the server is registered
-        :type endpoint_id: str or UUID
         :param server_id: The ID of the server to delete
-        :type server_id: str or int
 
         .. tab-set::
 
@@ -843,10 +792,8 @@ class TransferClient(client.BaseClient):
     ) -> IterableTransferResponse:
         """
         :param endpoint_id: The endpoint whose roles are being listed
-        :type endpoint_id: str or UUID
         :param query_params: Any additional parameters to be passed through
             as query params.
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -867,9 +814,7 @@ class TransferClient(client.BaseClient):
     ) -> response.GlobusHTTPResponse:
         """
         :param endpoint_id: The endpoint on which the role is being added
-        :type endpoint_id: str or UUID
         :param role_data: A role document for the new role
-        :type role_data: dict
 
         .. tab-set::
 
@@ -892,11 +837,8 @@ class TransferClient(client.BaseClient):
     ) -> response.GlobusHTTPResponse:
         """
         :param endpoint_id: The endpoint on which the role applies
-        :type endpoint_id: str or UUID
         :param role_id: The ID of the role
-        :type role_id: str
         :param query_params: Additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -917,9 +859,7 @@ class TransferClient(client.BaseClient):
     ) -> response.GlobusHTTPResponse:
         """
         :param endpoint_id: The endpoint on which the role applies
-        :type endpoint_id: str or UUID
         :param role_id: The ID of the role to delete
-        :type role_id: str
 
         .. tab-set::
 
@@ -945,9 +885,7 @@ class TransferClient(client.BaseClient):
     ) -> IterableTransferResponse:
         """
         :param endpoint_id: The endpoint whose ACLs are being listed
-        :type endpoint_id: str or UUID
         :param query_params: Additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -972,11 +910,8 @@ class TransferClient(client.BaseClient):
     ) -> response.GlobusHTTPResponse:
         """
         :param endpoint_id: The endpoint on which the access rule applies
-        :type endpoint_id: str or UUID
         :param rule_id: The ID of the rule to fetch
-        :type rule_id: str
         :param query_params: Additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -999,9 +934,7 @@ class TransferClient(client.BaseClient):
     ) -> response.GlobusHTTPResponse:
         """
         :param endpoint_id: ID of endpoint to which to add the acl
-        :type endpoint_id: str
         :param rule_data: A python dict representation of an ``access`` document
-        :type rule_data: dict
 
         .. tab-set::
 
@@ -1041,11 +974,8 @@ class TransferClient(client.BaseClient):
     ) -> response.GlobusHTTPResponse:
         """
         :param endpoint_id: The endpoint on which the access rule applies
-        :type endpoint_id: str or UUID
         :param rule_id: The ID of the access rule to modify
-        :type rule_id: str
         :param rule_data: A partial ``access`` document containing fields to update
-        :type rule_data: dict
 
         .. tab-set::
 
@@ -1068,9 +998,7 @@ class TransferClient(client.BaseClient):
     ) -> response.GlobusHTTPResponse:
         """
         :param endpoint_id: The endpoint on which the access rule applies
-        :type endpoint_id: str or UUID
         :param rule_id: The ID of the access rule to remove
-        :type rule_id: str
 
         .. tab-set::
 
@@ -1095,7 +1023,6 @@ class TransferClient(client.BaseClient):
     ) -> IterableTransferResponse:
         """
         :param query_params: Additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -1116,7 +1043,6 @@ class TransferClient(client.BaseClient):
     ) -> response.GlobusHTTPResponse:
         """
         :param bookmark_data: A bookmark document for the bookmark to create
-        :type bookmark_data: dict
 
         .. tab-set::
 
@@ -1138,9 +1064,7 @@ class TransferClient(client.BaseClient):
     ) -> response.GlobusHTTPResponse:
         """
         :param bookmark_id: The ID of the bookmark to lookup
-        :type bookmark_id: str or UUID
         :param query_params: Additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -1159,9 +1083,7 @@ class TransferClient(client.BaseClient):
     ) -> response.GlobusHTTPResponse:
         """
         :param bookmark_id: The ID of the bookmark to modify
-        :type bookmark_id: str or UUID
         :param bookmark_data: A partial bookmark document with fields to update
-        :type bookmark_data: dict
 
         .. tab-set::
 
@@ -1178,7 +1100,6 @@ class TransferClient(client.BaseClient):
     def delete_bookmark(self, bookmark_id: UUIDLike) -> response.GlobusHTTPResponse:
         """
         :param bookmark_id: The ID of the bookmark to delete
-        :type bookmark_id: str or UUID
 
         .. tab-set::
 
@@ -1215,33 +1136,24 @@ class TransferClient(client.BaseClient):
     ) -> IterableTransferResponse:
         """
         :param endpoint_id: The ID of the endpoint on which to do a dir listing
-        :type endpoint_id: str or UUID
         :param path: Path to a directory on the endpoint to list
-        :type path: str, optional
         :param show_hidden: Show hidden files (names beginning in dot).
             Defaults to true.
-        :type show_hidden: bool, optional
         :param limit: Limit the number of results returned. Defaults to 100,000 ,
             which is also the maximum.
-        :type limit: int, optional
         :param offset: Offset into the result list, which can be used to page results.
-        :type offset: int, optional
         :param orderby: One or more order-by options. Each option is
             either a field name or a field name followed by a space and 'ASC' or 'DESC'
             for ascending or descending.
-        :type orderby: str, optional
         :param filter: Only return file documents which match these filter clauses. For
             the filter syntax, see the **External Documentation** linked below. If a
             dict is supplied as the filter, it is formatted as a set of filter clauses.
             If a list is supplied, it is passed as multiple params.
             See :ref:`filter formatting <transfer_filter_formatting>` for details.
-        :type filter: str or dict, optional
         :param local_user: Optional value passed to identity mapping specifying which
             local user account to map to. Only usable with Globus Connect Server v5
             mapped collections.
-        :type local_user: str, optional
         :param query_params: Additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. note::
 
@@ -1329,15 +1241,11 @@ class TransferClient(client.BaseClient):
     ) -> response.GlobusHTTPResponse:
         """
         :param endpoint_id: The ID of the endpoint on which to create a directory
-        :type endpoint_id: str or UUID
         :param path: Path to the new directory to create
-        :type path: str
         :param local_user: Optional value passed to identity mapping specifying which
             local user account to map to. Only usable with Globus Connect Server v5
             mapped collections.
-        :type local_user: str, optional
         :param query_params: Additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -1380,17 +1288,12 @@ class TransferClient(client.BaseClient):
     ) -> response.GlobusHTTPResponse:
         """
         :param endpoint_id: The ID of the endpoint on which to rename a file
-        :type endpoint_id: str or UUID
         :param oldpath: Path to the old filename
-        :type oldpath: str
         :param newpath: Path to the new filename
-        :type newpath: str
         :param local_user: Optional value passed to identity mapping specifying which
             local user account to map to. Only usable with Globus Connect Server v5
             mapped collections.
-        :type local_user: str, optional
         :param query_params: Additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -1436,13 +1339,9 @@ class TransferClient(client.BaseClient):
     ) -> response.GlobusHTTPResponse:
         """
         :param endpoint_id: The ID of the endpoint on which to create a symlink
-        :type endpoint_id: str or UUID
         :param symlink_target: The path referenced by the new symlink
-        :type symlink_target: str
         :param path: The name of (path to) the new symlink
-        :type path: str
         :param query_params: Additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -1485,7 +1384,6 @@ class TransferClient(client.BaseClient):
     ) -> response.GlobusHTTPResponse:
         """
         :param query_params: Additional passthrough query parameters
-        :type query_params: dict, optional
 
         Submission IDs are required to submit tasks to the Transfer service
         via the :meth:`submit_transfer <.submit_transfer>` and
@@ -1518,7 +1416,6 @@ class TransferClient(client.BaseClient):
         :param data: A transfer task document listing files and directories, and setting
             various options. See :class:`TransferData <globus_sdk.TransferData>` for
             details
-        :type data: dict or TransferData
 
         Submit a Transfer Task.
 
@@ -1568,7 +1465,6 @@ class TransferClient(client.BaseClient):
         :param data: A delete task document listing files and directories, and setting
             various options. See :class:`DeleteData <globus_sdk.DeleteData>` for
             details
-        :type data: dict or DeleteData
 
         Submit a Delete Task.
 
@@ -1629,16 +1525,12 @@ class TransferClient(client.BaseClient):
         Get an iterable of task documents owned by the current user.
 
         :param limit: limit the number of results
-        :type limit: int, optional
         :param offset: offset used in paging
-        :type offset: int, optional
         :param filter: Only return task documents which match these filter clauses. For
             the filter syntax, see the **External Documentation** linked below. If a
             dict is supplied as the filter, it is formatted as a set of filter clauses.
             See :ref:`filter formatting <transfer_filter_formatting>` for details.
-        :type filter: str or dict, optional
         :param query_params: Additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -1714,13 +1606,9 @@ class TransferClient(client.BaseClient):
         List events (for example, faults and errors) for a given Task.
 
         :param task_id: The ID of the task to inspect
-        :type task_id: str or UUID
         :param limit: limit the number of results
-        :type limit: int, optional
         :param offset: offset used in paging
-        :type offset: int, optional
         :param query_params: Additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -1765,9 +1653,7 @@ class TransferClient(client.BaseClient):
     ) -> response.GlobusHTTPResponse:
         """
         :param task_id: The ID of the task to inspect
-        :type task_id: str or UUID
         :param query_params: Additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -1793,11 +1679,8 @@ class TransferClient(client.BaseClient):
         ``label`` and ``deadline`` fields can be updated.
 
         :param task_id: The ID of the task to modify
-        :type task_id: str or UUID
         :param data: A partial task document with fields to update
-        :type data: dict
         :param query_params: Additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -1816,7 +1699,6 @@ class TransferClient(client.BaseClient):
         Cancel a task which is still running.
 
         :param task_id: The ID of the task to cancel
-        :type task_id: str or UUID
 
         .. tab-set::
 
@@ -1839,12 +1721,9 @@ class TransferClient(client.BaseClient):
         ``True``.
 
         :param task_id: ID of the Task to wait on for completion
-        :type task_id: str or UUID
         :param timeout: Number of seconds to wait in total. Minimum 1. [Default: ``10``]
-        :type timeout: int, optional
         :param polling_interval: Number of seconds between queries to Globus about the
             Task status. Minimum 1. [Default: ``10``]
-        :type polling_interval: int, optional
 
         .. tab-set::
 
@@ -1946,9 +1825,7 @@ class TransferClient(client.BaseClient):
         Get info about why a task is paused or about to be paused.
 
         :param task_id: The ID of the task to inspect
-        :type task_id: str or UUID
         :param query_params: Additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -1983,11 +1860,8 @@ class TransferClient(client.BaseClient):
             skip_source_errors being set on the task.
 
         :param task_id: The ID of the task to inspect
-        :type task_id: str or UUID
         :param marker: A marker for pagination
-        :type marker: str
         :param query_params: Additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -2037,11 +1911,8 @@ class TransferClient(client.BaseClient):
         to skip_source_errors being set on a completed transfer Task.
 
         :param task_id: The ID of the task to inspect
-        :type task_id: str or UUID
         :param marker: A marker for pagination
-        :type marker: str
         :param query_params: Additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -2087,7 +1958,6 @@ class TransferClient(client.BaseClient):
         Get endpoints the current user is a monitor or manager on.
 
         :param query_params: Additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -2113,9 +1983,7 @@ class TransferClient(client.BaseClient):
         Get shared endpoints hosted on the given endpoint.
 
         :param endpoint_id: The ID of the host endpoint
-        :type endpoint_id: str or UUID
         :param query_params: Additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -2144,9 +2012,7 @@ class TransferClient(client.BaseClient):
         Get endpoint details as an admin.
 
         :param endpoint_id: The ID of the endpoint
-        :type endpoint_id: str or UUID
         :param query_params: Additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -2172,9 +2038,7 @@ class TransferClient(client.BaseClient):
         Get a list of access control rules on specified endpoint as an admin.
 
         :param endpoint_id: The ID of the endpoint
-        :type endpoint_id: str or UUID
         :param query_params: Additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -2225,13 +2089,11 @@ class TransferClient(client.BaseClient):
         :param filter_status: Return only tasks with any of the specified statuses
             Note that in-progress tasks will have status ``"ACTIVE"`` or ``"INACTIVE"``,
             and completed tasks will have status ``"SUCCEEDED"`` or ``"FAILED"``.
-        :type filter_status: str or iterable of str, optional
         :param filter_task_id: Return only tasks with any of the specified ids. If any
             of the specified tasks do not involve an endpoint the user has an
             appropriate role for, a ``PermissionDenied`` error will be returned. This
             filter can't be combined with any other filter.  If another filter is
             passed, a ``BadRequest`` will be returned. (limit: 50 task IDs)
-        :type filter_task_id: str, UUID, or iterable of str or UUID, optional
         :param filter_owner_id: A Globus Auth identity id. Limit results to tasks
             submitted by the specified identity, or linked to the specified identity,
             at submit time.  Returns ``UserNotFound`` if the identity does not exist or
@@ -2240,11 +2102,9 @@ class TransferClient(client.BaseClient):
             empty result set will be returned. Unless filtering for running tasks (i.e.
             ``filter_status`` is a subset of ``("ACTIVE", "INACTIVE")``,
             ``filter_endpoint`` is required when using ``filter_owner_id``.
-        :type filter_owner_id: str or UUID, optional
         :param filter_endpoint: Single endpoint id. Return only tasks with a matching
             source or destination endpoint or matching source or destination host
             endpoint.
-        :type filter_endpoint: str or UUID, optional
         :param filter_is_paused: Return only tasks with the specified ``is_paused``
             value. Requires that ``filter_status`` is also passed and contains a subset
             of ``"ACTIVE"`` and ``"INACTIVE"``. Completed tasks always have
@@ -2253,7 +2113,6 @@ class TransferClient(client.BaseClient):
             after a pause rule is inserted it will take time before the ``is_paused``
             flag is set on all affected tasks. Tasks paused by id will have the
             ``is_paused`` flag set immediately.
-        :type filter_is_paused: bool, optional
         :param filter_completion_time: Start and end date-times separated by a comma, or
             provided as a tuple of strings or datetime objects.  Returns only completed
             tasks with ``completion_time`` in the specified range. Date strings should
@@ -2264,23 +2123,18 @@ class TransferClient(client.BaseClient):
             may be used for either the start or end (but not both) to indicate no limit
             on that side. If the end date is blank, the filter will also include all
             active tasks, since they will complete some time in the future.
-        :type filter_completion_time: str, tuple of str, or tuple of datetime, optional
         :param filter_min_faults:  Minimum number of cumulative faults, inclusive.
             Return only tasks with ``faults >= N``, where ``N`` is the filter value.
             Use ``filter_min_faults=1`` to find all tasks with at least one fault.
             Note that many errors are not fatal and the task may still be successful
             even if ``faults >= 1``.
-        :type filter_min_faults: int, optional
         :param filter_local_user: A valid username for the target system running the
             endpoint, as a utf8 encoded string. Requires that ``filter_endpoint`` is
             also set. Return only tasks that have successfully fetched the local user
             from the endpoint, and match the values of ``filter_endpoint`` and
             ``filter_local_user`` on the source or on the destination.
-        :type filter_local_user: str, optional
         :param last_key: the last key, for paging
-        :type last_key: str, optional
         :param query_params: Additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -2366,9 +2220,7 @@ class TransferClient(client.BaseClient):
         the destination endpoint of the task.
 
         :param task_id: The ID of the task to inspect
-        :type task_id: str or UUID
         :param query_params: Additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -2404,16 +2256,12 @@ class TransferClient(client.BaseClient):
         endpoint of the task.
 
         :param task_id: The ID of the task to inspect
-        :type task_id: str or UUID
         :param limit: limit the number of results
-        :type limit: int, optional
         :param offset: offset used in paging
         :param filter_is_error: Return only events that are errors. A value of ``False``
             (returning only non-errors) is not supported. By default all events are
             returned.
-        :type filter_is_error: bool, optional
         :param query_params: Additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -2454,9 +2302,7 @@ class TransferClient(client.BaseClient):
         monitor effective role on the destination endpoint of the task.
 
         :param task_id: The ID of the task to inspect
-        :type task_id: str or UUID
         :param query_params: Additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -2486,11 +2332,8 @@ class TransferClient(client.BaseClient):
         Get the successful file transfers for a completed Task as an admin.
 
         :param task_id: The ID of the task to inspect
-        :type task_id: str or UUID
         :param marker: A marker for pagination
-        :type marker: str
         :param query_params: Additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -2535,11 +2378,8 @@ class TransferClient(client.BaseClient):
         Get skipped errors for a completed Task as an admin.
 
         :param task_id: The ID of the task to inspect
-        :type task_id: str
         :param marker: A marker for pagination
-        :type marker: str
         :param query_params: Additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -2579,11 +2419,8 @@ class TransferClient(client.BaseClient):
         role on the task(s) source or destination endpoint(s).
 
         :param task_ids: List of task ids to cancel
-        :type task_ids: iterable of str or UUID
         :param message: Message given to all users whose tasks have been canceled
-        :type message: str
         :param query_params: Additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -2614,9 +2451,7 @@ class TransferClient(client.BaseClient):
         endpoint_manager_cancel_tasks).
 
         :param admin_cancel_id: The ID of the the cancel job to inspect
-        :type admin_cancel_id: str or UUID
         :param query_params: Additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -2645,11 +2480,8 @@ class TransferClient(client.BaseClient):
         role on the task(s) source or destination endpoint(s).
 
         :param task_ids: List of task ids to pause
-        :type task_ids: iterable of str or UUID
         :param message: Message given to all users whose tasks have been paused
-        :type message: str
         :param query_params: Additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -2680,9 +2512,7 @@ class TransferClient(client.BaseClient):
         role on the task(s) source or destination endpoint(s).
 
         :param task_ids: List of task ids to resume
-        :type task_ids: iterable of str or UUID
         :param query_params: Additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -2717,9 +2547,7 @@ class TransferClient(client.BaseClient):
         :param filter_endpoint: An endpoint ID. Limit results to rules on endpoints
             hosted by this endpoint. Must be activity monitor on this endpoint, not just
             the hosted endpoints.
-        :type filter_endpoint: str
         :param query_params: Additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -2747,7 +2575,6 @@ class TransferClient(client.BaseClient):
         on the endpoint defined in the rule.
 
         :param data: A pause rule document describing the rule to create
-        :type data: dict
 
         .. tab-set::
 
@@ -2787,9 +2614,7 @@ class TransferClient(client.BaseClient):
         effective role on the endpoint defined in the rule.
 
         :param pause_rule_id: ID of pause rule to get
-        :type pause_rule_id: str
         :param query_params: Additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 
@@ -2816,9 +2641,7 @@ class TransferClient(client.BaseClient):
         Note that non update-able fields in data will be ignored.
 
         :param pause_rule_id: The ID of the pause rule to update
-        :type pause_rule_id: str
         :param data: A partial pause rule document with fields to update
-        :type data: dict
 
         .. tab-set::
 
@@ -2856,9 +2679,7 @@ class TransferClient(client.BaseClient):
         will no longer be once it is deleted.
 
         :param pause_rule_id: The ID of the pause rule to delete
-        :type pause_rule_id: str
         :param query_params: Additional passthrough query parameters
-        :type query_params: dict, optional
 
         .. tab-set::
 

--- a/src/globus_sdk/services/transfer/data/delete_data.py
+++ b/src/globus_sdk/services/transfer/data/delete_data.py
@@ -30,55 +30,41 @@ class DeleteData(utils.PayloadWrapper):
     :param transfer_client: A ``TransferClient`` instance which will be used to get a
         submission ID if one is not supplied. Should be the same instance that is used
         to submit the deletion.
-    :type transfer_client: :class:`TransferClient <globus_sdk.TransferClient>` or None
     :param endpoint: The endpoint ID which is targeted by this deletion Task
-    :type endpoint: str or UUID
     :param label: A string label for the Task
-    :type label: str, optional
     :param submission_id: A submission ID value fetched via
         :meth:`get_submission_id <globus_sdk.TransferClient.get_submission_id>`.
         Defaults to using ``transfer_client.get_submission_id`` if a ``transfer_client``
         is provided
-    :type submission_id: str or UUID, optional
     :param recursive: Recursively delete subdirectories on the target endpoint
       [default: ``False``]
-    :type recursive: bool
     :param ignore_missing: Ignore nonexistent files and directories instead of treating
         them as errors. [default: ``False``]
-    :type ignore_missing: bool
     :param interpret_globs: Enable expansion of ``\*?[]`` characters in the last
         component of paths, unless they are escaped with a preceding backslash, ``\\``
         [default: ``False``]
-    :type interpret_globs: bool
     :param deadline: An ISO-8601 timestamp (as a string) or a datetime object which
         defines a deadline for the deletion. At the deadline, even if the data deletion
         is not complete, the job will be canceled. We recommend ensuring that the
         timestamp is in UTC to avoid confusion and ambiguity. Examples of ISO-8601
         timestamps include ``2017-10-12 09:30Z``, ``2017-10-12 12:33:54+00:00``, and
         ``2017-10-12``
-    :type deadline: str or datetime, optional
     :param skip_activation_check: When true, allow submission even if the endpoint
         isn't currently activated
-    :type skip_activation_check: bool, optional
     :param notify_on_succeeded: Send a notification email when the delete task
         completes with a status of SUCCEEDED.
         [default: ``True``]
-    :type notify_on_succeeded: bool, optional
     :param notify_on_failed: Send a notification email when the delete task completes
         with a status of FAILED.
         [default: ``True``]
-    :type notify_on_failed: bool, optional
     :param notify_on_inactive: Send a notification email when the delete task changes
         status to INACTIVE. e.g. From credentials expiring.
         [default: ``True``]
-    :type notify_on_inactive: bool, optional
     :param local_user: Optional value passed to identity mapping specifying which local
         user account to map to. Only usable with Globus Connect Server v5 mapped
         collections.
-    :type local_user: string, optional
     :param additional_fields: additional fields to be added to the delete
         document. Mostly intended for internal use
-    :type additional_fields: dict, optional
 
     **Examples**
 
@@ -172,9 +158,7 @@ class DeleteData(utils.PayloadWrapper):
         document.
 
         :param path: Path to the directory or file to be deleted
-        :type path: str
         :param additional_fields: additional fields to be added to the delete item
-        :type additional_fields: dict, optional
         """
         item_data = {"DATA_TYPE": "delete_item", "path": path}
         if additional_fields is not None:

--- a/src/globus_sdk/services/transfer/data/transfer_data.py
+++ b/src/globus_sdk/services/transfer/data/transfer_data.py
@@ -57,88 +57,67 @@ class TransferData(utils.PayloadWrapper):
     :param transfer_client: A ``TransferClient`` instance which will be used to get a
         submission ID if one is not supplied. Should be the same instance that is used
         to submit the transfer.
-    :type transfer_client: :class:`TransferClient <globus_sdk.TransferClient>` or None
     :param source_endpoint: The endpoint ID of the source endpoint
-    :type source_endpoint: str or UUID
     :param destination_endpoint: The endpoint ID of the destination endpoint
-    :type destination_endpoint: str or UUID
     :param label: A string label for the Task
-    :type label: str, optional
     :param submission_id: A submission ID value fetched via :meth:`get_submission_id \
         <globus_sdk.TransferClient.get_submission_id>`. Defaults to using
         ``transfer_client.get_submission_id``
-    :type submission_id: str or UUID, optional
     :param sync_level: The method used to compare items between the source and
         destination. One of  ``"exists"``, ``"size"``, ``"mtime"``, or ``"checksum"``
         See the section below on sync-level for an explanation of values.
-    :type sync_level: int or str, optional
     :param verify_checksum: When true, after transfer verify that the source and
         destination file checksums match. If they don't, re-transfer the entire file and
         keep trying until it succeeds. This will create CPU load on both the origin and
         destination of the transfer, and may even be a bottleneck if the network speed
         is high enough.
         [default: ``False``]
-    :type verify_checksum: bool, optional
     :param preserve_timestamp: When true, Globus Transfer will attempt to set file
         timestamps on the destination to match those on the origin. [default: ``False``]
-    :type preserve_timestamp: bool, optional
     :param encrypt_data: When true, all files will be TLS-protected during transfer.
         [default: ``False``]
-    :type encrypt_data: bool, optional
     :param deadline: An ISO-8601 timestamp (as a string) or a datetime object which
         defines a deadline for the transfer. At the deadline, even if the data transfer
         is not complete, the job will be canceled. We recommend ensuring that the
         timestamp is in UTC to avoid confusion and ambiguity. Examples of ISO-8601
         timestamps include ``2017-10-12 09:30Z``, ``2017-10-12 12:33:54+00:00``, and
         ``2017-10-12``
-    :type deadline: str or datetime, optional
     :param recursive_symlinks: Specify the behavior of recursive directory transfers
         when encountering symlinks. One of ``"ignore"``, ``"keep"``, or ``"copy"``.
         ``"ignore"`` skips symlinks, ``"keep"`` creates symlinks at the destination
         matching the source (without modifying the link path at all), and
         ``"copy"`` follows symlinks on the source, failing if the link is invalid.
         [default: ``"ignore"``]
-    :type recursive_symlinks: str
     :param skip_activation_check: When true, allow submission even if the endpoints
         aren't currently activated
-    :type skip_activation_check: bool, optional
     :param skip_source_errors: When true, source permission denied and file
         not found errors from the source endpoint will cause the offending
         path to be skipped.
         [default: ``False``]
-    :type skip_source_errors: bool, optional
     :param fail_on_quota_errors: When true, quota exceeded errors will cause the
         task to fail.
         [default: ``False``]
-    :type fail_on_quota_errors: bool, optional
     :param delete_destination_extra: Delete files, directories, and symlinks on the
         destination endpoint which don’t exist on the source endpoint or are a
         different type. Only applies for recursive directory transfers.
         [default: ``False``]
-    :type delete_destination_extra: bool, optional
     :param notify_on_succeeded: Send a notification email when the transfer completes
         with a status of SUCCEEDED.
         [default: ``True``]
-    :type notify_on_succeeded: bool, optional
     :param notify_on_failed: Send a notification email when the transfer completes
         with a status of FAILED.
         [default: ``True``]
-    :type notify_on_failed: bool, optional
     :param notify_on_inactive: Send a notification email when the transfer changes
         status to INACTIVE. e.g. From credentials expiring.
         [default: ``True``]
-    :type notify_on_inactive: bool, optional
     :param source_local_user: Optional value passed to the source's identity mapping
         specifying which local user account to map to. Only usable with Globus Connect
         Server v5 mapped collections.
-    :type source_local_user: string, optional
     :param destination_local_user: Optional value passed to the destination's identity
         mapping specifying which local user account to map to. Only usable with Globus
         Connect Server v5 mapped collections.
-    :type destination_local_user: string, optional
     :param additional_fields: additional fields to be added to the transfer
         document. Mostly intended for internal use
-    :type additional_fields: dict, optional
 
     **Sync Levels**
 
@@ -290,23 +269,17 @@ class TransferData(utils.PayloadWrapper):
             for more details.
 
         :param source_path: Path to the source directory or file to be transferred
-        :type source_path: str
         :param destination_path: Path to the destination directory or file will be
             transferred to
-        :type destination_path: str
         :param recursive: Set to True if the target at source path is a directory
-        :type recursive: bool, optional
         :param external_checksum: A checksum to verify both source file and destination
             file integrity. The checksum will be verified after the data transfer and a
             failure will cause the entire task to fail. Cannot be used with directories.
             Assumed to be an MD5 checksum unless checksum_algorithm is also given.
-        :type external_checksum: str, optional
         :param checksum_algorithm: Specifies the checksum algorithm to be used when
             verify_checksum is True, sync_level is "checksum" or 3, or an
             external_checksum is given.
-        :type checksum_algorithm: str, optional
         :param additional_fields: additional fields to be added to the transfer item
-        :type additional_fields: dict, optional
         """
         item_data: dict[str, t.Any] = {
             "DATA_TYPE": "transfer_item",
@@ -341,9 +314,7 @@ class TransferData(utils.PayloadWrapper):
         transfer document.
 
         :param source_path: Path to the source symlink
-        :type source_path: str
         :param destination_path: Path to which the source symlink will be transferred
-        :type destination_path: str
         """
         item_data = {
             "DATA_TYPE": "transfer_symlink_item",
@@ -385,16 +356,13 @@ class TransferData(utils.PayloadWrapper):
             are character groups: ``*`` matches everything, ``?`` matches any single
             character, ``[]`` matches any single character within the brackets, and
             ``[!]`` matches any single character not within the brackets.
-        :type name: str
         :param method: The method to use for filtering. If "exclude" (the default)
             items matching this rule will not be included in the transfer. If
             "include" items matching this rule will be included in the transfer.
-        :type method: str, optional
         :param type: The types of items on which to apply this filter rule. Either
             ``"file"`` or ``"dir"``. If unspecified, the rule applies to both.
             Note that if a ``"dir"`` is excluded then all items within it will
             also be excluded regardless if they would have matched any include rules.
-        :type type: str, optional
 
         Example Usage:
 

--- a/src/globus_sdk/services/transfer/response/activation.py
+++ b/src/globus_sdk/services/transfer/response/activation.py
@@ -53,8 +53,6 @@ class ActivationRequirementsResponse(GlobusHTTPResponse):
         >>>           .format(endpoint_id), file=sys.stderr)
         >>>     # py3 calls it `input()` in py2, use `raw_input()`
         >>>     input("Please Hit Enter When You Are Done")
-
-        :rtype: ``bool``
         """
         return t.cast(bool, self["auto_activation_supported"])
 
@@ -83,8 +81,6 @@ class ActivationRequirementsResponse(GlobusHTTPResponse):
         >>>     print("Sending user to web anyway, just in case.",
         >>>           file=sys.stderr)
         >>> ...
-
-        :rtype: ``bool``
         """
         return (
             self.supports_auto_activation
@@ -124,15 +120,12 @@ class ActivationRequirementsResponse(GlobusHTTPResponse):
         >>> ...
 
         :param time_seconds: Number of seconds into the future.
-        :type time_seconds: int
         :param relative_time: Defaults to True. When False, ``time_seconds`` is treated
             as a POSIX timestamp (i.e. seconds since epoch as an integer) instead of
             its ordinary behavior.
-        :type relative_time: bool
 
 
         :return: True if the Endpoint will be active until the deadline, False otherwise
-        :rtype: ``bool``
         """
         # inactive endpoint
         if not self["activated"]:
@@ -151,7 +144,5 @@ class ActivationRequirementsResponse(GlobusHTTPResponse):
         """
         Returns True if the endpoint activation never expires
         (e.g. shared endpoints, globus connect personal endpoints).
-
-        :rtype: ``bool``
         """
         return t.cast(int, self["expires_in"]) == -1

--- a/src/globus_sdk/services/transfer/transport.py
+++ b/src/globus_sdk/services/transfer/transport.py
@@ -14,7 +14,6 @@ class TransferRequestsTransport(RequestsTransport):
 
         :param ctx: The context object which describes the state of the request and the
             retries which may already have been attempted
-        :type ctx: RetryContext
         """
         if ctx.response is not None and (
             ctx.response.status_code in self.TRANSIENT_ERROR_STATUS_CODES

--- a/src/globus_sdk/tokenstorage/base.py
+++ b/src/globus_sdk/tokenstorage/base.py
@@ -15,7 +15,6 @@ class StorageAdapter(metaclass=abc.ABCMeta):
         Store an `OAuthTokenResponse` in the underlying storage for this adapter.
 
         :param token_response: The token response to store
-        :type token_response: :class:`~.OAuthTokenResponse`
         """
 
     @abc.abstractmethod
@@ -29,7 +28,6 @@ class StorageAdapter(metaclass=abc.ABCMeta):
 
         :param resource_server: The resource_server string which uniquely identifies the
             token data to retriever from storage
-        :type resource_server: str
         """
 
     def on_refresh(self, token_response: OAuthTokenResponse) -> None:
@@ -38,7 +36,6 @@ class StorageAdapter(metaclass=abc.ABCMeta):
         stores the token response.
 
         :param token_response: The token response received from the refresh
-        :type token_response: :class:`~.OAuthTokenResponse`
         """
         self.store(token_response)
 

--- a/src/globus_sdk/tokenstorage/file_adapters.py
+++ b/src/globus_sdk/tokenstorage/file_adapters.py
@@ -89,7 +89,6 @@ class SimpleJSONFileAdapter(FileAdapter):
         resulting file can read or write it.
 
         :param token_response: The token data received from the refresh
-        :type token_response: :class:`~.OAuthTokenResponse`
         """
         to_write = self._load()
 

--- a/src/globus_sdk/tokenstorage/sqlite_adapter.py
+++ b/src/globus_sdk/tokenstorage/sqlite_adapter.py
@@ -14,16 +14,13 @@ class SQLiteAdapter(FileAdapter):
     """
     :param dbname: The name of the DB file to write to and read from. If the string
         ":memory:" is used, an in-memory database will be used instead.
-    :type dbname: str
     :param namespace: A "namespace" to use within the database. All operations will
         be performed indexed under this string, so that multiple distinct sets of tokens
         may be stored in the database. You might use usernames as the namespace to
         implement a multi-user system, or profile names to allow multiple Globus
         accounts to be used by a single user.
-    :type namespace: str, optional
     :param connect_params: A pass-through dictionary for fine-tuning the SQLite
          connection.
-    :type connect_params: dict, optional
 
     A storage adapter for storing tokens in sqlite databases.
 
@@ -114,9 +111,7 @@ CREATE TABLE sdk_storage_adapter_internal (
     ) -> None:
         """
         :param config_name: A string name for the configuration value
-        :type config_name: str
         :param config_dict: A dict of config which will be stored serialized as JSON
-        :type config_dict: Mapping
 
         Store a config dict under the current namespace in the config table.
         Allows arbitrary configuration data to be namespaced under the namespace, so
@@ -134,7 +129,6 @@ CREATE TABLE sdk_storage_adapter_internal (
     def read_config(self, config_name: str) -> dict[str, t.Any] | None:
         """
         :param config_name: A string name for the configuration value
-        :type config_name: str
 
         Load a config dict under the current namespace in the config table.
         If no value is found, returns None
@@ -156,7 +150,6 @@ CREATE TABLE sdk_storage_adapter_internal (
     def remove_config(self, config_name: str) -> bool:
         """
         :param config_name: A string name for the configuration value
-        :type config_name: str
 
         Delete a previously stored configuration value.
 
@@ -173,7 +166,6 @@ CREATE TABLE sdk_storage_adapter_internal (
         """
         :param token_response: a globus_sdk.OAuthTokenResponse object containing token
                                data to store
-        :type token_response: globus_sdk.OAuthTokenResponse
 
         By default, ``self.on_refresh`` is just an alias for this function.
 
@@ -202,7 +194,6 @@ CREATE TABLE sdk_storage_adapter_internal (
 
         :param resource_server: The name of a resource server to lookup in the DB, as
             one would use as a key in OAuthTokenResponse.by_resource_server
-        :type resource_server: str
         """
         for row in self._connection.execute(
             "SELECT token_data_json FROM token_storage "
@@ -245,7 +236,6 @@ CREATE TABLE sdk_storage_adapter_internal (
 
         :param resource_server: The name of the resource server to remove from the DB,
             as one would use as a key in OAuthTokenResponse.by_resource_server
-        :type resource_server: str
         """
         rowcount = self._connection.execute(
             "DELETE FROM token_storage WHERE namespace=? AND resource_server=?",
@@ -265,7 +255,6 @@ CREATE TABLE sdk_storage_adapter_internal (
         :param include_config_namespaces: Include namespaces which appear only in the
             configuration storage section of the sqlite database. By default, only
             namespaces which were used for token storage will be returned
-        :type include_config_namespaces: bool, optional
         """
         seen: set[str] = set()
         for row in self._connection.execute(

--- a/src/globus_sdk/transport/requests.py
+++ b/src/globus_sdk/transport/requests.py
@@ -67,25 +67,19 @@ class RequestsTransport:
 
     :param verify_ssl: Explicitly enable or disable SSL verification,
         or configure the path to a CA certificate bundle to use for SSL verification
-    :type verify_ssl: bool, str, or pathlib.Path, optional
     :param http_timeout: Explicitly set an HTTP timeout value in seconds. This parameter
         defaults to 60s but can be set via the ``GLOBUS_SDK_HTTP_TIMEOUT`` environment
         variable. Any value set via this parameter takes precedence over the environment
         variable.
-    :type http_timeout: float, optional
     :param retry_backoff: A function which determines how long to sleep between calls
         based on the RetryContext. Defaults to exponential backoff with jitter based on
         the context ``attempt`` number.
-    :type retry_backoff: callable, optional
     :param retry_checks: A list of initial retry checks. Any hooks registered,
         including the default hooks, will run after these checks.
-    :type retry_checks: list of callable, optional
     :param max_sleep: The maximum sleep time between retries (in seconds). If the
         computed sleep time or the backoff requested by a retry check exceeds this
         value, this amount of time will be used instead
-    :type max_sleep: float or int, optional
     :param max_retries: The maximum number of retries allowed by this transport
-    :type max_retries: int, optional
     """
 
     #: default maximum number of retries
@@ -163,18 +157,13 @@ class RequestsTransport:
 
         :param verify_ssl: Explicitly enable or disable SSL verification,
             or configure the path to a CA certificate bundle to use for SSL verification
-        :type verify_ssl: bool, str, or pathlib.Path, optional
         :param http_timeout: Explicitly set an HTTP timeout value in seconds
-        :type http_timeout: float, optional
         :param retry_backoff: A function which determines how long to sleep between
             calls based on the RetryContext
-        :type retry_backoff: callable, optional
         :param max_sleep: The maximum sleep time between retries (in seconds). If the
             computed sleep time or the backoff requested by a retry check exceeds this
             value, this amount of time will be used instead
-        :type max_sleep: float or int, optional
         :param max_retries: The maximum number of retries allowed by this transport
-        :type max_retries: int, optional
 
         **Examples**
 
@@ -268,7 +257,6 @@ class RequestsTransport:
 
         :param ctx: The context object which describes the state of the request and the
             retries which may already have been attempted.
-        :type ctx: RetryContext
         """
         sleep_period = min(self.retry_backoff(ctx), self.max_sleep)
         log.info("request retry_sleep(%s) [max=%s]", sleep_period, self.max_sleep)
@@ -290,29 +278,20 @@ class RequestsTransport:
         Send an HTTP request
 
         :param url: URL for the request
-        :type url: str
         :param method: HTTP request method, as an all caps string
-        :type method: str
         :param query_params: Parameters to be encoded as a query string
-        :type query_params: dict, optional
         :param headers: HTTP headers to add to the request
-        :type headers: dict
         :param data: Data to send as the request body. May pass through encoding.
-        :type data: dict or str
         :param encoding: A way to encode request data. "json", "form", and "text"
             are all valid values. Custom encodings can be used only if they are
             registered with the transport. By default, strings get "text" behavior and
             all other objects get "json".
-        :type encoding: str
         :param authorizer: The authorizer which is used to get or update authorization
             information for the request
-        :type authorizer: GlobusAuthorizer, optional
         :param allow_redirects: Follow Location headers on redirect response
             automatically. Defaults to ``True``
-        :type allow_redirects: bool
         :param stream: Do not immediately download the response content. Defaults to
             ``False``
-        :type stream: bool
 
         :return: ``requests.Response`` object
         """
@@ -373,7 +352,6 @@ class RequestsTransport:
         Multiple checks should be chainable and callable in any order.
 
         :param func: The function or other callable to register as a retry check
-        :type func: callable
         """
         self.retry_checks.append(func)
         return func
@@ -402,7 +380,6 @@ class RequestsTransport:
 
         :param ctx: The context object which describes the state of the request and the
             retries which may already have been attempted.
-        :type ctx: RetryContext
         """
         if ctx.exception and isinstance(ctx.exception, requests.RequestException):
             return RetryCheckResult.do_retry
@@ -414,7 +391,6 @@ class RequestsTransport:
 
         :param ctx: The context object which describes the state of the request and the
             retries which may already have been attempted.
-        :type ctx: RetryContext
         """
         if (
             ctx.response is None
@@ -433,7 +409,6 @@ class RequestsTransport:
 
         :param ctx: The context object which describes the state of the request and the
             retries which may already have been attempted.
-        :type ctx: RetryContext
         """
         if ctx.response is not None and (
             ctx.response.status_code in self.TRANSIENT_ERROR_STATUS_CODES
@@ -454,7 +429,6 @@ class RequestsTransport:
 
         :param ctx: The context object which describes the state of the request and the
             retries which may already have been attempted.
-        :type ctx: RetryContext
         """
         if (  # is the current check applicable?
             ctx.response is None

--- a/src/globus_sdk/transport/retry.py
+++ b/src/globus_sdk/transport/retry.py
@@ -24,14 +24,9 @@ class RetryContext:
     or ``exception`` will be present.
 
     :param attempt: The request attempt number, starting at 0.
-    :type attempt: int
     :param response: The response on a successful request
-    :type response: requests.Response
     :param exception: The error raised when trying to send the request
-    :type exception: Exception
     :param authorizer: The authorizer object from the client making the request
-    :type authorizer: :class:`GlobusAuthorizer \
-        <globus_sdk.authorizers.GlobusAuthorizer>`
     """
 
     def __init__(
@@ -84,7 +79,6 @@ def set_retry_check_flags(flag: RetryCheckFlags) -> t.Callable[[C], C]:
     >>> def foo(ctx): ...
 
     :param flag: The flag to set on the check
-    :type flag: RetryCheckFlags
     """
 
     def decorator(func: C) -> C:

--- a/src/globus_sdk/utils.py
+++ b/src/globus_sdk/utils.py
@@ -76,9 +76,7 @@ def slash_join(a: str, b: str | None) -> str:
     contain a trailing/leading slash or neither.
 
     :param a: the first path component
-    :type a: str
     :param b: the second path component
-    :type b: str, optional
     """
     if not b:  # "" or None, don't append a slash
         return a
@@ -98,7 +96,6 @@ def safe_strseq_iter(
     Given an Iterable (typically of strings), produce an iterator over it of strings.
 
     :param value: The stringifiable object or objects to iterate over
-    :type value: str, UUID, or iterable
 
     This is a passthrough with some caveats:
     - if the value is a solitary string, yield only that value


### PR DESCRIPTION
This includes some minor additional fixes but is mostly a long procedural change from using explicit `:type:` documentation to using autodoc type hints as much as possible.
This reduces a great deal of duplication and visual noise, making signatures significantly more readable in our rendered docs.

In a couple of cases, we need to get slightly "clever" in order for the hints to render well.

One of the more obvious ones of these is customized rendering of `globus_sdk.MISSING` as the bare string `MISSING` in signatures.
That makes `MISSING` usage look highly ergonomic in signatures.

In the case of Groups, there was one case of a class, `GroupPolicies`, whose docstring did not render correctly under autodoc.
A decorator, local to the module where `GroupPolicies` is defined, makes a modification to the `__doc__` of that class to give sphinx the appropriate values.

In `globus_sdk.paging`, there was a minor fix as this changeset uncovered a discrepancy between the type annotations and documented type.
The documentation was more correct (splatted args are a tuple, not a list), so changes have been made to align with that.

In `AuthClient`, there are some unions of `Literal[...]` with `MissingType` which sphinx only renders correctly if `MissingType` is the first member of the union, so for simplicitly these are handled by changing the union order to put `MissingType` first.
(This looks to be a sphinx bug, which will need a MRE + bug report.)

Under Flows, several methods had constraints (e.g. string length) documented in the type information.
That doesn't fit within the auspices of the Python type system -- there's no definition for constrained types within the language -- so this information was preserved by moving it to the parameter documentation in each case.

In a few cases, `:rtype:` and `:type:` have been used to explicitly document overrides which replace the autodoc type hint behavior.

<!-- readthedocs-preview globus-sdk-python start -->
----
:books: Documentation preview :books:: https://globus-sdk-python--928.org.readthedocs.build/en/928/

<!-- readthedocs-preview globus-sdk-python end -->

-----

Here's a pair of before/after clips of AuthClient. First of some innocuous methods, then of a pathological one.

case | before | after
---|---|---
simple | ![image](https://github.com/globus/globus-sdk-python/assets/1300022/c6280ad6-dec3-49f2-9abc-d590770a3159) | ![image](https://github.com/globus/globus-sdk-python/assets/1300022/57c8f8f6-25e9-4c3e-90b0-d8f7c24d184c)
pathological | ![image](https://github.com/globus/globus-sdk-python/assets/1300022/9f81b9e4-e4b8-4005-ae2b-bc87d56a623a) | ![image](https://github.com/globus/globus-sdk-python/assets/1300022/09ebaa67-e591-4954-b219-75878649faa1)

Note how the return type is now always annotated. Although things might be slightly longer in the simple cases, in the pathological cases they are _dramatically_ improved.