### PR TITLE
Add session_required_mfa to some missing auth interfaces

### DIFF
--- a/changelog.d/20240126_124046_derek_missing_session_params.rst
+++ b/changelog.d/20240126_124046_derek_missing_session_params.rst
@@ -1,0 +1,13 @@
+
+Added
+~~~~~
+
+- Added a `session_required_mfa` parameter to the `AuthorizationParameterInfo` error
+  info object and `oauth2_get_authorize_url` method (:pr:`NUMBER`)
+
+Fixed
+~~~~~
+
+- Included documentation in `AuthorizationParameterInfo` for `session_required_policies`
+  (:pr:`NUMBER`)
+

--- a/src/globus_sdk/exc/err_info.py
+++ b/src/globus_sdk/exc/err_info.py
@@ -37,12 +37,20 @@ class AuthorizationParameterInfo(ErrorInfo):
 
     :ivar session_message: A message from the server
     :vartype session_message: str, optional
+
     :ivar session_required_identities: A list of identity IDs as strings which are being
         requested by the server
     :vartype session_required_identities: list of str, optional
+
     :ivar session_required_single_domain: A list of domains which are being requested by
         the server ("single domain" because the user should choose one)
     :vartype session_required_single_domain: list of str, optional
+
+    :ivar session_required_policies: A list of policies required for the session.
+    :vartype session_required_policies: list of str, optional
+
+    :ivar session_required_mfa: Whether MFA is required for the session.
+    :vartype session_required_mfa: bool, optional
 
     **Examples**
 
@@ -77,6 +85,8 @@ class AuthorizationParameterInfo(ErrorInfo):
         self.session_required_policies: (
             list[str] | None
         ) = self._parse_session_required_policies(data)
+
+        self.session_required_mfa = self._parse_session_required_mfa(data)
 
     def _parse_session_message(self, data: dict[str, t.Any]) -> str | None:
         session_message = data.get("session_message")
@@ -126,6 +136,14 @@ class AuthorizationParameterInfo(ErrorInfo):
             self._warn_type(
                 "session_required_policies", "list[str]|str", session_required_policies
             )
+        return None
+
+    def _parse_session_required_mfa(self, data: dict[str, t.Any]) -> bool | None:
+        session_required_mfa = data.get("session_required_mfa")
+        if isinstance(session_required_mfa, bool):
+            return session_required_mfa
+        elif session_required_mfa is not None:
+            self._warn_type("session_required_mfa", "bool", session_required_mfa)
         return None
 
     def _warn_type(self, key: str, expected: str, got: t.Any) -> None:

--- a/src/globus_sdk/services/auth/client/base_login_client.py
+++ b/src/globus_sdk/services/auth/client/base_login_client.py
@@ -141,6 +141,7 @@ class AuthLoginClient(client.BaseClient):
         session_required_identities: UUIDLike | t.Iterable[UUIDLike] | None = None,
         session_required_single_domain: str | t.Iterable[str] | None = None,
         session_required_policies: UUIDLike | t.Iterable[UUIDLike] | None = None,
+        session_required_mfa: bool | None = None,
         prompt: Literal["login"] | None = None,
         query_params: dict[str, t.Any] | None = None,
     ) -> str:
@@ -155,6 +156,7 @@ class AuthLoginClient(client.BaseClient):
             which must be satisfied by identities added to the session.
         :param session_required_policies: A list of IDs for policies which must
             be satisfied by the user.
+        :param session_required_mfa: Whether MFA is required for the session.
         :param prompt:
             Control whether a user is required to log in before the authorization step.
 
@@ -186,6 +188,8 @@ class AuthLoginClient(client.BaseClient):
             query_params["session_required_policies"] = utils.commajoin(
                 session_required_policies
             )
