### PR TITLE
Improve how paginator contracts are tested

### DIFF
--- a/src/globus_sdk/paging/base.py
+++ b/src/globus_sdk/paging/base.py
@@ -45,6 +45,10 @@ class Paginator(t.Iterable[PageT], metaclass=abc.ABCMeta):
         ``{"c": 1}``. As with ``client_args``, it's passed to each paginated call.
     """
 
+    # the arguments which must be supported on the paginated method in order
+    # for the paginator to pass them
+    _REQUIRES_METHOD_KWARGS: tuple[str, ...] = ()
+
     def __init__(
         self,
         method: t.Callable[..., t.Any],

--- a/src/globus_sdk/paging/last_key.py
+++ b/src/globus_sdk/paging/last_key.py
@@ -6,6 +6,8 @@ from .base import PageT, Paginator
 
 
 class LastKeyPaginator(Paginator[PageT]):
+    _REQUIRES_METHOD_KWARGS = ("last_key",)
+
     def __init__(
         self,
         method: t.Callable[..., t.Any],

--- a/src/globus_sdk/paging/limit_offset.py
+++ b/src/globus_sdk/paging/limit_offset.py
@@ -6,6 +6,8 @@ from .base import PageT, Paginator
 
 
 class _LimitOffsetBasedPaginator(Paginator[PageT]):  # pylint: disable=abstract-method
+    _REQUIRES_METHOD_KWARGS = ("limit", "offset")
+
     def __init__(
         self,
         method: t.Callable[..., t.Any],

--- a/src/globus_sdk/paging/marker.py
+++ b/src/globus_sdk/paging/marker.py
@@ -13,6 +13,8 @@ class MarkerPaginator(Paginator[PageT]):
     This is the default method for GCS pagination, so it's very simple.
     """
 
+    _REQUIRES_METHOD_KWARGS = ("marker",)
+
     def __init__(
         self,
         method: t.Callable[..., t.Any],

--- a/src/globus_sdk/paging/next_token.py
+++ b/src/globus_sdk/paging/next_token.py
@@ -14,6 +14,8 @@ class NextTokenPaginator(Paginator[PageT]):
     get_shared_endpoint_list
     """
 
+    _REQUIRES_METHOD_KWARGS = ("next_token",)
+
     def __init__(
         self,
         method: t.Callable[..., t.Any],


### PR DESCRIPTION
Paginators now provide a class attribute (`_REQUIRES_METHOD_KWARGS`)
which is a tuple of the keyword args which are expected on the
paginated methods. The contract test for paginated methods can
therefore iterate over all paginated client methods and check this
tuple against the kwargs.

This eliminates explicit mapping from paginator types to these
sets of argument names in the testsuite.


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--934.org.readthedocs.build/en/934/

<!-- readthedocs-preview globus-sdk-python end -->