### PR TITLE
Support dependent token evaluation in GlobusApp

### DIFF
--- a/changelog.d/20240710_122120_derek_globus_app_dependent_token_support.rst
+++ b/changelog.d/20240710_122120_derek_globus_app_dependent_token_support.rst
@@ -1,0 +1,11 @@
+
+Fixed
+~~~~~
+
+- ``GlobusApp.add_scope_requirements`` now has the side effect of clearing the
+  authorizer cache for any referenced resource servers. (:pr:`NUMBER`)
+- ``GlobusAuthorizer.scope_requirements`` was made private and a new method for
+  accessing scope requirements was added at ``GlobusAuthorizer.get_scope_requirements``.
+  (:pr:`NUMBER`)
+- A ``GlobusApp`` will now auto-create an Auth consent client for dependent scope
+  evaluation against consents as a part of instantiation. (:pr:`NUMBER`)

--- a/src/globus_sdk/experimental/globus_app/_validating_token_storage.py
+++ b/src/globus_sdk/experimental/globus_app/_validating_token_storage.py
@@ -94,6 +94,14 @@ class ValidatingTokenStorage(TokenStorage):
             token_data_by_resource_server
         )
 
+    def set_consent_client(self, consent_client: AuthClient) -> None:
+        """
+        Set the consent client to be used for consent polling.
+
+        :param consent_client: An AuthClient to be used for consent polling.
+        """
+        self._consent_client = consent_client
+
     def store_token_data_by_resource_server(
         self, token_data_by_resource_server: dict[str, TokenData]
     ) -> None:

--- a/src/globus_sdk/experimental/globus_app/authorizer_factory.py
+++ b/src/globus_sdk/experimental/globus_app/authorizer_factory.py
@@ -55,7 +55,21 @@ class AuthorizerFactory(
             in the underlying ``ValidatingTokenStorage``.
         """
         self.token_storage.store_token_response(token_res)
-        self._authorizer_cache = {}
+        self.clear_cache()
+
+    def clear_cache(self, *resource_servers: str) -> None:
+        """
+        Clear the authorizer cache for the given resource servers.
+        If no resource servers are given, clear the entire cache.
+
+        :param resource_servers: The resource servers for which to clear the cache
+        """
+        if not resource_servers:
+            self._authorizer_cache = {}
+        else:
+            for resource_server in resource_servers:
+                if resource_server in self._authorizer_cache:
+                    del self._authorizer_cache[resource_server]
 
     def get_authorizer(self, resource_server: str) -> GA:
         """
@@ -102,6 +116,16 @@ class AccessTokenAuthorizerFactory(AuthorizerFactory[AccessTokenAuthorizer]):
     ) -> None:
         super().store_token_response_and_clear_cache(token_res)
         self._cached_authorizer_expiration = {}
