### PR TITLE
Update pre-commit hook URLs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
     - id: flake8
       name: "Lint python files"
       additional_dependencies:
-        - 'flake8-bugbear==23.9.16'
+        - 'flake8-bugbear==24.2.6'
         - 'flake8-comprehensions==3.14.0'
         - 'flake8-typing-as-t==0.0.3'
 - repo: https://github.com/PyCQA/isort

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ ci:
   autoupdate_schedule: "monthly"
 
 repos:
-- repo: https://github.com/pre-commit/pre-commit-hooks.git
+- repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.5.0
   hooks:
     - id: check-merge-conflict
@@ -17,12 +17,12 @@ repos:
   hooks:
     - id: pyupgrade
       args: ["--py37-plus"]
-- repo: https://github.com/psf/black
+- repo: https://github.com/psf/black-pre-commit-mirror
   rev: 24.3.0
   hooks:
     - id: black
       name: "Autoformat python files"
-- repo: https://github.com/asottile/blacken-docs
+- repo: https://github.com/adamchainz/blacken-docs
   rev: 1.16.0
   hooks:
     - id: blacken-docs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 ci:
-  autoupdate_schedule: "monthly"
+  autoupdate_schedule: "quarterly"
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
* Update hook URLs that redirect (`asottile/blacken-docs` -> `adamchainz/blacken-docs`)
* Use preferred URLs (2x faster compiled black hook URL)
* Run `upadup`
* Change the pre-commit auto-update schedule to 'quarterly'

<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--970.org.readthedocs.build/en/970/

<!-- readthedocs-preview globus-sdk-python end -->