### PR TITLE
Release v3.37.0

### DIFF
--- a/changelog.d/20240213_121717_sirosen_allow_bytes_for_http_methods.rst
+++ b/changelog.d/20240213_121717_sirosen_allow_bytes_for_http_methods.rst
@@ -1,7 +1,0 @@
-Added
-~~~~~
-
-- All of the basic HTTP methods of ``BaseClient`` and its derived classes which
-  accept a ``data`` parameter for a request body, e.g. ``TransferClient.post``
-  or ``GroupsClient.put``, now allow the ``data`` to be passed in the form of
-  already encoded ``bytes``. (:pr:`951`)

--- a/changelog.d/20240213_135046_derek_apply_endpoint_data_type.rst
+++ b/changelog.d/20240213_135046_derek_apply_endpoint_data_type.rst
@@ -1,6 +1,0 @@
-
-Fixed
-~~~~~
-
-- Update ``ensure_datatype`` to work with documents that set ``DATA_TYPE`` to
-  ``MISSING`` instead of omitting it (:pr:`952`)

--- a/changelog.rst
+++ b/changelog.rst
@@ -12,6 +12,25 @@ to a major new version of the SDK.
 
 .. scriv-insert-here
 
+.. _changelog-3.37.0:
+
+v3.37.0 (2024-02-14)
+--------------------
+
+Added
+~~~~~
+
+- All of the basic HTTP methods of ``BaseClient`` and its derived classes which
+  accept a ``data`` parameter for a request body, e.g. ``TransferClient.post``
+  or ``GroupsClient.put``, now allow the ``data`` to be passed in the form of
+  already encoded ``bytes``. (:pr:`951`)
+
+Fixed
+~~~~~
+
+- Update ``ensure_datatype`` to work with documents that set ``DATA_TYPE`` to
+  ``MISSING`` instead of omitting it (:pr:`952`)
+
 .. _changelog-3.36.0:
 
 v3.36.0 (2024-02-12)

--- a/src/globus_sdk/version.py
+++ b/src/globus_sdk/version.py
@@ -1,3 +1,3 @@
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "3.36.0"
+__version__ = "3.37.0"


### PR DESCRIPTION
# Changes

## Added

- All of the basic HTTP methods of `BaseClient` and its derived classes which accept a `data` parameter for a request body, e.g. `TransferClient.post` or `GroupsClient.put`, now allow the `data` to be passed in the form of already encoded `bytes`. (#951)

## Fixed

- Update `ensure_datatype` to work with documents that set `DATA_TYPE` to `MISSING` instead of omitting it (#952)

-----

I briefly considered numbering this v3.36.1 , but decided that the `bytes` support is not such a small feature that it doesn't merit a minor version bump.
In general, I like sticking with the rule that patch releases are "bugfix only", but being flexible when the feature changes are miniscule.


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--953.org.readthedocs.build/en/953/

<!-- readthedocs-preview globus-sdk-python end -->