### PR TITLE
Using a GlobusApp example doc

### DIFF
--- a/changelog.d/20240724_235513_derek_globus_app_usage_example.rst
+++ b/changelog.d/20240724_235513_derek_globus_app_usage_example.rst
@@ -1,0 +1,8 @@
+
+Documentation
+~~~~~~~~~~~~~
+
+-   ``GlobusApp``, ``UserApp`, and ``ClientApp`` class reference docs. (:pr:`NUMBER`)
+
+-   Added a narrative example titled ``Using a GlobusApp`` detailing the basics of
+    constructing and using a GlobusApp. (:pr:`NUMBER`)

--- a/docs/experimental/examples/oauth2/globus_app.rst
+++ b/docs/experimental/examples/oauth2/globus_app.rst
@@ -166,9 +166,10 @@ MFA token or rendering with a specific message:
 Manually Defining Scope Requirements
 ------------------------------------
 
-Globus service client classes all maintain internal list of default scope requirements
-to be attached to any bound app. These scopes represent an approximation of a
-"standard set" for each service. This list however is not sufficient for all use cases.
+Globus service client classes all maintain an internal list of default scope
+requirements to be attached to any bound app. These scopes represent an approximation of
+a "standard set" for each service. This list however is not sufficient for all use
+cases.
 
 For example, the FlowsClient defines its default scopes as ``flows:view_flows`` and
 ``flows:run_status`` (read-only access). These scopes will not be sufficient for a
@@ -193,7 +194,7 @@ This can be done in one of two ways:
 
     ..  code-block:: python
 
-        from globus_sdk import Scope, FlowsClient
+        from globus_sdk import FlowsClient
 
         flows_client = FlowsClient(app=my_app)
         flows_client.add_app_scope(FlowsClient.scopes.manage_flows)

--- a/docs/experimental/examples/oauth2/globus_app.rst
+++ b/docs/experimental/examples/oauth2/globus_app.rst
@@ -75,8 +75,8 @@ client's resource server and configuring the app as the service client's auth pr
 
         ..  Note::
 
-            ``UserApp.__init__(...)`` also accepts a `client_secret` keyword argument
-            which must be supplied for confidential clients.
+            ``UserApp.__init__(...)`` currently only supports Native clients.
+            Confidential client support is forthcoming.
 
         ..  code-block:: python
 

--- a/docs/experimental/examples/oauth2/globus_app.rst
+++ b/docs/experimental/examples/oauth2/globus_app.rst
@@ -21,11 +21,11 @@ tokens to bound clients as requested.
 There are two flavors of GlobusApp:
 
 *   :py:class:`~UserApp`, a GlobusApp for interactions between an end user and Globus
-    services. Facilitates interactions *on behalf of a user*.
+    services. Operations are performed as a *user identity*.
 
 *   :py:class:`~ClientApp`, a GlobusApp for interactions between a client
-    (i.e. service account) and Globus services. Facilitates interactions
-    *as the script itself*.
+    (i.e. service account) and Globus services. Operations are performed as a
+    *client identity*.
 
 Setup
 -----
@@ -55,9 +55,10 @@ instantiation only requires two parameters:
 
     ..  Note::
 
-        Both UserApps and ClientApps require a client to operate. In a UserApp those
-        interactions are done on behalf of a user but the client is still the actor
-        requesting them.
+        Both UserApps and ClientApps require a client.
+
+        In a UserApp, the client sends requests representing a user identity; whereas in
+        a ClientApp, the requests represent the client identity itself.
 
 
 Once instantiated, a GlobusApp can be passed to any service client using the init

--- a/docs/experimental/examples/oauth2/globus_app.rst
+++ b/docs/experimental/examples/oauth2/globus_app.rst
@@ -1,5 +1,202 @@
 
-Using a Globus App
-==================
+.. _using_globus_app:
 
-TODO
+.. py:currentmodule:: globus_sdk.experimental.globus_app
+
+Using a GlobusApp
+=================
+
+Programmatic communication with Globus services relies on the authorization of requests.
+Management and resolution of this authorization can become an arduous task, especially
+when a script needs to interact with different services each carrying an individual set
+of complex auth requirements. To assist with this task, this library provides a utility
+construct called a GlobusApp.
+
+A :py:class:`~GlobusApp` is a distinct object which will manage auth requirements
+(i.e. **scopes**) identified by their associated service (i.e. **resource server**).
+In addition to storing these requirements, a GlobusApp provides a mechanism to resolve
+unmet ones through browser and api-based auth flows, supplying the resulting tokens to
+bound clients as requested.
+
+There are two flavors of GlobusApp:
+
+*   :py:class:`~UserApp`, a GlobusApp for interactions between an end user and Globus
+    services. Facilitates interactions *on behalf of a user*.
+
+*   :py:class:`~ClientApp`, a GlobusApp for interactions between a client
+    (i.e. service account) and Globus services. Facilitates interactions
+    *as the script itself*.
+
+Setup
+-----
+
+A GlobusApp is heavily configurable object. For common scripting usage however,
+instantiation only requires two parameters:
+
+#.  **App Name** - A human readable slug to identify your app in http requests and token
+    caches.
+
+#.  **Client Info** - either a *Native Client's* ID or a *Confidential Client's* ID and
+    secret pair.
+
+    *   There are important distinctions to consider when choosing your client type; see
+        `Developing an Application Using Globus Auth <https://docs.globus.org/api/auth/developer-guide/#developing-apps>`_.
+
+        For a simplified heuristic however:
+
+        *   Use a *Confidential Client* when your client needs to own cloud resources
+            itself and will be used in a trusted environment where you can securely
+            hold a secret.
+
+        *   Use a *Native Client* when your client will be facilitating interactions
+            between a user and a service, particularly if it is bundled within a
+            script or cli tool to be distributed to end-user's machines.
+
+
+..  Note::
+
+    Even in the context of a UserApp, client info is required to interact with a
+    service. Those interactions will be performed on behalf of a user instead of the
+    client itself, but the client is necessary to facilitate the interaction.
+
+
+Once instantiated, an app can be passed to any service client using the init
+``app`` kwarg (e.g. ``TransferClient(app=my_app)``). Doing this will bind the app to the
+client, registering a default set of scopes requirements for the service client's
+resource server and configuring the app as the service client's auth provider.
+
+
+..  tab-set::
+
+    ..  tab-item:: UserApp
+
+        Construct a UserApp then bind it to a transfer client and a flows client.
+
+        ..  Note::
+
+            ``UserApp.__init__(...)`` also accepts a `client_secret` kwarg which must be
+            supplied for confidential clients.
+
+        ..  code-block:: python
+
+            import globus_sdk
+            from globus_sdk.experimental.globus_app import UserApp
+
+            CLIENT_ID = "..."
+            my_app = UserApp("my-user-app", client_id=CLIENT_ID)
+
+            transfer_client = globus_sdk.TransferClient(app=my_app)
+            flows_client = globus_Sdk.FlowsClient(app=my_app)
+
+
+    .. tab-item:: ClientApp
+
+        Construct a ClientApp then bind it to a transfer client and flows_client.
+
+        ..  Note::
+
+            ``ClientApp.__init__(...)`` does not allow omission of the `client_secret`
+            kwarg as native clients are not allowed.
+
+        ..  code-block:: python
+
+            import globus_sdk
+            from globus_sdk.experimental.globus_app import ClientApp
+
+            CLIENT_ID = "..."
+            CLIENT_SECRET = "..."
+            my_app = ClientApp("my-client-app", client_id=CLIENT_ID, client_secret=CLIENT_SECRET)
+
+            transfer_client = globus_sdk.TransferClient(app=my_app)
+            flows_client = globus_sdk.FlowsClient(app=my_app)
+
+
+Usage
+-----
+
+From this point, the app manages scope validation, token caching, and authorizer
+supply for any the clients it is bound to.
+
+In the above example, listing a client's or user's flows becomes as simple as:
+
+..  code-block:: python
+
+    flows = flows_client.list_flows()["flows"]
+
+If cached tokens are missing, expired, or otherwise insufficient (e.g. the first time
+you run the script), the app will automatically initiate an auth flow to acquire new
+tokens. For a UserApp, this will print out a URL to terminal with a prompt instructing a
+the user to follow the link and enter the code they're given back into the terminal. For
+a ClientApp, the app will retrieve tokens programmatically through an Auth API.
+
+Once this auth flow has finished, the app will cache tokens for future use and
+invocation of your requested method will proceed as expected.
+
+
+Manually Running Login Flows
+----------------------------
+
+While your app will automatically initiate and oversee auth flows as detected, sometimes
+the programmer knows timing better. To manually trigger a login flow, call
+``GlobusApp.run_login_flow(...)``. This will initiate a flow requesting new tokens
+based on the app's currently defined scope requirements, caching the resulting tokens
+for future use.
+
+This method accepts a single optional parameter, ``auth_params``, where a caller
+may specify additional session-based auth parameters such as requiring the use of an
+mfa token or rendering with a specific message:
+
+
+..  code-block:: python
+
+    from globus_sdk.experimental.auth_requirements_error import GlobusAuthorizationParameters
+
+    ...
+
+    my_app.run_login_flow(
+        auth_params=GlobusAuthorizationParameters(
+            session_message="Please authenticate with MFA",
+            session_required_mfa=True,
+        )
+    )
+
+
+Manually Defining Scope Requirements
+------------------------------------
+
+Globus service clients all maintain as a part of their class definition a list of
+default scope requirements to be attached to any bound app. These scopes represent our
+best approximation of a "standard set" for this service; unfortunately however,
+this list will note be sufficient for all use cases.
+
+For example, the FlowsClient defines its default scopes as ``flows:view_flows`` and
+``flows:run_status`` (read-only access). These scopes will not be sufficient for a
+script which needs to create new flows or modify existing ones. For that script, the
+author must manually attach the ``flows:manage_flows`` scope to the app.
+
+This can be done in one of two ways:
+
+#.  Through a service client initialization, using the ``app_scopes`` kwarg.
+
+    ..  code-block:: python
+
+        from globus_sdk import Scope, FlowsClient
+
+        FlowsClient(app=my_app, app_scopes=[Scope(FlowsClient.scopes.manage_flows)])
+
+    This approach results in an app which only requires the ``flows:manage_flows``
+    scope. Neither default scope (``flows:view_flows`` and ``flows:run_status``) are
+    registered.
+
+#.  Through a service client's ``add_app_scope`` method.
+
+    ..  code-block:: python
+
+        from globus_sdk import Scope, FlowsClient
+
+        flows_client = FlowsClient(app=my_app)
+        flows_client.add_app_scope(Scope(FlowsClient.scopes.manage_flows))
+
+    This approach will add the ``flows:manage_flows`` scope to the app's existing set of
+    scopes. Since ``app_scopes`` was omitted in the client initialization, the default
+    scopes are registered as well.

