### PR TITLE
Remove at-least-one-field-must-be-set restriction

### DIFF
--- a/changelog.d/20240612_130031_ada_allow_empty_authorization_parameters.rst
+++ b/changelog.d/20240612_130031_ada_allow_empty_authorization_parameters.rst
@@ -1,0 +1,5 @@
+Changed
+~~~~~~~
+
+- ``GlobusAuthorizationParameters`` no longer enforces that at least one
+  field is set. (:pr:`NUMBER`)

--- a/src/globus_sdk/experimental/auth_requirements_error/_auth_requirements_error.py
+++ b/src/globus_sdk/experimental/auth_requirements_error/_auth_requirements_error.py
@@ -75,18 +75,6 @@ class GlobusAuthorizationParameters(_serializable.Serializable):
         self.prompt = _validators.opt_str("prompt", prompt)
         self.extra = extra or {}
 
-        # Enforce that the error contains at least one of the fields we expect
-        requires_at_least_one = [
-            name for name in self._supported_fields() if name != "session_message"
-        ]
-        if all(
-            getattr(self, field_name) is None for field_name in requires_at_least_one
-        ):
-            raise _validators.ValidationError(
-                "Must include at least one supported authorization parameter: "
-                + ", ".join(requires_at_least_one)
-            )
-
 
 class GlobusAuthRequirementsError(_serializable.Serializable):
     """

--- a/src/globus_sdk/experimental/auth_requirements_error/_variants.py
+++ b/src/globus_sdk/experimental/auth_requirements_error/_variants.py
@@ -132,18 +132,6 @@ class LegacyAuthorizationParameters(_serializable.Serializable):
             raise _validators.ValidationError("'prompt' must be 'login' or null")
         self.extra = extra or {}
 
-        # Enforce that the error contains at least one of the fields we expect
-        requires_at_least_one = [
-            name for name in self._supported_fields() if name != "session_message"
-        ]
-        if all(
-            getattr(self, field_name) is None for field_name in requires_at_least_one
-        ):
-            raise _validators.ValidationError(
-                "Must include at least one supported authorization parameter: "
-                + ", ".join(requires_at_least_one)
-            )
-
     def to_authorization_parameters(
         self,
     ) -> GlobusAuthorizationParameters:

--- a/tests/unit/experimental/test_auth_requirements_error.py
+++ b/tests/unit/experimental/test_auth_requirements_error.py
@@ -453,11 +453,7 @@ def test_error_from_dict_insufficient_input(target_class, data, expect_message):
         _variants.LegacyAuthorizationParameters,
     ],
 )
-def test_authorization_parameters_from_dict_insufficient_input(target_class):
+def test_authorization_parameters_from_empty_dict(target_class):
     """ """
-    with pytest.raises(ValueError) as exc_info:
-        target_class.from_dict({})
-
-    assert "Must include at least one supported authorization parameter" in str(
-        exc_info.value
-    )
+    authorization_params = target_class.from_dict({})
+    assert authorization_params.to_dict() == {}


### PR DESCRIPTION
This removes a prior restriction that required at least one field in the `GlobusAuthorizationParameters` object to be set, reflecting a change in the Globus Auth Requirements Error specification to allow an empty `authorization_parameters` object. An empty `authorization_parameters` may be used to indicate that _any_ authentication is required.

Signed-off-by: Ada <ada@globus.org>


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--989.org.readthedocs.build/en/989/

<!-- readthedocs-preview globus-sdk-python end -->