### PR TITLE
Fix EndpointDocument Data Type

### DIFF
--- a/changelog.d/20240213_135046_derek_apply_endpoint_data_type.rst
+++ b/changelog.d/20240213_135046_derek_apply_endpoint_data_type.rst
@@ -1,0 +1,6 @@
+
+Fixed
+~~~~~
+
+- Update ``ensure_datatype`` to work with documents that set ``DATA_TYPE`` to
+  ``MISSING`` instead of omitting it (:pr:`NUMBER`)

--- a/src/globus_sdk/services/gcs/data/_common.py
+++ b/src/globus_sdk/services/gcs/data/_common.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import sys
 import typing as t
 
+from globus_sdk.utils import MISSING
+
 if sys.version_info < (3, 8):
     from typing_extensions import Protocol
 else:
@@ -32,7 +34,7 @@ class DocumentWithInducedDatatype(Protocol):
 def deduce_datatype_version(obj: DocumentWithInducedDatatype) -> str:
     max_deduced_version = (1, 0, 0)
     for fieldname, version in obj.DATATYPE_VERSION_IMPLICATIONS.items():
-        if fieldname not in obj:
+        if fieldname not in obj or obj[fieldname] is MISSING:
             continue
         if version > max_deduced_version:
             max_deduced_version = version
@@ -44,5 +46,5 @@ def deduce_datatype_version(obj: DocumentWithInducedDatatype) -> str:
 
 
 def ensure_datatype(obj: DocumentWithInducedDatatype) -> None:
-    if "DATA_TYPE" not in obj:
+    if "DATA_TYPE" not in obj or obj["DATA_TYPE"] is MISSING:
         obj["DATA_TYPE"] = f"{obj.DATATYPE_BASE}#{deduce_datatype_version(obj)}"

--- a/tests/functional/services/gcs/test_endpoints.py
+++ b/tests/functional/services/gcs/test_endpoints.py
@@ -31,3 +31,25 @@ def test_update_endpoint_including_endpoint_in_response(client):
     assert update_response["DATA_TYPE"] == "endpoint#1.2.0"
     assert update_response["display_name"] == meta["display_name"]
     assert update_response["id"] == meta["endpoint_id"]
+
+
+def test_endpoint_document_infers_data_type():
+    doc = globus_sdk.EndpointDocument(display_name="My Endpoint")
+
+    assert doc["DATA_TYPE"] == "endpoint#1.0.0"
+
+
+def test_endpoint_document_infers_data_type_when_control_port_specified():
+    doc = globus_sdk.EndpointDocument(
+        display_name="My Endpoint", gridftp_control_channel_port=2811
+    )
+
+    assert doc["DATA_TYPE"] == "endpoint#1.1.0"
+
+
+def test_endpoint_document_respects_explicit_data_type():
+    doc = globus_sdk.EndpointDocument(
+        data_type="endpoint#0.15.x", display_name="My Endpoint"
+    )
+
+    assert doc["DATA_TYPE"] == "endpoint#0.15.x"


### PR DESCRIPTION
## What?
Set EndpointDocument (and any future missing-style payload wrapper's) `DATA_TYPE` automatically if omitted.

## Why?
This functionality is already applied to previously PayloadWrappers. `EndpointDocument`was the first one to use `MISSING` vals and those were not accounted for in the `ensure_datatype` and `deduce_datatype_version` gcs functions.

## Testing
Added tests to the `EndpointDocument` type.

<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--952.org.readthedocs.build/en/952/

<!-- readthedocs-preview globus-sdk-python end -->