### PR TITLE
Fix doc example for scope construction

### DIFF
--- a/docs/scopes.rst
+++ b/docs/scopes.rst
@@ -143,12 +143,14 @@ alias for ``serialize``. For example, the following is valid usage to demonstrat
     >>> bar = MutableScope("bar")
     >>> bar.add_dependency("baz")
     >>> foo.add_dependency(bar)
-    >>> print(str(MutableScope("foo")))
-    foo[bar *baz]
+    >>> print(str(foo))
+    foo[bar[baz]]
     >>> print(bar.serialize())
     bar[baz]
     >>> alpha = MutableScope("alpha")
     >>> alpha.add_dependency(MutableScope("beta", optional=True))
+    >>> print(str(alpha))
+    alpha[*beta]
     >>> print(repr(alpha))
     MutableScope("alpha", dependencies=[MutableScope("beta", optional=True)])
 


### PR DESCRIPTION
The example didn't match output against the demo'ed inputs. Fix it to be accurate.


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--943.org.readthedocs.build/en/943/

<!-- readthedocs-preview globus-sdk-python end -->