### PR TITLE
update transfer api links

### DIFF
--- a/src/globus_sdk/services/transfer/client.py
+++ b/src/globus_sdk/services/transfer/client.py
@@ -472,7 +472,7 @@ class TransferClient(client.BaseClient):
 
                 .. extdoclink:: Get my guest collection list
                     :ref: transfer/endpoints_and_collections/#get_my_guest_collection_list
-        """
+        """  # noqa: E501
         log.info(f"TransferClient.my_shared_endpoint_list({endpoint_id}, ...)")
         return IterableTransferResponse(
             self.get(
@@ -582,7 +582,7 @@ class TransferClient(client.BaseClient):
 
                 .. extdoclink:: Get endpoint or collection server list
                     :ref: transfer/endpoints_and_collections/#get_endpoint_or_collection_server_list
-        """
+        """  # noqa: E501
         log.info(f"TransferClient.endpoint_server_list({endpoint_id}, ...)")
         return IterableTransferResponse(
             self.get(f"endpoint/{endpoint_id}/server_list", query_params=query_params)
@@ -1838,7 +1838,7 @@ class TransferClient(client.BaseClient):
 
                 .. extdoclink:: Get monitored endpoints and collections
                     :ref: transfer/advanced_collection_management/#get_monitored_endpoints_and_collections
-        """
+        """  # noqa: E501
         log.info(f"TransferClient.endpoint_manager_monitored_endpoints({query_params})")
         return IterableTransferResponse(
             self.get("endpoint_manager/monitored_endpoints", query_params=query_params)
@@ -1893,7 +1893,7 @@ class TransferClient(client.BaseClient):
 
                 .. extdoclink:: Get endpoint as admin
                     :ref: transfer/advanced_collection_management/#mc_get_endpoint_or_collection
-        """
+        """  # noqa: E501
         log.info(f"TransferClient.endpoint_manager_get_endpoint({endpoint_id})")
         return self.get(
             f"endpoint_manager/endpoint/{endpoint_id}", query_params=query_params
@@ -2332,7 +2332,7 @@ class TransferClient(client.BaseClient):
 
                 .. extdoclink:: Get cancel status by ID
                     :ref: transfer/advanced_collection_management/#get_cancel_status_by_id
-        """
+        """  # noqa: E501
         log.info(f"TransferClient.endpoint_manager_cancel_status({admin_cancel_id})")
         return self.get(
             f"endpoint_manager/admin_cancel/{admin_cancel_id}",

--- a/src/globus_sdk/services/transfer/client.py
+++ b/src/globus_sdk/services/transfer/client.py
@@ -136,8 +136,8 @@ class TransferClient(client.BaseClient):
 
                 ``GET /endpoint/<endpoint_id>``
 
-                .. extdoclink:: Get Endpoint by ID
-                    :ref: transfer/endpoint/#get_endpoint_by_id
+                .. extdoclink:: Get Endpoint or Collection by ID
+                    :ref: transfer/endpoints_and_collections/#get_endpoint_or_collection_by_id
         """  # noqa: E501
         log.info(f"TransferClient.get_endpoint({endpoint_id})")
         return self.get(f"endpoint/{endpoint_id}", query_params=query_params)
@@ -172,8 +172,8 @@ class TransferClient(client.BaseClient):
 
                 ``PUT /endpoint/<endpoint_id>``
 
-                .. extdoclink:: Update Endpoint by ID
-                    :ref: transfer/endpoint/#update_endpoint_by_id
+                .. extdoclink:: Update Globus Connect Personal collection by id
+                    :ref: transfer/gcp_management/#update_collection_by_id
         """  # noqa: E501
         if data.get("myproxy_server"):
             if data.get("oauth_server"):
@@ -194,32 +194,8 @@ class TransferClient(client.BaseClient):
         """
         :param data: An endpoint document with fields for the new endpoint
 
-        .. tab-set::
-
-            .. tab-item:: Example Usage
-
-                .. code-block:: python
-
-                    tc = globus_sdk.TransferClient(...)
-                    ep_data = {
-                        "DATA_TYPE": "endpoint",
-                        "display_name": display_name,
-                        "DATA": [
-                            {
-                                "DATA_TYPE": "server",
-                                "hostname": "gridftp.example.edu",
-                            },
-                        ],
-                    }
-                    create_result = tc.create_endpoint(ep_data)
-                    endpoint_id = create_result["id"]
-
-            .. tab-item:: API Info
-
-                ``POST /endpoint/<endpoint_id>``
-
-                .. extdoclink:: Create Endpoint
-                    :ref: transfer/endpoint/#create_endpoint
+        DEPRECATION WARNING: this helper is deprecated with the end of Globus Connect
+        Server v4 support and may no longer function with the Transfer API.
         """
         if data.get("myproxy_server") and data.get("oauth_server"):
             raise exc.GlobusSDKUsageError(
@@ -248,8 +224,8 @@ class TransferClient(client.BaseClient):
 
                 ``DELETE /endpoint/<endpoint_id>``
 
-                .. extdoclink:: Delete Endpoint by ID
-                    :ref: transfer/endpoint/#delete_endpoint_by_id
+                .. extdoclink:: Delete Globus Connect Personal collection by id
+                    :ref: transfer/gcp_management/#delete_collection_by_id
         """
         log.info(f"TransferClient.delete_endpoint({endpoint_id})")
         return self.delete(f"endpoint/{endpoint_id}")
@@ -327,8 +303,8 @@ class TransferClient(client.BaseClient):
                     GET /endpoint_search\
                     ?filter_fulltext=<filter_fulltext>&filter_scope=<filter_scope>
 
-                .. extdoclink:: Endpoint Search
-                    :ref: transfer/endpoint_search
+                .. extdoclink:: Endpoint and Collection Search
+                    :ref: transfer/endpoint_and_collection_search
         """  # noqa: E501
         if query_params is None:
             query_params = {}
@@ -366,60 +342,8 @@ class TransferClient(client.BaseClient):
         :param query_params: Any additional parameters will be passed through
             as query params.
 
-        The following example will try to "auto" activate the endpoint
-        using a credential available from another endpoint or sign in by
-        the user with the same identity provider, but only if the
-        endpoint is not already activated or going to expire within an
-        hour (3600 seconds). If that fails, direct the user to the
-        globus website to perform activation:
-
-        .. tab-set::
-
-            .. tab-item:: Example Usage
-
-                .. code-block:: python
-
-                    tc = globus_sdk.TransferClient(...)
-                    r = tc.endpoint_autoactivate(ep_id, if_expires_in=3600)
-                    while r["code"] == "AutoActivationFailed":
-                        print(
-                            "Endpoint requires manual activation, please open "
-                            "the following URL in a browser to activate the endpoint: "
-                            f"https://app.globus.org/file-manager?origin_id={ep_id}"
-                        )
-                        input("Press ENTER after activating the endpoint:")
-                        r = tc.endpoint_autoactivate(ep_id, if_expires_in=3600)
-
-                This is the recommended flow for most thick client applications,
-                because many endpoints require activation via OAuth MyProxy,
-                which must be done in a browser anyway. Web based clients can
-                link directly to the URL.
-
-                You also might want messaging or logging depending on why and how the
-                operation succeeded, in which case you'll need to look at the value of
-                the "code" field and either decide on your own messaging or use the
-                response's "message" field.
-
-                .. code-block:: python
-
-                    tc = globus_sdk.TransferClient(...)
-                    r = tc.endpoint_autoactivate(ep_id, if_expires_in=3600)
-                    if r["code"] == "AutoActivationFailed":
-                        print(f"Endpoint({ep_id}) Not Active! Error! Source message: {r['message']}")
-                        sys.exit(1)
-                    elif r["code"] == "AutoActivated.CachedCredential":
-                        print(f"Endpoint({ep_id}) autoactivated using a cached credential.")
-                    elif r["code"] == "AutoActivated.GlobusOnlineCredential":
-                        print(f"Endpoint({ep_id}) autoactivated using a built-in Globus credential.")
-                    elif r["code"] == "AlreadyActivated":
-                        print(f"Endpoint({ep_id}) already active for at least 3600 seconds")
-
-            .. tab-item:: API Info
-
-                ``POST /endpoint/<endpoint_id>/autoactivate``
-
-                .. extdoclink:: Autoactivate Endpoint
-                    :ref: transfer/endpoint_activation/#autoactivate_endpoint
+        DEPRECATION WARNING: this helper is deprecated with the end of Globus Connect
+        Server v4 support and may no longer function with the Transfer API.
         """  # noqa: E501
         if query_params is None:
             query_params = {}
@@ -441,14 +365,8 @@ class TransferClient(client.BaseClient):
         :param query_params: Any additional parameters will be passed through
             as query params.
 
-        .. tab-set::
-
-            .. tab-item:: API Info
-
-                ``POST /endpoint/<endpoint_id>/deactivate``
-
-                .. extdoclink:: Deactivate Endpoint
-                    :ref: transfer/endpoint_activation/#deactivate_endpoint
+        DEPRECATION WARNING: this helper is deprecated with the end of Globus Connect
+        Server v4 support and may no longer function with the Transfer API.
         """
         log.info(f"TransferClient.endpoint_deactivate({endpoint_id})")
         return self.post(
@@ -471,17 +389,8 @@ class TransferClient(client.BaseClient):
         :param query_params: Any additional parameters will be passed through
             as query params.
 
-        Consider using autoactivate and web activation instead, described
-        in the example for :meth:`~endpoint_autoactivate`.
-
-        .. tab-set::
-
-            .. tab-item:: API Info
-
-                ``POST /endpoint/<endpoint_id>/activate``
-
-                .. extdoclink:: Activate Endpoint
-                    :ref: transfer/endpoint_activation/#activate_endpoint
+        DEPRECATION WARNING: this helper is deprecated with the end of Globus Connect
+        Server v4 support and may no longer function with the Transfer API.
         """
         log.info(f"TransferClient.endpoint_activate({endpoint_id})")
         return self.post(
@@ -502,14 +411,8 @@ class TransferClient(client.BaseClient):
         :param query_params: Any additional parameters will be passed through
             as query params.
 
-        .. tab-set::
-
-            .. tab-item:: API Info
-
-                ``GET /endpoint/<endpoint_id>/activation_requirements``
-
-                .. extdoclink:: Get Activation Requirements
-                    :ref: transfer/endpoint_activation/#get_activation_requirements
+        DEPRECATION WARNING: this helper is deprecated with the end of Globus Connect
+        Server v4 support and may no longer function with the Transfer API.
         """
         return ActivationRequirementsResponse(
             self.get(
@@ -535,8 +438,8 @@ class TransferClient(client.BaseClient):
 
                 ``GET /endpoint/<endpoint_id>/my_effective_pause_rule_list``
 
-                .. extdoclink:: Get my effective endpoint pause rules
-                    :ref: transfer/endpoint/#get_endpoint_pause_rules
+                .. extdoclink:: Get my effective collection pause rules
+                    :ref: transfer/endpoints_and_collections/#get_collection_pause_rules
         """
         log.info(f"TransferClient.my_effective_pause_rule_list({endpoint_id}, ...)")
         return IterableTransferResponse(
@@ -567,8 +470,8 @@ class TransferClient(client.BaseClient):
 
                 ``GET /endpoint/<endpoint_id>/my_shared_endpoint_list``
 
-                .. extdoclink:: Get shared endpoint list
-                    :ref: transfer/endpoint/#get_shared_endpoint_list
+                .. extdoclink:: Get my guest collection list
+                    :ref: transfer/endpoints_and_collections/#get_my_guest_collection_list
         """
         log.info(f"TransferClient.my_shared_endpoint_list({endpoint_id}, ...)")
         return IterableTransferResponse(
@@ -606,8 +509,8 @@ class TransferClient(client.BaseClient):
 
                 ``GET /endpoint/<endpoint_id>/shared_endpoint_list``
 
-                .. extdoclink:: Get shared endpoint list (2)
-                    :ref: transfer/endpoint/#get_shared_endpoint_list2
+                .. extdoclink:: Get guest collection list
+                    :ref: transfer/endpoints_and_collections/get_guest_collection_list
         """
         log.info(f"TransferClient.get_shared_endpoint_list({endpoint_id}, ...)")
         if query_params is None:
@@ -652,8 +555,8 @@ class TransferClient(client.BaseClient):
 
                 ``POST /shared_endpoint``
 
-                .. extdoclink:: Create Shared Endpoint
-                    :ref: transfer/endpoint/#create_shared_endpoint
+                .. extdoclink:: Create guest collection
+                    :ref: transfer/gcp_management/#create_guest_collection
         """
         log.info("TransferClient.create_shared_endpoint(...)")
         return self.post("shared_endpoint", data=data)
@@ -677,8 +580,8 @@ class TransferClient(client.BaseClient):
 
                 ``GET /endpoint/<endpoint_id>/server_list``
 
-                .. extdoclink:: Get endpoint server list
-                    :ref: transfer/endpoint/#get_endpoint_server_list
+                .. extdoclink:: Get endpoint or collection server list
+                    :ref: transfer/endpoints_and_collections/#get_endpoint_or_collection_server_list
         """
         log.info(f"TransferClient.endpoint_server_list({endpoint_id}, ...)")
         return IterableTransferResponse(
@@ -703,8 +606,8 @@ class TransferClient(client.BaseClient):
 
                 ``GET /endpoint/<endpoint_id>/server/<server_id>``
 
-                .. extdoclink:: Get endpoint server by id
-                    :ref: transfer/endpoint/#get_endpoint_server_by_id
+                .. extdoclink:: Get server by id
+                    :ref: transfer/endpoints_and_collections/#get_server_by_id
         """
         log.info(
             "TransferClient.get_endpoint_server(%s, %s, ...)", endpoint_id, server_id
@@ -720,14 +623,8 @@ class TransferClient(client.BaseClient):
         :param endpoint_id: The endpoint under which the server is being registered
         :param server_data: Fields for the new server, as a server document
 
-        .. tab-set::
-
-            .. tab-item:: API Info
-
-                ``POST /endpoint/<endpoint_id>/server``
-
-                .. extdoclink:: Add endpoint server
-                    :ref: transfer/endpoint/#add_endpoint_server
+        DEPRECATION WARNING: this helper is deprecated with the end of Globus Connect
+        Server v4 support and may no longer function with the Transfer API.
         """
         log.info(f"TransferClient.add_endpoint_server({endpoint_id}, ...)")
         return self.post(f"endpoint/{endpoint_id}/server", data=server_data)
@@ -743,14 +640,8 @@ class TransferClient(client.BaseClient):
         :param server_id: The ID of the server to update
         :param server_data: Fields on the server to update, as a partial server document
 
-        .. tab-set::
-
-            .. tab-item:: API Info
-
-                ``PUT /endpoint/<endpoint_id>/server/<server_id>``
-
-                .. extdoclink:: Update endpoint server by ID
-                    :ref: transfer/endpoint/#update_endpoint_server_by_id
+        DEPRECATION WARNING: this helper is deprecated with the end of Globus Connect
+        Server v4 support and may no longer function with the Transfer API.
         """
         log.info(
             "TransferClient.update_endpoint_server(%s, %s, ...)",
@@ -766,14 +657,8 @@ class TransferClient(client.BaseClient):
         :param endpoint_id: The endpoint under which the server is registered
         :param server_id: The ID of the server to delete
 
-        .. tab-set::
-
-            .. tab-item:: API Info
-
-                ``DELETE /endpoint/<endpoint_id>/server/<server_id>``
-
-                .. extdoclink:: Delete endpoint server by ID
-                    :ref: transfer/endpoint/#delete_endpoint_server_by_id
+        DEPRECATION WARNING: this helper is deprecated with the end of Globus Connect
+        Server v4 support and may no longer function with the Transfer API.
         """
         log.info(
             "TransferClient.delete_endpoint_server(%s, %s)", endpoint_id, server_id
@@ -801,8 +686,8 @@ class TransferClient(client.BaseClient):
 
                 ``GET /endpoint/<endpoint_id>/role_list``
 
-                .. extdoclink:: Get list of endpoint roles
-                    :ref: transfer/endpoint_roles/#role_list
+                .. extdoclink:: Get list of roles
+                    :ref: transfer/roles/#role_list
         """
         log.info(f"TransferClient.endpoint_role_list({endpoint_id}, ...)")
         return IterableTransferResponse(
@@ -822,8 +707,8 @@ class TransferClient(client.BaseClient):
 
                 ``POST /endpoint/<endpoint_id>/role``
 
-                .. extdoclink:: Create endpoint role
-                    :ref: transfer/endpoint_roles/#create_role
+                .. extdoclink:: Create Globus Connect Personal collection role
+                    :ref: transfer/roles/#create_role
         """
         log.info(f"TransferClient.add_endpoint_role({endpoint_id}, ...)")
         return self.post(f"endpoint/{endpoint_id}/role", data=role_data)
@@ -846,8 +731,8 @@ class TransferClient(client.BaseClient):
 
                 ``GET /endpoint/<endpoint_id>/role/<role_id>``
 
-                .. extdoclink:: Get endpoint role by ID
-                    :ref: transfer/endpoint_roles/#get_endpoint_role_by_id
+                .. extdoclink:: Get role by id
+                    :ref: transfer/roles/#get_role_by_id
         """
         log.info(f"TransferClient.get_endpoint_role({endpoint_id}, {role_id}, ...)")
         return self.get(
@@ -867,8 +752,8 @@ class TransferClient(client.BaseClient):
 
                 ``DELETE /endpoint/<endpoint_id>/role/<role_id>``
 
-                .. extdoclink:: Delete endpoint role by ID
-                    :ref: transfer/endpoint_roles/#delete_endpoint_role_by_id
+                .. extdoclink:: Delete Globus Connect Personal collection role by id
+                    :ref: transfer/roles/#delete_role_by_id
         """
         log.info(f"TransferClient.delete_endpoint_role({endpoint_id}, {role_id})")
         return self.delete(f"endpoint/{endpoint_id}/role/{role_id}")
@@ -1031,7 +916,7 @@ class TransferClient(client.BaseClient):
                 ``GET /bookmark_list``
 
                 .. extdoclink:: Get list of bookmarks
-                    :ref: transfer/endpoint_bookmarks/#get_list_of_bookmarks
+                    :ref: transfer/collection_bookmarks/#get_list_of_bookmarks
         """
         log.info(f"TransferClient.bookmark_list({query_params})")
         return IterableTransferResponse(
@@ -1051,7 +936,7 @@ class TransferClient(client.BaseClient):
                 ``POST /bookmark``
 
                 .. extdoclink:: Create bookmark
-                    :ref: transfer/endpoint_bookmarks/#create_bookmark
+                    :ref: transfer/collection_bookmarks/#create_bookmark
         """
         log.info(f"TransferClient.create_bookmark({bookmark_data})")
         return self.post("bookmark", data=bookmark_data)
@@ -1073,7 +958,7 @@ class TransferClient(client.BaseClient):
                 ``GET /bookmark/<bookmark_id>``
 
                 .. extdoclink:: Get bookmark by ID
-                    :ref: transfer/endpoint_bookmarks/#get_bookmark_by_id
+                    :ref: transfer/collection_bookmarks/#get_bookmark_by_id
         """
         log.info(f"TransferClient.get_bookmark({bookmark_id})")
         return self.get(f"bookmark/{bookmark_id}", query_params=query_params)
@@ -1092,7 +977,7 @@ class TransferClient(client.BaseClient):
                 ``PUT /bookmark/<bookmark_id>``
 
                 .. extdoclink:: Update bookmark
-                    :ref: transfer/endpoint_bookmarks/#update_bookmark
+                    :ref: transfer/collection_bookmarks/#update_bookmark
         """
         log.info(f"TransferClient.update_bookmark({bookmark_id})")
         return self.put(f"bookmark/{bookmark_id}", data=bookmark_data)
@@ -1108,7 +993,7 @@ class TransferClient(client.BaseClient):
                 ``DELETE /bookmark/<bookmark_id>``
 
                 .. extdoclink:: Delete bookmark by ID
-                    :ref: transfer/endpoint_bookmarks/#delete_bookmark_by_id
+                    :ref: transfer/collection_bookmarks/#delete_bookmark_by_id
         """
         log.info(f"TransferClient.delete_bookmark({bookmark_id})")
         return self.delete(f"bookmark/{bookmark_id}")
@@ -1343,21 +1228,7 @@ class TransferClient(client.BaseClient):
         :param path: The name of (path to) the new symlink
         :param query_params: Additional passthrough query parameters
 
-        .. tab-set::
-
-            .. tab-item:: Example Usage
-
-                .. code-block:: python
-
-                    tc = globus_sdk.TransferClient(...)
-                    tc.operation_symlink(ep_id, symlink_target="/~/file1.txt", path="/~/link-to-file1.txt")
-
-            .. tab-item:: API Info
-
-                ``POST /operation/endpoint/<endpoint_id>/symlink``
-
-                .. extdoclink:: Symlink
-                    :ref: transfer/file_operations/#symlink
+        WARNING: This helper is not currently supported by any collections.
         """  # noqa: E501
         log.info(
             "TransferClient.operation_symlink({}, {}, {}, {})".format(
@@ -1965,8 +1836,8 @@ class TransferClient(client.BaseClient):
 
                 ``GET endpoint_manager/monitored_endpoints``
 
-                .. extdoclink:: Get monitored endpoints
-                    :ref: transfer/advanced_endpoint_management/#get_monitored_endpoints
+                .. extdoclink:: Get monitored endpoints and collections
+                    :ref: transfer/advanced_collection_management/#get_monitored_endpoints_and_collections
         """
         log.info(f"TransferClient.endpoint_manager_monitored_endpoints({query_params})")
         return IterableTransferResponse(
@@ -1992,7 +1863,7 @@ class TransferClient(client.BaseClient):
                 ``GET /endpoint_manager/endpoint/<endpoint_id>/hosted_endpoint_list``
 
                 .. extdoclink:: Get hosted endpoint list
-                    :ref: transfer/advanced_endpoint_management/#get_hosted_endpoint_list
+                    :ref: transfer/advanced_collection_management/#get_hosted_collection_list
         """  # noqa: E501
         log.info(f"TransferClient.endpoint_manager_hosted_endpoint_list({endpoint_id})")
         return IterableTransferResponse(
@@ -2021,7 +1892,7 @@ class TransferClient(client.BaseClient):
                 ``GET /endpoint_manager/endpoint/<endpoint_id>``
 
                 .. extdoclink:: Get endpoint as admin
-                    :ref: transfer/advanced_endpoint_management/#mc_get_endpoint
+                    :ref: transfer/advanced_collection_management/#mc_get_endpoint_or_collection
         """
         log.info(f"TransferClient.endpoint_manager_get_endpoint({endpoint_id})")
         return self.get(
@@ -2046,8 +1917,8 @@ class TransferClient(client.BaseClient):
 
                 ``GET endpoint_manager/endpoint/<endpoint_id>/access_list``
 
-                .. extdoclink:: Get endpoint access list as admin
-                    :ref: transfer/advanced_endpoint_management/#get_endpoint_access_list_as_admin
+                .. extdoclink:: Get guest collection access list as admin
+                    :ref: transfer/advanced_collection_management/#get_guest_collection_access_list_as_admin
         """  # noqa: E501
         log.info(
             f"TransferClient.endpoint_manager_endpoint_acl_list({endpoint_id}, ...)"
@@ -2176,8 +2047,8 @@ class TransferClient(client.BaseClient):
 
                 ``GET endpoint_manager/task_list``
 
-                .. extdoclink:: Advanced Endpoint Management: Get tasks
-                    :ref: transfer/advanced_endpoint_management/#get_tasks
+                .. extdoclink:: Advanced Collection Management: Get tasks
+                    :ref: transfer/advanced_collection_management/#get_tasks
         """  # noqa: E501
         log.info("TransferClient.endpoint_manager_task_list(...)")
         if query_params is None:
@@ -2228,8 +2099,8 @@ class TransferClient(client.BaseClient):
 
                 ``GET /endpoint_manager/task/<task_id>``
 
-                .. extdoclink:: Get task as admin
-                    :ref: transfer/advanced_endpoint_management/#get_task
+                .. extdoclink:: Advanced Collection Management: Get task
+                    :ref: transfer/advanced_collection_management/#get_task
         """
         log.info(f"TransferClient.endpoint_manager_get_task({task_id}, ...)")
         return self.get(f"endpoint_manager/task/{task_id}", query_params=query_params)
@@ -2273,8 +2144,8 @@ class TransferClient(client.BaseClient):
 
                 ``GET /task/<task_id>/event_list``
 
-                .. extdoclink:: Get task events as admin
-                    :ref: transfer/advanced_endpoint_management/#get_task_events
+                .. extdoclink:: Advanced Collection Management: Get task events
+                    :ref: transfer/advanced_collection_management/#get_task_events
         """
         log.info(f"TransferClient.endpoint_manager_task_event_list({task_id}, ...)")
         if query_params is None:
@@ -2311,7 +2182,7 @@ class TransferClient(client.BaseClient):
                 ``GET /endpoint_manager/task/<task_id>/pause_info``
 
                 .. extdoclink:: Get task pause info as admin
-                    :ref: transfer/advanced_endpoint_management/#get_task_pause_info_as_admin
+                    :ref: transfer/advanced_collection_management/#get_task_pause_info_as_admin
         """  # noqa: E501
         log.info(f"TransferClient.endpoint_manager_task_pause_info({task_id}, ...)")
         return self.get(
@@ -2346,7 +2217,7 @@ class TransferClient(client.BaseClient):
                 ``GET /endpoint_manager/task/<task_id>/successful_transfers``
 
                 .. extdoclink:: Get task successful transfers as admin
-                    :ref: transfer/advanced_endpoint_management/\
+                    :ref: transfer/advanced_collection_management/\
                             #get_task_successful_transfers_as_admin
         """
         log.info(
@@ -2392,7 +2263,7 @@ class TransferClient(client.BaseClient):
                 ``GET /endpoint_manager/task/<task_id>/skipped_errors``
 
                 .. extdoclink:: Get task skipped errors as admin
-                    :ref: transfer/advanced_endpoint_management/\
+                    :ref: transfer/advanced_collection_management/\
                             #get_task_skipped_errors_as_admin
         """
         log.info(f"TransferClient.endpoint_manager_task_skipped_errors({task_id}, ...)")
@@ -2429,7 +2300,7 @@ class TransferClient(client.BaseClient):
                 ``POST /endpoint_manager/admin_cancel``
 
                 .. extdoclink:: Cancel tasks as admin
-                    :ref: transfer/advanced_endpoint_management/#admin_cancel
+                    :ref: transfer/advanced_collection_management/#admin_cancel
         """
         str_task_ids = [str(i) for i in task_ids]
         log.info(
@@ -2460,7 +2331,7 @@ class TransferClient(client.BaseClient):
                 ``GET /endpoint_manager/admin_cancel/<admin_cancel_id>``
 
                 .. extdoclink:: Get cancel status by ID
-                    :ref: transfer/advanced_endpoint_management/#get_cancel_status_by_id
+                    :ref: transfer/advanced_collection_management/#get_cancel_status_by_id
         """
         log.info(f"TransferClient.endpoint_manager_cancel_status({admin_cancel_id})")
         return self.get(
@@ -2490,7 +2361,7 @@ class TransferClient(client.BaseClient):
                 ``POST /endpoint_manager/admin_pause``
 
                 .. extdoclink:: Pause tasks as admin
-                    :ref: transfer/advanced_endpoint_management/#pause_tasks_as_admin
+                    :ref: transfer/advanced_collection_management/#pause_tasks_as_admin
         """
         str_task_ids = [str(i) for i in task_ids]
         log.info(
@@ -2521,7 +2392,7 @@ class TransferClient(client.BaseClient):
                 ``POST /endpoint_manager/admin_resume``
 
                 .. extdoclink:: Resume tasks as admin
-                    :ref: transfer/advanced_endpoint_management/#resume_tasks_as_admin
+                    :ref: transfer/advanced_collection_management/#resume_tasks_as_admin
         """
         str_task_ids = [str(i) for i in task_ids]
         log.info(f"TransferClient.endpoint_manager_resume_tasks({str_task_ids})")
@@ -2556,7 +2427,7 @@ class TransferClient(client.BaseClient):
                 ``GET /endpoint_manager/pause_rule_list``
 
                 .. extdoclink:: Get pause rules
-                    :ref: transfer/advanced_endpoint_management/#get_pause_rules
+                    :ref: transfer/advanced_collection_management/#get_pause_rules
         """
         log.info("TransferClient.endpoint_manager_pause_rule_list(...)")
         if query_params is None:
@@ -2598,7 +2469,7 @@ class TransferClient(client.BaseClient):
                 ``POST /endpoint_manager/pause_rule``
 
                 .. extdoclink:: Create pause rule
-                    :ref: transfer/advanced_endpoint_management/#create_pause_rule
+                    :ref: transfer/advanced_collection_management/#create_pause_rule
         """
         log.info("TransferClient.endpoint_manager_create_pause_rule(...)")
         return self.post("endpoint_manager/pause_rule", data=data)
@@ -2623,7 +2494,7 @@ class TransferClient(client.BaseClient):
                 ``GET /endpoint_manager/pause_rule/<pause_rule_id>``
 
                 .. extdoclink:: Get pause rule
-                    :ref: transfer/advanced_endpoint_management/#get_pause_rule
+                    :ref: transfer/advanced_collection_management/#get_pause_rule
         """
         log.info(f"TransferClient.endpoint_manager_get_pause_rule({pause_rule_id})")
         return self.get(
@@ -2662,7 +2533,7 @@ class TransferClient(client.BaseClient):
                 ``PUT /endpoint_manager/pause_rule/<pause_rule_id>``
 
                 .. extdoclink:: Update pause rule
-                    :ref: transfer/advanced_endpoint_management/#update_pause_rule
+                    :ref: transfer/advanced_collection_management/#update_pause_rule
         """
         log.info(f"TransferClient.endpoint_manager_update_pause_rule({pause_rule_id})")
         return self.put(f"endpoint_manager/pause_rule/{pause_rule_id}", data=data)
@@ -2688,7 +2559,7 @@ class TransferClient(client.BaseClient):
                 ``DELETE /endpoint_manager/pause_rule/<pause_rule_id>``
 
                 .. extdoclink:: Delete pause rule
-                    :ref: transfer/advanced_endpoint_management/#delete_pause_rule
+                    :ref: transfer/advanced_collection_management/#delete_pause_rule
         """
         log.info(f"TransferClient.endpoint_manager_delete_pause_rule({pause_rule_id})")
         return self.delete(


### PR DESCRIPTION
SC: https://app.shortcut.com/globus/story/29602/sdk-update-links-to-transfer-api-docs

Updates links that were broken by transfer doc changes for v4 eol and switching to collection terminology. There may be more breaks on the way, but this should be the biggest set.

Many of the existing links were aspirational in their `#` subsections, I opened a docs PR to make those actually work: https://github.com/globusonline/docs.globus.org/pull/1533 and will go through and verify all the links work once that's merged.

Not sure about the "DEPRECATION WARNING" and "WARNING" sections, will need to see how those render at the very least and am open to suggestions on text.

I didn't mess with the descriptions beyond warnings for things that can't really be used, might be worthwhile to make another story to do some work to use collection terminology there as well, or maybe we should just wait until the next major version where we can change the method names too.

<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--938.org.readthedocs.build/en/938/

<!-- readthedocs-preview globus-sdk-python end -->