### PR TITLE
Add subscription_id support to create_flow

### DIFF
--- a/changelog.d/20240208_133445_sirosen_add_flow_create_subscription_id.rst
+++ b/changelog.d/20240208_133445_sirosen_add_flow_create_subscription_id.rst
@@ -1,0 +1,4 @@
+Added
+~~~~~
+
+- ``FlowsClient.create_flow`` now supports ``subscription_id`` as a parameter. (:pr:`NUMBER`)

--- a/src/globus_sdk/_testing/data/flows/create_flow.py
+++ b/src/globus_sdk/_testing/data/flows/create_flow.py
@@ -27,7 +27,11 @@ RESPONSES = ResponseSet(
         path="/flows",
         method="POST",
         json=TWO_HOP_TRANSFER_FLOW_DOC,
-        match=[matchers.json_params_matcher(params=_two_hop_transfer_create_request)],
+        match=[
+            matchers.json_params_matcher(
+                params=_two_hop_transfer_create_request, strict_match=False
+            )
+        ],
     ),
     bad_admin_principal_error=RegisteredResponse(
         service="flows",

--- a/src/globus_sdk/services/flows/client.py
+++ b/src/globus_sdk/services/flows/client.py
@@ -41,6 +41,7 @@ class FlowsClient(client.BaseClient):
         flow_starters: list[str] | None = None,
         flow_administrators: list[str] | None = None,
         keywords: list[str] | None = None,
+        subscription_id: UUIDLike | None = None,
         additional_fields: dict[str, t.Any] | None = None,
     ) -> GlobusHTTPResponse:
         """
@@ -105,6 +106,8 @@ class FlowsClient(client.BaseClient):
 
         :param keywords: A set of terms used to categorize the flow used in query and
             discovery operations (0 - 1024 items)
+        :param subscription_id: The ID of the subscription to associate with the flow,
+            marking as a subscription tier flow.
         :param additional_fields: Additional Key/Value pairs sent to the create API
 
         .. tab-set::
@@ -156,6 +159,7 @@ class FlowsClient(client.BaseClient):
                 "flow_starters": flow_starters,
                 "flow_administrators": flow_administrators,
                 "keywords": keywords,
+                "subscription_id": subscription_id,
             }.items()
             if v is not None
         }

--- a/tests/functional/services/flows/test_flow_crud.py
+++ b/tests/functional/services/flows/test_flow_crud.py
@@ -1,14 +1,26 @@
+import json
+
 import pytest
 
 from globus_sdk import FlowsAPIError
-from globus_sdk._testing import load_response
+from globus_sdk._testing import get_last_request, load_response
 
 
-def test_create_flow(flows_client):
+@pytest.mark.parametrize("subscription_id", [None, "dummy_subscription_id"])
+def test_create_flow(flows_client, subscription_id):
     metadata = load_response(flows_client.create_flow).metadata
 
-    resp = flows_client.create_flow(**metadata["params"])
+    resp = flows_client.create_flow(
+        **metadata["params"], subscription_id=subscription_id
+    )
     assert resp.data["title"] == "Multi Step Transfer"
+
+    last_req = get_last_request()
+    req_body = json.loads(last_req.body)
+    if subscription_id:
+        assert req_body["subscription_id"] == subscription_id
+    else:
+        assert "subscription_id" not in req_body
 
 
 def test_create_flow_error_parsing(flows_client):


### PR DESCRIPTION
- add the param
- add a test for the param
- adjust the test matcher to be more lenient

The test is just a param being optionally passed to the existing
create_flow test. This revealed a strict match in the test fixture,
which I've here loosened to be non-strict (matches on a subset of
parameters).


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--949.org.readthedocs.build/en/949/

<!-- readthedocs-preview globus-sdk-python end -->