### PR TITLE
Ensure that normalization handles Scope objects

### DIFF
--- a/src/globus_sdk/_types.py
+++ b/src/globus_sdk/_types.py
@@ -5,7 +5,7 @@ import sys
 import typing as t
 import uuid
 
-from globus_sdk.scopes import MutableScope
+from globus_sdk.scopes import MutableScope, Scope
 
 if sys.version_info < (3, 8):
     from typing_extensions import Protocol
@@ -21,7 +21,8 @@ DateLike = t.Union[str, datetime.datetime]
 ScopeCollectionType = t.Union[
     str,
     MutableScope,
-    t.Iterable[t.Union[str, MutableScope]],
+    Scope,
+    t.Iterable[t.Union[str, MutableScope, Scope]],
 ]
 
 

--- a/src/globus_sdk/authorizers/client_credentials.py
+++ b/src/globus_sdk/authorizers/client_credentials.py
@@ -4,7 +4,7 @@ import logging
 import typing as t
 
 from globus_sdk._types import ScopeCollectionType
-from globus_sdk.scopes import MutableScope
+from globus_sdk.scopes import scopes_to_str
 
 from .renewing import RenewingAuthorizer
 
@@ -66,7 +66,7 @@ class ClientCredentialsAuthorizer(RenewingAuthorizer):
     ):
         # values for _get_token_data
         self.confidential_client = confidential_client
