### PR TITLE
Globus app configurable environment

### DIFF
--- a/changelog.d/20240711_090442_derek_globus_app_configurable_environment.rst
+++ b/changelog.d/20240711_090442_derek_globus_app_configurable_environment.rst
@@ -1,0 +1,6 @@
+
+Added
+~~~~~
+
+- Added the configuration parameter ``GlobusAppConfig.environment``. (:pr:`NUMBER`)
+

--- a/src/globus_sdk/client.py
+++ b/src/globus_sdk/client.py
@@ -75,6 +75,8 @@ class BaseClient:
         # the env var -- and in the special case of `production` translate to
         # `default`, regardless of the source of that value
         # logs the environment when it isn't `default`
+        if environment is None and app is not None:
+            environment = app.config.environment
         self.environment = config.get_environment_name(environment)
 
         if self.service_name == "_base":

--- a/src/globus_sdk/client.py
+++ b/src/globus_sdk/client.py
@@ -71,11 +71,11 @@ class BaseClient:
         app_name: str | None = None,
         transport_params: dict[str, t.Any] | None = None,
     ):
-        # Environment determining logic (fallthrough):
-        #   1. If an environment was explicitly passed, use it
-        #   2. If an app was passed, use the app's config environment
-        #   3. If the environment variable `GLOBUS_SDK_ENVIRONMENT` is set, use it
-        #   4. Use the default environment (production)
+        # Environment selection precedence order:
+        #   1. Through the client's `environment` init param
+        #   2. Through the `app`'s `config.environment`
+        #   3. Through the environment variable `GLOBUS_SDK_ENVIRONMENT`
+        #   4. The default environment (production)
         if environment is not None:
             self.environment = environment
         elif app:

--- a/src/globus_sdk/experimental/globus_app/globus_app.py
+++ b/src/globus_sdk/experimental/globus_app/globus_app.py
@@ -106,7 +106,7 @@ class GlobusAppConfig:
     :param token_validation_error_handler: A callable that will be called when a
         token validation error is encountered. The default behavior is to retry the
         login flow automatically.
