### PR TITLE
Fix LocalServer on MacOS py3.10 and earlier

### DIFF
--- a/changelog.d/20240712_133910_derek_fix_local_server_login_on_mac.rst
+++ b/changelog.d/20240712_133910_derek_fix_local_server_login_on_mac.rst
@@ -1,0 +1,6 @@
+
+Fixed
+~~~~~
+
+- Fixed a GlobusApp bug which would cause LocalServerLoginFlowManager to error on
+  MacOS when versions earlier than python 3.11. (:pr:`NUMBER`)

--- a/changelog.d/20240712_133910_derek_fix_local_server_login_on_mac.rst
+++ b/changelog.d/20240712_133910_derek_fix_local_server_login_on_mac.rst
@@ -3,4 +3,4 @@ Fixed
 ~~~~~
 
 - Fixed a GlobusApp bug which would cause LocalServerLoginFlowManager to error on
-  MacOS when versions earlier than python 3.11. (:pr:`NUMBER`)
+  MacOS when versions earlier than Python 3.11. (:pr:`NUMBER`)

--- a/src/globus_sdk/experimental/login_flow_manager/local_server_login_flow_manager.py
+++ b/src/globus_sdk/experimental/login_flow_manager/local_server_login_flow_manager.py
@@ -58,12 +58,12 @@ def _open_webbrowser(url: str) -> None:
         browser = webbrowser.get()
         if hasattr(browser, "name"):
             browser_name = browser.name
-        elif isinstance(browser, webbrowser.MacOSXOSAScript):
+        elif hasattr(browser, "_name"):
             # MacOSXOSAScript only supports a public name attribute in py311 and later.
             # https://github.com/python/cpython/issues/82828
-            browser_name = browser._name  # type: ignore[attr-defined]
+            browser_name = browser._name
         else:
-            raise LocalServerLoginFlowError("Failed to determine browser name.")
+            raise LocalServerLoginFlowError("Unable to determine local browser name.")
 
         if browser_name in BROWSER_BLACKLIST:
             raise LocalServerLoginFlowError(


### PR DESCRIPTION

## What?
* Added a special handling case when evaluating the browser name.

## Why?
* The webbrowser class `MacOSXOSAScript` only implements a public `name` attribute starting in python3.11
  * https://github.com/python/cpython/issues/82828
* It's an odd edge case, but without this fix, all MacOS usages of LocalServerLoginFlowManager on python3.10 and earlier fail.

## Testing
* built the code & tested locally on my mac using python versions: [py38, py310, py311, py312]
* Observed successful login flows for all versions

<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1003.org.readthedocs.build/en/1003/

<!-- readthedocs-preview globus-sdk-python end -->