### PR TITLE
LocalServerLoginFlowManager

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include src/globus_sdk/experimental/html_files/*

--- a/changelog.d/20240415_145157_aaschaer_local_server_login_flow_manager.rst
+++ b/changelog.d/20240415_145157_aaschaer_local_server_login_flow_manager.rst
@@ -1,0 +1,4 @@
+Added
+~~~~~
+
+- Added ``LocalServerLoginFlowManager`` to experimental (:pr:`NUMBER`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,8 @@ dependencies = [
     # depend on the latest version of typing-extensions on python versions which do
     # not have all of the typing features we use
     'typing_extensions>=4.0; python_version<"3.10"',
+    # python versions older than 3.9 don't have importlib.resources
+    'importlib_resources>=5.12.0; python_version<"3.9"',
 ]
 dynamic = ["version"]
 

--- a/src/globus_sdk/experimental/html_files/local_server_landing_page.html
+++ b/src/globus_sdk/experimental/html_files/local_server_landing_page.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en-US">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="x-ua-compatible" content="ie=edge">
+  <title>Globus Login</title>
+  <style type="text/css" media="screen">
+    html { font: 75% "Helvetica Neue","Arial","Helvetica",sans-serif }
+    html, body { display: block; margin: 0; padding: 0 }
+    a { color: #5783a6; text-decoration: none; }
+    a img { border: none; }
+    header { background: #2e5793; }
+    main { padding: 25px 0 50px; }
+    main h1 { border-bottom: solid 1px #aaa; font-size: 233.33%;
+              font-weight: normal; }
+    main img { display: block; margin: 0 auto; max-width: 100%; height: auto; }
+    main p { color: #333; font-size: 116.67%; max-width: 560px;
+             margin: 1em auto; line-height: 150%; }
+    header > div, main, footer { display: block; max-width: 980px;
+                                 margin: 0 auto; }
+  </style>
+</head>
+<body>
+  <header><div><a href="https://www.globus.org" title="Go to Globus.org Home">
+    <img alt="Globus" width="215" height="64"
+         src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAANcAAABACAQAAAAjFyrFAAAPM0lEQVR42u2caXhTx7nH/5IlWRuy5QXvGLCN5Q0L2RCWQIB7SW6229InJHAJJG0ohJaQtA1NaC5cSiE3TcIS2pQEAiW0hSwWW0IgvcQhLAWSFBLAxqEJBq8xlrGEbMvS0Tnv/SDJ0pF1hGxEn7o9837xM885M2fmN/POu4wMgigDR8QpEHGJIuISRcQl4hJFxCWKiGtg4gouvAekzGTmeXclV08uInKxV5nTnZvbH30vCdJ+dylQRBg3hyueWc41UsjCOTorqsdCBomI6x8Bl5RdxFkpfOGum/fm9h2ZiCvKuDrTuUqKqLitVQ9D2TdgIq6o4nIWcleoD6V2BTR9OclEXFHE1Z3HNVMfy9e/gjZyYCKuqOEiLVdDfS/sscegiVQliriihovdTv0qjPXZUVCKuP6uuJip4aFY/1a95/NtX+2+Vk1E5LJ1tnR96xHimvYjGTIR198RF3dKGFVH468XYxxKs4rvHgXDH3/Q3br/fzEeZRj1u0c+W8e6iGvc2bqy7YEvMm50iom4ooKLmRAGVsO/fRfGkuHXt5OLyHXl1LwNd1b+BDlIrvt+8LPOU1d/PCeMrSjiigou92Zhh3jVIhiR0v27ngp25/T0LMRD7jaHesF1ufq7UIQ2PkRcUcHF1QnRajiBscj8fAgx/jrLcWRCBSlzVAhx08uh/TERVxRwObKFVeGO5SiCjvkpjwYz1gQtQRAXEV3ZgEG9gYm4ooCLuVN42sf9B4ZA4d7Fr103B4mQhMNF9HEIf6wvuCJ9jttEBC3k/ZgCcm2FBjFRnNJbuBT9u+sxoSl3WDAGyZCy1fz6t5YgFTHhcTmaS4Yj9tbjYrYQIQ+6/uCyvoWhUA0wXN1PCXpb38AEPYFr59fvW45MyMPjIjr+P78d4XjE+ZLrD84tncuap8xQQHKLcJmQ2B9cFjMKoRlguDp/EAZXKeIInI1ff3A1hkBxI1zuDmJ5NuOlph8iFlIR103huj5daMI7m7242vj1u5Yj+8a4QhXb/idTECPiuglczUWCThdrHI94AnOOX//yfGTxcVmqdq54Zu6iGZt/XPUHZ1s4YNdPTE6FTMTVb1yTZcHKzl/+tAhJkDq28YLwTNFUpEEWiOvtlSjDMKQhFZljShv2hQNW9yb0/B0m4uoDLki6BKe37gCyoGi+l+c6n0Q535Dn2DvvwzBoIEMM5FAjuXVvuKsDW++DJtDsEB46k+N+kTtNROT+wvn7ptshZzfzDffQuNzT2AquloiIvczsbr0/ZJzFi4tbwH7EtRNx7czh9rmIDfQXw7gJvdyAnnZqmcP2xb5TOvq48O0swZllnr8Hg6DoOuzfW8/NRwG0BOdBX13zZxiNZP8wEfNclrudiKjr6t8OfL6t6u1rFwJbbfwQaYEKUQgXt4CIqOODli3NW21/Zm1Ebasdb/IN99643OXcX4k4q/2g/z3m7NeTeyEji3nrXVwtEXO25Y269W0VTD2R86g5259fCOMm8N0APXeIyHm0dbOvHebsjmGQ3xJcK7TuRsGzpubuHCheGdJ+iIio89tNS+fdc3oulJA43/c9s+VZFGIQr/GYa6+7Wt5dqZyIUShAHvLffKSrpw+2u6gUmhvhYh8k6tz/xCSMQhEMMKCwrYKItRGh3I8nGBf7INfOXj73U4xCqfe9oi+fdjWwtvr5UPMiLWQ/xdpc5w7OgBElMCAfhRdXEjnPb8rz7acwqpanStnNRJ99H0YUIx8jUPDl0xYzcqDtz32xG+KCtHlRmJh81YHboULizNtm3626bdFd3V9VPwYdZD5cbTWy8ciEgt981aiFZSjCUCRACzU0iF9i7G7ytblhLhL86jDkB+q5duYsTChCGnTQQAMdUuwHiYhwmxAudznX7jy6eCJKMQxJPe8l/dLYcZK1nbgX6oAJJCJn44J/RwmGQA8N1NAi6eITRC1bkOhRc5Hi4todx1GGnJ52EjEEGVDfkt3FTGCOhbW/uY6Pr62u+1nDauu7XBfRkYVIgcKDi+NWPI5ixPUKOMkwCHFQ+tYzJIj94mFfg+afI81vboT6PPdSouPzMRLJAWoz5oSJiAjjhHBxhzjr4okoRoq/ZwKkUG4cwdo6TiI94BwiosOrUIZUv5qEFFrHMaLnyj0gIsVFZPszjAFLUAoFYhETdVykYNf31Xva8zQyoXBVEhGd2IYxvElADx5pMMKhSpc39r9jCTIhD4eL/YizohzZUAQqTcjdV4RxucuJGtfAiNQQ3yNvX0V0cEbAwiL3dUzBcP7VBUgtjxKd+bnnLI4UF3OYaN8s6HvHbaKKixTce313dt94EpmQM58S1R8eNBE5kV6ugaTLGyxev+BGuLjazhMwIYlvQULi3COsDN1LifbMxojQxnnT7USXNyC9x5Ag+6cYG2gieZ8zEDVtQzYUkeOqKWZtRG2v1RRDxkcWVVzshvBgLNUNxxuPWb/i1z7zX8gok3PXLJWpd8CAuEivrgGOP3paYOwnHofaN7DQXlFbBUZCFzx05++FTQ33G0QoQ0bomyOQEVnMyO3ZTdS6C8beVh9iiCxm5EMdOS7IX81vqyAich6xPRkYaosiLpeJuPC4PngZt6FkwwOBdV0tg8YhxT7FvimhCPnQR56CAOwre3pkz/zIB0zQiS2CNhiXayt/AgMn1Pt3skAuW0JkMaPAf95YzCiGVuC5Qmj6gEsCBZJ/MfrKK64GIs5qWwlV1P0u99Ybqb1rF/QlSILu6hu+GqZz7U9Qgrj6DOiQivi+5IsAxB6d5e7whoC71oyHEhKBs+tyx8lQuJhdwrgcy4j2zBbC5S4nurwhEJf9VChcTI7/OSFc7vLeMRHIoEEKct+f2XGSqHM/4qNsaggn/QNc2r0zMiCD5sCsmu0XKj5eP+0eGJEGhc/26WOQRgrNxw/52r78DgZDJhBc2s3aUNJbGXK1wsqwroCoaRsyQycr3S8SvfqfyPErQ/f1UMqQeYjok4XIg0oYF7uZ6Oru4BAWgBiooEdWw1qimsXQ9f/HVSFwhcLT9lXlb1fMe+C+VXOqtttqOI7I2Xz1+aqJs1KQjhzkIhuJiIXEI/2IqUmgsnnjIY4W5An5JrY5RBd/heTAhItn5QubGpA5j7C27dNCuadMDtfe9ReYkOY3NYjOv9Db1GA/4qwwIQtygnMN0cb7g/er5yua94XA5RmhHHoiixlDgr3RKOP6607ZRJRiONKRggzkDi//5Ywd844sPDO7aupCPdRQ9XVHhRpOW8/dDxgRJxDVULivuBqWm6AKxMVWhPO7IDk7krW5GtYW9pomPXeJs268H4XQ+Q15ImfTchM/n8wtIKpfh1IkQkKwP0x0YTXSeWPWc5ecR4ia3wsw5HMgCbQIbXlETds85krUcLENfFj2K7JJyEcClJAhBjKooEMiUpCCROigvNl7Db5if9x7enWjHHoBXNKLU1gbU3/6LsT6JoLbRNRdxcflXEP0yUIM9kCA/OsHWRtT37IEKv+u4RZwlzjr8flBHhnZP3XbXQ2eHrxPPkvkjU+oPIuGs7qvV073uyrsg9wl9vLPxgXuLu5ZIvuKygyf4096toLIPMejUKOGy/E2H1ftRzD5wi8B7m4MZJBDjpibjYD5ius3XjfhHEyIFwzxKmpmsjYi51HHOscyt5lrJ6p+6upuIozx47pUyFldDW2v1U+EHBJIoDx1j6OaiLM69zrWOdcwu7h2Ite5fbNgRBbvF2nUuuuFWa4Gfg/2Az+aggLoPbAhbZjO2ogcx7xP1BI5jj01AYWBZ1fN4O59RESuT/zt1K2HKVT44CZwNQXlka01KOaHaqMr3rWn4Lyxww/XogiDBHFJoHqxuG69o5q1ETF17e+8fi9Gtr9DhDI/LsjOTus4SVSzGHrICJBAhfQT8yxmpp7I897x+TChCOlQ8RYcWcwwIbdhra8H+8GjC2CCAUl+zw2x74+3mF0NAW2VwoDkQMsQMdBXTreY/e3smQ0Thkf+25yIcBUpus/ygW15FPHR6yI0Lva/fVcLMicjG7EIZ5YokYwcFGEkSlGCEUh17uXbapBAiTQUwOD7YQUkUCAeWTBgJIwwYiQMyEJ8cAIFOuRhKHRIwHBvDyNRgCzoAt1sSKBEKvJRCiNKUYJ8ZCIOMsQhz59AgQw6ZCAfJd52DMiABtLoRjUkZyZzDO+6WeMSY/B1s+jiYiaRy5PSfPlJjIReaEj+sC5U0CEBCYiHBjL3me4qmJDAm1A5P5zsrdMgHolIRDw0kPdehJBDCw1iIIWypwdt70QmJJD1bsv3dlCPcT1fKg8TAugnLkBeuzTofmD9vjuE7rjfPC5mAnkvGnywHmOQ4QnghsWFYEO+rcJz4ecfT2598l8Cde2vgzPIra/tHhrN2609juoPyeHpYd9LGIuh4YJQoYfOHSIyz4EhmjcsBhIuQArtl0+zziBk7s79lkXflMwPVCKxXZl9d417DO4i7kPfmfXCExiNbI9uF8ZFevfSmsEBWTE9d4iofh3KomlxDTRcgBTazVOtp0PGoBi2njnHnGPOcy1ERMyF9mVVhX016ZlJ7nc9oV3WeWZH8Z0oRQbU4aPWgHup3zh2rnFXEhHVr0N55Ambf05cgBQqddqHi20XIst3uWrsG1tnVg3pnYAMEjUzjVnLXfI6xdfP7njgeyhHLhKhiOAmlPybGS1bPMYxa3Oeb9my8X6YkBPNSNzAxOWxa+KQ9epDNX/qiPh/a7Dfuj5xvG5fZpt7/b5rE6xlnaZOk/2Ozu90z3eucu1kq3y/CnO11n/w9jNZk2BCLgZDHXyPV2DoUmiRgXwUe43jYuQh1a9CB0a5Nbg8yBSIQxryZk3d8dSJV6rfqj3QeKTx2KWDF8wnN5lXHFxde6CzoQ9JZ85R27T/5EsrZmI0jDAgCwlQIyayBHnPIlIjDglIRALioA7O1f4r4/L5GCrEIRmZGIY8GFCAQhgwAsORjWEwTL799QX/t+rLbVcOXavuqHNa3A4fHbfd1Wq/2Hay8cD5zYeWvzJn4h0woRQGDEMq9NBAIbQvIlUsA7HcQlwIPM3kUEINDbTQQgM1lIiFEhrEIQnpyEYuClACI0wox2ivlGEUSlEMA3KRjTQkIQ4aKEPtqFsxpH9m6f8KlkKGWKiggQ5xiIceCV7RIx46DIIGKigiV1wijIhwiSLiEkXEJYo4BSIuUURcooi4Bpr8P1XUcWL+V5XVAAAAAElFTkSuQmCC">
+  </a></div></header>
+
+  <main>
+    <h1>Globus Login Result</h1>
+    <p>
+      $login_result. You may close this tab.
+    <p>
+      $post_login_message
+    </p>
+  </main>
+</body>
+</html>

--- a/src/globus_sdk/experimental/login_flow_manager/__init__.py
+++ b/src/globus_sdk/experimental/login_flow_manager/__init__.py
@@ -1,7 +1,9 @@
 from .command_line_login_flow_manager import CommandLineLoginFlowManager
+from .local_server_login_flow_manager import LocalServerLoginFlowManager
 from .login_flow_manager import LoginFlowManager
 
 __all__ = [
     "LoginFlowManager",
     "CommandLineLoginFlowManager",
+    "LocalServerLoginFlowManager",
 ]

--- a/src/globus_sdk/experimental/login_flow_manager/_local_server.py
+++ b/src/globus_sdk/experimental/login_flow_manager/_local_server.py
@@ -15,47 +15,17 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 from string import Template
 from urllib.parse import parse_qsl, urlparse
 
-DEFAULT_HTML_TEMPLATE = Template(
-    """
-<!DOCTYPE html>
-<html lang="en-US">
-<head>
-  <meta charset="utf-8">
-  <meta http-equiv="x-ua-compatible" content="ie=edge">
-  <title>Globus Login</title>
-  <style type="text/css" media="screen">
-    html { font: 75% "Helvetica Neue","Arial","Helvetica",sans-serif }
-    html, body { display: block; margin: 0; padding: 0 }
-    a { color: #5783a6; text-decoration: none; }
-    a img { border: none; }
-    header { background: #2e5793; }
-    main { padding: 25px 0 50px; }
-    main h1 { border-bottom: solid 1px #aaa; font-size: 233.33%;
-              font-weight: normal; }
-    main img { display: block; margin: 0 auto; max-width: 100%; height: auto; }
-    main p { color: #333; font-size: 116.67%; max-width: 560px;
-             margin: 1em auto; line-height: 150%; }
-    header > div, main, footer { display: block; max-width: 980px;
-                                 margin: 0 auto; }
-  </style>
-</head>
-<body>
-  <header><div><a href="https://www.globus.org" title="Go to Globus.org Home">
-    <img alt="Globus" width="215" height="64"
-         src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAANcAAABACAQAAAAjFyrFAAAPM0lEQVR42u2caXhTx7nH/5IlWRuy5QXvGLCN5Q0L2RCWQIB7SW6229InJHAJJG0ohJaQtA1NaC5cSiE3TcIS2pQEAiW0hSwWW0IgvcQhLAWSFBLAxqEJBq8xlrGEbMvS0Tnv/SDJ0pF1hGxEn7o9837xM885M2fmN/POu4wMgigDR8QpEHGJIuISRcQl4hJFxCWKiGtg4gouvAekzGTmeXclV08uInKxV5nTnZvbH30vCdJ+dylQRBg3hyueWc41UsjCOTorqsdCBomI6x8Bl5RdxFkpfOGum/fm9h2ZiCvKuDrTuUqKqLitVQ9D2TdgIq6o4nIWcleoD6V2BTR9OclEXFHE1Z3HNVMfy9e/gjZyYCKuqOEiLVdDfS/sscegiVQliriihovdTv0qjPXZUVCKuP6uuJip4aFY/1a95/NtX+2+Vk1E5LJ1tnR96xHimvYjGTIR198RF3dKGFVH468XYxxKs4rvHgXDH3/Q3br/fzEeZRj1u0c+W8e6iGvc2bqy7YEvMm50iom4ooKLmRAGVsO/fRfGkuHXt5OLyHXl1LwNd1b+BDlIrvt+8LPOU1d/PCeMrSjiigou92Zhh3jVIhiR0v27ngp25/T0LMRD7jaHesF1ufq7UIQ2PkRcUcHF1QnRajiBscj8fAgx/jrLcWRCBSlzVAhx08uh/TERVxRwObKFVeGO5SiCjvkpjwYz1gQtQRAXEV3ZgEG9gYm4ooCLuVN42sf9B4ZA4d7Fr103B4mQhMNF9HEIf6wvuCJ9jttEBC3k/ZgCcm2FBjFRnNJbuBT9u+sxoSl3WDAGyZCy1fz6t5YgFTHhcTmaS4Yj9tbjYrYQIQ+6/uCyvoWhUA0wXN1PCXpb38AEPYFr59fvW45MyMPjIjr+P78d4XjE+ZLrD84tncuap8xQQHKLcJmQ2B9cFjMKoRlguDp/EAZXKeIInI1ff3A1hkBxI1zuDmJ5NuOlph8iFlIR103huj5daMI7m7242vj1u5Yj+8a4QhXb/idTECPiuglczUWCThdrHI94AnOOX//yfGTxcVmqdq54Zu6iGZt/XPUHZ1s4YNdPTE6FTMTVb1yTZcHKzl/+tAhJkDq28YLwTNFUpEEWiOvtlSjDMKQhFZljShv2hQNW9yb0/B0m4uoDLki6BKe37gCyoGi+l+c6n0Q535Dn2DvvwzBoIEMM5FAjuXVvuKsDW++DJtDsEB46k+N+kTtNROT+wvn7ptshZzfzDffQuNzT2AquloiIvczsbr0/ZJzFi4tbwH7EtRNx7czh9rmIDfQXw7gJvdyAnnZqmcP2xb5TOvq48O0swZllnr8Hg6DoOuzfW8/NRwG0BOdBX13zZxiNZP8wEfNclrudiKjr6t8OfL6t6u1rFwJbbfwQaYEKUQgXt4CIqOODli3NW21/Zm1Ebasdb/IN99643OXcX4k4q/2g/z3m7NeTeyEji3nrXVwtEXO25Y269W0VTD2R86g5259fCOMm8N0APXeIyHm0dbOvHebsjmGQ3xJcK7TuRsGzpubuHCheGdJ+iIio89tNS+fdc3oulJA43/c9s+VZFGIQr/GYa6+7Wt5dqZyIUShAHvLffKSrpw+2u6gUmhvhYh8k6tz/xCSMQhEMMKCwrYKItRGh3I8nGBf7INfOXj73U4xCqfe9oi+fdjWwtvr5UPMiLWQ/xdpc5w7OgBElMCAfhRdXEjnPb8rz7acwqpanStnNRJ99H0YUIx8jUPDl0xYzcqDtz32xG+KCtHlRmJh81YHboULizNtm3626bdFd3V9VPwYdZD5cbTWy8ciEgt981aiFZSjCUCRACzU0iF9i7G7ytblhLhL86jDkB+q5duYsTChCGnTQQAMdUuwHiYhwmxAudznX7jy6eCJKMQxJPe8l/dLYcZK1nbgX6oAJJCJn44J/RwmGQA8N1NAi6eITRC1bkOhRc5Hi4todx1GGnJ52EjEEGVDfkt3FTGCOhbW/uY6Pr62u+1nDauu7XBfRkYVIgcKDi+NWPI5ixPUKOMkwCHFQ+tYzJIj94mFfg+afI81vboT6PPdSouPzMRLJAWoz5oSJiAjjhHBxhzjr4okoRoq/ZwKkUG4cwdo6TiI94BwiosOrUIZUv5qEFFrHMaLnyj0gIsVFZPszjAFLUAoFYhETdVykYNf31Xva8zQyoXBVEhGd2IYxvElADx5pMMKhSpc39r9jCTIhD4eL/YizohzZUAQqTcjdV4RxucuJGtfAiNQQ3yNvX0V0cEbAwiL3dUzBcP7VBUgtjxKd+bnnLI4UF3OYaN8s6HvHbaKKixTce313dt94EpmQM58S1R8eNBE5kV6ugaTLGyxev+BGuLjazhMwIYlvQULi3COsDN1LifbMxojQxnnT7USXNyC9x5Ag+6cYG2gieZ8zEDVtQzYUkeOqKWZtRG2v1RRDxkcWVVzshvBgLNUNxxuPWb/i1z7zX8gok3PXLJWpd8CAuEivrgGOP3paYOwnHofaN7DQXlFbBUZCFzx05++FTQ33G0QoQ0bomyOQEVnMyO3ZTdS6C8beVh9iiCxm5EMdOS7IX81vqyAich6xPRkYaosiLpeJuPC4PngZt6FkwwOBdV0tg8YhxT7FvimhCPnQR56CAOwre3pkz/zIB0zQiS2CNhiXayt/AgMn1Pt3skAuW0JkMaPAf95YzCiGVuC5Qmj6gEsCBZJ/MfrKK64GIs5qWwlV1P0u99Ybqb1rF/QlSILu6hu+GqZz7U9Qgrj6DOiQivi+5IsAxB6d5e7whoC71oyHEhKBs+tyx8lQuJhdwrgcy4j2zBbC5S4nurwhEJf9VChcTI7/OSFc7vLeMRHIoEEKct+f2XGSqHM/4qNsaggn/QNc2r0zMiCD5sCsmu0XKj5eP+0eGJEGhc/26WOQRgrNxw/52r78DgZDJhBc2s3aUNJbGXK1wsqwroCoaRsyQycr3S8SvfqfyPErQ/f1UMqQeYjok4XIg0oYF7uZ6Oru4BAWgBiooEdWw1qimsXQ9f/HVSFwhcLT9lXlb1fMe+C+VXOqtttqOI7I2Xz1+aqJs1KQjhzkIhuJiIXEI/2IqUmgsnnjIY4W5An5JrY5RBd/heTAhItn5QubGpA5j7C27dNCuadMDtfe9ReYkOY3NYjOv9Db1GA/4qwwIQtygnMN0cb7g/er5yua94XA5RmhHHoiixlDgr3RKOP6607ZRJRiONKRggzkDi//5Ywd844sPDO7aupCPdRQ9XVHhRpOW8/dDxgRJxDVULivuBqWm6AKxMVWhPO7IDk7krW5GtYW9pomPXeJs268H4XQ+Q15ImfTchM/n8wtIKpfh1IkQkKwP0x0YTXSeWPWc5ecR4ia3wsw5HMgCbQIbXlETds85krUcLENfFj2K7JJyEcClJAhBjKooEMiUpCCROigvNl7Db5if9x7enWjHHoBXNKLU1gbU3/6LsT6JoLbRNRdxcflXEP0yUIM9kCA/OsHWRtT37IEKv+u4RZwlzjr8flBHhnZP3XbXQ2eHrxPPkvkjU+oPIuGs7qvV073uyrsg9wl9vLPxgXuLu5ZIvuKygyf4096toLIPMejUKOGy/E2H1ftRzD5wi8B7m4MZJBDjpibjYD5ius3XjfhHEyIFwzxKmpmsjYi51HHOscyt5lrJ6p+6upuIozx47pUyFldDW2v1U+EHBJIoDx1j6OaiLM69zrWOdcwu7h2Ite5fbNgRBbvF2nUuuuFWa4Gfg/2Az+aggLoPbAhbZjO2ogcx7xP1BI5jj01AYWBZ1fN4O59RESuT/zt1K2HKVT44CZwNQXlka01KOaHaqMr3rWn4Lyxww/XogiDBHFJoHqxuG69o5q1ETF17e+8fi9Gtr9DhDI/LsjOTus4SVSzGHrICJBAhfQT8yxmpp7I897x+TChCOlQ8RYcWcwwIbdhra8H+8GjC2CCAUl+zw2x74+3mF0NAW2VwoDkQMsQMdBXTreY/e3smQ0Thkf+25yIcBUpus/ygW15FPHR6yI0Lva/fVcLMicjG7EIZ5YokYwcFGEkSlGCEUh17uXbapBAiTQUwOD7YQUkUCAeWTBgJIwwYiQMyEJ8cAIFOuRhKHRIwHBvDyNRgCzoAt1sSKBEKvJRCiNKUYJ8ZCIOMsQhz59AgQw6ZCAfJd52DMiABtLoRjUkZyZzDO+6WeMSY/B1s+jiYiaRy5PSfPlJjIReaEj+sC5U0CEBCYiHBjL3me4qmJDAm1A5P5zsrdMgHolIRDw0kPdehJBDCw1iIIWypwdt70QmJJD1bsv3dlCPcT1fKg8TAugnLkBeuzTofmD9vjuE7rjfPC5mAnkvGnywHmOQ4QnghsWFYEO+rcJz4ecfT2598l8Cde2vgzPIra/tHhrN2609juoPyeHpYd9LGIuh4YJQoYfOHSIyz4EhmjcsBhIuQArtl0+zziBk7s79lkXflMwPVCKxXZl9d417DO4i7kPfmfXCExiNbI9uF8ZFevfSmsEBWTE9d4iofh3KomlxDTRcgBTazVOtp0PGoBi2njnHnGPOcy1ERMyF9mVVhX016ZlJ7nc9oV3WeWZH8Z0oRQbU4aPWgHup3zh2rnFXEhHVr0N55Ambf05cgBQqddqHi20XIst3uWrsG1tnVg3pnYAMEjUzjVnLXfI6xdfP7njgeyhHLhKhiOAmlPybGS1bPMYxa3Oeb9my8X6YkBPNSNzAxOWxa+KQ9epDNX/qiPh/a7Dfuj5xvG5fZpt7/b5rE6xlnaZOk/2Ozu90z3eucu1kq3y/CnO11n/w9jNZk2BCLgZDHXyPV2DoUmiRgXwUe43jYuQh1a9CB0a5Nbg8yBSIQxryZk3d8dSJV6rfqj3QeKTx2KWDF8wnN5lXHFxde6CzoQ9JZ85R27T/5EsrZmI0jDAgCwlQIyayBHnPIlIjDglIRALioA7O1f4r4/L5GCrEIRmZGIY8GFCAQhgwAsORjWEwTL799QX/t+rLbVcOXavuqHNa3A4fHbfd1Wq/2Hay8cD5zYeWvzJn4h0woRQGDEMq9NBAIbQvIlUsA7HcQlwIPM3kUEINDbTQQgM1lIiFEhrEIQnpyEYuClACI0wox2ivlGEUSlEMA3KRjTQkIQ4aKEPtqFsxpH9m6f8KlkKGWKiggQ5xiIceCV7RIx46DIIGKigiV1wijIhwiSLiEkXEJYo4BSIuUURcooi4Bpr8P1XUcWL+V5XVAAAAAElFTkSuQmCC">
-  </a></div></header>
+if sys.version_info >= (3, 9):
+    import importlib.resources as importlib_resources
+else:  # Python < 3.9
+    import importlib_resources
 
-  <main>
-    <h1>Globus Login Result</h1>
-    <p>
-      $login_result. You may close this tab.
-    <p>
-      $post_login_message
-    </p>
-  </main>
-</body>
-</html>
-"""
+from globus_sdk.experimental import html_files
+
+DEFAULT_HTML_TEMPLATE = Template(
+    importlib_resources.files(html_files)
+    .joinpath("local_server_landing_page.html")
+    .read_text()
 )
 
 

--- a/src/globus_sdk/experimental/login_flow_manager/_local_server.py
+++ b/src/globus_sdk/experimental/login_flow_manager/_local_server.py
@@ -1,0 +1,140 @@
+"""
+Classes used by the LocalServerLoginFlowManager to automatically receive an
+auth code from a redirect after user authentication through a locally run web-server.
+
+These classes generally shouldn't need to be used directly.
+"""
+
+from __future__ import annotations
+
+import queue
+import socket
+import sys
+import typing as t
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from string import Template
+from urllib.parse import parse_qsl, urlparse
+
+DEFAULT_HTML_TEMPLATE = Template(
+    """
+<!DOCTYPE html>
+<html lang="en-US">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="x-ua-compatible" content="ie=edge">
+  <title>Globus Login</title>
+  <style type="text/css" media="screen">
+    html { font: 75% "Helvetica Neue","Arial","Helvetica",sans-serif }
+    html, body { display: block; margin: 0; padding: 0 }
+    a { color: #5783a6; text-decoration: none; }
+    a img { border: none; }
+    header { background: #2e5793; }
+    main { padding: 25px 0 50px; }
+    main h1 { border-bottom: solid 1px #aaa; font-size: 233.33%;
+              font-weight: normal; }
+    main img { display: block; margin: 0 auto; max-width: 100%; height: auto; }
+    main p { color: #333; font-size: 116.67%; max-width: 560px;
+             margin: 1em auto; line-height: 150%; }
+    header > div, main, footer { display: block; max-width: 980px;
+                                 margin: 0 auto; }
+  </style>
+</head>
+<body>
+  <header><div><a href="https://www.globus.org" title="Go to Globus.org Home">
+    <img alt="Globus" width="215" height="64"
+         src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAANcAAABACAQAAAAjFyrFAAAPM0lEQVR42u2caXhTx7nH/5IlWRuy5QXvGLCN5Q0L2RCWQIB7SW6229InJHAJJG0ohJaQtA1NaC5cSiE3TcIS2pQEAiW0hSwWW0IgvcQhLAWSFBLAxqEJBq8xlrGEbMvS0Tnv/SDJ0pF1hGxEn7o9837xM885M2fmN/POu4wMgigDR8QpEHGJIuISRcQl4hJFxCWKiGtg4gouvAekzGTmeXclV08uInKxV5nTnZvbH30vCdJ+dylQRBg3hyueWc41UsjCOTorqsdCBomI6x8Bl5RdxFkpfOGum/fm9h2ZiCvKuDrTuUqKqLitVQ9D2TdgIq6o4nIWcleoD6V2BTR9OclEXFHE1Z3HNVMfy9e/gjZyYCKuqOEiLVdDfS/sscegiVQliriihovdTv0qjPXZUVCKuP6uuJip4aFY/1a95/NtX+2+Vk1E5LJ1tnR96xHimvYjGTIR198RF3dKGFVH468XYxxKs4rvHgXDH3/Q3br/fzEeZRj1u0c+W8e6iGvc2bqy7YEvMm50iom4ooKLmRAGVsO/fRfGkuHXt5OLyHXl1LwNd1b+BDlIrvt+8LPOU1d/PCeMrSjiigou92Zhh3jVIhiR0v27ngp25/T0LMRD7jaHesF1ufq7UIQ2PkRcUcHF1QnRajiBscj8fAgx/jrLcWRCBSlzVAhx08uh/TERVxRwObKFVeGO5SiCjvkpjwYz1gQtQRAXEV3ZgEG9gYm4ooCLuVN42sf9B4ZA4d7Fr103B4mQhMNF9HEIf6wvuCJ9jttEBC3k/ZgCcm2FBjFRnNJbuBT9u+sxoSl3WDAGyZCy1fz6t5YgFTHhcTmaS4Yj9tbjYrYQIQ+6/uCyvoWhUA0wXN1PCXpb38AEPYFr59fvW45MyMPjIjr+P78d4XjE+ZLrD84tncuap8xQQHKLcJmQ2B9cFjMKoRlguDp/EAZXKeIInI1ff3A1hkBxI1zuDmJ5NuOlph8iFlIR103huj5daMI7m7242vj1u5Yj+8a4QhXb/idTECPiuglczUWCThdrHI94AnOOX//yfGTxcVmqdq54Zu6iGZt/XPUHZ1s4YNdPTE6FTMTVb1yTZcHKzl/+tAhJkDq28YLwTNFUpEEWiOvtlSjDMKQhFZljShv2hQNW9yb0/B0m4uoDLki6BKe37gCyoGi+l+c6n0Q535Dn2DvvwzBoIEMM5FAjuXVvuKsDW++DJtDsEB46k+N+kTtNROT+wvn7ptshZzfzDffQuNzT2AquloiIvczsbr0/ZJzFi4tbwH7EtRNx7czh9rmIDfQXw7gJvdyAnnZqmcP2xb5TOvq48O0swZllnr8Hg6DoOuzfW8/NRwG0BOdBX13zZxiNZP8wEfNclrudiKjr6t8OfL6t6u1rFwJbbfwQaYEKUQgXt4CIqOODli3NW21/Zm1Ebasdb/IN99643OXcX4k4q/2g/z3m7NeTeyEji3nrXVwtEXO25Y269W0VTD2R86g5259fCOMm8N0APXeIyHm0dbOvHebsjmGQ3xJcK7TuRsGzpubuHCheGdJ+iIio89tNS+fdc3oulJA43/c9s+VZFGIQr/GYa6+7Wt5dqZyIUShAHvLffKSrpw+2u6gUmhvhYh8k6tz/xCSMQhEMMKCwrYKItRGh3I8nGBf7INfOXj73U4xCqfe9oi+fdjWwtvr5UPMiLWQ/xdpc5w7OgBElMCAfhRdXEjnPb8rz7acwqpanStnNRJ99H0YUIx8jUPDl0xYzcqDtz32xG+KCtHlRmJh81YHboULizNtm3626bdFd3V9VPwYdZD5cbTWy8ciEgt981aiFZSjCUCRACzU0iF9i7G7ytblhLhL86jDkB+q5duYsTChCGnTQQAMdUuwHiYhwmxAudznX7jy6eCJKMQxJPe8l/dLYcZK1nbgX6oAJJCJn44J/RwmGQA8N1NAi6eITRC1bkOhRc5Hi4todx1GGnJ52EjEEGVDfkt3FTGCOhbW/uY6Pr62u+1nDauu7XBfRkYVIgcKDi+NWPI5ixPUKOMkwCHFQ+tYzJIj94mFfg+afI81vboT6PPdSouPzMRLJAWoz5oSJiAjjhHBxhzjr4okoRoq/ZwKkUG4cwdo6TiI94BwiosOrUIZUv5qEFFrHMaLnyj0gIsVFZPszjAFLUAoFYhETdVykYNf31Xva8zQyoXBVEhGd2IYxvElADx5pMMKhSpc39r9jCTIhD4eL/YizohzZUAQqTcjdV4RxucuJGtfAiNQQ3yNvX0V0cEbAwiL3dUzBcP7VBUgtjxKd+bnnLI4UF3OYaN8s6HvHbaKKixTce313dt94EpmQM58S1R8eNBE5kV6ugaTLGyxev+BGuLjazhMwIYlvQULi3COsDN1LifbMxojQxnnT7USXNyC9x5Ag+6cYG2gieZ8zEDVtQzYUkeOqKWZtRG2v1RRDxkcWVVzshvBgLNUNxxuPWb/i1z7zX8gok3PXLJWpd8CAuEivrgGOP3paYOwnHofaN7DQXlFbBUZCFzx05++FTQ33G0QoQ0bomyOQEVnMyO3ZTdS6C8beVh9iiCxm5EMdOS7IX81vqyAich6xPRkYaosiLpeJuPC4PngZt6FkwwOBdV0tg8YhxT7FvimhCPnQR56CAOwre3pkz/zIB0zQiS2CNhiXayt/AgMn1Pt3skAuW0JkMaPAf95YzCiGVuC5Qmj6gEsCBZJ/MfrKK64GIs5qWwlV1P0u99Ybqb1rF/QlSILu6hu+GqZz7U9Qgrj6DOiQivi+5IsAxB6d5e7whoC71oyHEhKBs+tyx8lQuJhdwrgcy4j2zBbC5S4nurwhEJf9VChcTI7/OSFc7vLeMRHIoEEKct+f2XGSqHM/4qNsaggn/QNc2r0zMiCD5sCsmu0XKj5eP+0eGJEGhc/26WOQRgrNxw/52r78DgZDJhBc2s3aUNJbGXK1wsqwroCoaRsyQycr3S8SvfqfyPErQ/f1UMqQeYjok4XIg0oYF7uZ6Oru4BAWgBiooEdWw1qimsXQ9f/HVSFwhcLT9lXlb1fMe+C+VXOqtttqOI7I2Xz1+aqJs1KQjhzkIhuJiIXEI/2IqUmgsnnjIY4W5An5JrY5RBd/heTAhItn5QubGpA5j7C27dNCuadMDtfe9ReYkOY3NYjOv9Db1GA/4qwwIQtygnMN0cb7g/er5yua94XA5RmhHHoiixlDgr3RKOP6607ZRJRiONKRggzkDi//5Ywd844sPDO7aupCPdRQ9XVHhRpOW8/dDxgRJxDVULivuBqWm6AKxMVWhPO7IDk7krW5GtYW9pomPXeJs268H4XQ+Q15ImfTchM/n8wtIKpfh1IkQkKwP0x0YTXSeWPWc5ecR4ia3wsw5HMgCbQIbXlETds85krUcLENfFj2K7JJyEcClJAhBjKooEMiUpCCROigvNl7Db5if9x7enWjHHoBXNKLU1gbU3/6LsT6JoLbRNRdxcflXEP0yUIM9kCA/OsHWRtT37IEKv+u4RZwlzjr8flBHhnZP3XbXQ2eHrxPPkvkjU+oPIuGs7qvV073uyrsg9wl9vLPxgXuLu5ZIvuKygyf4096toLIPMejUKOGy/E2H1ftRzD5wi8B7m4MZJBDjpibjYD5ius3XjfhHEyIFwzxKmpmsjYi51HHOscyt5lrJ6p+6upuIozx47pUyFldDW2v1U+EHBJIoDx1j6OaiLM69zrWOdcwu7h2Ite5fbNgRBbvF2nUuuuFWa4Gfg/2Az+aggLoPbAhbZjO2ogcx7xP1BI5jj01AYWBZ1fN4O59RESuT/zt1K2HKVT44CZwNQXlka01KOaHaqMr3rWn4Lyxww/XogiDBHFJoHqxuG69o5q1ETF17e+8fi9Gtr9DhDI/LsjOTus4SVSzGHrICJBAhfQT8yxmpp7I897x+TChCOlQ8RYcWcwwIbdhra8H+8GjC2CCAUl+zw2x74+3mF0NAW2VwoDkQMsQMdBXTreY/e3smQ0Thkf+25yIcBUpus/ygW15FPHR6yI0Lva/fVcLMicjG7EIZ5YokYwcFGEkSlGCEUh17uXbapBAiTQUwOD7YQUkUCAeWTBgJIwwYiQMyEJ8cAIFOuRhKHRIwHBvDyNRgCzoAt1sSKBEKvJRCiNKUYJ8ZCIOMsQhz59AgQw6ZCAfJd52DMiABtLoRjUkZyZzDO+6WeMSY/B1s+jiYiaRy5PSfPlJjIReaEj+sC5U0CEBCYiHBjL3me4qmJDAm1A5P5zsrdMgHolIRDw0kPdehJBDCw1iIIWypwdt70QmJJD1bsv3dlCPcT1fKg8TAugnLkBeuzTofmD9vjuE7rjfPC5mAnkvGnywHmOQ4QnghsWFYEO+rcJz4ecfT2598l8Cde2vgzPIra/tHhrN2609juoPyeHpYd9LGIuh4YJQoYfOHSIyz4EhmjcsBhIuQArtl0+zziBk7s79lkXflMwPVCKxXZl9d417DO4i7kPfmfXCExiNbI9uF8ZFevfSmsEBWTE9d4iofh3KomlxDTRcgBTazVOtp0PGoBi2njnHnGPOcy1ERMyF9mVVhX016ZlJ7nc9oV3WeWZH8Z0oRQbU4aPWgHup3zh2rnFXEhHVr0N55Ambf05cgBQqddqHi20XIst3uWrsG1tnVg3pnYAMEjUzjVnLXfI6xdfP7njgeyhHLhKhiOAmlPybGS1bPMYxa3Oeb9my8X6YkBPNSNzAxOWxa+KQ9epDNX/qiPh/a7Dfuj5xvG5fZpt7/b5rE6xlnaZOk/2Ozu90z3eucu1kq3y/CnO11n/w9jNZk2BCLgZDHXyPV2DoUmiRgXwUe43jYuQh1a9CB0a5Nbg8yBSIQxryZk3d8dSJV6rfqj3QeKTx2KWDF8wnN5lXHFxde6CzoQ9JZ85R27T/5EsrZmI0jDAgCwlQIyayBHnPIlIjDglIRALioA7O1f4r4/L5GCrEIRmZGIY8GFCAQhgwAsORjWEwTL799QX/t+rLbVcOXavuqHNa3A4fHbfd1Wq/2Hay8cD5zYeWvzJn4h0woRQGDEMq9NBAIbQvIlUsA7HcQlwIPM3kUEINDbTQQgM1lIiFEhrEIQnpyEYuClACI0wox2ivlGEUSlEMA3KRjTQkIQ4aKEPtqFsxpH9m6f8KlkKGWKiggQ5xiIceCV7RIx46DIIGKigiV1wijIhwiSLiEkXEJYo4BSIuUURcooi4Bpr8P1XUcWL+V5XVAAAAAElFTkSuQmCC">
+  </a></div></header>
+
+  <main>
+    <h1>Globus Login Result</h1>
+    <p>
+      $login_result. You may close this tab.
+    <p>
+      $post_login_message
+    </p>
+  </main>
+</body>
+</html>
+"""
+)
+
+
+class LocalServerError(Exception):
+    """
+    Error class for errors raised by the local server when using a
+    LocalServerLoginFlowManager
+    """
+
+
+class RedirectHTTPServer(HTTPServer):
+    """
+    HTTPServer that accepts an html_template to be displayed to the user
+    and uses a Queue to receive an auth_code from its RequestHandler.
+    """
+
+    def __init__(
+        self,
+        server_address: tuple[str, int],
+        handler_class: type[BaseHTTPRequestHandler],
+        html_template: Template,
+    ) -> None:
+        super().__init__(server_address, handler_class)
+
+        self.html_template = html_template
+        self._auth_code_queue: queue.Queue[str | BaseException] = queue.Queue()
+
+    def handle_error(
+        self,
+        request: socket.socket | tuple[bytes, socket.socket],
+        client_address: t.Any,
+    ) -> None:
+        _, excval, _ = sys.exc_info()
+        assert excval is not None
+        self._auth_code_queue.put(excval)
+
+    def return_code(self, code: str | BaseException) -> None:
+        self._auth_code_queue.put_nowait(code)
+
+    def wait_for_code(self) -> str | BaseException:
+        # timeout is set as a workaround for handling control-c interrupt on Windows
+        # https://docs.python.org/3/library/queue.html#queue.Queue.get
+        try:
+            return self._auth_code_queue.get(block=True, timeout=3600)
+        except queue.Empty as exc:
+            raise LocalServerError("Login timed out. Please try again.") from exc
+
+
+class RedirectHandler(BaseHTTPRequestHandler):
+    """
+    BaseHTTPRequestHandler to be used by RedirectHTTPServer.
+    Displays the RedirectHTTPServer's html_template and parses auth_code out of
+    the redirect url.
+    """
+
+    server: RedirectHTTPServer
+
+    def do_GET(self) -> None:
+        self.send_response(200)
+        self.send_header("Content-type", "text/html")
+        self.end_headers()
+
+        html_template = self.server.html_template
+        query_params = dict(parse_qsl(urlparse(self.path).query))
+        code = query_params.get("code")
+        if code:
+            self.wfile.write(
+                html_template.substitute(
+                    post_login_message="", login_result="Login successful"
+                ).encode("utf-8")
+            )
+            self.server.return_code(code)
+        else:
+            msg = query_params.get("error_description", query_params.get("error"))
+
+            self.wfile.write(
+                html_template.substitute(
+                    post_login_message=msg, login_result="Login failed"
+                ).encode("utf-8")
+            )
+
+            self.server.return_code(LocalServerError(msg))

--- a/src/globus_sdk/experimental/login_flow_manager/_local_server.py
+++ b/src/globus_sdk/experimental/login_flow_manager/_local_server.py
@@ -81,7 +81,7 @@ class RedirectHTTPServer(HTTPServer):
         else:
             try:
                 return self._auth_code_queue.get(block=True, timeout=3600)
-            except queue.Empty as exc:
+            except queue.Empty:
                 pass
         raise LocalServerError("Login timed out. Please try again.")
 

--- a/src/globus_sdk/experimental/login_flow_manager/_local_server.py
+++ b/src/globus_sdk/experimental/login_flow_manager/_local_server.py
@@ -78,12 +78,12 @@ class RedirectHTTPServer(HTTPServer):
                     return self._auth_code_queue.get()
                 except queue.Empty:
                     time.sleep(1)
-            raise LocalServerError("Login timed out. Please try again.")
         else:
             try:
                 return self._auth_code_queue.get(block=True, timeout=3600)
             except queue.Empty as exc:
-                raise LocalServerError("Login timed out. Please try again.") from exc
+                pass
+        raise LocalServerError("Login timed out. Please try again.")
 
 
 class RedirectHandler(BaseHTTPRequestHandler):

--- a/src/globus_sdk/experimental/login_flow_manager/local_server_login_flow_manager.py
+++ b/src/globus_sdk/experimental/login_flow_manager/local_server_login_flow_manager.py
@@ -72,8 +72,8 @@ class LocalServerLoginFlowManager(LoginFlowManager):
             to the authentication flow to control how the user will authenticate.
         """
         with self.start_local_server() as server:
-            _, port = server.socket.getsockname()
-            redirect_uri = f"http://localhost:{port}"
+            host, port = server.socket.getsockname()
+            redirect_uri = f"http://{host}:{port}"
 
             # type is ignored here as AuthLoginClient does not provide a signature for
             # oauth2_start_flow since it has different positional arguments between

--- a/src/globus_sdk/experimental/login_flow_manager/local_server_login_flow_manager.py
+++ b/src/globus_sdk/experimental/login_flow_manager/local_server_login_flow_manager.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import threading
+import typing as t
+import webbrowser
+from contextlib import contextmanager
+from string import Template
+
+from globus_sdk import AuthLoginClient, OAuthTokenResponse
+from globus_sdk.experimental.auth_requirements_error import (
+    GlobusAuthorizationParameters,
+)
+
+from ._local_server import (
+    DEFAULT_HTML_TEMPLATE,
+    LocalServerError,
+    RedirectHandler,
+    RedirectHTTPServer,
+)
+from .login_flow_manager import LoginFlowManager
+
+
+class LocalServerLoginFlowManager(LoginFlowManager):
+    """
+    A ``LocalServerLoginFlowManager`` is a ``LoginFlowManager`` that uses a locally
+    hosted server to automatically receive the auth code from Globus auth after the
+    user has authenticated.
+
+    Example usage:
+
+    >>> login_client = globus_sdk.NativeAppAuthClient(...)
+    >>> login_flow_manager = LocalServerLoginFlowManager(login_client)
+    >>> scopes = [globus_sdk.scopes.TransferScopes.all]
+    >>> auth_params = GlobusAuthorizationParameters(required_scopes=scopes)
+    >>> tokens = login_flow_manager.run_login_flow(auth_params)
+
+    """
+
+    def __init__(
+        self,
+        login_client: AuthLoginClient,
+        *,
+        refresh_tokens: bool = False,
+        server_address: tuple[str, int] = ("127.0.0.1", 0),
+        html_template: Template = DEFAULT_HTML_TEMPLATE,
+    ):
+        """
+        :param login_client: The ``AuthLoginClient`` that will be making the Globus
+            Auth API calls needed for the authentication flow. Note that this
+            must either be a NativeAppAuthClient or a templated
+            ConfidentialAppAuthClient, standard ConfidentialAppAuthClients cannot
+            use the web auth-code flow.
+        :param refresh_tokens: Control whether refresh tokens will be requested.
+        :param html_template: Optional HTML Template to be populated with the values
+            login_result and post_login_message and displayed to the user.
+        :param server_address: Optional tuple of the form (host, port) to specify an
+            address to run the local server at.
+        """
+        self.server_address = server_address
+        self.html_template = html_template
+        super().__init__(login_client, refresh_tokens=refresh_tokens)
+
+    def run_login_flow(
+        self,
+        auth_parameters: GlobusAuthorizationParameters,
+    ) -> OAuthTokenResponse:
+        """
+        Run an interactive login flow using a locally hosted server to get tokens
+        for the user.
+
+        :param auth_parameters: ``GlobusAuthorizationParameters`` passed through
+            to the authentication flow to control how the user will authenticate.
+        """
+        with self.start_local_server() as server:
+            _, port = server.socket.getsockname()
+            redirect_uri = f"http://localhost:{port}"
+
+            # type is ignored here as AuthLoginClient does not provide a signature for
+            # oauth2_start_flow since it has different positional arguments between
+            # NativeAppAuthClient and ConfidentialAppAuthClient
+            self.login_client.oauth2_start_flow(  # type: ignore
+                redirect_uri=redirect_uri,
+                refresh_tokens=self.refresh_tokens,
+                requested_scopes=auth_parameters.required_scopes,
+            )
+
+            # open authorize url in web-browser for user to authenticate
+            url = self.login_client.oauth2_get_authorize_url(
+                session_required_identities=auth_parameters.session_required_identities,
+                session_required_single_domain=(
+                    auth_parameters.session_required_single_domain
+                ),
+                session_required_policies=auth_parameters.session_required_policies,
+                session_required_mfa=auth_parameters.session_required_mfa,
+                prompt=auth_parameters.prompt,  # type: ignore
+            )
+            webbrowser.open(url, new=1)
+
+            # get auth code from server
+            auth_code = server.wait_for_code()
+
+        if isinstance(auth_code, BaseException):
+            raise LocalServerError(
+                f"Authorization failed with unexpected error:\n{auth_code}"
+            )
+
+        # get and return tokens
+        return self.login_client.oauth2_exchange_code_for_tokens(auth_code)
+
+    @contextmanager
+    def start_local_server(self) -> t.Iterator[RedirectHTTPServer]:
+        """
+        Starts a RedirectHTTPServer in a thread as a context manager.
+        """
+        server = RedirectHTTPServer(
+            server_address=self.server_address,
+            handler_class=RedirectHandler,
+            html_template=self.html_template,
+        )
+        thread = threading.Thread(target=server.serve_forever)
+        thread.daemon = True
+        thread.start()
+
+        yield server
+
+        server.shutdown()

--- a/tests/functional/test_login_manager.py
+++ b/tests/functional/test_login_manager.py
@@ -1,9 +1,14 @@
+from unittest.mock import Mock, patch
+
 from globus_sdk import ConfidentialAppAuthClient, NativeAppAuthClient
 from globus_sdk._testing import load_response
 from globus_sdk.experimental.auth_requirements_error import (
     GlobusAuthorizationParameters,
 )
-from globus_sdk.experimental.login_flow_manager import CommandLineLoginFlowManager
+from globus_sdk.experimental.login_flow_manager import (
+    CommandLineLoginFlowManager,
+    LocalServerLoginFlowManager,
+)
 
 
 def _mock_input(s):
@@ -71,3 +76,66 @@ def test_command_line_login_flower_manager_confidential(monkeypatch, capsys):
     assert "https://auth.globus.org/v2/oauth2/authorize" in captured_output
     assert "client_id=mock_client_id" in captured_output
     assert "&session_required_single_domain=org.edu" in captured_output
+
+
+class MockRedirectServer:
+    def __init__(self, *args, **kwargs):
+        self.socket = Mock()
+        self.socket.getsockname.return_value = ("", 0)
+
+    def serve_forever(self):
+        pass
+
+    def shutdown(self):
+        pass
+
+    def wait_for_code(self):
+        return "auth_code"
+
+
+@patch(
+    "globus_sdk.experimental.login_flow_manager.local_server_login_flow_manager.RedirectHTTPServer",  # noqa E501
+    new=MockRedirectServer,
+)
+def test_local_server_login_flower_manager_native():
+    """
+    test LocalServerLoginManager with a NativeAppAuthClient
+    """
+    login_client = NativeAppAuthClient("mock_client_id")
+    load_response(login_client.oauth2_exchange_code_for_tokens)
+    login_flow_manager = LocalServerLoginFlowManager(
+        login_client,
+    )
+    auth_params = GlobusAuthorizationParameters(
+        required_scopes=["urn:globus:auth:scope:transfer.api.globus.org:all"],
+    )
+    token_res = login_flow_manager.run_login_flow(auth_params)
+    assert (
+        token_res.by_resource_server["transfer.api.globus.org"]["access_token"]
+        == "transfer_access_token"
+    )
+
+
+@patch(
+    "globus_sdk.experimental.login_flow_manager.local_server_login_flow_manager.RedirectHTTPServer",  # noqa E501
+    new=MockRedirectServer,
+)
+def test_local_server_login_flower_manager_confidential():
+    """
+    test LocalServerLoginManager with a ConfidentialAppAuthClient
+    """
+    login_client = ConfidentialAppAuthClient(
+        client_id="mock_client_id", client_secret="mock_client_secret"
+    )
+    load_response(login_client.oauth2_exchange_code_for_tokens)
+    login_flow_manager = LocalServerLoginFlowManager(
+        login_client,
+    )
+    auth_params = GlobusAuthorizationParameters(
+        required_scopes=["urn:globus:auth:scope:transfer.api.globus.org:all"],
+    )
+    token_res = login_flow_manager.run_login_flow(auth_params)
+    assert (
+        token_res.by_resource_server["transfer.api.globus.org"]["access_token"]
+        == "transfer_access_token"
+    )

--- a/tests/functional/test_login_manager.py
+++ b/tests/functional/test_login_manager.py
@@ -94,6 +94,10 @@ class MockRedirectServer:
 
 
 @patch(
+    "globus_sdk.experimental.login_flow_manager.local_server_login_flow_manager._open_webbrowser",  # noqa E501
+    new=lambda url: None,
+)
+@patch(
     "globus_sdk.experimental.login_flow_manager.local_server_login_flow_manager.RedirectHTTPServer",  # noqa E501
     new=MockRedirectServer,
 )
@@ -116,6 +120,10 @@ def test_local_server_login_flower_manager_native():
     )
 
 
+@patch(
+    "globus_sdk.experimental.login_flow_manager.local_server_login_flow_manager._open_webbrowser",  # noqa E501
+    new=lambda url: None,
+)
 @patch(
     "globus_sdk.experimental.login_flow_manager.local_server_login_flow_manager.RedirectHTTPServer",  # noqa E501
     new=MockRedirectServer,

--- a/tests/unit/experimental/test_local_server.py
+++ b/tests/unit/experimental/test_local_server.py
@@ -1,0 +1,53 @@
+from unittest.mock import Mock
+
+import pytest
+
+from globus_sdk.experimental.login_flow_manager._local_server import (
+    DEFAULT_HTML_TEMPLATE,
+    LocalServerError,
+    RedirectHandler,
+    RedirectHTTPServer,
+)
+
+
+@pytest.mark.parametrize(
+    "url,expected_result",
+    [
+        (b"localhost?code=abc123", "abc123"),
+        (b"localhost?error=bad_login", LocalServerError("bad_login")),
+        (b"localhost", LocalServerError(None)),
+    ],
+)
+def test_server(url, expected_result):
+    """
+    Setup a RedirectHTTPServer and pass it mocked HTTP GET requests to have
+    its RedirectHandler handle
+    """
+    server = RedirectHTTPServer(
+        server_address=("", 0),
+        handler_class=RedirectHandler,
+        html_template=DEFAULT_HTML_TEMPLATE,
+    )
+
+    # setup Mocks to look like a connection to a file for reading the HTTP data
+    mock_file = Mock()
+    mock_file.readline.side_effect = [
+        b"GET " + url + b" HTTP/1.1",
+        b"Host: localhost",
+        b"",
+    ]
+    mock_conn = Mock()
+    mock_conn.makefile.return_value = mock_file
+
+    # handle the request, then cleanup
+    server.finish_request(mock_conn, ("", 0))
+    server.server_close()
+
+    # confirm expected results
+    result = server.wait_for_code()
+    if isinstance(result, str):
+        assert result == expected_result
+    elif isinstance(result, LocalServerError):
+        assert result.args == expected_result.args
+    else:
+        raise AssertionError("unexpected result type")


### PR DESCRIPTION
Shortcut: https://app.shortcut.com/globus/story/30774/sdk-localwebserverloginflowmanager

Mostly the same as in the CLI. Notable change is the ability to specify a `server_address` or `html_template` when instantiating a `LocalServerLoginFlowManager` for customization purposes.

~One thing notably missing from this that's present in various levels across the CLI/GCP/FAIR login is the ability to fallback to a link login in known failure cases around the browser/server. We could maybe detect those cases here and raise an error, but for an end user that's probably not very helpful? I'm wondering if we need something like a `FlexibleLoginFlowManager` that tries to use a browser and server if it can, but falls back to a link and copy and paste if it can't.~
I've added LocalServerLoginFlowError to be raised in these cases, so hopefully the CLI can do something like
```
try:
    login_manager = LocalServerLoginFlowManager(...)
    login_manager.run_login_flow(...)
except LocalServerLoginFLowError:
    login_manager = CommandLineLoginFlowManager(...)
    login_manager.run_login_flow(...)
```

There is also a bit of a testing gap around the use of `webbrowser`, but I think that's fine.

<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--977.org.readthedocs.build/en/977/

<!-- readthedocs-preview globus-sdk-python end -->