### PR TITLE
Fix AuthClient.create_policy signature

### DIFF
--- a/changelog.d/20231218_161848_sirosen_fix_create_policy.rst
+++ b/changelog.d/20231218_161848_sirosen_fix_create_policy.rst
@@ -1,0 +1,6 @@
+Changed
+~~~~~~~
+
+- The argument specification for ``AuthClient.create_policy`` was incorrect.
+  The corrected method will emit deprecation warnings if called with positional
+  arguments, as the corrected version uses keyword-only arguments. (:pr:`NUMBER`)

--- a/src/globus_sdk/_testing/data/auth/create_policy.py
+++ b/src/globus_sdk/_testing/data/auth/create_policy.py
@@ -7,8 +7,6 @@ from globus_sdk._testing.models import RegisteredResponse, ResponseSet
 
 POLICY_REQUEST_ARGS = {
     "project_id": str(uuid.uuid1()),
-    "high_assurance": False,
-    "authentication_assurance_timeout": 35,
     "display_name": "Policy of Foo",
     "description": "Controls access to Foo",
 }
@@ -45,6 +43,7 @@ def make_response_body(request_args: t.Dict[str, t.Any]) -> t.Dict[str, t.Any]:
 
 def register_response(
     args: t.Mapping[str, t.Any],
+    match: t.Any = None,
 ) -> RegisteredResponse:
     request_args = {**POLICY_REQUEST_ARGS, **args}
     request_body = make_request_body(request_args)
@@ -61,15 +60,19 @@ def register_response(
             # Test functions use 'response' to verify response
             "response": response_body,
         },
-        match=[json_params_matcher({"policy": request_body})],
+        match=(
+            [json_params_matcher({"policy": request_body})] if match is None else match
+        ),
     )
 
 
 RESPONSES = ResponseSet(
-    default=register_response({}),
+    default=register_response({}, match=[]),
     project_id_str=register_response({"project_id": str(uuid.uuid1())}),
     project_id_uuid=register_response({"project_id": uuid.uuid1()}),
-    high_assurance=register_response({"high_assurance": True}),
+    high_assurance=register_response(
+        {"high_assurance": True, "authentication_assurance_timeout": 35}
+    ),
     not_high_assurance=register_response({"high_assurance": False}),
     authentication_assurance_timeout=register_response(
         {"authentication_assurance_timeout": 23}

--- a/tests/functional/services/auth/service_client/test_create_policy.py
+++ b/tests/functional/services/auth/service_client/test_create_policy.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import json
+
 import pytest
 
-from globus_sdk._testing import load_response
+from globus_sdk import exc
+from globus_sdk._testing import get_last_request, load_response
 
 
 @pytest.mark.parametrize(
@@ -32,3 +35,49 @@ def test_create_policy(
     res = service_client.create_policy(**meta["args"])
     for k, v in meta["response"].items():
         assert res["policy"][k] == v
+
+
+def test_compatible_create_policy_usage_rejects_too_many_positionals(service_client):
+    load_response(service_client.create_policy)
+    with pytest.raises(
+        TypeError,
+        match=r"create_policy\(\) takes 5 positional arguments but 6 were given",
+    ):
+        service_client.create_policy(1, 2, 3, 4, 5, 6)
+
+
+def test_valid_compatible_policy_usage_emits_warning(service_client):
+    load_response(service_client.create_policy)
+    with pytest.warns(
+        exc.RemovedInV4Warning,
+        match=r"'AuthClient\.create_policy' received positional arguments",
+    ):
+        service_client.create_policy(
+            "my_project_id",
+            True,
+            101,
+            display_name="my_display_name",
+            description="my_description",
+        )
+
+    lastreq = get_last_request()
+    sent_data = json.loads(lastreq.body)
+    assert sent_data["policy"] == {
+        "project_id": "my_project_id",
+        "high_assurance": True,
+        "authentication_assurance_timeout": 101,
+        "display_name": "my_display_name",
+        "description": "my_description",
+    }
+
+
+def test_policy_usage_warns_and_errors_when_argument_is_supplied_twice(service_client):
+    with pytest.raises(
+        TypeError,
+        match="create_policy\\(\\) got multiple values for argument 'project_id'",
+    ):
+        with pytest.warns(
+            exc.RemovedInV4Warning,
+            match="'AuthClient.create_policy()' received positional arguments",
+        ):
+            service_client.create_policy("my_project_id", project_id="my_project_id2")

--- a/tests/non-pytest/mypy-ignore-tests/auth_client_create_policy.py
+++ b/tests/non-pytest/mypy-ignore-tests/auth_client_create_policy.py
@@ -1,0 +1,19 @@
+import globus_sdk
+
+ac = globus_sdk.AuthClient()
+
+# create new policy with keyword-only args, as supported
+ac.create_policy(
+    project_id="foo",
+    display_name="My Policy",
+    description="This is a policy",
+)
+
+# create using positional args (deprecated/unsupported)
+ac.create_policy(  # type: ignore[misc]
+    "foo",
+    True,  # type: ignore[arg-type]
+    101,  # type: ignore[arg-type]
+    "My Policy",  # type: ignore[arg-type]
+    "This is a policy",  # type: ignore[arg-type]
+)


### PR DESCRIPTION
I've taken another iteration on this approach to strip it all the way down to the bare essentials.
The new definition puts all of the compatibility code into the decorator. That means
- the definition is now entirely correct in v3, and in v4 we can just remove the compat decorator
- this approach to shimming lets us do a very simple `zip` rather than inspection of locals

---

This is done with a compatibility wrapper which unpacks arguments to ensure that legacy (positional-argument usage) is supported under SDK v3.

<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--936.org.readthedocs.build/en/936/

<!-- readthedocs-preview globus-sdk-python end -->