--- a/docs/experimental/globus_app.rst
+++ b/docs/experimental/globus_app.rst
@@ -1,0 +1,18 @@
+
+.. py:currentmodule:: globus_sdk.experimental.globus_app
+
+Globus App
+==========
+
+This page provides reference documentation for ``GlobusApp`` and associated classes.
+For a narrative-style introduction to the concepts contained within GlobusApp, see
+:ref:`using_globus_app`.
+
+..  autoclass:: GlobusApp
+    :members:
+
+..  autoclass:: UserApp
+    :members:
+
+..  autoclass:: ClientApp
+    :members:

--- a/docs/experimental/index.rst
+++ b/docs/experimental/index.rst
@@ -19,3 +19,4 @@ Globus SDK Experimental Components
     auth_requirements_errors
     scope_parser
     consents
+    globus_app

--- a/src/globus_sdk/experimental/globus_app/globus_app.py
+++ b/src/globus_sdk/experimental/globus_app/globus_app.py
@@ -126,7 +126,7 @@ _DEFAULT_CONFIG = GlobusAppConfig()
 
 class GlobusApp(metaclass=abc.ABCMeta):
     """
-    ``GlobusApp` is an abstract base class providing an interface for simplifying
+    ``GlobusApp`` is an abstract base class providing an interface for simplifying
     authentication with Globus services.
 
     A ``GlobusApp`` manages scope requirements across multiple resource servers,
@@ -134,9 +134,9 @@ class GlobusApp(metaclass=abc.ABCMeta):
     validation through its ``ValidatingTokenStorage``, and provides up-to-date
     authorizers from its ``AuthorizerFactory`` through ``get_authorizer``.
 
-    In the near future, a ``GlobusApp`` will be accepted as an initialization parameter
-    to any Globus service client, automatically handling the client's default
-    scope requirements and providing the client an authorizer.
+    A ``GlobusApp`` is accepted as an initialization parameter to any SDK-hosted Globus
+    service client, automatically handling the client's default scope requirements and
+    providing the client with an authorizer.
     """
 
     _login_client: AuthLoginClient
