### PR TITLE
Implement the X-Globus-Client-Info header as a feature of transport objects

### DIFF
--- a/changelog.d/20240621_130106_sirosen_globus_clientinfo.rst
+++ b/changelog.d/20240621_130106_sirosen_globus_clientinfo.rst
@@ -1,0 +1,7 @@
+Added
+~~~~~
+
+- Clients will now emit a ``X-Globus-Client-Info`` header which reports the
+  version of the ``globus-sdk`` which was used to send a request. Users may
+  customize this header further by modifying the ``globus_clientinfo`` object
+  attached to the transport object. (:pr:`NUMBER`)

--- a/docs/core/transport.rst
+++ b/docs/core/transport.rst
@@ -14,6 +14,15 @@ Transport
    :members:
    :member-order: bysource
 
+``RequestsTransport`` objects include an attribute, ``globus_clientinfo`` which
+provides the ``X-Globus-Client-Info`` header which is sent to Globus services.
+It is an instance of ``GlobusClientInfo`` pre-populated with ``globus-sdk``
+information.
+
+.. autoclass:: globus_sdk.transport.GlobusClientInfo
+   :members:
+   :member-order: bysource
+
 Retries
 ~~~~~~~
 

--- a/docs/core/transport.rst
+++ b/docs/core/transport.rst
@@ -14,10 +14,9 @@ Transport
    :members:
    :member-order: bysource
 
-``RequestsTransport`` objects include an attribute, ``globus_clientinfo`` which
+``RequestsTransport`` objects include an attribute, ``globus_client_info`` which
 provides the ``X-Globus-Client-Info`` header which is sent to Globus services.
-It is an instance of ``GlobusClientInfo`` pre-populated with ``globus-sdk``
-information.
+It is an instance of ``GlobusClientInfo``:
 
 .. autoclass:: globus_sdk.transport.GlobusClientInfo
    :members:

--- a/src/globus_sdk/transport/__init__.py
+++ b/src/globus_sdk/transport/__init__.py
@@ -1,3 +1,4 @@
+from ._clientinfo import GlobusClientInfo
 from .encoders import FormRequestEncoder, JSONRequestEncoder, RequestEncoder
 from .requests import RequestsTransport
 from .retry import (
@@ -20,4 +21,5 @@ __all__ = (
     "RequestEncoder",
     "JSONRequestEncoder",
     "FormRequestEncoder",
+    "GlobusClientInfo",
 )

--- a/src/globus_sdk/transport/_clientinfo.py
+++ b/src/globus_sdk/transport/_clientinfo.py
@@ -2,21 +2,8 @@
 This module models a read-write object representation of the
 X-Globus-ClientInfo header.
 
-The spec for X-Globus-ClientInfo is as follows:
-
-Header Name: X-Globus-Client-Info
-Header Value
-  - A semicolon (;) separated list of client information.
-  - Client information is a comma-separated list of `=` delimited key-value pairs.
-    Well-known values for client-information are:
-        product - A unique identifier of the product.
-        version - Relevant version information for the product.
-  - Based on the above, the characters `;,=` should be considered reserved and
-    should NOT be included in client information values to ensure proper parsing.
-
-Examples:
-  X-Globus-ClientInfo: product=python-sdk,version=3.32.1
-  X-Globus-ClientInfo: product=python-sdk,version=3.32.1;product=cli,version=4.0.0a1
+The spec for X-Globus-ClientInfo is documented, in brief, in the GlobusClientInfo class
+docstring.
 """
 
 from __future__ import annotations
@@ -31,8 +18,41 @@ _RESERVED_CHARS = ";,="
 
 class GlobusClientInfo:
     """
-    An implementation of X-Globus-Client-Info as an object model.
-    """
+    An implementation of X-Globus-Client-Info as an object. This header encodes a
+    mapping of multiple products to versions and potentially other information.
+
+    Values can be added to a clientinfo object via the ``add()`` method.
+
+    .. rubric:: ``X-Globus-Client-Info`` Specification
+
+    Header Name: ``X-Globus-Client-Info``
+
+    Header Value:
+
+    - A semicolon (``;``) separated list of client information.
+
+    - Client information is a comma-separated list of ``=`` delimited key-value pairs.
+      Well-known values for client-information are:
+
+      - ``product``: A unique identifier of the product.
+      - ``version``: Relevant version information for the product.
+
+    - Based on the above, the characters ``;,=`` should be considered reserved and
+      should NOT be included in client information values to ensure proper parsing.
+
+    .. rubric:: Example Headers
+
+    .. code-block:: none
+
+        X-Globus-ClientInfo: product=python-sdk,version=3.32.1
+        X-Globus-ClientInfo: product=python-sdk,version=3.32.1;product=cli,version=4.0.0a1
+
+    .. note::
+
+        The ``GlobusClientInfo`` object is not guaranteed to reject all invalid usages.
+        For example, ``product`` is required to be unique per header, and users are
+        expected to enforce this in their usage.
+    """  # noqa: E501
 
     def __init__(self) -> None:
         self.infos: list[str] = []
@@ -52,7 +72,7 @@ class GlobusClientInfo:
 
         :param value: The element to add to the client-info. If it is a dict,
             it may not contain reserved characters in any keys or values. If it is a
-            string, it cannot contain the ';' separator.
+            string, it cannot contain the ``;`` separator.
         """
         if not isinstance(value, str):
             value = ",".join(_format_items(value))

--- a/src/globus_sdk/transport/_clientinfo.py
+++ b/src/globus_sdk/transport/_clientinfo.py
@@ -1,0 +1,95 @@
+"""
+This module models a read-write object representation of the
+X-Globus-ClientInfo header.
+
+The spec for X-Globus-ClientInfo is as follows:
+
+Header Name: X-Globus-Client-Info
+Header Value
+  - A semicolon (;) separated list of client information.
+  - Client information is a comma-separated list of `=` delimited key-value pairs.
+    Well-known values for client-information are:
+        product - A unique identifier of the product.
+        version - Relevant version information for the product.
+  - Based on the above, the characters `;,=` should be considered reserved and
+    should NOT be included in client information values to ensure proper parsing.
+
+Examples:
+  X-Globus-ClientInfo: product=python-sdk,version=3.32.1
+  X-Globus-ClientInfo: product=python-sdk,version=3.32.1;product=cli,version=4.0.0a1
+"""
+
+from __future__ import annotations
+
+import typing as t
+
+from globus_sdk import exc
+from globus_sdk.version import __version__
+
+_RESERVED_CHARS = ";,="
+
+
+class GlobusClientInfo:
+    """
+    An implementation of X-Globus-Client-Info as an object model.
+    """
+
+    def __init__(self) -> None:
+        self.infos: list[str] = []
+
+    def __bool__(self) -> bool:
+        """Check if there are any values present."""
+        return bool(self.infos)
+
+    def format(self) -> str:
+        """Format as a header value."""
+        return ";".join(self.infos)
+
+    def add(self, value: str | dict[str, str]) -> None:
+        """
+        Add an item to the clientinfo. The item is either already formatted
+        as a string, or is a dict containing values to format.
+
+        :param value: The element to add to the client-info. If it is a dict,
+            it may not contain reserved characters in any keys or values. If it is a
+            string, it cannot contain the ';' separator.
+        """
+        if not isinstance(value, str):
+            value = ",".join(_format_items(value))
+        elif ";" in value:
+            raise exc.GlobusSDKUsageError(
+                "GlobusClientInfo.add() cannot be used to add multiple items in "
+                "an already-joined string. Add items separately instead. "
+                f"Bad usage: '{value}'"
+            )
+        self.infos.append(value)
+
+
+class DefaultGlobusClientInfo(GlobusClientInfo):
+    """
+    A variant of GlobusClientInfo which always initializes itself to start with
+
+        product=python-sdk,version=...
+
+    using the current package version information.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.add({"product": "python-sdk", "version": __version__})
+
+
+def _format_items(info: dict[str, str]) -> t.Iterable[str]:
+    """Format the items in a dict, yielding the contents as an iterable."""
+    for key, value in info.items():
+        _check_reserved_chars(key, value)
+        yield f"{key}={value}"
+
+
+def _check_reserved_chars(key: str, value: str) -> None:
+    """Check a key-value pair to see if it uses reserved chars."""
+    if any(c in x for c in _RESERVED_CHARS for x in (key, value)):
+        raise exc.GlobusSDKUsageError(
+            "X-Globus-Client-Info reserved characters cannot be used in keys or "
+            f"values. Bad usage: '{key}: {value}'"
+        )

--- a/src/globus_sdk/transport/_clientinfo.py
+++ b/src/globus_sdk/transport/_clientinfo.py
@@ -1,8 +1,8 @@
 """
 This module models a read-write object representation of the
-X-Globus-ClientInfo header.
+X-Globus-Client-Info header.
 
-The spec for X-Globus-ClientInfo is documented, in brief, in the GlobusClientInfo class
+The spec for X-Globus-Client-Info is documented, in brief, in the GlobusClientInfo class
 docstring.
 """
 
@@ -22,6 +22,12 @@ class GlobusClientInfo:
     mapping of multiple products to versions and potentially other information.
 
     Values can be added to a clientinfo object via the ``add()`` method.
+
+    The object always initializes itself to start with
+
+        product=python-sdk,version=...
+
+    using the current package version information.
 
     .. rubric:: ``X-Globus-Client-Info`` Specification
 
@@ -44,8 +50,8 @@ class GlobusClientInfo:
 
     .. code-block:: none
 
-        X-Globus-ClientInfo: product=python-sdk,version=3.32.1
-        X-Globus-ClientInfo: product=python-sdk,version=3.32.1;product=cli,version=4.0.0a1
+        X-Globus-Client-Info: product=python-sdk,version=3.32.1
+        X-Globus-Client-Info: product=python-sdk,version=3.32.1;product=cli,version=4.0.0a1
 
     .. note::
 
@@ -56,6 +62,7 @@ class GlobusClientInfo:
 
     def __init__(self) -> None:
         self.infos: list[str] = []
+        self.add({"product": "python-sdk", "version": __version__})
 
     def __bool__(self) -> bool:
         """Check if there are any values present."""
@@ -83,20 +90,6 @@ class GlobusClientInfo:
                 f"Bad usage: '{value}'"
             )
         self.infos.append(value)