+
+    def clear_cache(self, *resource_servers: str) -> None:
+        if not resource_servers:
+            self._cached_authorizer_expiration = {}
+        else:
+            for resource_server in resource_servers:
+                if resource_server in self._cached_authorizer_expiration:
+                    del self._cached_authorizer_expiration[resource_server]
+
+        super().clear_cache(*resource_servers)
 
     def get_authorizer(self, resource_server: str) -> AccessTokenAuthorizer:
         """

--- a/tests/unit/experimental/globus_app/test_globus_app.py
+++ b/tests/unit/experimental/globus_app/test_globus_app.py
@@ -113,6 +113,13 @@ def test_user_app_default_token_storage():
         )
 
 
+def test_user_app_creates_consent_client():
+    client_id = "mock_client_id"
+    user_app = UserApp("test-app", client_id=client_id)
+
+    assert user_app._validating_token_storage._consent_client is not None
+
+
 def test_user_app_templated():
     client_id = "mock_client_id"
     client_secret = "mock_client_secret"
@@ -209,6 +216,29 @@ def test_user_app_get_authorizer():
     authorizer = user_app.get_authorizer("auth.globus.org")
     assert isinstance(authorizer, AccessTokenAuthorizer)
     assert authorizer.access_token == "mock_access_token"
+
+
+def test_user_app_get_authorizer_clears_cache_when_adding_scope_requirements():
+    client_id = "mock_client_id"
+    memory_storage = MemoryTokenStorage()
+    memory_storage.store_token_data_by_resource_server(_mock_token_data_by_rs())
+    config = GlobusAppConfig(token_storage=memory_storage)
+    user_app = UserApp("test-app", client_id=client_id, config=config)
+
+    initial_authorizer = user_app.get_authorizer("auth.globus.org")
+    assert isinstance(initial_authorizer, AccessTokenAuthorizer)
+    assert initial_authorizer.access_token == "mock_access_token"
+
+    # We should've cached the authorizer from the first call
+    assert user_app.get_authorizer("auth.globus.org") == initial_authorizer
+
+    user_app.add_scope_requirements({"auth.globus.org": [Scope("openid")]})
+
+    # The cache should've been cleared
+    updated_authorizer = user_app.get_authorizer("auth.globus.org")
+    assert initial_authorizer != updated_authorizer
+    assert isinstance(updated_authorizer, AccessTokenAuthorizer)
+    assert updated_authorizer.access_token == "mock_access_token"
 
 
 def test_user_app_get_authorizer_refresh():

--- a/tests/unit/experimental/globus_app/test_globus_app.py
+++ b/tests/unit/experimental/globus_app/test_globus_app.py
@@ -230,15 +230,17 @@ def test_user_app_get_authorizer_clears_cache_when_adding_scope_requirements():
     assert initial_authorizer.access_token == "mock_access_token"
 
     # We should've cached the authorizer from the first call
-    assert user_app.get_authorizer("auth.globus.org") == initial_authorizer
+    assert user_app.get_authorizer("auth.globus.org") is initial_authorizer
 
     user_app.add_scope_requirements({"auth.globus.org": [Scope("openid")]})
 
     # The cache should've been cleared
     updated_authorizer = user_app.get_authorizer("auth.globus.org")
-    assert initial_authorizer != updated_authorizer
+    assert initial_authorizer is not updated_authorizer
     assert isinstance(updated_authorizer, AccessTokenAuthorizer)
     assert updated_authorizer.access_token == "mock_access_token"
+
+    assert user_app.get_authorizer("auth.globus.org") is updated_authorizer
 
 
 def test_user_app_get_authorizer_refresh():

--- a/tests/unit/experimental/test_client_integration.py
+++ b/tests/unit/experimental/test_client_integration.py
@@ -7,7 +7,7 @@ def test_transfer_client_default_scopes():
     app = UserApp("test-app", client_id="client_id")
     globus_sdk.TransferClient(app=app)
 
-    assert [str(s) for s in app.scope_requirements["transfer.api.globus.org"]] == [
+    assert [str(s) for s in app.get_scope_requirements("transfer.api.globus.org")] == [
         "urn:globus:auth:scope:transfer.api.globus.org:all"
     ]
 
@@ -17,7 +17,7 @@ def test_transfer_client_add_app_data_access_scope():
     client = globus_sdk.TransferClient(app=app)
 
     client.add_app_data_access_scope("collection_id")
-    str_list = [str(s) for s in app.scope_requirements["transfer.api.globus.org"]]
+    str_list = [str(s) for s in app.get_scope_requirements("transfer.api.globus.org")]
     expected = "urn:globus:auth:scope:transfer.api.globus.org:all[*https://auth.globus.org/scopes/collection_id/data_access]"  # noqa
     assert expected in str_list
 
@@ -28,7 +28,7 @@ def test_transfer_client_add_app_data_access_scope_chaining():
         "collection_id_1"
     ).add_app_data_access_scope("collection_id_2")
 
-    str_list = [str(s) for s in app.scope_requirements["transfer.api.globus.org"]]
+    str_list = [str(s) for s in app.get_scope_requirements("transfer.api.globus.org")]
     expected_1 = "urn:globus:auth:scope:transfer.api.globus.org:all[*https://auth.globus.org/scopes/collection_id_1/data_access]"  # noqa
     expected_2 = "urn:globus:auth:scope:transfer.api.globus.org:all[*https://auth.globus.org/scopes/collection_id_2/data_access]"  # noqa
     assert expected_1 in str_list
@@ -39,7 +39,7 @@ def test_auth_client_default_scopes():
     app = UserApp("test-app", client_id="client_id")
     globus_sdk.AuthClient(app=app)
 
-    str_list = [str(s) for s in app.scope_requirements["auth.globus.org"]]
+    str_list = [str(s) for s in app.get_scope_requirements("auth.globus.org")]
     assert "openid" in str_list
     assert "profile" in str_list
     assert "email" in str_list
@@ -49,7 +49,7 @@ def test_groups_client_default_scopes():
     app = UserApp("test-app", client_id="client_id")
     globus_sdk.GroupsClient(app=app)
 
-    assert [str(s) for s in app.scope_requirements["groups.api.globus.org"]] == [
+    assert [str(s) for s in app.get_scope_requirements("groups.api.globus.org")] == [
         "urn:globus:auth:scope:groups.api.globus.org:view_my_groups_and_memberships"
     ]
 
@@ -58,7 +58,7 @@ def test_search_client_default_scopes():
     app = UserApp("test-app", client_id="client_id")
     globus_sdk.SearchClient(app=app)
 
-    assert [str(s) for s in app.scope_requirements["search.api.globus.org"]] == [
+    assert [str(s) for s in app.get_scope_requirements("search.api.globus.org")] == [
         "urn:globus:auth:scope:search.api.globus.org:search"
     ]
 
@@ -67,32 +67,27 @@ def test_timer_client_default_scopes():
     app = UserApp("test-app", client_id="client_id")
     globus_sdk.TimerClient(app=app)
 
-    assert [
-        str(s) for s in app.scope_requirements["524230d7-ea86-4a52-8312-86065a9e0417"]
-    ] == ["https://auth.globus.org/scopes/524230d7-ea86-4a52-8312-86065a9e0417/timer"]
+    timer_client_id = "524230d7-ea86-4a52-8312-86065a9e0417"
+    str_list = [str(s) for s in app.get_scope_requirements(timer_client_id)]
+    assert str_list == [f"https://auth.globus.org/scopes/{timer_client_id}/timer"]
 
 
 def test_flows_client_default_scopes():
     app = UserApp("test-app", client_id="client_id")
     globus_sdk.FlowsClient(app=app)
 
-    str_list = [str(s) for s in app.scope_requirements["flows.globus.org"]]
+    flows_client_id = "eec9b274-0c81-4334-bdc2-54e90e689b9a"
+    str_list = [str(s) for s in app.get_scope_requirements("flows.globus.org")]
     assert len(str_list) == 2
-    assert (
-        "https://auth.globus.org/scopes/eec9b274-0c81-4334-bdc2-54e90e689b9a/view_flows"
-        in str_list
-    )
-    assert (
-        "https://auth.globus.org/scopes/eec9b274-0c81-4334-bdc2-54e90e689b9a/run_status"
-        in str_list
-    )
+    assert f"https://auth.globus.org/scopes/{flows_client_id}/view_flows" in str_list
+    assert f"https://auth.globus.org/scopes/{flows_client_id}/run_status" in str_list
 
 
 def test_specific_flow_client_default_scopes():
     app = UserApp("test-app", client_id="client_id")
     globus_sdk.SpecificFlowClient("flow_id", app=app)
 
-    assert [str(s) for s in app.scope_requirements["flow_id"]] == [
+    assert [str(s) for s in app.get_scope_requirements("flow_id")] == [
         "https://auth.globus.org/scopes/flow_id/flow_flow_id_user"
     ]
 
@@ -105,6 +100,6 @@ def test_gcs_client_default_scopes():
     app = UserApp("test-app", client_id="client_id")
     globus_sdk.GCSClient(domain_name, app=app)
 
-    assert [str(s) for s in app.scope_requirements[endpoint_client_id]] == [
+    assert [str(s) for s in app.get_scope_requirements(endpoint_client_id)] == [
         f"urn:globus:auth:scope:{endpoint_client_id}:manage_collections"
     ]

--- a/tests/unit/test_base_client.py
+++ b/tests/unit/test_base_client.py
@@ -226,7 +226,7 @@ def test_app_integration(base_client_class):
     assert c.app_name == "SDK Test"
 
     # confirm default_required_scopes were automatically added
-    assert [str(s) for s in app.scope_requirements[c.resource_server]] == [
+    assert [str(s) for s in app.get_scope_requirements(c.resource_server)] == [
         TransferScopes.all
     ]
 
@@ -244,7 +244,7 @@ def test_app_scopes(base_client_class):
     c = base_client_class(app=app, app_scopes=[Scope("foo")])
 
     # confirm app_scopes were added and default_required_scopes were not
-    assert [str(s) for s in app.scope_requirements[c.resource_server]] == ["foo"]
+    assert [str(s) for s in app.get_scope_requirements(c.resource_server)] == ["foo"]
 
 
 def test_add_app_scope(base_client_class):
@@ -252,7 +252,7 @@ def test_add_app_scope(base_client_class):
     c = base_client_class(app=app)
 
     c.add_app_scope("foo")
-    str_list = [str(s) for s in app.scope_requirements[c.resource_server]]
+    str_list = [str(s) for s in app.get_scope_requirements(c.resource_server)]
     assert len(str_list) == 2
     assert TransferScopes.all in str_list
     assert "foo" in str_list
@@ -261,7 +261,7 @@ def test_add_app_scope(base_client_class):
 def test_add_app_scope_chaining(base_client_class):
     app = UserApp("SDK Test", client_id="client_id")
     c = base_client_class(app=app).add_app_scope("foo").add_app_scope("bar")
-    str_list = [str(s) for s in app.scope_requirements[c.resource_server]]
+    str_list = [str(s) for s in app.get_scope_requirements(c.resource_server)]
     assert len(str_list) == 3
     assert TransferScopes.all in str_list
     assert "foo" in str_list


### PR DESCRIPTION

- `GlobusApp.add_scope_requirements` now has the side effect of clearing the authorizer
  cache for any referenced resource servers.
- `GlobusAuthorizer.scope_requirements` was made private and a new method for
  accessing scope requirements was added at `GlobusAuthorizer.get_scope_requirements`.
- A `GlobusApp` will now auto-create an Auth consent client for dependent scope
  evaluation against consents as a part of instantiation.


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1000.org.readthedocs.build/en/1000/

<!-- readthedocs-preview globus-sdk-python end -->