### PR TITLE
Improve changelog script to support post and pre

### DIFF
--- a/scripts/changelog2md.py
+++ b/scripts/changelog2md.py
@@ -18,7 +18,9 @@ import typing as t
 REPO_ROOT = pathlib.Path(__file__).parent.parent
 CHANGELOG_PATH = REPO_ROOT / "changelog.rst"
 
-CHANGELOG_ANCHOR_PATTERN = re.compile(r"^\.\. _changelog-\d+\.\d+\.\d+:$", re.MULTILINE)
+CHANGELOG_ANCHOR_PATTERN = re.compile(
+    r"^\.\. _changelog-\d+\.\d+\.\d+(?:\.?(?:post|a|b|dev)\d+)?:$", re.MULTILINE
+)
 CHANGELOG_HEADER_PATTERN = re.compile(r"^v(\d+\.\d+\.\d+).*$", re.MULTILINE)
 
 H2_RST_PATTERN = re.compile(r"-+")


### PR DESCRIPTION
Prerelease and post-release patterns are now supported as part of the
expected format of the anchor string.
You can compare the before-and-after of this change on `main` today
to see that it incorrectly includes the 3.33.0.post0 release in
generated notes without this fix, and works correctly with the change.


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--932.org.readthedocs.build/en/932/

<!-- readthedocs-preview globus-sdk-python end -->