### PR TITLE
Remove unwritten example updates from toctree

### DIFF
--- a/changelog.d/20240725_115935_derek_unindex_todo_examples.rst
+++ b/changelog.d/20240725_115935_derek_unindex_todo_examples.rst
@@ -1,0 +1,5 @@
+
+Documentation
+~~~~~~~~~~~~~
+
+- Remove unwritten example updates from toctree. (:pr:`NUMBER`)

--- a/docs/experimental/examples/endpoints_and_collections/identifying_entity_type.rst
+++ b/docs/experimental/examples/endpoints_and_collections/identifying_entity_type.rst
@@ -1,4 +1,6 @@
 
+:orphan:
+
 Identifying Entity Type
 =======================
 

--- a/docs/experimental/examples/endpoints_and_collections/index.rst
+++ b/docs/experimental/examples/endpoints_and_collections/index.rst
@@ -5,5 +5,4 @@ Endpoints and Collections
 .. toctree::
     :maxdepth: 1
 
-    identifying_entity_type
     create_guest_collection/index

--- a/docs/experimental/examples/flows/index.rst
+++ b/docs/experimental/examples/flows/index.rst
@@ -1,4 +1,6 @@
 
+:orphan:
+
 Flows
 =====
 

--- a/docs/experimental/examples/index.rst
+++ b/docs/experimental/examples/index.rst
@@ -17,6 +17,4 @@ existing examples section.
 
     transferring_data/index
     endpoints_and_collections/index
-    flows/index
-    projects/index
     oauth2/index

--- a/docs/experimental/examples/oauth2/authorizers.rst
+++ b/docs/experimental/examples/oauth2/authorizers.rst
@@ -1,4 +1,6 @@
 
+:orphan:
+
 Using Authorizers
 =================
 

--- a/docs/experimental/examples/oauth2/customizing_token_storage.rst
+++ b/docs/experimental/examples/oauth2/customizing_token_storage.rst
@@ -1,4 +1,6 @@
 
+:orphan:
+
 Customizing Token Storage
 =========================
 

--- a/docs/experimental/examples/oauth2/index.rst
+++ b/docs/experimental/examples/oauth2/index.rst
@@ -6,7 +6,3 @@ OAuth2 at Globus
     :maxdepth: 1
 
     globus_app
-    authorizers
-    login_flows
-    customizing_token_storage
-    three_legged_oauth

--- a/docs/experimental/examples/oauth2/login_flows.rst
+++ b/docs/experimental/examples/oauth2/login_flows.rst
@@ -1,4 +1,6 @@
 
+:orphan:
+
 Running Login Flows
 ===================
 

--- a/docs/experimental/examples/oauth2/three_legged_oauth.rst
+++ b/docs/experimental/examples/oauth2/three_legged_oauth.rst
@@ -1,4 +1,6 @@
 
+:orphan:
+
 Performing Three-Legged OAuth in Flask
 ========================================
 

--- a/docs/experimental/examples/projects/index.rst
+++ b/docs/experimental/examples/projects/index.rst
@@ -1,4 +1,6 @@
 
+:orphan:
+
 Auth Projects
 =============
 

--- a/docs/experimental/examples/transferring_data/index.rst
+++ b/docs/experimental/examples/transferring_data/index.rst
@@ -6,6 +6,3 @@ Transferring Data
     :maxdepth: 1
 
     submit_transfer/index
-    schedule_transfer/index
-    task_deadlines
-    recursive_ls

--- a/docs/experimental/examples/transferring_data/recursive_ls.rst
+++ b/docs/experimental/examples/transferring_data/recursive_ls.rst
@@ -1,4 +1,6 @@
 
+:orphan:
+
 Recursively Listing a Filesystem
 ================================
 

--- a/docs/experimental/examples/transferring_data/schedule_transfer/index.rst
+++ b/docs/experimental/examples/transferring_data/schedule_transfer/index.rst
@@ -1,4 +1,6 @@
 
+:orphan:
+
 Scheduling a Transfer
 =====================
 

--- a/docs/experimental/examples/transferring_data/task_deadlines.rst
+++ b/docs/experimental/examples/transferring_data/task_deadlines.rst
@@ -1,4 +1,6 @@
 
+:orphan:
+
 Setting Task Deadlines
 ======================
 


### PR DESCRIPTION

In order to ensure the already written examples are more easily explored, remove any unwritten "TODO" examples from the toctree (leaving their documents behind to show the ultimate heirarchy which will be filled in over time).