### PR TITLE
Exclude twine==5.1.0 and set `--strict`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -79,12 +79,12 @@ commands = sphinx-build -j auto -d _build/doctrees -b dirhtml -W . _build/dirhtm
 [testenv:twine-check]
 skip_install = true
 deps = build
-       twine
+       twine!=5.1.0
 allowlist_externals = rm
 commands_pre = rm -rf dist/
 # check that twine validating package data works
 commands = python -m build
-           twine check dist/*
+           twine check --strict dist/*
 
 [testenv:poetry-check]
 skip_install = true


### PR DESCRIPTION
5.1.0 has a bug with how it interacts with `importlib_metadata>=8.0`.

A fix is in progress, but it's not clear when it will be released (probably soon).


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--992.org.readthedocs.build/en/992/

<!-- readthedocs-preview globus-sdk-python end -->