### PR TITLE
Implement tokenstorage.MemoryAdapter

### DIFF
--- a/changelog.d/20240318_160407_sirosen_add_memory_tokenstorage.rst
+++ b/changelog.d/20240318_160407_sirosen_add_memory_tokenstorage.rst
@@ -1,0 +1,5 @@
+Added
+~~~~~
+
+- Add ``globus_sdk.tokenstorage.MemoryAdapter`` for the simplest possible
+  in-memory token storage mechanism. (:pr:`NUMBER`)

--- a/docs/tokenstorage.rst
+++ b/docs/tokenstorage.rst
@@ -83,12 +83,16 @@ Adapter Types
 .. module:: globus_sdk.tokenstorage
 
 ``globus_sdk.tokenstorage`` provides base classes for building your own storage
-adapters, and two complete adapters.
+adapters, and several complete adapters.
 
-The :class:`SimpleJSONFileAdapter` is good for the "simplest possible" storage, using a
-JSON file to store token data.
+The :class:`SimpleJSONFileAdapter` is good for the "simplest possible"
+persistent storage, using a JSON file to store token data.
 
-The :class:`SQLiteAdapter` is the next step up in complexity, for applications like the
+:class:`MemoryAdapter` is even simpler still, and is great for writing and
+testing code which uses the `StorageAdapter` interface backed by an in-memory
+structure.
+
+The :class:`SQLiteAdapter` is more complex, for applications like the
 globus-cli which need to store various tokens and additional configuration. In
 addition to basic token storage, the :class:`SQLiteAdapter` provides for namespacing
 of the token data, and for additional configuration storage.
@@ -97,6 +101,11 @@ Reference
 ---------
 
 .. autoclass:: StorageAdapter
+   :members:
+   :member-order: bysource
+   :show-inheritance:
+
+.. autoclass:: MemoryAdapter
    :members:
    :member-order: bysource
    :show-inheritance:

--- a/src/globus_sdk/tokenstorage/__init__.py
+++ b/src/globus_sdk/tokenstorage/__init__.py
@@ -1,5 +1,12 @@
 from globus_sdk.tokenstorage.base import FileAdapter, StorageAdapter
 from globus_sdk.tokenstorage.file_adapters import SimpleJSONFileAdapter
+from globus_sdk.tokenstorage.memory_adapter import MemoryAdapter
 from globus_sdk.tokenstorage.sqlite_adapter import SQLiteAdapter
 
-__all__ = ("SimpleJSONFileAdapter", "SQLiteAdapter", "StorageAdapter", "FileAdapter")
+__all__ = (
+    "SimpleJSONFileAdapter",
+    "SQLiteAdapter",
+    "StorageAdapter",
+    "FileAdapter",
+    "MemoryAdapter",
+)

--- a/src/globus_sdk/tokenstorage/memory_adapter.py
+++ b/src/globus_sdk/tokenstorage/memory_adapter.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import typing as t
+
+from globus_sdk.services.auth import OAuthTokenResponse
+from globus_sdk.tokenstorage.base import StorageAdapter
+
+
+class MemoryAdapter(StorageAdapter):
+    """
+    A token storage adapter which stores tokens in process memory.
+
+    Tokens are lost when the process exits.
+    """
+
+    def __init__(self) -> None:
+        self._tokens: dict[str, dict[str, t.Any]] = {}
+
+    def store(self, token_response: OAuthTokenResponse) -> None:
+        self._tokens.update(token_response.by_resource_server)
+
+    def get_token_data(self, resource_server: str) -> dict[str, t.Any] | None:
+        return self._tokens.get(resource_server)

--- a/tests/unit/test_tokenstorage.py
+++ b/tests/unit/test_tokenstorage.py
@@ -1,8 +1,10 @@
 import json
+import time
+from unittest import mock
 
 import pytest
 
-from globus_sdk.tokenstorage import SimpleJSONFileAdapter, SQLiteAdapter
+from globus_sdk.tokenstorage import MemoryAdapter, SimpleJSONFileAdapter, SQLiteAdapter
 from globus_sdk.version import __version__ as sdkversion
 
 
@@ -74,3 +76,57 @@ def test_simplejson_reading_unsupported_format_version(tmp_path):
 
     with pytest.raises(ValueError, match="existing data file is in an unknown format"):
         adapter.get_by_resource_server()
+
+
+def test_memory_adapter_store_overwrites_only_new_data():
+    # setup a mock token response
+    expiration_time = int(time.time()) + 3600
+    mock_response = mock.Mock()
+    mock_response.by_resource_server = {
+        "resource_server_1": {
+            "access_token": "access_token_1",
+            "expires_at_seconds": expiration_time,
+            "refresh_token": "refresh_token_1",
+            "resource_server": "resource_server_1",
+            "scope": "scope1",
+            "token_type": "bearer",
+        },
+        "resource_server_2": {
+            "access_token": "access_token_2",
+            "expires_in": expiration_time,
+            "refresh_token": "refresh_token_2",
+            "resource_server": "resource_server_2",
+            "scope": "scope2 scope2:0 scope2:1",
+            "token_type": "bearer",
+        },
+    }
+
+    # "store" it in memory
+    adapter = MemoryAdapter()
+    adapter.store(mock_response)
+
+    # read back a sample piece of data
+    fetch1 = adapter.get_token_data("resource_server_1")
+    assert fetch1["access_token"] == "access_token_1"
+
+    # "store" a new mock response which overwrites only one piece of data
+    mock_response2 = mock.Mock()
+    mock_response2.by_resource_server = {
+        "resource_server_1": {
+            "access_token": "access_token_1_new",
+            "expires_at_seconds": expiration_time,
+            "refresh_token": "refresh_token_1",
+            "resource_server": "resource_server_1",
+            "scope": "scope1",
+            "token_type": "bearer",
+        }
+    }
+    adapter.store(mock_response2)
+
+    # the overwritten data is updated
+    fetch2 = adapter.get_token_data("resource_server_1")
+    assert fetch2["access_token"] == "access_token_1_new"
+
+    # but the existing data is preserved
+    fetch3 = adapter.get_token_data("resource_server_2")
+    assert fetch3["access_token"] == "access_token_2"


### PR DESCRIPTION
This is a borderline-trivial implementation, which stores token
response data in an in-memory dict.

It provides a mechanism to conform a dict (actual storage) to the
required interface (`StorageAdapter`).


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--964.org.readthedocs.build/en/964/

<!-- readthedocs-preview globus-sdk-python end -->