+        if session_required_mfa is not None:
+            query_params["session_required_mfa"] = session_required_mfa
         if prompt is not None:
             query_params["prompt"] = prompt
         auth_url = self.current_oauth2_flow_manager.get_authorize_url(

--- a/tests/functional/services/auth/test_auth_client_flow.py
+++ b/tests/functional/services/auth/test_auth_client_flow.py
@@ -34,6 +34,7 @@ def confidential_client(no_retry_transport):
 #   domain: str | list[str]
 #   identities: uuid | str | list[uuid] | list[str] | list[str | uuid]
 #   policies: uuid | str | list[uuid] | list[str] | list[str | uuid]
+#   mfa: True | False
 #   prompt: Literal["prompt"] | None
 #
 # The order of these options is consequential.
@@ -55,15 +56,16 @@ policy_options = (
     ["baz-id", "quux-id"],
     ["baz-id", uuid.UUID(int=5)],
 )
+mfa_options = (True, False)
 prompt_options = ("login",)
 # Seed an all-`None` option test, then use a loop to fill in the rest.
 # There must be 4 parameters so parametrized tuple unpacking works in the test.
-_ALL_SESSION_PARAM_COMBINATIONS = [(None,) * 4]
+_ALL_SESSION_PARAM_COMBINATIONS = [(None,) * 5]
 for idx, options in enumerate(
-    (domain_options, identity_options, policy_options, prompt_options)
+    (domain_options, identity_options, policy_options, mfa_options, prompt_options)
 ):
     for option in options:
-        parameters = [None] * 4
+        parameters = [None] * 5
         parameters[idx] = option
         _ALL_SESSION_PARAM_COMBINATIONS.append(tuple(parameters))
 
@@ -71,7 +73,7 @@ for idx, options in enumerate(
 @pytest.mark.parametrize("flow_type", ("native_app", "confidential_app"))
 # parametrize over both what is and what *is not* passed as a parameter
 @pytest.mark.parametrize(
-    "domain_option, identity_option, policy_option, prompt_option",
+    "domain_option, identity_option, policy_option, mfa_option, prompt_option",
     _ALL_SESSION_PARAM_COMBINATIONS,
 )
 def test_oauth2_get_authorize_url_supports_session_params(
@@ -81,6 +83,7 @@ def test_oauth2_get_authorize_url_supports_session_params(
     domain_option,
     identity_option,
     policy_option,
+    mfa_option,
     prompt_option,
 ):
     if flow_type == "native_app":
@@ -96,6 +99,7 @@ def test_oauth2_get_authorize_url_supports_session_params(
         session_required_single_domain=domain_option,
         session_required_identities=identity_option,
         session_required_policies=policy_option,
+        session_required_mfa=mfa_option,
         prompt=prompt_option,
     )
 
@@ -108,6 +112,7 @@ def test_oauth2_get_authorize_url_supports_session_params(
         "session_required_single_domain" if domain_option else None,
         "session_required_identities" if identity_option else None,
         "session_required_policies" if policy_option else None,
+        "session_required_mfa" if mfa_option is not None else None,
         "prompt" if prompt_option else None,
     }
     expected_params_keys.discard(None)
@@ -115,6 +120,7 @@ def test_oauth2_get_authorize_url_supports_session_params(
         "session_required_single_domain",
         "session_required_identities",
         "session_required_policies",
+        "session_required_mfa",
         "prompt",
     } - expected_params_keys
     parsed_params_keys = set(parsed_params.keys())
@@ -146,6 +152,10 @@ def test_oauth2_get_authorize_url_supports_session_params(
             else str(policy_option)
         )
         assert parsed_params["session_required_policies"] == [strized_option]
+
+    if mfa_option is not None:
+        strized_option = "True" if mfa_option else "False"
+        assert parsed_params["session_required_mfa"] == [strized_option]
 
     if prompt_option is not None:
         assert parsed_params["prompt"] == [prompt_option]

--- a/tests/functional/services/auth/test_auth_client_flow.py
+++ b/tests/functional/services/auth/test_auth_client_flow.py
@@ -59,7 +59,7 @@ policy_options = (
 mfa_options = (True, False)
 prompt_options = ("login",)
 # Seed an all-`None` option test, then use a loop to fill in the rest.
-# There must be 4 parameters so parametrized tuple unpacking works in the test.
+# The number of parameters here must match the test parameters:
 _ALL_SESSION_PARAM_COMBINATIONS = [(None,) * 5]
 for idx, options in enumerate(
     (domain_options, identity_options, policy_options, mfa_options, prompt_options)

--- a/tests/unit/errors/test_common_functionality.py
+++ b/tests/unit/errors/test_common_functionality.py
@@ -361,12 +361,13 @@ def test_authz_params_info_containing_malformed_session_required_policies():
     )
 
 
-def test_authz_params_info_containing_malformed_session_required_mfa():
-    body = {"authorization_parameters": {"session_required_mfa": True}}
+@pytest.mark.parametrize("mfa_value", [True, False])
+def test_authz_params_info_containing_session_required_mfa(mfa_value):
+    body = {"authorization_parameters": {"session_required_mfa": mfa_value}}
     err = construct_error(body=body, http_status=403)
 
     assert bool(err.info.authorization_parameters) is True
-    assert err.info.authorization_parameters.session_required_mfa is True
+    assert err.info.authorization_parameters.session_required_mfa is mfa_value
     _strmatch_any_order(
         str(err.info.authorization_parameters),
         "AuthorizationParameterInfo(",
@@ -375,7 +376,27 @@ def test_authz_params_info_containing_malformed_session_required_mfa():
             "session_required_identities=None",
             "session_required_single_domain=None",
             "session_required_policies=None",
-            "session_required_mfa=True",
+            f"session_required_mfa={mfa_value}",
+        ],
+        ")",
+    )
+
+
+def test_authz_params_info_containing_malformed_session_required_mfa():
+    body = {"authorization_parameters": {"session_required_mfa": "foobarjohn"}}
+    err = construct_error(body=body, http_status=403)
+
+    assert bool(err.info.authorization_parameters) is True
+    assert err.info.authorization_parameters.session_required_mfa is None
+    _strmatch_any_order(
+        str(err.info.authorization_parameters),
+        "AuthorizationParameterInfo(",
+        [
+            "session_message=None",
+            "session_required_identities=None",
+            "session_required_single_domain=None",
+            "session_required_policies=None",
+            "session_required_mfa=None",
         ],
         ")",
     )

--- a/tests/unit/errors/test_common_functionality.py
+++ b/tests/unit/errors/test_common_functionality.py
@@ -177,6 +177,8 @@ def test_authz_params_info_containing_session_message():
     assert err.info.authorization_parameters.session_required_identities is None
     assert err.info.authorization_parameters.session_required_single_domain is None
     assert err.info.authorization_parameters.session_required_policies is None
+    print("derk")
+    print(str(err.info.authorization_parameters))
     _strmatch_any_order(
         str(err.info.authorization_parameters),
         "AuthorizationParameterInfo(",
@@ -185,6 +187,7 @@ def test_authz_params_info_containing_session_message():
             "session_required_identities=None",
             "session_required_single_domain=None",
             "session_required_policies=None",
+            "session_required_mfa=None",
         ],
         ")",
     )
@@ -207,6 +210,7 @@ def test_authz_params_info_containing_malformed_session_message():
             "session_required_identities=None",
             "session_required_single_domain=None",
             "session_required_policies=None",
+            "session_required_mfa=None",
         ],
         ")",
     )
