### PR TITLE
Use tmp_path rather than tempfile in tests

### DIFF
--- a/tests/functional/tokenstorage/conftest.py
+++ b/tests/functional/tokenstorage/conftest.py
@@ -1,16 +1,7 @@
-import shutil
-import tempfile
 import time
 from unittest import mock
 
 import pytest
-
-
-@pytest.fixture
-def tempdir():
-    d = tempfile.mkdtemp()
-    yield d
-    shutil.rmtree(d)
 
 
 @pytest.fixture

--- a/tests/functional/tokenstorage/test_simplejson_file.py
+++ b/tests/functional/tokenstorage/test_simplejson_file.py
@@ -20,7 +20,7 @@ def test_file_does_not_exist(json_file):
 
 
 def test_file_exists(json_file):
-    open(json_file, "w").close()  # open and close to touch
+    json_file.touch()
     adapter = SimpleJSONFileAdapter(json_file)
     assert adapter.file_exists()
 
@@ -30,8 +30,7 @@ def test_store(json_file, mock_response):
     assert not adapter.file_exists()
     adapter.store(mock_response)
 
-    with open(json_file) as f:
-        data = json.load(f)
+    data = json.loads(json_file.read_text())
     assert data["globus-sdk.version"] == __version__
     assert data["by_rs"]["resource_server_1"]["access_token"] == "access_token_1"
     assert data["by_rs"]["resource_server_2"]["access_token"] == "access_token_2"
@@ -73,5 +72,5 @@ def test_store_perms(json_file, mock_response):
 
     # mode|0600 should be 0600 -- meaning that those are the maximal
     # permissions given
-    st_mode = os.stat(json_file).st_mode & 0o777  # & 777 to remove extra bits
+    st_mode = json_file.stat().st_mode & 0o777  # & 777 to remove extra bits
     assert st_mode | 0o600 == 0o600

--- a/tests/functional/tokenstorage/test_simplejson_file.py
+++ b/tests/functional/tokenstorage/test_simplejson_file.py
@@ -10,35 +10,35 @@ IS_WINDOWS = os.name == "nt"
 
 
 @pytest.fixture
-def filename(tempdir):
-    return os.path.join(tempdir, "mydata.json")
+def json_file(tmp_path):
+    return tmp_path / "mydata.json"
 
 
-def test_file_does_not_exist(filename):
-    adapter = SimpleJSONFileAdapter(filename)
+def test_file_does_not_exist(json_file):
+    adapter = SimpleJSONFileAdapter(json_file)
     assert not adapter.file_exists()
 
 
-def test_file_exists(filename):
-    open(filename, "w").close()  # open and close to touch
-    adapter = SimpleJSONFileAdapter(filename)
+def test_file_exists(json_file):
+    open(json_file, "w").close()  # open and close to touch
+    adapter = SimpleJSONFileAdapter(json_file)
     assert adapter.file_exists()
 
 
-def test_store(filename, mock_response):
-    adapter = SimpleJSONFileAdapter(filename)
+def test_store(json_file, mock_response):
+    adapter = SimpleJSONFileAdapter(json_file)
     assert not adapter.file_exists()
     adapter.store(mock_response)
 
-    with open(filename) as f:
+    with open(json_file) as f:
         data = json.load(f)
     assert data["globus-sdk.version"] == __version__
     assert data["by_rs"]["resource_server_1"]["access_token"] == "access_token_1"
     assert data["by_rs"]["resource_server_2"]["access_token"] == "access_token_2"
 
 
-def test_get_token_data(filename, mock_response):
-    adapter = SimpleJSONFileAdapter(filename)
+def test_get_token_data(json_file, mock_response):
+    adapter = SimpleJSONFileAdapter(json_file)
     assert not adapter.file_exists()
     adapter.store(mock_response)
 
@@ -46,8 +46,8 @@ def test_get_token_data(filename, mock_response):
     assert data["access_token"] == "access_token_1"
 
 
