### PR TITLE
Define 'extdoclink' role and use it for Search

### DIFF
--- a/src/globus_sdk/_sphinxext.py
+++ b/src/globus_sdk/_sphinxext.py
@@ -216,7 +216,15 @@ def _derive_doc_url_base(service: str | None) -> str:
         raise ValueError(f"Unsupported extdoclink service '{service}'")
 
 
-def extdoclink_role(name, rawtext, text, lineno, inliner, options=None, content=None):
+def extdoclink_role(
+    name,  # pylint: disable=unused-argument
+    rawtext,
+    text,
+    lineno,  # pylint: disable=unused-argument
+    inliner,  # pylint: disable=unused-argument
+    options=None,  # pylint: disable=unused-argument
+    content=None,  # pylint: disable=unused-argument
+):
     if " " not in text:
         raise ValueError("extdoclink role must contain space-separated text")
     linktext, _, ref = text.rpartition(" ")

--- a/src/globus_sdk/services/search/client.py
+++ b/src/globus_sdk/services/search/client.py
@@ -209,6 +209,9 @@ class SearchClient(client.BaseClient):
             but may result in BadRequest errors when used if the query is invalid
         :param query_params: additional parameters to pass as query params
 
+        For details on query syntax, including the ``advanced`` query behavior, see
+        the :extdoclink:`Search Query Syntax <search/query#query_syntax>` documentation.
+
         .. tab-set::
 
             .. tab-item:: Example Usage
@@ -271,6 +274,9 @@ class SearchClient(client.BaseClient):
         :param data: A Search Query document containing the query and any other fields
         :param offset: offset used in paging (overwrites any offset in ``data``)
         :param limit: limit the number of results (overwrites any limit in ``data``)
+
+        For details on query syntax, including the ``advanced`` query behavior, see
+        the :extdoclink:`Search Query Syntax <search/query#query_syntax>` documentation.
 
         .. tab-set::
 
@@ -339,6 +345,9 @@ class SearchClient(client.BaseClient):
         :param index_id: The index on which to search
         :param data: A Search Scroll Query document
         :param marker: marker used in paging (overwrites any marker in ``data``)
+
+        For details on query syntax, including the ``advanced`` query behavior, see
+        the :extdoclink:`Search Query Syntax <search/query#query_syntax>` documentation.
 
         .. tab-set::
 


### PR DESCRIPTION
The end-goal here was to add several link references to the Search
docs for the `advanced` query string syntax, which is mentioned in
these docs but not fully explained.

In a few docstrings, we're adding links to the Search API docs.

In support of this, define an `extdoclink` role, in the custom sphinx
extension, which can be used as a simplified version of the `extdoclink`
directive:
- extract URL deduction into a helper for use in both
- do some very simplistic parsing to make the role easy to implement
  and read
- do not support all of the features of the extdoclink directive --
  e.g. you cannot customize `service` at present
- enable the role via `app.add_role` in sphinx `setup`


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--945.org.readthedocs.build/en/945/

<!-- readthedocs-preview globus-sdk-python end -->