### PR TITLE
Refactor experimental SQLiteTokenStorage ("v2") to better accord with its parent class

### DIFF
--- a/changelog.d/20240712_155421_sirosen_experimental_tokenstorage_refactor.rst
+++ b/changelog.d/20240712_155421_sirosen_experimental_tokenstorage_refactor.rst
@@ -1,0 +1,17 @@
+Changed
+~~~~~~~
+
+- The ``SQLiteTokenStorage`` component in ``globus_sdk.experimental`` has been
+  changed in several ways to improve its interface. (:pr:`NUMBER`)
+
+  - ``:memory:`` is no longer accepted as a database name. Attempts to use it
+    will trigger errors directing users to use ``MemoryTokenStorage`` instead.
+
+  - Parent directories for a target file are automatically created, and this
+    behavior is inherited from the ``FileTokenStorage`` base class. (This was
+    previously a feature only of the ``JSONTokenStorage``.)
+
+  - The ``config_storage`` table has been removed from the generated database
+    schema, the schema version number has been incremented to ``2``, and
+    methods and parameters related to manipulation of ``config_storage`` have
+    been removed.

--- a/src/globus_sdk/experimental/tokenstorage/base.py
+++ b/src/globus_sdk/experimental/tokenstorage/base.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import abc
 import contextlib
 import os
+import pathlib
 import typing as t
 
 from globus_sdk.services.auth import OAuthTokenResponse
@@ -107,7 +108,20 @@ class FileTokenStorage(TokenStorage, metaclass=abc.ABCMeta):
     files.
     """
 
-    filename: str
+    def __init__(self, filename: pathlib.Path | str, *, namespace: str = "DEFAULT"):
+        """
+        :param filename: the name of the file to write to and read from
+        :param namespace: A user-supplied namespace for partitioning token data
+        """
+        self.filename = str(filename)
+        self._ensure_containing_dir_exists()
+        super().__init__(namespace=namespace)
+
+    def _ensure_containing_dir_exists(self) -> None:
+        """
+        Ensure that the directory containing the given filename exists.
+        """
+        os.makedirs(os.path.dirname(self.filename), exist_ok=True)
 
     def file_exists(self) -> bool:
         """

--- a/src/globus_sdk/experimental/tokenstorage/json.py
+++ b/src/globus_sdk/experimental/tokenstorage/json.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import json
-import os
-import pathlib
 import typing as t
 
 from globus_sdk.experimental.tokenstorage.base import FileTokenStorage
@@ -34,21 +32,6 @@ class JSONTokenStorage(FileTokenStorage):
 
     # the supported versions (data not in these versions causes an error)
     supported_versions = ("1.0", "2.0")
-
-    def __init__(self, filename: pathlib.Path | str, *, namespace: str = "DEFAULT"):
-        """
-        :param filename: the name of the file to write to and read from
-        :param namespace: A user-supplied namespace for partitioning token data
-        """
-        self.filename = str(filename)
-        self._ensure_containing_dir_exists()
-        super().__init__(namespace=namespace)
-
-    def _ensure_containing_dir_exists(self) -> None:
-        """
-        Ensure that the directory containing the given filename exists.
-        """
-        os.makedirs(os.path.dirname(self.filename), exist_ok=True)
 
     def _invalid(self, msg: str) -> t.NoReturn:
         raise ValueError(

--- a/src/globus_sdk/experimental/tokenstorage/sqlite.py
+++ b/src/globus_sdk/experimental/tokenstorage/sqlite.py
@@ -46,9 +46,9 @@ class SQLiteTokenStorage(FileTokenStorage):
                 "If you want memory-backed TokenStorage, use MemoryTokenStorage "
                 "instead."
             )
-        self.filename = str(filename)
+
+        super().__init__(filename, namespace=namespace)
         self._connection = self._init_and_connect(connect_params)
