### PR TITLE
Fix client credentials example doc typo

### DIFF
--- a/docs/examples/client_credentials.rst
+++ b/docs/examples/client_credentials.rst
@@ -115,7 +115,7 @@ Use it like so:
     scopes = "urn:globus:auth:scope:transfer.api.globus.org:all"
     cc_authorizer = globus_sdk.ClientCredentialsAuthorizer(confidential_client, scopes)
     # create a new client
-    transfer_client = globus_sdk.TransferClient(authorizer=cc_authorizer)
+    tc = globus_sdk.TransferClient(authorizer=cc_authorizer)
 
     # usage is still the same
     print("Endpoints Belonging to {}@clients.auth.globus.org:".format(CLIENT_ID))


### PR DESCRIPTION

The transfer client in this example is instantiated into the variable `transfer_client` but then referenced as `tc` (line 122 in the current code rev).

This change updates the instantiation to use `tc` (mirrors the variable name in the other example on the same page). 


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1010.org.readthedocs.build/en/1010/

<!-- readthedocs-preview globus-sdk-python end -->