-def test_store_and_refresh(filename, mock_response, mock_refresh_response):
-    adapter = SimpleJSONFileAdapter(filename)
+def test_store_and_refresh(json_file, mock_response, mock_refresh_response):
+    adapter = SimpleJSONFileAdapter(json_file)
     assert not adapter.file_exists()
     adapter.store(mock_response)
 
@@ -66,12 +66,12 @@ def test_store_and_refresh(filename, mock_response, mock_refresh_response):
 
 
 @pytest.mark.xfail(IS_WINDOWS, reason="cannot set umask perms on Windows")
-def test_store_perms(filename, mock_response):
-    adapter = SimpleJSONFileAdapter(filename)
+def test_store_perms(json_file, mock_response):
+    adapter = SimpleJSONFileAdapter(json_file)
     assert not adapter.file_exists()
     adapter.store(mock_response)
 
     # mode|0600 should be 0600 -- meaning that those are the maximal
     # permissions given
-    st_mode = os.stat(filename).st_mode & 0o777  # & 777 to remove extra bits
+    st_mode = os.stat(json_file).st_mode & 0o777  # & 777 to remove extra bits
     assert st_mode | 0o600 == 0o600

--- a/tests/functional/tokenstorage/test_sqlite.py
+++ b/tests/functional/tokenstorage/test_sqlite.py
@@ -1,13 +1,11 @@
-import os
-
 import pytest
 
 from globus_sdk.tokenstorage import SQLiteAdapter
 
 
 @pytest.fixture
-def db_filename(tempdir):
-    return os.path.join(tempdir, "test.db")
+def db_file(tmp_path):
+    return tmp_path / "test.db"
 
 
 MEMORY_DBNAME = ":memory:"
@@ -44,16 +42,16 @@ def make_adapter(adapters_to_close):
         (False, True, {"dbname": MEMORY_DBNAME, "namespace": "foo"}),
     ],
 )
-def test_constructor(success, use_file, kwargs, db_filename, make_adapter):
+def test_constructor(success, use_file, kwargs, db_file, make_adapter):
     if success:
         if use_file:
-            make_adapter(db_filename, **kwargs)
+            make_adapter(db_file, **kwargs)
         else:
             make_adapter(**kwargs)
     else:
         with pytest.raises(TypeError):
             if use_file:
-                make_adapter(db_filename, **kwargs)
+                make_adapter(db_file, **kwargs)
             else:
                 make_adapter(**kwargs)
 
@@ -84,9 +82,9 @@ def test_on_refresh_and_retrieve(mock_response, make_adapter):
     assert data == mock_response.by_resource_server
 
 
-def test_multiple_adapters_store_and_retrieve(mock_response, db_filename, make_adapter):
-    adapter1 = make_adapter(db_filename)
-    adapter2 = make_adapter(db_filename)
+def test_multiple_adapters_store_and_retrieve(mock_response, db_file, make_adapter):
+    adapter1 = make_adapter(db_file)
+    adapter2 = make_adapter(db_file)
     adapter1.store(mock_response)
 
     data = adapter2.get_by_resource_server()