-
-
-class DefaultGlobusClientInfo(GlobusClientInfo):
-    """
-    A variant of GlobusClientInfo which always initializes itself to start with
-
-        product=python-sdk,version=...
-
-    using the current package version information.
-    """
-
-    def __init__(self) -> None:
-        super().__init__()
-        self.add({"product": "python-sdk", "version": __version__})
 
 
 def _format_items(info: dict[str, str]) -> t.Iterable[str]:

--- a/src/globus_sdk/transport/requests.py
+++ b/src/globus_sdk/transport/requests.py
@@ -18,6 +18,7 @@ from globus_sdk.transport.encoders import (
 )
 from globus_sdk.version import __version__
 
+from ._clientinfo import DefaultGlobusClientInfo, GlobusClientInfo
 from .retry import (
     RetryCheck,
     RetryCheckFlags,
@@ -114,6 +115,7 @@ class RequestsTransport:
         self.verify_ssl = config.get_ssl_verify(verify_ssl)
         self.http_timeout = config.get_http_timeout(http_timeout)
         self._user_agent = self.BASE_USER_AGENT
+        self.globus_clientinfo: GlobusClientInfo = DefaultGlobusClientInfo()
 
         # retry parameters
         self.retry_backoff = retry_backoff
@@ -135,7 +137,10 @@ class RequestsTransport:
 
     @property
     def _headers(self) -> dict[str, str]:
-        return {"Accept": "application/json", "User-Agent": self.user_agent}
+        headers = {"Accept": "application/json", "User-Agent": self.user_agent}
+        if self.globus_clientinfo:
+            headers["X-Globus-ClientInfo"] = self.globus_clientinfo.format()
+        return headers
 
     @contextlib.contextmanager
     def tune(

--- a/src/globus_sdk/transport/requests.py
+++ b/src/globus_sdk/transport/requests.py
@@ -18,7 +18,7 @@ from globus_sdk.transport.encoders import (
 )
 from globus_sdk.version import __version__
 
-from ._clientinfo import DefaultGlobusClientInfo, GlobusClientInfo
+from ._clientinfo import GlobusClientInfo
 from .retry import (
     RetryCheck,
     RetryCheckFlags,
@@ -115,7 +115,7 @@ class RequestsTransport:
         self.verify_ssl = config.get_ssl_verify(verify_ssl)
         self.http_timeout = config.get_http_timeout(http_timeout)
         self._user_agent = self.BASE_USER_AGENT
-        self.globus_clientinfo: GlobusClientInfo = DefaultGlobusClientInfo()
+        self.globus_client_info: GlobusClientInfo = GlobusClientInfo()
 
         # retry parameters
         self.retry_backoff = retry_backoff
@@ -138,8 +138,8 @@ class RequestsTransport:
     @property
     def _headers(self) -> dict[str, str]:
         headers = {"Accept": "application/json", "User-Agent": self.user_agent}
-        if self.globus_clientinfo:
-            headers["X-Globus-ClientInfo"] = self.globus_clientinfo.format()
+        if self.globus_client_info:
+            headers["X-Globus-Client-Info"] = self.globus_client_info.format()
         return headers
 
     @contextlib.contextmanager

--- a/tests/functional/base_client/test_default_headers.py
+++ b/tests/functional/base_client/test_default_headers.py
@@ -1,0 +1,34 @@
+from globus_sdk import __version__
+from globus_sdk._testing import RegisteredResponse, get_last_request
+
+
+def test_clientinfo_header_default(client):
+    RegisteredResponse(
+        path="https://foo.api.globus.org/bar",
+        json={"foo": "bar"},
+    ).add()
+    res = client.request("GET", "/bar")
+    assert res.http_status == 200
+
+    req = get_last_request()
+    assert "X-Globus-Client-Info" in req.headers
+    assert (
+        req.headers["X-Globus-Client-Info"]
+        == f"product=python-sdk,version={__version__}"
+    )
+
+
+def test_clientinfo_header_can_be_supressed(client):
+    RegisteredResponse(
+        path="https://foo.api.globus.org/bar",
+        json={"foo": "bar"},
+    ).add()
+
+    # clear the X-Globus-Client-Info header
+    client.transport.globus_client_info.infos = []
+
+    res = client.request("GET", "/bar")
+    assert res.http_status == 200
+
+    req = get_last_request()
+    assert "X-Globus-Client-Info" not in req.headers

--- a/tests/unit/transport/test_clientinfo.py
+++ b/tests/unit/transport/test_clientinfo.py
@@ -1,7 +1,7 @@
 import pytest
 
 from globus_sdk import __version__
-from globus_sdk.transport._clientinfo import GlobusClientInfo
+from globus_sdk.transport import GlobusClientInfo
 
 
 def make_empty_clientinfo():

--- a/tests/unit/transport/test_clientinfo.py
+++ b/tests/unit/transport/test_clientinfo.py
@@ -1,6 +1,52 @@
 import pytest
 
+from globus_sdk import __version__
 from globus_sdk.transport._clientinfo import DefaultGlobusClientInfo, GlobusClientInfo
+
+
+def parse_clientinfo(header):
+    """
+    Sample parser.
+
+    Including this in the testsuite not only validates the mechanical implementation of
+    X-Globus-Client-Info, but also acts as a safety check that we've thought through the
+    ability of consumers to parse this data.
+    """
+    mappings = {}
+    for segment in header.split(";"):
+        segment_dict = {}
+
+        segment = segment.strip()
+        elements = segment.split(",")
+
+        for element in elements:
+            if "=" not in element:
+                raise ValueError(
+                    f"Bad X-Globus-Client-Info element: '{element}' in '{header}'"
+                )
+            key, _, value = element.partition("=")
+            if "=" in value:
+                raise ValueError(
+                    f"Bad X-Globus-Client-Info element: '{element}' in '{header}'"
+                )
+            if key in segment_dict:
+                raise ValueError(
+                    f"Bad X-Globus-Client-Info element: '{element}' in '{header}'"
+                )
+            segment_dict[key] = value
+        if "product" not in segment_dict:
+            raise ValueError(
+                "Bad X-GlobusClientInfo segment missing product: "
+                f"'{segment}' in '{header}'"
+            )
+        product = segment_dict["product"]
+        if product in mappings:
+            raise ValueError(
+                "Bad X-GlobusClientInfo header repeats product: "
+                f"'{product}' in '{header}'"
+            )
+        mappings[product] = segment_dict
+    return mappings
 
 
 def test_clientinfo_bool_after_init():
@@ -39,3 +85,21 @@ def test_format_of_multiple_items(values, expect_str):
     for value in values:
         info.add(value)
     assert info.format() == expect_str
+
+
+def test_clientinfo_parses_as_expected():
+    default = DefaultGlobusClientInfo()
+    default.add("alpha=b01,product=my-cool-tool")
+    header_str = default.format()
+
+    parsed = parse_clientinfo(header_str)
+    assert parsed == {
+        "python-sdk": {
+            "product": "python-sdk",
+            "version": __version__,
+        },
+        "my-cool-tool": {
+            "product": "my-cool-tool",
+            "alpha": "b01",
+        },
+    }

--- a/tests/unit/transport/test_clientinfo.py
+++ b/tests/unit/transport/test_clientinfo.py
@@ -1,0 +1,41 @@
+import pytest
+
+from globus_sdk.transport._clientinfo import DefaultGlobusClientInfo, GlobusClientInfo
+
+
+def test_clientinfo_bool_after_init():
+    # base clientinfo starts empty and should bool false
+    base = GlobusClientInfo()
+    assert bool(base) is False
+    # default clientinfo starts with the SDK version and should bool true
+    default = DefaultGlobusClientInfo()
+    assert bool(default) is True
+
+
+@pytest.mark.parametrize(
+    "value, expect_str",
+    (
+        ("x=y", "x=y"),
+        ("x=y,omicron=iota", "x=y,omicron=iota"),
+        ({"x": "y"}, "x=y"),
+        ({"x": "y", "alpha": "b01"}, "x=y,alpha=b01"),
+    ),
+)
+def test_format_of_simple_item(value, expect_str):
+    info = GlobusClientInfo()
+    info.add(value)
+    assert info.format() == expect_str
+
+
+@pytest.mark.parametrize(
+    "values, expect_str",
+    (
+        (("x=y",), "x=y"),
+        (("x=y", "alpha=b01,omicron=iota"), "x=y;alpha=b01,omicron=iota"),
+    ),
+)
+def test_format_of_multiple_items(values, expect_str):
+    info = GlobusClientInfo()
+    for value in values:
+        info.add(value)
+    assert info.format() == expect_str


### PR DESCRIPTION
## Why

The goal of this PR is to start emitting a `X-Globus-Client-Info` header
which encodes the SDK version, and can easily be expanded to include other
product name/version combinations. (e.g. compute SDK, globus-cli, etc)

`X-Globus-Client-Info` is a recent spec we've put together in collaboration
with our frontend dev team and supersedes the use of a custom User-Agent to
encode app information (`app_name`). We needed some new art in this space as
setting a custom User-Agent is not an appropriate solution for the browser
context.

The `app_name` value and `User-Agent` behavior is not deprecated at this
time. In future SDK versions, we may choose to deprecate that behavior if we
feel it is in our interest to only provide this data via the new header.

## What

- Add a new class to implement basic encoding of the header,
  `GlobusClientInfo`. This class is documented and provides the public
  interface for this component. However, it is only exported at the
  `globus_sdk.transport` layer, as most users will not need to interact with
  it directly.

- Add a private, custom subclass, `DefaultGlobusClientInfo`, which seeds
  `product=python-sdk,version={globus_sdk.__version__}` on init.

- `RequestsTransport` has been enhanced to include
  `self.globus_clientinfo = DefaultGlobusClientInfo()` on init, meaning that
  it seeds and stores this information in a publicly accessible attribute.
  When `RequestsTransport` builds headers for a request, it now also includes
  `self.globus_clientinfo`.

## Notes

- `DefaultGlobusClientInfo` behavior could simply be baked into the base
  `GlobusClientInfo` -- input and debate welcome. There are various
  equally-valid ways of seeding this information. The goals are to ensure that
  this data is set for all SDK calls, that the implementation is easy to
  understand, and that it is easy to extend, modify, and even disable.

- A clear target use-case here is ``globus-cli``. The intent here is that the
  CLI can update such that each client builder adds a call to

    ```python
    newclient.transport.globus_clientinfo.add(
        {"product": "cli", "version": globus_cli.__version__}
    )
    ```

  A better/easier hooking interface could be added in the future, if one can be
  designed based on our experience in that context.


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--990.org.readthedocs.build/en/990/

<!-- readthedocs-preview globus-sdk-python end -->