-    :param environment: The globus environment being targeted by this app. This is
+    :param environment: The Globus environment being targeted by this app. This is
         predominately for internal use and can be ignored in most cases.
     """
 

--- a/src/globus_sdk/experimental/globus_app/globus_app.py
+++ b/src/globus_sdk/experimental/globus_app/globus_app.py
@@ -12,8 +12,8 @@ from globus_sdk import (
     ConfidentialAppAuthClient,
     NativeAppAuthClient,
     Scope,
-    config,
 )
+from globus_sdk import config as sdk_config
 from globus_sdk._types import UUIDLike
 from globus_sdk.authorizers import GlobusAuthorizer
 from globus_sdk.exc import GlobusSDKUsageError
@@ -116,7 +116,9 @@ class GlobusAppConfig:
     token_validation_error_handler: TokenValidationErrorHandler | None = (
         resolve_by_login_flow
     )
-    environment: str = dataclasses.field(default_factory=config.get_environment_name)
+    environment: str = dataclasses.field(
+        default_factory=sdk_config.get_environment_name
+    )
 
 
 _DEFAULT_CONFIG = GlobusAppConfig()

--- a/tests/unit/experimental/globus_app/test_globus_app.py
+++ b/tests/unit/experimental/globus_app/test_globus_app.py
@@ -72,7 +72,7 @@ def test_user_app_native():
 
 
 def test_user_app_login_client():
-    mock_client = mock.Mock()
+    mock_client = mock.Mock(environment="production")
     user_app = UserApp("test-app", login_client=mock_client)
 
     assert user_app.app_name == "test-app"
@@ -91,10 +91,20 @@ def test_user_app_both_client_and_id():
 
     with pytest.raises(GlobusSDKUsageError) as exc:
         UserApp("test-app", login_client=mock_client, client_id=client_id)
-    assert (
-        str(exc.value)
-        == "login_client is mutually exclusive with client_id and client_secret."
-    )
+
+    expected = "login_client is mutually exclusive with client_id and client_secret."
+    assert str(exc.value) == expected
+
+
+def test_user_app_login_client_environment_mismatch():
+    mock_client = mock.Mock(environment="sandbox")
+
+    with pytest.raises(GlobusSDKUsageError) as exc:
+        config = GlobusAppConfig(environment="preview")
+        UserApp("test-app", login_client=mock_client, config=config)
+
+    expected = "[Environment Mismatch] The login_client's environment (sandbox) does not match the GlobusApp's configured environment (preview)."  # noqa
+    assert str(exc.value) == expected
 
 
 def test_user_app_default_token_storage():

--- a/tests/unit/experimental/test_client_integration.py
+++ b/tests/unit/experimental/test_client_integration.py
@@ -1,10 +1,36 @@
+import pytest
+
 import globus_sdk
 from globus_sdk._testing import load_response
-from globus_sdk.experimental.globus_app import UserApp
+from globus_sdk.experimental.globus_app import GlobusApp, GlobusAppConfig, UserApp
+from globus_sdk.experimental.tokenstorage import MemoryTokenStorage
 
 
-def test_transfer_client_default_scopes():
-    app = UserApp("test-app", client_id="client_id")
+@pytest.fixture
+def app() -> GlobusApp:
+    config = GlobusAppConfig(token_storage=MemoryTokenStorage())
+    return UserApp("test-app", client_id="client_id", config=config)
+
+
+def test_client_inherits_environment_from_globus_app():
+    config = GlobusAppConfig(token_storage=MemoryTokenStorage(), environment="sandbox")
+    app = UserApp("test-app", client_id="client_id", config=config)
+
+    client = globus_sdk.AuthClient(app=app)
+
+    assert client.environment == "sandbox"
+
+
+def test_client_environment_param_overrides_globus_app_environment():
+    config = GlobusAppConfig(token_storage=MemoryTokenStorage(), environment="sandbox")
+    app = UserApp("test-app", client_id="client_id", config=config)
+
+    client = globus_sdk.AuthClient(app=app, environment="preview")
+
+    assert client.environment == "preview"
+
+
+def test_transfer_client_default_scopes(app):
     globus_sdk.TransferClient(app=app)
 
     assert [str(s) for s in app.get_scope_requirements("transfer.api.globus.org")] == [
@@ -12,8 +38,7 @@ def test_transfer_client_default_scopes():
     ]
 
 
-def test_transfer_client_add_app_data_access_scope():
-    app = UserApp("test-app", client_id="client_id")
+def test_transfer_client_add_app_data_access_scope(app):
     client = globus_sdk.TransferClient(app=app)
 
     client.add_app_data_access_scope("collection_id")
@@ -22,11 +47,12 @@ def test_transfer_client_add_app_data_access_scope():
     assert expected in str_list
 
 
-def test_transfer_client_add_app_data_access_scope_chaining():
-    app = UserApp("test-app", client_id="client_id")
-    globus_sdk.TransferClient(app=app).add_app_data_access_scope(
-        "collection_id_1"
-    ).add_app_data_access_scope("collection_id_2")
+def test_transfer_client_add_app_data_access_scope_chaining(app):
+    (
+        globus_sdk.TransferClient(app=app)
+        .add_app_data_access_scope("collection_id_1")
+        .add_app_data_access_scope("collection_id_2")
+    )
 
     str_list = [str(s) for s in app.get_scope_requirements("transfer.api.globus.org")]
     expected_1 = "urn:globus:auth:scope:transfer.api.globus.org:all[*https://auth.globus.org/scopes/collection_id_1/data_access]"  # noqa
@@ -35,8 +61,7 @@ def test_transfer_client_add_app_data_access_scope_chaining():
     assert expected_2 in str_list
 
 
-def test_auth_client_default_scopes():
-    app = UserApp("test-app", client_id="client_id")
+def test_auth_client_default_scopes(app):
     globus_sdk.AuthClient(app=app)
 
     str_list = [str(s) for s in app.get_scope_requirements("auth.globus.org")]
@@ -45,8 +70,7 @@ def test_auth_client_default_scopes():
     assert "email" in str_list
 
 
-def test_groups_client_default_scopes():
-    app = UserApp("test-app", client_id="client_id")
+def test_groups_client_default_scopes(app):
     globus_sdk.GroupsClient(app=app)
 
     assert [str(s) for s in app.get_scope_requirements("groups.api.globus.org")] == [
@@ -54,8 +78,7 @@ def test_groups_client_default_scopes():
     ]
 
 
-def test_search_client_default_scopes():
-    app = UserApp("test-app", client_id="client_id")
+def test_search_client_default_scopes(app):
     globus_sdk.SearchClient(app=app)
 
     assert [str(s) for s in app.get_scope_requirements("search.api.globus.org")] == [
@@ -63,8 +86,7 @@ def test_search_client_default_scopes():
     ]
 
 
-def test_timer_client_default_scopes():
-    app = UserApp("test-app", client_id="client_id")
+def test_timer_client_default_scopes(app):
     globus_sdk.TimerClient(app=app)
 
     timer_client_id = "524230d7-ea86-4a52-8312-86065a9e0417"
@@ -72,8 +94,7 @@ def test_timer_client_default_scopes():
     assert str_list == [f"https://auth.globus.org/scopes/{timer_client_id}/timer"]
 
 
-def test_flows_client_default_scopes():
-    app = UserApp("test-app", client_id="client_id")
+def test_flows_client_default_scopes(app):
     globus_sdk.FlowsClient(app=app)
 
     flows_client_id = "eec9b274-0c81-4334-bdc2-54e90e689b9a"
@@ -83,8 +104,7 @@ def test_flows_client_default_scopes():
     assert f"https://auth.globus.org/scopes/{flows_client_id}/run_status" in str_list
 
 
-def test_specific_flow_client_default_scopes():
-    app = UserApp("test-app", client_id="client_id")
+def test_specific_flow_client_default_scopes(app):
     globus_sdk.SpecificFlowClient("flow_id", app=app)
 
     assert [str(s) for s in app.get_scope_requirements("flow_id")] == [
@@ -92,12 +112,11 @@ def test_specific_flow_client_default_scopes():
     ]
 
 
-def test_gcs_client_default_scopes():
+def test_gcs_client_default_scopes(app):
     meta = load_response(globus_sdk.GCSClient.get_gcs_info).metadata
     endpoint_client_id = meta["endpoint_client_id"]
     domain_name = meta["domain_name"]
 
-    app = UserApp("test-app", client_id="client_id")
     globus_sdk.GCSClient(domain_name, app=app)
 
     assert [str(s) for s in app.get_scope_requirements(endpoint_client_id)] == [


### PR DESCRIPTION
Added `GlobusAppConfig.environment`.

If omitted, this value is set by looking up the `GLOBUS_SDK_ENVIRONMENT` variable, defaulting to `"production"` if unset.

---

Notable changes:

(A) A client's environment inference heirarchy is now:
  * If GlobusApp is supplied, the client's environment must either match the app's or be omitted
     * GlobusApp environment can be supplied explicitly via `GlobusAppConfig` or is read from the `GLOBUS_SDK_ENVIRONMENT` environment variable.
  * Otherwise:
     * The explicitly provided environment to the client constructor
     * The environment variable `GLOBUS_SDK_ENVIRONMENT`
     * The default (production)

(B) GlobusApp default token storage is now prefixed with the environment name for lower envs.
So for example, in the following snippet
```python
config1 = GlobusAppConfig(environment="production")
app1 = UserApp("my-cool-app", client_id=..., config=config1)

config2 = GlobusAppConfig(environment="sandbox")
app2 = UserApp("my-cool-app", client_id=..., config=config2)
```
`app1`'s tokens would be stored at `~/.globus/app/my-cool-app/tokens.json`
`app2`'s tokens would be stored at `~/.globus/app/my-cool-app/sandbox-tokens.json`

<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1001.org.readthedocs.build/en/1001/

<!-- readthedocs-preview globus-sdk-python end -->