### PR TITLE
Allow updating subscriptions assigned to flows

### DIFF
--- a/changelog.d/20240405_160918_kurtmckee_update_flow_subscription_ids_sc_30163.rst
+++ b/changelog.d/20240405_160918_kurtmckee_update_flow_subscription_ids_sc_30163.rst
@@ -1,0 +1,4 @@
+Added
+~~~~~
+
+- Support updating subscriptions assigned to flows in the Flows service. (:pr:`NUMBER`)

--- a/src/globus_sdk/_testing/data/flows/update_flow.py
+++ b/src/globus_sdk/_testing/data/flows/update_flow.py
@@ -7,6 +7,7 @@ from ._common import TWO_HOP_TRANSFER_FLOW_DOC, TWO_HOP_TRANSFER_FLOW_ID
 _two_hop_transfer_update_request = {
     "subtitle": "Specifically, in two steps",
     "description": "Transfer from source to destination, stopping off at staging",
+    "subscription_id": "00000000-3ba7-456e-9df7-fc40028f3331",
 }
 
 

--- a/src/globus_sdk/services/flows/client.py
+++ b/src/globus_sdk/services/flows/client.py
@@ -7,6 +7,7 @@ from globus_sdk import GlobusHTTPResponse, client, paging, scopes, utils
 from globus_sdk._types import UUIDLike
 from globus_sdk.authorizers import GlobusAuthorizer
 from globus_sdk.scopes import ScopeBuilder
+from globus_sdk.utils import MISSING, MissingType
 
 from .errors import FlowsAPIError
 from .response import (
@@ -324,7 +325,7 @@ class FlowsClient(client.BaseClient):
         flow_starters: list[str] | None = None,
         flow_administrators: list[str] | None = None,
         keywords: list[str] | None = None,
-        subscription_id: UUIDLike | t.Literal["DEFAULT"] | None = None,
+        subscription_id: UUIDLike | t.Literal["DEFAULT"] | MissingType = MISSING,
         additional_fields: dict[str, t.Any] | None = None,
     ) -> GlobusHTTPResponse:
         """
@@ -437,7 +438,7 @@ class FlowsClient(client.BaseClient):
                 "keywords": keywords,
                 "subscription_id": subscription_id,
             }.items()
-            if v is not None
+            if v is not None and v is not MISSING
         }
         data.update(additional_fields or {})
 

--- a/src/globus_sdk/services/flows/client.py
+++ b/src/globus_sdk/services/flows/client.py
@@ -324,6 +324,7 @@ class FlowsClient(client.BaseClient):
         flow_starters: list[str] | None = None,
         flow_administrators: list[str] | None = None,
         keywords: list[str] | None = None,
+        subscription_id: UUIDLike | t.Literal["DEFAULT"] | None = None,
         additional_fields: dict[str, t.Any] | None = None,
     ) -> GlobusHTTPResponse:
         """
@@ -393,6 +394,7 @@ class FlowsClient(client.BaseClient):
 
         :param keywords: A set of terms used to categorize the flow used in query and
             discovery operations (0 - 1024 items)
+        :param subscription_id: A subscription ID to assign to the flow.
         :param additional_fields: Additional Key/Value pairs sent to the create API
 
         .. tab-set::
@@ -433,6 +435,7 @@ class FlowsClient(client.BaseClient):
                 "flow_starters": flow_starters,
                 "flow_administrators": flow_administrators,
                 "keywords": keywords,
+                "subscription_id": subscription_id,
             }.items()
             if v is not None
         }


### PR DESCRIPTION
Added
-----

* Support updating subscriptions assigned to flows in the Flows service.


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--974.org.readthedocs.build/en/974/

<!-- readthedocs-preview globus-sdk-python end -->