### PR TITLE
Very minor changelog entry tweak

### DIFF
--- a/changelog.d/20240709_111157_derek_auto_create_json_token_path.rst
+++ b/changelog.d/20240709_111157_derek_auto_create_json_token_path.rst
@@ -1,6 +1,5 @@
-
 Fixed
 ~~~~~
 
 - When a JSONTokenStorage is used, the containing directory will be automatically be
-  created if it doesn't exist instead of erroring (on Mac).
+  created if it doesn't exist. (:pr:`998`)


### PR DESCRIPTION
This is just my feedback on #998 reified in a follow-up.

I don't think we should mention platforms, since it's not a platform-specific behavior. I actually dropped a full clause from the end of the entry, since I don't think it was necessary.

<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--999.org.readthedocs.build/en/999/

<!-- readthedocs-preview globus-sdk-python end -->