### PR TITLE
Add 'query_params' to token introspect

### DIFF
--- a/changelog.d/20240508_113916_sirosen_add_query_params.rst
+++ b/changelog.d/20240508_113916_sirosen_add_query_params.rst
@@ -1,0 +1,6 @@
+Added
+~~~~~
+
+- Add support for added query parameters to
+  ``ConfidentialAppAuthClient.oauth2_token_introspect`` via a ``query_params``
+  argument. (:pr:`NUMBER`)

--- a/src/globus_sdk/_testing/data/auth/oauth2_token_introspect.py
+++ b/src/globus_sdk/_testing/data/auth/oauth2_token_introspect.py
@@ -1,0 +1,44 @@
+import uuid
+
+from globus_sdk._testing.models import RegisteredResponse, ResponseSet
+
+_kingfish = {
+    "username": "kingfish@globus.org",
+    "name": "Christone Ingram",
+    "id": str(uuid.uuid1()),
+    "email": "kingfish@globus.org",
+}
+_client_id = str(uuid.uuid1())
+_scope = "urn:globus:auth:scope:auth.globus.org:view_identity_set profile email openid"
+
+
+RESPONSES = ResponseSet(
+    default=RegisteredResponse(
+        service="auth",
+        path="/v2/oauth2/token/introspect",
+        method="POST",
+        json={
+            "active": True,
+            "token_type": "Bearer",
+            "scope": _scope,
+            "client_id": _client_id,
+            "username": _kingfish["username"],
+            "name": _kingfish["name"],
+            "email": _kingfish["email"],
+            "exp": 1715289767,
+            "iat": 1715116967,
+            "nbf": 1715116967,
+            "sub": _kingfish["id"],
+            "aud": [
+                "auth.globus.org",
+                _client_id,
+            ],
+            "iss": "https://auth.globus.org",
+        },
+        metadata={
+            "client_id": _client_id,
+            "scope": _scope,
+            **_kingfish,
+        },
+    )
+)

--- a/src/globus_sdk/services/auth/client/confidential_client.py
+++ b/src/globus_sdk/services/auth/client/confidential_client.py
@@ -269,7 +269,11 @@ class ConfidentialAppAuthClient(AuthLoginClient):
         return self.oauth2_token(form_data, response_class=OAuthDependentTokenResponse)
 
     def oauth2_token_introspect(
-        self, token: str, *, include: str | None = None
+        self,
+        token: str,
+        *,
+        include: str | None = None,
+        query_params: dict[str, t.Any] | None = None,
     ) -> GlobusHTTPResponse:
         """
         Get information about a Globus Auth token.
@@ -277,6 +281,8 @@ class ConfidentialAppAuthClient(AuthLoginClient):
         :param token: An Access Token as a raw string, being evaluated
         :param include: A value for the ``include`` parameter in the request body.
             Default is to omit the parameter.
+        :param query_params: Any additional parameters to be passed through
+            as query params.
 
         .. tab-set::
 
@@ -308,7 +314,12 @@ class ConfidentialAppAuthClient(AuthLoginClient):
         body = {"token": token}
         if include is not None:
             body["include"] = include
-        return self.post("/v2/oauth2/token/introspect", data=body, encoding="form")
+        return self.post(
+            "/v2/oauth2/token/introspect",
+            data=body,
+            encoding="form",
+            query_params=query_params,
+        )
 
     def create_child_client(
         self,

--- a/tests/functional/services/auth/confidential_client/test_oauth2_token_introspect.py
+++ b/tests/functional/services/auth/confidential_client/test_oauth2_token_introspect.py
@@ -1,6 +1,23 @@
-import pytest
+from globus_sdk._testing import get_last_request, load_response
 
 
-@pytest.mark.xfail
-def test_oauth2_token_introspect():
-    raise NotImplementedError
+def test_oauth2_token_introspect(auth_client):
+    meta = load_response(auth_client.oauth2_token_introspect).metadata
+    response = auth_client.oauth2_token_introspect("some_very_cool_token")
+    assert response["username"] == meta["username"]
+    assert response["sub"] == meta["id"]
+
+    last_req = get_last_request()
+    assert len(last_req.params) == 0
+
+
+def test_oauth2_token_introspect_allows_added_query_params(auth_client):
+    meta = load_response(auth_client.oauth2_token_introspect).metadata
+    response = auth_client.oauth2_token_introspect(
+        "some_very_cool_token", query_params={"foo": "bar"}
+    )
+    assert response["username"] == meta["username"]
+    assert response["sub"] == meta["id"]
+
+    last_req = get_last_request()
+    assert last_req.params["foo"] == "bar"


### PR DESCRIPTION
This is a passthrough to allow arbitrary parameter passthrough. It is
being added based on a conversation with the Auth team indicating that
introspect may support query parameters in the future, and that this
passthrough will be useful for development of such parameters.

Importantly, this adds two tests + test data for introspect, to ensure
that passing no values for query params does not send query params,
and that params can be passed successfully.


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--984.org.readthedocs.build/en/984/

<!-- readthedocs-preview globus-sdk-python end -->