### PR TITLE
Fixed infinitely recursing GlobusApp login

### DIFF
--- a/changelog.d/20240712_101420_derek_globus_app_fix_infinite_login_loop.rst
+++ b/changelog.d/20240712_101420_derek_globus_app_fix_infinite_login_loop.rst
@@ -1,0 +1,6 @@
+
+Fixed
+~~~~~
+
+- Fixed a bug where specifying dependent tokens in a new GlobusApp would cause the app
+  to infinitely prompt for log in. (:pr:`NUMBER`)

--- a/tests/unit/experimental/globus_app/test_validating_token_storage.py
+++ b/tests/unit/experimental/globus_app/test_validating_token_storage.py
@@ -74,10 +74,11 @@ def test_validating_token_storage_evaluates_dependent_scope_requirements(
         consent_client=consent_client,
     )
     token_response = make_token_response(scopes={"rs1": "scope"})
+    adapter.store_token_response(token_response)
 
     consent_client.mocked_forest = make_consent_forest("scope[different_subscope]")
     with pytest.raises(UnmetScopeRequirementsError):
-        adapter.store_token_response(token_response)
+        adapter.get_token_data("rs1")
 
     consent_client.mocked_forest = make_consent_forest("scope[subscope]")
     adapter.store_token_response(token_response)


### PR DESCRIPTION

* Fixed a bug where specifying dependent tokens in a new GlobusApp would cause the app
  to infinitely prompt for log in.

---

### Why was this happening?

[pr-1000](https://github.com/globus/globus-sdk-python/pull/1000) added support for dependent token evaluation by means of an AuthClient which leverages the attached GlobusApp and is used for polling user consents. With this addition, users could unintentionally get themselves into an infinitely recursing login loop with the following script.

```python
import globus_sdk
from globus_sdk.experimental.globus_app import UserApp

NATIVE_CLIENT_ID = "61338d24-54d5-408f-a10d-66c06b59f6d2"
user_app = UserApp("my-simple-app", client_id=NATIVE_CLIENT_ID)

transfer = globus_sdk.TransferClient(app=user_app).add_app_data_access_scope("996383e6-0c85-4339-a5ea-c3cd855c2692")

user_app.get_authorizer(transfer.resource_server)
```

Assuming the app `"my-simple-app"` has no pre-existing tokens, the call to `get_authorizer` would raise a `MissingTokenError`. This error would be intercepted by the app and automatically drive a login flow to supply new tokens. Upon receiving an authorization code, the tokens would be passed through to `ValidatingTokenAdapater.store_token_data_by_resource_server(...)`.

As a part of storing the token data, we validate that they meet both root scope requirements and dependent scope requirements. Evaluating dependent scope requirements involves that aforementioned AuthClient however polling Globus Auth for the user's current consents. This call (`AuthClient.get_consents`) would attempt to get an authorizer, which would in turn raise a `MissingTokenError` (the in flight tokens have yet to be stored as they're in the middle of validation). This error would be intercepted by the app and automatically drive a login flow to supply new tokens. And the loop continues indefinitely (goto previous paragraph).

---

To solves this problem, I removed dependent scope evaluation from token store. Dependent scopes are still evaluated on token retrieval. Root scopes are still evaluated on token storage.

<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1002.org.readthedocs.build/en/1002/

<!-- readthedocs-preview globus-sdk-python end -->