@@ -319,7 +319,7 @@ class UserApp(GlobusApp):
     """
     A ``GlobusApp`` for login methods that require an interactive flow with a user.
 
-    ``UserApp`s are most commonly used with native application clients by passing a
+    ``UserApp`` s are most commonly used with native application clients by passing a
     ``NativeAppAuthClient`` as ``login_client`` or the native application's
     ``client_id``.
 
@@ -338,7 +338,6 @@ class UserApp(GlobusApp):
 
                 app = UserApp("myapp", client_id=NATIVE_APP_CLIENT_ID)
                 client = TransferClient(app=app)
-                app.run_login_flow()
                 res = client.endpoint_search("Tutorial Collection")
 
     """
@@ -441,11 +440,11 @@ class ClientApp(GlobusApp):
     A ``GlobusApp`` using client credentials - useful for service accounts and
     automation use cases.
 
-    ``ClientApp``s are always used with confidential clients either by passing
+    ``ClientApp`` s are always used with confidential clients either by passing
     a ``ConfidentialAppAuthClient`` as ``login_client`` or providing the client's
     ``client_id`` and ``client_secret`` pair.
 
-    ``ClientApp``s do not use a ``LoginFlowManager`` and will raise an error
+    ``ClientApp`` s do not use a ``LoginFlowManager`` and will raise an error
     if given one through ``config``.
 
     .. tab-set::
