### PR TITLE
Implement get_groups_by_subscription_id

### DIFF
--- a/changelog.d/20240223_173042_sirosen_add_get_group_by_subscription_id.rst
+++ b/changelog.d/20240223_173042_sirosen_add_get_group_by_subscription_id.rst
@@ -1,0 +1,6 @@
+Added
+~~~~~
+
+- Add ``GroupsClient.get_group_by_subscription_id`` for resolving subscriptions
+  to groups. This also expands the ``_testing`` data for ``get_group`` to
+  include a subscription group case. (:pr:`NUMBER`)

--- a/src/globus_sdk/_testing/data/groups/_common.py
+++ b/src/globus_sdk/_testing/data/groups/_common.py
@@ -1,8 +1,33 @@
 from __future__ import annotations
 
 import typing as t
+import uuid
 
-GROUP_ID = "d3974728-6458-11e4-b72d-123139141556"
+GROUP_ID = str(uuid.uuid1())
+USER_ID = str(uuid.uuid1())
+SUBSCRIPTION_ID = str(uuid.uuid1())
+SUBSCRIPTION_GROUP_ID = str(uuid.uuid1())
+SUBSCRIPTION_INFO = {
+    "name": "Golems R Us",
+    "subscriber_name": "University of Chicago Golem Lab",
+    "is_high_assurance": True,
+    "is_baa": False,
+    "connectors": {
+        "052be037-7dda-4d20-b163-3077314dc3e6": {"is_ha": True, "is_baa": False},
+        "1b6374b0-f6a4-4cf7-a26f-f262d9c6ca72": {"is_ha": True, "is_baa": False},
+        "28ef55da-1f97-11eb-bdfd-12704e0d6a4d": {"is_ha": True, "is_baa": False},
+        "49b00fd6-63f1-48ae-b27f-d8af4589f876": {"is_ha": True, "is_baa": False},
+        "56366b96-ac98-11e9-abac-9cb6d0d9fd63": {"is_ha": True, "is_baa": False},
+        "7251f6c8-93c9-11eb-95ba-12704e0d6a4d": {"is_ha": True, "is_baa": False},
+        "7643e831-5f6c-4b47-a07f-8ee90f401d23": {"is_ha": True, "is_baa": False},
+        "7c100eae-40fe-11e9-95a3-9cb6d0d9fd63": {"is_ha": True, "is_baa": False},
+        "7e3f3f5e-350c-4717-891a-2f451c24b0d4": {"is_ha": True, "is_baa": False},
+        "9436da0c-a444-11eb-af93-12704e0d6a4d": {"is_ha": True, "is_baa": False},
+        "976cf0cf-78c3-4aab-82d2-7c16adbcc281": {"is_ha": True, "is_baa": False},
+        "e47b6920-ff57-11ea-8aaa-000c297ab3c2": {"is_ha": True, "is_baa": False},
+        "fb656a17-0f69-4e59-95ff-d0a62ca7bdf5": {"is_ha": True, "is_baa": False},
+    },
+}
 
 BASE_GROUP_DOC: dict[str, t.Any] = {
     "name": "Claptrap's Rough Riders",
@@ -16,8 +41,8 @@ BASE_GROUP_DOC: dict[str, t.Any] = {
     "my_memberships": [
         {
             "group_id": GROUP_ID,
-            "identity_id": "ae332d86-d274-11e5-b885-b31714a110e9",
-            "username": "sirosen@globusid.org",
+            "identity_id": USER_ID,
+            "username": "claptrap@globus.org",
             "role": "member",
             "status": "active",
         }
@@ -26,4 +51,32 @@ BASE_GROUP_DOC: dict[str, t.Any] = {
         "group_visibility": "private",
         "group_members_visibility": "managers",
     },
+    "subscription_id": None,
+    "subscription_info": None,
+}
+
+SUBSCRIPTION_GROUP_DOC: dict[str, t.Any] = {
+    "name": "University of Chicago, Department of Magical Automata",
+    "description": "The finest in machines that go 'ping!' and 'whomp!' and 'bzzt!'",
+    "parent_id": None,
+    "id": SUBSCRIPTION_GROUP_ID,
+    "group_type": "plus",
+    "enforce_session": True,
+    "session_limit": 1800,
+    "session_timeouts": {},
+    "my_memberships": [
+        {
+            "group_id": SUBSCRIPTION_GROUP_ID,
+            "identity_id": USER_ID,
+            "username": "claptrap@globus.org",
+            "role": "member",
+            "status": "active",
+        }
+    ],
+    "policies": {
+        "group_visibility": "private",
+        "group_members_visibility": "managers",
+    },
+    "subscription_id": SUBSCRIPTION_ID,
+    "subscription_info": SUBSCRIPTION_INFO,
 }

--- a/src/globus_sdk/_testing/data/groups/get_group.py
+++ b/src/globus_sdk/_testing/data/groups/get_group.py
@@ -1,6 +1,12 @@
 from globus_sdk._testing.models import RegisteredResponse, ResponseSet
 
-from ._common import BASE_GROUP_DOC, GROUP_ID
+from ._common import (
+    BASE_GROUP_DOC,
+    GROUP_ID,
+    SUBSCRIPTION_GROUP_DOC,
+    SUBSCRIPTION_GROUP_ID,
+    SUBSCRIPTION_ID,
+)
 
 RESPONSES = ResponseSet(
     metadata={"group_id": GROUP_ID},
@@ -8,5 +14,14 @@ RESPONSES = ResponseSet(
         service="groups",
         path=f"/groups/{GROUP_ID}",
         json=BASE_GROUP_DOC,
+    ),
+    subscription=RegisteredResponse(
+        service="groups",
+        path=f"/groups/{SUBSCRIPTION_GROUP_ID}",
+        json=SUBSCRIPTION_GROUP_DOC,
+        metadata={
+            "group_id": SUBSCRIPTION_GROUP_ID,
+            "subscription_id": SUBSCRIPTION_ID,
+        },
     ),
 )

--- a/src/globus_sdk/_testing/data/groups/get_group_by_subscription_id.py
+++ b/src/globus_sdk/_testing/data/groups/get_group_by_subscription_id.py
@@ -1,0 +1,21 @@
+from globus_sdk._testing.models import RegisteredResponse, ResponseSet
+
+from ._common import SUBSCRIPTION_GROUP_ID, SUBSCRIPTION_ID, SUBSCRIPTION_INFO
+
+RESPONSES = ResponseSet(
+    metadata={"group_id": SUBSCRIPTION_GROUP_ID, "subscription_id": SUBSCRIPTION_ID},
+    default=RegisteredResponse(
+        service="groups",
+        path=f"/subscription_info/{SUBSCRIPTION_ID}",
+        json={
+            "group_id": SUBSCRIPTION_GROUP_ID,
+            "subscription_id": SUBSCRIPTION_ID,
+            # this API returns restricted subscription_info
+            "subscription_info": {
+                k: v
+                for k, v in SUBSCRIPTION_INFO.items()
+                if k in ("is_high_assurance", "is_baa", "connectors")
+            },
+        },
+    ),
+)

--- a/src/globus_sdk/services/groups/client.py
+++ b/src/globus_sdk/services/groups/client.py
@@ -81,6 +81,39 @@ class GroupsClient(client.BaseClient):
             query_params["include"] = ",".join(utils.safe_strseq_iter(include))
         return self.get(f"/groups/{group_id}", query_params=query_params)
 
+    def get_group_by_subscription_id(
+        self, subscription_id: UUIDLike
+    ) -> response.GlobusHTTPResponse:
+        """
+        Using a subscription ID, find the group which provides that subscription.
+
+        :param subscription_id: the subscription ID of the group
+
+        .. tab-set::
+
+            .. tab-item:: Example Usage
+
+                .. code-block:: python
+
+                    from globus_sdk import GroupsClient
+
+                    groups = GroupsClient(...)
+                    group_id = groups.get_group_by_subscription_id(subscription_id)["group_id"]
+
+            .. tab-item:: Example Response Data
+
+                .. expandtestfixture:: groups.get_group_by_subscription_id
+
+            .. tab-item:: API Info
+
+                ``GET /v2/subscription_info/<subscription_id>``
+
+                .. extdoclink:: Get Group by Subscription ID
+                    :service: groups
+                    :ref: get_group_by_subscription_id_v2_subscription_info__subscription_id__get
+        """  # noqa: E501
+        return self.get(f"/subscription_info/{subscription_id}")
+
     def delete_group(
         self,
         group_id: UUIDLike,

--- a/tests/functional/services/groups/test_get_group_by_subscription_id.py
+++ b/tests/functional/services/groups/test_get_group_by_subscription_id.py
@@ -1,0 +1,27 @@
+from globus_sdk._testing import load_response
+
+
+def test_get_group_by_subscription_id(groups_client):
+    meta = load_response(groups_client.get_group_by_subscription_id).metadata
+
+    res = groups_client.get_group_by_subscription_id(meta["subscription_id"])
+    assert res.http_status == 200
+    assert res["group_id"] == meta["group_id"]
+    assert "description" not in res
+    assert "name" not in res
+
+
+def test_two_step_get_group_by_subscription_id(groups_client):
+    meta = load_response(groups_client.get_group_by_subscription_id).metadata
+    load_response(groups_client.get_group, case="subscription").metadata
+
+    res = groups_client.get_group_by_subscription_id(meta["subscription_id"])
+    assert res.http_status == 200
+    assert res["group_id"] == meta["group_id"]
+    assert "description" not in res
+    assert "name" not in res
+
+    res2 = groups_client.get_group(meta["group_id"])
+    assert res2.http_status == 200
+    assert res2["id"] == meta["group_id"]
+    assert "name" in res2


### PR DESCRIPTION
This is a Groups API method for getting a group by subscription ID.
No parameters are supported at this time.

As reflected in the example data, the response contains stripped down
group info and stripped down subscription_info.


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--957.org.readthedocs.build/en/957/

<!-- readthedocs-preview globus-sdk-python end -->