### PR TITLE
Fix automodule docs and missing/undocumented public symbols

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,3 +65,9 @@ repos:
       types_or: [python,rst]
       language: pygrep
       entry: "\\.\\. +code-block::$"
+    - id: ensure-all-exports-documented
+      name: "Check that all public symbols are documented"
+      entry: ./scripts/ensure_exports_are_documented.py
+      language: python
+      always_run: true
+      pass_filenames: false

--- a/changelog.d/20240223_162805_sirosen_fix_module_docs.rst
+++ b/changelog.d/20240223_162805_sirosen_fix_module_docs.rst
@@ -1,0 +1,5 @@
+Added
+~~~~~
+
+- ``IterableGCSResponse`` and ``UnpackingGCSResponse`` are now available as
+  top-level exported names. (:pr:`NUMBER`)

--- a/docs/core/exceptions.rst
+++ b/docs/core/exceptions.rst
@@ -158,3 +158,13 @@ attributes should be tested before use, as in
 .. autoclass:: globus_sdk.exc.ConsentRequiredInfo
     :members:
     :show-inheritance:
+
+Warnings
+--------
+
+The following warnings can be emitted by the Globus SDK to indicate a
+problem which is not necessarily an error.
+
+.. autoclass:: globus_sdk.RemovedInV4Warning
+    :members:
+    :show-inheritance:

--- a/docs/services/auth.rst
+++ b/docs/services/auth.rst
@@ -65,6 +65,10 @@ Auth Responses
    :members:
    :show-inheritance:
 
+.. autoclass:: GetIdentitiesResponse
+   :members:
+   :show-inheritance:
+
 OAuth2 Flow Managers
 --------------------
 

--- a/docs/services/flows.rst
+++ b/docs/services/flows.rst
@@ -57,3 +57,9 @@ When an error occurs, a :class:`FlowsClient` will raise a ``FlowsAPIError``.
    :members:
    :show-inheritance:
 
+Responses
+---------
+
+.. autoclass:: IterableFlowsResponse
+   :members:
+   :show-inheritance:

--- a/docs/services/gcs.rst
+++ b/docs/services/gcs.rst
@@ -26,14 +26,114 @@ The primary interface for the GCS Manager API is the :class:`GCSClient` class.
 Helper Objects
 --------------
 
-.. automodule:: globus_sdk.services.gcs.data
+.. autoclass:: EndpointDocument
+   :members:
+   :show-inheritance:
+
+.. autoclass:: GCSRoleDocument
+   :members:
+   :show-inheritance:
+
+.. autoclass:: StorageGatewayDocument
+   :members:
+   :show-inheritance:
+
+.. autoclass:: UserCredentialDocument
+   :members:
+   :show-inheritance:
+
+Collections
+~~~~~~~~~~~
+
+.. autoclass:: CollectionDocument
+   :members:
+   :show-inheritance:
+
+.. autoclass:: MappedCollectionDocument
+   :members:
+   :show-inheritance:
+
+.. autoclass:: GuestCollectionDocument
+   :members:
+   :show-inheritance:
+
+Storage Gateway Policies
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: StorageGatewayPolicies
+   :members:
+   :show-inheritance:
+
+.. autoclass:: ActiveScaleStoragePolicies
+   :members:
+   :show-inheritance:
+
+.. autoclass:: AzureBlobStoragePolicies
+   :members:
+   :show-inheritance:
+
+.. autoclass:: BlackPearlStoragePolicies
+   :members:
+   :show-inheritance:
+
+.. autoclass:: BoxStoragePolicies
+   :members:
+   :show-inheritance:
+
+.. autoclass:: CephStoragePolicies
+   :members:
+   :show-inheritance:
+
+.. autoclass:: CollectionPolicies
+   :members:
+   :show-inheritance:
+
+.. autoclass:: GoogleCloudStorageCollectionPolicies
+   :members:
+   :show-inheritance:
+
+.. autoclass:: GoogleCloudStoragePolicies
+   :members:
+   :show-inheritance:
+
+.. autoclass:: GoogleDriveStoragePolicies
+   :members:
+   :show-inheritance:
+
+.. autoclass:: HPSSStoragePolicies
+   :members:
+   :show-inheritance:
+
+.. autoclass:: IrodsStoragePolicies
+   :members:
+   :show-inheritance:
+
+.. autoclass:: OneDriveStoragePolicies
+   :members:
+   :show-inheritance:
+
+.. autoclass:: POSIXCollectionPolicies
+   :members:
+   :show-inheritance:
+
+.. autoclass:: POSIXStagingCollectionPolicies
+   :members:
+   :show-inheritance:
+
+.. autoclass:: POSIXStagingStoragePolicies
+   :members:
+   :show-inheritance:
+
+.. autoclass:: POSIXStoragePolicies
+   :members:
+   :show-inheritance:
+
+.. autoclass:: S3StoragePolicies
    :members:
    :show-inheritance:
 
 Client Errors
 -------------