-        super().__init__(namespace=namespace)
 
     def _init_and_connect(
         self,

--- a/src/globus_sdk/experimental/tokenstorage/sqlite.py
+++ b/src/globus_sdk/experimental/tokenstorage/sqlite.py
@@ -43,8 +43,7 @@ class SQLiteTokenStorage(FileTokenStorage):
         if filename == ":memory:":
             raise exc.GlobusSDKUsageError(
                 "SQLiteTokenStorage cannot be used with a ':memory:' database. "
-                "If you want memory-backed TokenStorage, use MemoryTokenStorage "
-                "instead."
+                "If you want to store tokens in memory, use MemoryTokenStorage instead."
             )
 
         super().__init__(filename, namespace=namespace)

--- a/tests/functional/tokenstorage_v2/test_sqlite_token_storage.py
+++ b/tests/functional/tokenstorage_v2/test_sqlite_token_storage.py
@@ -57,15 +57,6 @@ def test_constructor(success, use_file, kwargs, db_file, make_adapter):
                 make_adapter(**kwargs)
 
 
-def test_store_and_retrieve_simple_config(make_adapter):
-    adapter = make_adapter(MEMORY_DBNAME)
-    store_val = {"val1": True, "val2": None, "val3": 1.4}
-    adapter.store_config("myconf", store_val)
-    read_val = adapter.read_config("myconf")
-    assert read_val == store_val
-    assert read_val is not store_val
-
-
 def test_store_and_get_token_data_by_resource_server(
     mock_token_data_by_resource_server, make_adapter
 ):
@@ -101,11 +92,6 @@ def test_multiple_adapters_store_and_retrieve_different_namespaces(
     assert data == {}
 
 
-def test_load_missing_config_data(make_adapter):
-    adapter = make_adapter(MEMORY_DBNAME)
-    assert adapter.read_config("foo") is None
-
-
 def test_load_missing_token_data(make_adapter):
     adapter = make_adapter(MEMORY_DBNAME)
     assert adapter.get_token_data_by_resource_server() == {}
@@ -125,55 +111,22 @@ def test_remove_tokens(mock_response, make_adapter):
     assert not removed
 
 
-def test_remove_config(make_adapter):
-    adapter = make_adapter(MEMORY_DBNAME)
-    store_val = {"val1": True, "val2": None, "val3": 1.4}
-    adapter.store_config("myconf", store_val)
-    adapter.store_config("myconf2", store_val)
-    removed = adapter.remove_config("myconf")
-    assert removed
-    read_val = adapter.read_config("myconf")
-    assert read_val is None
-    read_val = adapter.read_config("myconf2")
-    assert read_val == store_val
-
-    removed = adapter.remove_config("myconf")
-    assert not removed
-
-
 def test_iter_namespaces(mock_response, db_file, make_adapter):
     foo_adapter = make_adapter(db_file, namespace="foo")
     bar_adapter = make_adapter(db_file, namespace="bar")
-    baz_adapter = make_adapter(db_file, namespace="baz")
 
-    for adapter in [foo_adapter, bar_adapter, baz_adapter]:
+    for adapter in [foo_adapter, bar_adapter]:
         assert list(adapter.iter_namespaces()) == []
-        assert list(adapter.iter_namespaces(include_config_namespaces=True)) == []
 
     foo_adapter.store_token_response(mock_response)
 
-    for adapter in [foo_adapter, bar_adapter, baz_adapter]:
+    for adapter in [foo_adapter, bar_adapter]:
         assert list(adapter.iter_namespaces()) == ["foo"]
-        assert list(adapter.iter_namespaces(include_config_namespaces=True)) == ["foo"]
 
     bar_adapter.store_token_response(mock_response)
 
-    for adapter in [foo_adapter, bar_adapter, baz_adapter]:
+    for adapter in [foo_adapter, bar_adapter]:
         assert set(adapter.iter_namespaces()) == {"foo", "bar"}
-        assert set(adapter.iter_namespaces(include_config_namespaces=True)) == {
-            "foo",
-            "bar",
-        }
-
-    baz_adapter.store_config("some_conf", {})
-
-    for adapter in [foo_adapter, bar_adapter, baz_adapter]:
-        assert set(adapter.iter_namespaces()) == {"foo", "bar"}
-        assert set(adapter.iter_namespaces(include_config_namespaces=True)) == {
-            "foo",
-            "bar",
-            "baz",
-        }
 
 
 def test_backwards_compatible_storage(mock_response, db_file, make_adapter):


### PR DESCRIPTION
These changes are all related, although not necessarily in a perfectly obvious way.

The story runs thusly:
- First, we agreed that we wanted to move the "ensure dir" dynamics to the parent class, FileTokenStorage.
- Second, we discovered that this would conflict with use of `:memory:` databases. (Probably solvable, but a red flag about being a "FileTokenStorage" but not having a file.)
- Third, we considered whether or not such usages could simply use MemoryTokenStorage. But there are concerns around use of the 'config_storage' area making SQLiteTokenStorage the "only production storage mechanism".
- Fourth, we agreed upon a resolution trajectory in which, at least until we see evidence to the contrary, we will remove the 'config_storage' table and make these classes more uniform.
- Fifth, this PR.

One notable addition to the above:
- This changeset sets the "schema version" to `2` for the database. It's not yet certain, IMO, that this field will be useful, but we could use it to trivially check if `config_storage` is expected to be present and to manage data migrations.


I have already started to think about what a data migration for globus-cli would look like, and it's definitely nontrivial.
We will need to develop some kind of compatibility layer which migrates data and presents a uniform interface to its callers, but doing so in a way which doesn't break the upgrade-downgrade path will require careful thought.
I'm not certain that this will turn out to be worth the pain, but we could, *at the very least*, provide a distinct (non-TokenStorage) interface for accessing the `config_storage` table found in the sqlite DB. That is: the remodeling of classes done here is robust to the possibility of our deciding against a migration of the `config_storage` table to some other source of truth.


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1004.org.readthedocs.build/en/1004/

<!-- readthedocs-preview globus-sdk-python end -->