@@ -232,6 +236,7 @@ def test_authz_params_info_containing_session_required_identities():
             "session_required_identities=['foo', 'bar']",
             "session_required_single_domain=None",
             "session_required_policies=None",
+            "session_required_mfa=None",
         ],
         ")",
     )
@@ -254,6 +259,7 @@ def test_authz_params_info_containing_malformed_session_required_identities():
             "session_required_identities=None",
             "session_required_single_domain=None",
             "session_required_policies=None",
+            "session_required_mfa=None",
         ],
         ")",
     )
@@ -281,6 +287,7 @@ def test_authz_params_info_containing_session_required_single_domain():
             "session_required_identities=None",
             "session_required_single_domain=['foo', 'bar']",
             "session_required_policies=None",
+            "session_required_mfa=None",
         ],
         ")",
     )
@@ -303,6 +310,7 @@ def test_authz_params_info_containing_malformed_session_required_single_domain()
             "session_required_identities=None",
             "session_required_single_domain=None",
             "session_required_policies=None",
+            "session_required_mfa=None",
         ],
         ")",
     )
@@ -325,6 +333,7 @@ def test_authz_params_info_containing_session_required_policies(policies_value):
             "session_required_identities=None",
             "session_required_single_domain=None",
             "session_required_policies=['foo', 'bar']",
+            "session_required_mfa=None",
         ],
         ")",
     )
@@ -346,6 +355,27 @@ def test_authz_params_info_containing_malformed_session_required_policies():
             "session_required_identities=None",
             "session_required_single_domain=None",
             "session_required_policies=None",
+            "session_required_mfa=None",
+        ],
+        ")",
+    )
+
+
+def test_authz_params_info_containing_malformed_session_required_mfa():
+    body = {"authorization_parameters": {"session_required_mfa": True}}
+    err = construct_error(body=body, http_status=403)
+
+    assert bool(err.info.authorization_parameters) is True
+    assert err.info.authorization_parameters.session_required_mfa is True
+    _strmatch_any_order(
+        str(err.info.authorization_parameters),
+        "AuthorizationParameterInfo(",
+        [
+            "session_message=None",
+            "session_required_identities=None",
+            "session_required_single_domain=None",
+            "session_required_policies=None",
+            "session_required_mfa=True",
         ],
         ")",
     )


### PR DESCRIPTION
## What?
1. Add `session_required_mfa` to `globus_sdk.exc.AuthorizationParameterInfo`
2. Add `session_required_policies` to docstring of `globus_sdk.exc.AuthorizationParameterInfo` (attribute already existed)
3. Add `session_required_mfa` to `AuthLoginClient.oauth2_get_authorize_url`

## Why?
Bring auth python objects closer to parity with Auth specification:
* [Required Error Format for Services](https://docs.globus.org/api/auth/sessions/#required-error-format)
* [Authorize URL Params](https://docs.globus.org/api/auth/reference/#authorization_code_grant_preferred)

## Testing
Updated relevant unit tests to supply `session_required_mfa` values.

<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--939.org.readthedocs.build/en/939/

<!-- readthedocs-preview globus-sdk-python end -->