-
-.. currentmodule:: globus_sdk
 
 When an error occurs, a :class:`GCSClient` will raise this specialized type of
 error, rather than a generic :class:`GlobusAPIError`.
@@ -45,6 +145,10 @@ error, rather than a generic :class:`GlobusAPIError`.
 GCS Responses
 -------------
 
-.. automodule:: globus_sdk.services.gcs.response
+.. autoclass:: IterableGCSResponse
+   :members:
+   :show-inheritance:
+
+.. autoclass:: UnpackingGCSResponse
    :members:
    :show-inheritance:

--- a/docs/services/transfer.rst
+++ b/docs/services/transfer.rst
@@ -42,6 +42,10 @@ error, rather than a generic :class:`GlobusAPIError`.
 Transfer Responses
 ------------------
 
-.. automodule:: globus_sdk.services.transfer.response
+.. autoclass:: ActivationRequirementsResponse
+   :members:
+   :show-inheritance:
+
+.. autoclass:: IterableTransferResponse
    :members:
    :show-inheritance:

--- a/scripts/ensure_exports_are_documented.py
+++ b/scripts/ensure_exports_are_documented.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import glob
 import os
 import pathlib

--- a/scripts/ensure_exports_are_documented.py
+++ b/scripts/ensure_exports_are_documented.py
@@ -1,0 +1,65 @@
+import glob
+import os
+import pathlib
+import re
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).parent.parent
+
+_NAME_PAT = re.compile(r'\s+"(\w+)",?')
+
+
+_DOC_CACHE: dict[str, str] = {}
+
+
+def load_docs() -> dict[str, str]:
+    if _DOC_CACHE:
+        return _DOC_CACHE
+    for file in glob.glob("docs/**/*.rst", recursive=True):
+        with open(file) as f:
+            _DOC_CACHE[file] = f.read()
+    return _DOC_CACHE
+
+
+# TODO: is there a better way to test that a name is documented?
+# should we check that it appears in a class, autoclass, or similar directive?
+def is_documented(name: str) -> bool:
+    for data in load_docs().values():
+        if name in data:
+            return True
+    return False
+
+
+def get_names_from_all_list() -> list[str]:
+    with open("src/globus_sdk/__init__.py") as fp:
+        contents = fp.readlines()
+
+    names: list[str] = []
+    found_all = False
+    for line in contents:
+        if found_all:
+            if line.strip() == ")":
+                break
+            names.append(_NAME_PAT.match(line).group(1))
+        else:
+            if line.strip() == "__all__ = (":
+                found_all = True
+            else:
+                continue
+    return [n for n in names if not n.startswith("_")]
+
+
+def ensure_exports_are_documented() -> bool:
+    success = True
+    for name in get_names_from_all_list():
+        if not is_documented(name):
+            print(f"{name} is not documented")
+            success = False
+    return success
+
+
+if __name__ == "__main__":
+    os.chdir(REPO_ROOT)
+    if not ensure_exports_are_documented():
+        exit(1)
+    sys.exit(0)