@@ -94,10 +92,10 @@ def test_multiple_adapters_store_and_retrieve(mock_response, db_filename, make_a
 
 
 def test_multiple_adapters_store_and_retrieve_different_namespaces(
-    mock_response, db_filename, make_adapter
+    mock_response, db_file, make_adapter
 ):
-    adapter1 = make_adapter(db_filename, namespace="foo")
-    adapter2 = make_adapter(db_filename, namespace="bar")
+    adapter1 = make_adapter(db_file, namespace="foo")
+    adapter2 = make_adapter(db_file, namespace="bar")
     adapter1.store(mock_response)
 
     data = adapter2.get_by_resource_server()
@@ -164,10 +162,10 @@ def test_store_and_refresh(mock_response, mock_refresh_response, make_adapter):
     assert data["access_token"] == "access_token_2_refreshed"
 
 
-def test_iter_namespaces(mock_response, db_filename, make_adapter):
-    foo_adapter = make_adapter(db_filename, namespace="foo")
-    bar_adapter = make_adapter(db_filename, namespace="bar")
-    baz_adapter = make_adapter(db_filename, namespace="baz")
+def test_iter_namespaces(mock_response, db_file, make_adapter):
+    foo_adapter = make_adapter(db_file, namespace="foo")
+    bar_adapter = make_adapter(db_file, namespace="bar")
+    baz_adapter = make_adapter(db_file, namespace="baz")
 
     for adapter in [foo_adapter, bar_adapter, baz_adapter]:
         assert list(adapter.iter_namespaces()) == []

--- a/tests/functional/tokenstorage_v2/conftest.py
+++ b/tests/functional/tokenstorage_v2/conftest.py
@@ -1,18 +1,9 @@
-import shutil
-import tempfile
 import time
 from unittest import mock
 
 import pytest
 
 from globus_sdk.experimental.tokenstorage import TokenData
-
-
-@pytest.fixture
-def tempdir():
-    d = tempfile.mkdtemp()
-    yield d
-    shutil.rmtree(d)
 
 
 @pytest.fixture

--- a/tests/functional/tokenstorage_v2/test_json_token_storage.py
+++ b/tests/functional/tokenstorage_v2/test_json_token_storage.py
@@ -21,7 +21,7 @@ def test_file_does_not_exist(json_file):
 
 
 def test_file_exists(json_file):
-    open(json_file, "w").close()  # open and close to touch
+    json_file.touch()
     adapter = JSONTokenStorage(json_file)
     assert adapter.file_exists()
 
@@ -47,8 +47,7 @@ def test_store_token_response_with_namespace(json_file, mock_response):
     assert not adapter.file_exists()
     adapter.store_token_response(mock_response)
 
-    with open(json_file) as f:
-        data = json.load(f)
+    data = json.loads(json_file.read_text())
     assert data["globus-sdk.version"] == __version__
     assert data["data"]["foo"]["resource_server_1"]["access_token"] == "access_token_1"
     assert data["data"]["foo"]["resource_server_2"]["access_token"] == "access_token_2"
@@ -87,7 +86,7 @@ def test_store_perms(json_file, mock_response):
 
     # mode|0600 should be 0600 -- meaning that those are the maximal
     # permissions given
-    st_mode = os.stat(json_file).st_mode & 0o777  # & 777 to remove extra bits
+    st_mode = json_file.stat().st_mode & 0o777  # & 777 to remove extra bits
     assert st_mode | 0o600 == 0o600
 
 
@@ -104,6 +103,5 @@ def test_migrate_from_simple(json_file, mock_response):
 
     # confirm version is overwritten on next store
     new_adapter.store_token_response(mock_response)
-    with open(json_file) as f:
-        data = json.load(f)
+    data = json.loads(json_file.read_text())
     assert data["format_version"] == "2.0"

--- a/tests/functional/tokenstorage_v2/test_json_token_storage.py
+++ b/tests/functional/tokenstorage_v2/test_json_token_storage.py
@@ -11,25 +11,25 @@ IS_WINDOWS = os.name == "nt"
 
 
 @pytest.fixture
-def filename(tempdir):
-    return os.path.join(tempdir, "mydata.json")
+def json_file(tmp_path):
+    return tmp_path / "mydata.json"
 
 
-def test_file_does_not_exist(filename):
-    adapter = JSONTokenStorage(filename)
+def test_file_does_not_exist(json_file):
+    adapter = JSONTokenStorage(json_file)
     assert not adapter.file_exists()
 
 
-def test_file_exists(filename):
-    open(filename, "w").close()  # open and close to touch
-    adapter = JSONTokenStorage(filename)
+def test_file_exists(json_file):
+    open(json_file, "w").close()  # open and close to touch
+    adapter = JSONTokenStorage(json_file)
     assert adapter.file_exists()
 
 
 def test_store_and_get_token_data_by_resource_server(
-    filename, mock_token_data_by_resource_server
+    json_file, mock_token_data_by_resource_server
 ):
-    adapter = JSONTokenStorage(filename)
+    adapter = JSONTokenStorage(json_file)
     assert not adapter.file_exists()
     adapter.store_token_data_by_resource_server(mock_token_data_by_resource_server)
 
@@ -42,28 +42,28 @@ def test_store_and_get_token_data_by_resource_server(
         )
 
 
-def test_store_token_response_with_namespace(filename, mock_response):
-    adapter = JSONTokenStorage(filename, namespace="foo")
+def test_store_token_response_with_namespace(json_file, mock_response):
+    adapter = JSONTokenStorage(json_file, namespace="foo")
     assert not adapter.file_exists()
     adapter.store_token_response(mock_response)
 
-    with open(filename) as f:
+    with open(json_file) as f:
         data = json.load(f)
     assert data["globus-sdk.version"] == __version__
     assert data["data"]["foo"]["resource_server_1"]["access_token"] == "access_token_1"
     assert data["data"]["foo"]["resource_server_2"]["access_token"] == "access_token_2"
 
 
-def test_get_token_data(filename, mock_response):
-    adapter = JSONTokenStorage(filename)
+def test_get_token_data(json_file, mock_response):
+    adapter = JSONTokenStorage(json_file)
     assert not adapter.file_exists()
     adapter.store_token_response(mock_response)
 
     assert adapter.get_token_data("resource_server_1").access_token == "access_token_1"
 
 
-def test_remove_token_data(filename, mock_response):
-    adapter = JSONTokenStorage(filename)
+def test_remove_token_data(json_file, mock_response):
+    adapter = JSONTokenStorage(json_file)
     assert not adapter.file_exists()
     adapter.store_token_response(mock_response)
 
@@ -80,30 +80,30 @@ def test_remove_token_data(filename, mock_response):
 
 
 @pytest.mark.xfail(IS_WINDOWS, reason="cannot set umask perms on Windows")
-def test_store_perms(filename, mock_response):
-    adapter = JSONTokenStorage(filename)
+def test_store_perms(json_file, mock_response):
+    adapter = JSONTokenStorage(json_file)
     assert not adapter.file_exists()
     adapter.store_token_response(mock_response)
 
     # mode|0600 should be 0600 -- meaning that those are the maximal
     # permissions given
-    st_mode = os.stat(filename).st_mode & 0o777  # & 777 to remove extra bits
+    st_mode = os.stat(json_file).st_mode & 0o777  # & 777 to remove extra bits
     assert st_mode | 0o600 == 0o600
 
 
-def test_migrate_from_simple(filename, mock_response):
+def test_migrate_from_simple(json_file, mock_response):
     # write with a SimpleJSONFileAdapter
-    old_adapter = SimpleJSONFileAdapter(filename)
+    old_adapter = SimpleJSONFileAdapter(json_file)
     old_adapter.store(mock_response)
 
     # confirm able to read with JSONTokenStorage
-    new_adapter = JSONTokenStorage(filename)
+    new_adapter = JSONTokenStorage(json_file)
     assert (
         new_adapter.get_token_data("resource_server_1").access_token == "access_token_1"
     )
 
     # confirm version is overwritten on next store
     new_adapter.store_token_response(mock_response)
-    with open(filename) as f:
+    with open(json_file) as f:
         data = json.load(f)
     assert data["format_version"] == "2.0"


### PR DESCRIPTION
For testing purposes, rather than manually managing temporary files ourselves, rely on the standard `tmp_path` pytest fixture to do this.  It appears to be more robust in some circumstances than the on-yield-teardown behavior, and reduces the amount of code which we are maintaining.

Most changes here are name changes and conversions from strings to pathlib.Path objects (as is convenien with the new fixture).  Slightly more changes are applied to the GCP object tests, since those make more elaborate use of the temporary directory they manage.

---

In #1004, I found that a switch from `tempfile` to `tmp_path` fixed an otherwise inscrutable issue in the testsuite. My best guess at present is that `tmp_path` uses a pytest finalizer, rather than the `yield` fixture structure. I've read that the teardown-after-yield behavior is less robust than finalizers, although I'm not clear about the implementation differences.

<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1007.org.readthedocs.build/en/1007/

<!-- readthedocs-preview globus-sdk-python end -->