### PR TITLE
Fix a test suite concurrency problem

### DIFF
--- a/changelog.d/20240405_154552_kurtmckee_prevent_isorted_files_causing_test_failures.rst
+++ b/changelog.d/20240405_154552_kurtmckee_prevent_isorted_files_causing_test_failures.rst
@@ -1,0 +1,5 @@
+Development
+~~~~~~~~~~~
+
+- Fix concurrency problems in the test suite
+  caused by isort's `.isorted` temporary files. (:pr:`NUMBER`)

--- a/tox.ini
+++ b/tox.ini
@@ -24,8 +24,8 @@ deps =
     mindeps: -r requirements/py{py_dot_ver}/test-mindeps.txt
 commands = coverage run -m pytest {posargs}
 depends =
-    py{37,38,39,310,311,37-mindeps}: coverage_clean
-    coverage_report: py{37,38,39,310,311,37-mindeps}
+    py{312,311,310,39,38,37}{-mindeps,}: coverage_clean, lint
+    coverage_report: py{312,311,310,39,38,37}{-mindeps,}
 
 [testenv:coverage_clean]
 deps = coverage


### PR DESCRIPTION
TIL isort writes `.isorted` files...and that when those are written to the test directory while running tox environments in parallel, pytest's test finder can experience a race condition where it can list a `.isorted` temporary file but then cannot read it. Neat!

[relevant isort code](https://github.com/PyCQA/isort/blob/7de182933fd50e04a7c47cc8be75a6547754b19c/isort/api.py#L349-L350)
```python
def _tmp_file(source_file: File) -> Path:
    return source_file.path.with_suffix(source_file.path.suffix + ".isorted")
```

This PR:

* Fixes a missing `py312` environment dependency, likely overlooked due to inconsistent sorting of the `py{37,38,...}` vs `py{312,311,...}` sorting of tox environment dependencies.
* Add `lint` as a dependency for running `py{XY}` environments.