### PR TITLE
Automatically create the directory path for a JSONTokenStorage

### DIFF
--- a/changelog.d/20240709_111157_derek_auto_create_json_token_path.rst
+++ b/changelog.d/20240709_111157_derek_auto_create_json_token_path.rst
@@ -1,0 +1,6 @@
+
+Fixed
+~~~~~
+
+- When a JSONTokenStorage is used, the containing directory will be automatically be
+  created if it doesn't exist instead of erroring (on Mac).

--- a/src/globus_sdk/experimental/tokenstorage/json.py
+++ b/src/globus_sdk/experimental/tokenstorage/json.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import pathlib
 import typing as t
 
@@ -40,7 +41,14 @@ class JSONTokenStorage(FileTokenStorage):
         :param namespace: A user-supplied namespace for partitioning token data
         """
         self.filename = str(filename)
+        self._ensure_containing_dir_exists()
         super().__init__(namespace=namespace)
+
+    def _ensure_containing_dir_exists(self) -> None:
+        """
+        Ensure that the directory containing the given filename exists.
+        """
+        os.makedirs(os.path.dirname(self.filename), exist_ok=True)
 
     def _invalid(self, msg: str) -> t.NoReturn:
         raise ValueError(


### PR DESCRIPTION
## What?
* Automatically create the directory path for a JSONTokenStorage

## Why?
* The first usage of GlobusApp with default configuration raised an error on my machine (`~/.globus/app` dir didn't exist).

<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--998.org.readthedocs.build/en/998/

<!-- readthedocs-preview globus-sdk-python end -->