### PR TITLE
Add deprecation warning for operation_symlink

### DIFF
--- a/changelog.d/20240129_105042_sirosen_runtime_deprecation_for_operation_symlink.rst
+++ b/changelog.d/20240129_105042_sirosen_runtime_deprecation_for_operation_symlink.rst
@@ -1,0 +1,5 @@
+Deprecated
+~~~~~~~~~~
+
+- ``TransferClient.operation_symlink`` is now officially deprecated and will
+  emit a ``RemovedInV4Warning`` if used. (:pr:`NUMBER`)

--- a/src/globus_sdk/services/transfer/client.py
+++ b/src/globus_sdk/services/transfer/client.py
@@ -1248,6 +1248,10 @@ class TransferClient(client.BaseClient):
 
             This method is not currently supported by any collections.
         """  # noqa: E501
+        exc.warn_deprecated(
+            "operation_symlink is not currently supported by any collections. "
+            "To reduce confusion, this method will be removed."
+        )
         log.info(
             "TransferClient.operation_symlink({}, {}, {}, {})".format(
                 endpoint_id, symlink_target, path, query_params

--- a/tests/functional/services/transfer/test_operation_symlink.py
+++ b/tests/functional/services/transfer/test_operation_symlink.py
@@ -1,6 +1,29 @@
+import uuid
+
 import pytest
 
+from globus_sdk import exc
+from globus_sdk._testing import RegisteredResponse
 
-@pytest.mark.xfail
-def test_operation_symlink():
-    raise NotImplementedError
+
+@pytest.fixture
+def symlink_endpoint_id():
+    return str(uuid.uuid1())
+
+
+@pytest.fixture(autouse=True)
+def _setup_symlink_response(symlink_endpoint_id):
+    RegisteredResponse(
+        service="transfer",
+        method="POST",
+        path=f"/operation/endpoint/{symlink_endpoint_id}/symlink",
+        json={},
+    ).add()
+
+
+def test_operation_symlink_warns(client, symlink_endpoint_id):
+    with pytest.warns(
+        exc.RemovedInV4Warning,
+        match="operation_symlink is not currently supported by any collections",
+    ):
+        client.operation_symlink(symlink_endpoint_id, "some_link_target", "/some/path")


### PR DESCRIPTION
And add a test for it, with some dummy data.

---

Follow-up to #941


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--942.org.readthedocs.build/en/942/

<!-- readthedocs-preview globus-sdk-python end -->