### PR TITLE
Minor typing fix in experimental

### DIFF
--- a/src/globus_sdk/experimental/consents/_model.py
+++ b/src/globus_sdk/experimental/consents/_model.py
@@ -190,7 +190,9 @@ class ConsentForest:
     def get_node(self, consent_id: int) -> Consent:
         return self._node_by_id[consent_id]
 
-    def meets_scope_requirements(self, scopes: Scope | str | list[Scope | str]) -> bool:
+    def meets_scope_requirements(
+        self, scopes: Scope | str | t.Sequence[Scope | str]
+    ) -> bool:
         """
         Check whether this consent meets one or more scope requirements.
 
@@ -298,7 +300,9 @@ class ConsentTree:
         return _str
 
 
-def _normalize_scope_types(scopes: Scope | str | list[Scope | str]) -> list[Scope]:
+def _normalize_scope_types(
+    scopes: Scope | str | t.Sequence[Scope | str],
+) -> list[Scope]:
     """
     Normalize the input scope types into a list of Scope objects.
 

--- a/tests/non-pytest/mypy-ignore-tests/test_consents_usage.py
+++ b/tests/non-pytest/mypy-ignore-tests/test_consents_usage.py
@@ -1,0 +1,26 @@
+import uuid
+
+from globus_sdk import AuthClient, Scope
+
+# setup: get a consent forest
+ac = AuthClient()
+identity_id = uuid.uuid1()
+consents = ac.get_consents(identity_id)
+consent_forest = consents.to_forest()
+
+# create some variant types
+xfer_str: str = "urn:globus:auth:scope:transfer.api.globus.org:all"
+strlist: list[str] = [xfer_str]
+scopelist: list[Scope] = Scope.parse(xfer_str)
+
+# all should be allowed
+b: bool
+b = consent_forest.meets_scope_requirements(xfer_str)
+b = consent_forest.meets_scope_requirements((xfer_str,))
+b = consent_forest.meets_scope_requirements(strlist)
+b = consent_forest.meets_scope_requirements(scopelist)
+
+# and we really are validating the type, since a bool or list[bool] is not allowed
+consent_forest.meets_scope_requirements(b)  # type: ignore[arg-type]
+blist: list[bool] = [b]
+consent_forest.meets_scope_requirements(blist)  # type: ignore[arg-type]


### PR DESCRIPTION
Switch from `list[...]` to `Sequence[...]` for a signature. `meets_scope_requirements` should accept covariant arg types, not invariant ones.

This also allows it to be called with sets, tuples, etc.

To guard against regression, a small type checking test for consents is added.