-        self.scopes = MutableScope.scopes2str(scopes)
+        self.scopes = scopes_to_str(scopes)
 
         log.info(
             "Setting up ClientCredentialsAuthorizer with confidential_client="

--- a/src/globus_sdk/scopes/__init__.py
+++ b/src/globus_sdk/scopes/__init__.py
@@ -1,3 +1,4 @@
+from ._normalize import scopes_to_str
 from .builder import ScopeBuilder
 from .data import (
     AuthScopes,
@@ -29,4 +30,5 @@ __all__ = (
     "SearchScopes",
     "TimerScopes",
     "TransferScopes",
+    "scopes_to_str",
 )

--- a/src/globus_sdk/scopes/_normalize.py
+++ b/src/globus_sdk/scopes/_normalize.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import typing as t
+
+from .representation import Scope
+from .scope_definition import MutableScope
+
+if t.TYPE_CHECKING:
+    from globus_sdk._types import ScopeCollectionType
+
+
+def scopes_to_str(scopes: ScopeCollectionType) -> str:
+    """
+    Convert a scope collection to a space-separated string.
+
+    :param scopes: A scope string or object, or an iterable of scope strings or objects.
+    """
+    return " ".join(_iter_scope_collection(scopes))
+
+
+def _iter_scope_collection(obj: ScopeCollectionType) -> t.Iterator[str]:
+    if isinstance(obj, str):
+        yield obj
+    elif isinstance(obj, (MutableScope, Scope)):
+        yield str(obj)
+    else:
+        for item in obj:
+            yield str(item)

--- a/src/globus_sdk/scopes/scope_definition.py
+++ b/src/globus_sdk/scopes/scope_definition.py
@@ -16,16 +16,6 @@ if t.TYPE_CHECKING:
     from globus_sdk._types import ScopeCollectionType
 
 
-def _iter_scope_collection(obj: ScopeCollectionType) -> t.Iterator[str]:
-    if isinstance(obj, str):
-        yield obj
-    elif isinstance(obj, MutableScope):
-        yield str(obj)
-    else:
-        for item in obj:
-            yield str(item)
-
-
 class MutableScope:
     """
     A scope object is a representation of a scope which allows modifications to be
@@ -114,10 +104,16 @@ class MutableScope:
     @staticmethod
     def scopes2str(obj: ScopeCollectionType) -> str:
         """
+        .. warning::
+
+            Deprecated. Prefer ``globus_sdk.scopes.scopes_to_str``.
+
         Given a scope string, a collection of scope strings, a MutableScope object, a
         collection of MutableScope objects, or a mixed collection of strings and
         Scopes, convert to a string which can be used in a request.
 
         :param obj: The object or collection to convert to a string
         """
-        return " ".join(_iter_scope_collection(obj))
+        from ._normalize import scopes_to_str
+
+        return scopes_to_str(obj)

--- a/src/globus_sdk/services/auth/_common.py
+++ b/src/globus_sdk/services/auth/_common.py
@@ -12,7 +12,7 @@ from globus_sdk._types import ScopeCollectionType
 from globus_sdk.exc import GlobusSDKUsageError
 from globus_sdk.exc.warnings import warn_deprecated
 from globus_sdk.response import GlobusHTTPResponse
-from globus_sdk.scopes import AuthScopes, MutableScope, TransferScopes
+from globus_sdk.scopes import AuthScopes, TransferScopes, scopes_to_str
 
 if sys.version_info >= (3, 8):
     from typing import Literal, Protocol, runtime_checkable
@@ -39,7 +39,7 @@ def stringify_requested_scopes(requested_scopes: ScopeCollectionType | None) -> 
         )
         requested_scopes = _DEFAULT_REQUESTED_SCOPES
 
-    requested_scopes_string: str = MutableScope.scopes2str(requested_scopes)
+    requested_scopes_string: str = scopes_to_str(requested_scopes)
     if requested_scopes_string == "":
         raise GlobusSDKUsageError(
             "requested_scopes cannot be the empty string or empty collection"

--- a/tests/non-pytest/mypy-ignore-tests/scope_collection_type.py
+++ b/tests/non-pytest/mypy-ignore-tests/scope_collection_type.py
@@ -1,6 +1,6 @@
 import globus_sdk
 from globus_sdk._types import ScopeCollectionType
-from globus_sdk.scopes import MutableScope
+from globus_sdk.scopes import MutableScope, scopes_to_str
 from globus_sdk.services.auth import (
     GlobusAuthorizationCodeFlowManager,
     GlobusNativeAppFlowManager,
@@ -21,9 +21,13 @@ cc_client = globus_sdk.ConfidentialAppAuthClient(
 )
 
 
-# this function should type-check okay
+# these functions should type-check okay
 def foo(x: ScopeCollectionType) -> str:
     return MutableScope.scopes2str(x)
+
+
+def foo2(x: ScopeCollectionType) -> str:
+    return scopes_to_str(x)
 
 
 foo("somestring")

--- a/tests/unit/scopes/test_scope_normalization.py
+++ b/tests/unit/scopes/test_scope_normalization.py
@@ -1,0 +1,37 @@
+import pytest
+
+from globus_sdk.scopes import MutableScope, Scope, scopes_to_str
+
+
+def test_scopes_to_str_roundtrip_simple_str():
+    assert scopes_to_str("scope1") == "scope1"
+
+
+def test_scopes_to_str_stringifies_single_scope():
+    assert scopes_to_str(Scope("scope1")) == "scope1"
+
+
+@pytest.mark.parametrize(
+    "scope_collection",
+    (
+        ("scope1",),
+        ["scope1"],
+        {"scope1"},
+        (s for s in ["scope1"]),
+    ),
+)
+def test_scopes_to_str_roundtrip_simple_str_in_collection(scope_collection):
+    assert scopes_to_str(scope_collection) == "scope1"
+
+
+@pytest.mark.parametrize(
+    "scope_collection, expect_str",
+    (
+        (("scope1", Scope("scope2")), "scope1 scope2"),
+        (("scope1", MutableScope("scope2")), "scope1 scope2"),
+        ((Scope("scope1"), MutableScope("scope2")), "scope1 scope2"),
+        ((Scope("scope1"), MutableScope("scope2"), "scope3"), "scope1 scope2 scope3"),
+    ),
+)
+def test_scopes_to_str_handles_mixed_data(scope_collection, expect_str):
+    assert scopes_to_str(scope_collection) == expect_str


### PR DESCRIPTION
1. Move MutableScope.scopes2str to `globus_sdk.scopes.scopes_to_str`, which "detaches" this functionality from the legacy class
2. Update `scopes_to_str` to handle Scope objects
3. Update all uses of `scopes2str` to use `scopes_to_str` instead
4. Add some unit tests for scopes_to_str

<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--975.org.readthedocs.build/en/975/

<!-- readthedocs-preview globus-sdk-python end -->