@@ -454,9 +453,8 @@ class ClientApp(GlobusApp):
 
             .. code-block:: python
 
-                app = UserApp("myapp", CLIENT_ID, CLIENT_SECRET)
+                app = ClientApp("myapp", CLIENT_ID, CLIENT_SECRET)
                 client = TransferClient(app=app)
-                app.run_login_flow()
                 res = client.endpoint_search("Tutorial Collection")
 
     """

--- a/src/globus_sdk/experimental/globus_app/globus_app.py
+++ b/src/globus_sdk/experimental/globus_app/globus_app.py
@@ -367,6 +367,8 @@ class UserApp(GlobusApp):
         )
 
         if client_secret or isinstance(self._login_client, ConfidentialAppAuthClient):
+            # UserApps need more information to be accepted to properly support
+            # Confidential Clients. Raise an error to avoid a confusing failure later.
             raise GlobusSDKUsageError(
                 "UserApps don't currently support Confidential Clients"
             )

--- a/src/globus_sdk/experimental/globus_app/globus_app.py
+++ b/src/globus_sdk/experimental/globus_app/globus_app.py
@@ -134,7 +134,7 @@ class GlobusApp(metaclass=abc.ABCMeta):
     validation through its ``ValidatingTokenStorage``, and provides up-to-date
     authorizers from its ``AuthorizerFactory`` through ``get_authorizer``.
 
-    A ``GlobusApp`` is accepted as an initialization parameter to any SDK-hosted Globus
+    A ``GlobusApp`` is accepted as an initialization parameter to any SDK-provided
     service client, automatically handling the client's default scope requirements and
     providing the client with an authorizer.
     """
@@ -319,7 +319,7 @@ class UserApp(GlobusApp):
     """
     A ``GlobusApp`` for login methods that require an interactive flow with a user.
 
-    ``UserApp`` s are most commonly used with native application clients by passing a
+    ``UserApp``\\s are most commonly used with native application clients by passing a
     ``NativeAppAuthClient`` as ``login_client`` or the native application's
     ``client_id``.
 
@@ -440,11 +440,11 @@ class ClientApp(GlobusApp):
     A ``GlobusApp`` using client credentials - useful for service accounts and
     automation use cases.
 
-    ``ClientApp`` s are always used with confidential clients either by passing
+    ``ClientApp``\\s are always used with confidential clients either by passing
     a ``ConfidentialAppAuthClient`` as ``login_client`` or providing the client's
     ``client_id`` and ``client_secret`` pair.
 
-    ``ClientApp`` s do not use a ``LoginFlowManager`` and will raise an error
+    ``ClientApp``\\s do not use a ``LoginFlowManager`` and will raise an error
     if given one through ``config``.
 
     .. tab-set::

--- a/src/globus_sdk/experimental/globus_app/globus_app.py
+++ b/src/globus_sdk/experimental/globus_app/globus_app.py
@@ -366,6 +366,11 @@ class UserApp(GlobusApp):
             config=config,
         )
 
+        if client_secret or isinstance(self._login_client, ConfidentialAppAuthClient):
+            raise GlobusSDKUsageError(
+                "UserApps don't currently support Confidential Clients"
+            )
+
         # get or instantiate config's login_flow_manager
         if self.config.login_flow_manager:
             if isinstance(self.config.login_flow_manager, LoginFlowManager):

--- a/tests/unit/experimental/globus_app/test_globus_app.py
+++ b/tests/unit/experimental/globus_app/test_globus_app.py
@@ -130,6 +130,7 @@ def test_user_app_creates_consent_client():
     assert user_app._validating_token_storage._consent_client is not None
 
 
+@pytest.mark.xfail(reason="UserApp does not yet support confidential clients")
 def test_user_app_templated():
     client_id = "mock_client_id"
     client_secret = "mock_client_secret"


### PR DESCRIPTION
Added a doc explaining how to use a GlobusApp.

Not Included
  * Custom configuration of a globus app (custom token storage, custom login managers, etc.)

New Example doc link: https://globus-sdk-python--1013.org.readthedocs.build/en/1013/experimental/examples/oauth2/globus_app.html


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1013.org.readthedocs.build/en/1013/

<!-- readthedocs-preview globus-sdk-python end -->