--- a/src/globus_sdk/__init__.py
+++ b/src/globus_sdk/__init__.py
@@ -91,6 +91,8 @@ _LAZY_IMPORT_TABLE = {
         "IrodsStoragePolicies",
         "HPSSStoragePolicies",
         "UserCredentialDocument",
+        "IterableGCSResponse",
+        "UnpackingGCSResponse",
     },
     "services.flows": {
         "FlowsClient",
@@ -196,6 +198,8 @@ if t.TYPE_CHECKING:
     from .services.gcs import IrodsStoragePolicies
     from .services.gcs import HPSSStoragePolicies
     from .services.gcs import UserCredentialDocument
+    from .services.gcs import IterableGCSResponse
+    from .services.gcs import UnpackingGCSResponse
     from .services.flows import FlowsClient
     from .services.flows import FlowsAPIError
     from .services.flows import IterableFlowsResponse
@@ -311,6 +315,7 @@ __all__ = (
     "IdentityMap",
     "IrodsStoragePolicies",
     "IterableFlowsResponse",
+    "IterableGCSResponse",
     "IterableResponse",
     "IterableTransferResponse",
     "LocalGlobusConnectPersonal",
@@ -347,6 +352,7 @@ __all__ = (
     "TransferClient",
     "TransferData",
     "TransferTimer",
+    "UnpackingGCSResponse",
     "UserCredentialDocument",
 )
 

--- a/src/globus_sdk/_generate_init.py
+++ b/src/globus_sdk/_generate_init.py
@@ -157,6 +157,8 @@ _LAZY_IMPORT_TABLE: list[tuple[str, tuple[str, ...]]] = [
             "IrodsStoragePolicies",
             "HPSSStoragePolicies",
             "UserCredentialDocument",
+            "IterableGCSResponse",
+            "UnpackingGCSResponse",
         ),
     ),
     (

--- a/src/globus_sdk/exc/warnings.py
+++ b/src/globus_sdk/exc/warnings.py
@@ -4,7 +4,13 @@ import warnings
 
 
 class RemovedInV4Warning(DeprecationWarning):
-    pass
+    """
+    This warning indicates that a feature or usage was detected which will be
+    unsupported in globus-sdk version 4.
+
+    Users are encouraged to resolve these warnings when possible, so that they will be
+    able to upgrade to version 4 without issue.
+    """
 
 
 def warn_deprecated(message: str, stacklevel: int = 2) -> None:

--- a/src/globus_sdk/exc/warnings.py
+++ b/src/globus_sdk/exc/warnings.py
@@ -8,8 +8,7 @@ class RemovedInV4Warning(DeprecationWarning):
     This warning indicates that a feature or usage was detected which will be
     unsupported in globus-sdk version 4.
 
-    Users are encouraged to resolve these warnings when possible, so that they will be
-    able to upgrade to version 4 without issue.
+    Users are encouraged to resolve these warnings when possible.
     """
 
 


### PR DESCRIPTION
Originally, the focus of this work was on `automodule` directives which rendered using the source module name rather than `globus_sdk`.
To fix this, I switched from `automodule` to the component `autoclass` directives (which respect the `current_module` setting).
That presented an opportunity to cleanup the GCS docs a little bit.

Having done this, a problem became apparent: how do we know that everything in the SDK is documented?
How do we keep our docs in sync as new features (classes) are added?
For this, a quick-and-dirty lint check is added, which simply does substring checking of the public exports in `globus_sdk.__all__` against all of `docs/**/*.rst`.

Getting the linter to pass requires some further doc tweaks, and then it can be added to `pre-commit` with `always-run: true`.

---

- Replace automodule directives with autoclass
- Add script to check that exports are documented
- Add exported symbol checker to pre-commit


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--956.org.readthedocs.build/en/956/

<!-- readthedocs-preview globus-sdk-python end -->