### PR TITLE
add additional _testing cases for stat

### DIFF
--- a/src/globus_sdk/_testing/data/transfer/operation_stat.py
+++ b/src/globus_sdk/_testing/data/transfer/operation_stat.py
@@ -24,4 +24,28 @@ RESPONSES = ResponseSet(
             "user": "tutorial",
         },
     ),
+    not_found=RegisteredResponse(
+        service="transfer",
+        method="GET",
+        path=f"/operation/endpoint/{ENDPOINT_ID}/stat",
+        status=404,
+        json={
+            "code": "NotFound",
+            "message": f"Path not found, Error (list)\nEndpoint: Globus Tutorial Collection 1 ({ENDPOINT_ID})\nServer: 100.26.231.26:443\nMessage: No such file or directory\n---\nDetails: Error: '~/foo' not found\\r\\n550-GlobusError: v=1 c=PATH_NOT_FOUND\\r\\n550-GridFTP-Errno: 2\\r\\n550-GridFTP-Reason: System error in stat\\r\\n550-GridFTP-Error-String: No such file or directory\\r\\n550 End.\\r\\n\n",  # noqa 501
+            "request_id": "aaabbbccc",
+            "resource": f"/operation/endpoint/{ENDPOINT_ID}/stat",
+        },
+    ),
+    permission_denied=RegisteredResponse(
+        service="transfer",
+        method="GET",
+        path=f"/operation/endpoint/{ENDPOINT_ID}/stat",
+        status=403,
+        json={
+            "code": "EndpointPermissionDenied",
+            "message": f"Denied by endpoint, Error (list)\nEndpoint: Globus Tutorial Collection 1 ({ENDPOINT_ID})\nServer: 100.26.231.26:443\nCommand: MLST /foo\nMessage: Fatal FTP Response\n---\nDetails: 500 Command failed : Path not allowed.\\r\\n\n",  # noqa 501
+            "request_id": "aaabbbccc",
+            "resource": f"/operation/endpoint/{ENDPOINT_ID}/stat",
+        },
+    ),
 )


### PR DESCRIPTION
Mostly for https://github.com/globus/globus-cli/pull/963, but since at least one other service (TransferAP) will have special cases around NotFound errors, these seemed like good things to have generally available in the SDK rather than just the CLI

<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--962.org.readthedocs.build/en/962/

<!-- readthedocs-preview globus-sdk-python end -->