### PR TITLE
Client based token caching

### DIFF
--- a/changelog.d/20240728_220953_derek_client_based_token_caching.rst
+++ b/changelog.d/20240728_220953_derek_client_based_token_caching.rst
@@ -1,0 +1,24 @@
+
+Changed
+~~~~~~~
+
+-   Changed the experimental ``GlobusApp`` class in the following way (:pr:`NUMBER`):
+
+    -   ``app_name`` is no longer required (defaults to "DEFAULT")
+
+    -   Token storage now defaults to including the client id in the path.
+
+        -   Old (unix) : ``~/.globus/app/{app_name}/tokens.json``
+
+        -   New (unix): ``~/.globus/app/{client_id}/{app_name}/tokens.json``
+
+        -   Old (win): ``~\AppData\Local\globus\app\{app_name}\tokens.json``
+
+        -   New (win): ``~\AppData\Local\globus\app\{client_id}\{app_name}\tokens.json``
+
+    -   ``GlobusAppConfig.token_storage`` now accepts shorthand string references:
+        ``"json"`` to use a ``JSONTokenStorage``, ``"sqlite"`` to use a
+        ``SQLiteTokenStorage`` and ``"memory"`` to use a ``MemoryTokenStorage``.
+
+    -   ``GlobusAppConfig.token_storage`` also now accepts a ``TokenStorageProvidable``,
+        a class with a ``for_globus_app(...) -> TokenStorage`` class method.

--- a/changelog.d/20240728_220953_derek_client_based_token_caching.rst
+++ b/changelog.d/20240728_220953_derek_client_based_token_caching.rst
@@ -20,5 +20,8 @@ Changed
         ``"json"`` to use a ``JSONTokenStorage``, ``"sqlite"`` to use a
         ``SQLiteTokenStorage`` and ``"memory"`` to use a ``MemoryTokenStorage``.
 
-    -   ``GlobusAppConfig.token_storage`` also now accepts a ``TokenStorageProvidable``,
+    -   ``GlobusAppConfig.token_storage`` also now accepts a ``TokenStorageProvider``,
         a class with a ``for_globus_app(...) -> TokenStorage`` class method.
+
+    -   Renamed the experimental ``FileTokenStorage`` attribute ``.filename`` to
+        ``.filepath``.

--- a/docs/experimental/examples/oauth2/globus_app.rst
+++ b/docs/experimental/examples/oauth2/globus_app.rst
@@ -33,8 +33,8 @@ Setup
 A GlobusApp is a heavily configurable object. For common scripting usage however,
 instantiation only requires two parameters:
 
-#.  **App Name** - A human readable slug to identify your app in HTTP requests and token
-    caches.
+#.  **App Name** - A human readable name to identify your app in HTTP requests and token
+    caching (e.g., "My Cool Weathervane").
 
 #.  **Client Info** - either a *Native Client's* ID or a *Confidential Client's* ID and
     secret pair.

--- a/src/globus_sdk/experimental/globus_app/globus_app.py
+++ b/src/globus_sdk/experimental/globus_app/globus_app.py
@@ -196,8 +196,7 @@ class GlobusApp(metaclass=abc.ABCMeta):
             client_secret=client_secret,
             login_client=login_client,
         )
-
-        self._scope_requirements = self._setup_scope_requirements(scope_requirements)
+        self._scope_requirements = self._resolve_scope_requirements(scope_requirements)
         self._token_storage = self._resolve_token_storage(
             app_name=self.app_name,
             client_id=self.client_id,
@@ -221,7 +220,7 @@ class GlobusApp(metaclass=abc.ABCMeta):
         consent_client = AuthClient(app=self, app_scopes=[Scope(AuthScopes.openid)])
         self._validating_token_storage.set_consent_client(consent_client)
 
-    def _setup_scope_requirements(
+    def _resolve_scope_requirements(
         self, scope_requirements: dict[str, ScopeCollectionType] | None
     ) -> dict[str, list[Scope]]:
         if scope_requirements is None:

--- a/src/globus_sdk/experimental/tokenstorage/base.py
+++ b/src/globus_sdk/experimental/tokenstorage/base.py
@@ -116,12 +116,12 @@ class FileTokenStorage(TokenStorage, metaclass=abc.ABCMeta):
     # File suffix associated with files of this type (e.g., "csv")
     file_format: str = "_UNSET_"  # must be overridden by subclasses
 
-    def __init__(self, filename: pathlib.Path | str, *, namespace: str = "DEFAULT"):
+    def __init__(self, filepath: pathlib.Path | str, *, namespace: str = "DEFAULT"):
         """
-        :param filename: the name of the file to write to and read from
+        :param filepath: the name of the file to write to and read from
         :param namespace: A user-supplied namespace for partitioning token data
         """
-        self.filename = str(filename)
+        self.filepath = str(filepath)
         self._ensure_containing_dir_exists()
         super().__init__(namespace=namespace)
 
@@ -146,20 +146,20 @@ class FileTokenStorage(TokenStorage, metaclass=abc.ABCMeta):
         :param config: The GlobusAppConfig object for the Globus App.
         :param namespace: A user-supplied namespace for partitioning token data.
         """
-        filename = _default_globus_app_filename(client_id, app_name, config.environment)
-        return cls(filename=f"{filename}.{cls.file_format}", namespace=namespace)
+        filepath = _default_globus_app_filepath(client_id, app_name, config.environment)
+        return cls(filepath=f"{filepath}.{cls.file_format}", namespace=namespace)
 
     def _ensure_containing_dir_exists(self) -> None:
         """
-        Ensure that the directory containing the given filename exists.
+        Ensure that the directory containing the given filepath exists.
         """
-        os.makedirs(os.path.dirname(self.filename), exist_ok=True)
+        os.makedirs(os.path.dirname(self.filepath), exist_ok=True)
 
     def file_exists(self) -> bool:
         """
         Check if the file used by this file storage adapter exists.
         """
-        return os.path.exists(self.filename)
+        return os.path.exists(self.filepath)
 
     @contextlib.contextmanager
     def user_only_umask(self) -> t.Iterator[None]:
@@ -182,12 +182,12 @@ class FileTokenStorage(TokenStorage, metaclass=abc.ABCMeta):
             os.umask(old_umask)
 
 
-def _default_globus_app_filename(
+def _default_globus_app_filepath(
     client_id: UUIDLike, app_name: str, environment: str
 ) -> str:
     r"""
-    Construct a default TokenStorage filename for a globus app.
-    The filename will have no file format suffix.
+    Construct a default TokenStorage filepath for a GlobusApp.
+    For flexibility, the filepath will omit the file format suffix.
 
     On Windows, this will be:
         ``~\AppData\Local\globus\app\{client_id}\{app_name}\tokens``

--- a/src/globus_sdk/experimental/tokenstorage/base.py
+++ b/src/globus_sdk/experimental/tokenstorage/base.py
@@ -251,13 +251,13 @@ def _slugify_app_name(app_name: str) -> str:
 
     if _RESERVED_FS_NAMES.fullmatch(app_name):
         msg = (
-            f'App name results in a reserved filename ("{app_name}"). Please choose a'
-            "different name."
+            f'App name results in a reserved filename ("{app_name}"). '
+            "Please choose a different name."
         )
         raise GlobusSDKUsageError(msg)
 
     if not app_name:
-        msg = "App name is empty after slugification. Please choose a different name."
+        msg = "App name results in the empty string. Please choose a different name."
         raise GlobusSDKUsageError(msg)
 
     return app_name

--- a/src/globus_sdk/experimental/tokenstorage/json.py
+++ b/src/globus_sdk/experimental/tokenstorage/json.py
@@ -37,7 +37,7 @@ class JSONTokenStorage(FileTokenStorage):
 
     def _invalid(self, msg: str) -> t.NoReturn:
         raise ValueError(
-            f"{msg} while loading from '{self.filename}' for JSON Token Storage"
+            f"{msg} while loading from '{self.filepath}' for JSON Token Storage"
         )
 
     def _raw_load(self) -> dict[str, t.Any]:
@@ -45,7 +45,7 @@ class JSONTokenStorage(FileTokenStorage):
         Load the file contents as JSON and return the resulting dict
         object. If a dict is not found, raises an error.
         """
-        with open(self.filename, encoding="utf-8") as f:
+        with open(self.filepath, encoding="utf-8") as f:
             val = json.load(f)
         if not isinstance(val, dict):
             self._invalid("Found non-dict root data")
@@ -60,7 +60,7 @@ class JSONTokenStorage(FileTokenStorage):
         format_version = read_data.get("format_version")
         if format_version not in self.supported_versions:
             raise ValueError(
-                f"cannot store data using SimpleJSONTokenStorage({self.filename}) "
+                f"cannot store data using SimpleJSONTokenStorage({self.filepath}) "
                 "existing data file is in an unknown format "
                 f"(format_version={format_version})"
             )
@@ -80,7 +80,7 @@ class JSONTokenStorage(FileTokenStorage):
 
         if not isinstance(read_data.get("data"), dict):
             raise ValueError(
-                f"cannot store data using SimpleJSONTokenStorage({self.filename}) "
+                f"cannot store data using SimpleJSONTokenStorage({self.filepath}) "
                 "existing data file is malformed"
             )
         if any(
@@ -119,7 +119,7 @@ class JSONTokenStorage(FileTokenStorage):
         self, token_data_by_resource_server: dict[str, TokenData]
     ) -> None:
         """
-        Store token data as JSON data in ``self.filename`` under the current namespace
+        Store token data as JSON data in ``self.filepath`` under the current namespace
 
         Additionally will write the version of ``globus_sdk``which was in use.
 
@@ -145,7 +145,7 @@ class JSONTokenStorage(FileTokenStorage):
 
         # write the file, denying rwx to Group and World, exec to User
         with self.user_only_umask():
-            with open(self.filename, "w", encoding="utf-8") as f:
+            with open(self.filepath, "w", encoding="utf-8") as f:
                 json.dump(to_write, f)
 
     def get_token_data_by_resource_server(self) -> dict[str, TokenData]:
@@ -163,7 +163,7 @@ class JSONTokenStorage(FileTokenStorage):
     def remove_token_data(self, resource_server: str) -> bool:
         """
         Remove all tokens for a resource server from the JSON data, then overwrite
-        ``self.filename``.
+        ``self.filepath``.
 
         Returns True if token data was removed, False if none was found to remove.
 
@@ -176,7 +176,7 @@ class JSONTokenStorage(FileTokenStorage):
 
         # overwrite the file, denying rwx to Group and World, exec to User
         with self.user_only_umask():
-            with open(self.filename, "w", encoding="utf-8") as f:
+            with open(self.filepath, "w", encoding="utf-8") as f:
                 json.dump(to_write, f)
 
         return popped is not None

--- a/src/globus_sdk/experimental/tokenstorage/json.py
+++ b/src/globus_sdk/experimental/tokenstorage/json.py
@@ -33,6 +33,8 @@ class JSONTokenStorage(FileTokenStorage):
     # the supported versions (data not in these versions causes an error)
     supported_versions = ("1.0", "2.0")
 
+    file_format = "json"
+
     def _invalid(self, msg: str) -> t.NoReturn:
         raise ValueError(
             f"{msg} while loading from '{self.filename}' for JSON Token Storage"

--- a/src/globus_sdk/experimental/tokenstorage/memory.py
+++ b/src/globus_sdk/experimental/tokenstorage/memory.py
@@ -25,9 +25,11 @@ class MemoryTokenStorage(TokenStorage):
     @classmethod
     def for_globus_app(
         cls,
+        # pylint: disable=unused-argument
         client_id: UUIDLike,
         app_name: str,
         config: GlobusAppConfig,
+        # pylint: enable=unused-argument
         namespace: str,
     ) -> MemoryTokenStorage:
         return cls(namespace=namespace)

--- a/src/globus_sdk/experimental/tokenstorage/memory.py
+++ b/src/globus_sdk/experimental/tokenstorage/memory.py
@@ -6,6 +6,10 @@ from globus_sdk.experimental.tokenstorage.base import TokenStorage
 
 from .token_data import TokenData
 
+if t.TYPE_CHECKING:
+    from globus_sdk._types import UUIDLike
+    from globus_sdk.experimental.globus_app import GlobusAppConfig
+
 
 class MemoryTokenStorage(TokenStorage):
     """
@@ -17,6 +21,16 @@ class MemoryTokenStorage(TokenStorage):
     def __init__(self, *, namespace: str = "DEFAULT") -> None:
         self._tokens: dict[str, dict[str, t.Any]] = {}
         super().__init__(namespace=namespace)
+
+    @classmethod
+    def for_globus_app(
+        cls,
+        client_id: UUIDLike,
+        app_name: str,
+        config: GlobusAppConfig,
+        namespace: str,
+    ) -> MemoryTokenStorage:
+        return cls(namespace=namespace)
 
     def store_token_data_by_resource_server(
         self, token_data_by_resource_server: dict[str, TokenData]

--- a/src/globus_sdk/experimental/tokenstorage/sqlite.py
+++ b/src/globus_sdk/experimental/tokenstorage/sqlite.py
@@ -27,6 +27,8 @@ class SQLiteTokenStorage(FileTokenStorage):
     documentation for SQLite-specific parameters.
     """
 
+    file_format = "db"
+
     def __init__(
         self,
         filename: pathlib.Path | str,

--- a/src/globus_sdk/experimental/tokenstorage/sqlite.py
+++ b/src/globus_sdk/experimental/tokenstorage/sqlite.py
@@ -31,24 +31,24 @@ class SQLiteTokenStorage(FileTokenStorage):
 
     def __init__(
         self,
-        filename: pathlib.Path | str,
+        filepath: pathlib.Path | str,
         *,
         connect_params: dict[str, t.Any] | None = None,
         namespace: str = "DEFAULT",
     ):
         """
-        :param filename: The name of the DB file to write to and read from.
+        :param filepath: The path of the DB file to write to and read from.
         :param connect_params: A pass-through dictionary for fine-tuning the SQLite
              connection.
         :param namespace: A user-supplied namespace for partitioning token data.
         """
-        if filename == ":memory:":
+        if filepath == ":memory:":
             raise exc.GlobusSDKUsageError(
                 "SQLiteTokenStorage cannot be used with a ':memory:' database. "
                 "If you want to store tokens in memory, use MemoryTokenStorage instead."
             )
 
-        super().__init__(filename, namespace=namespace)
+        super().__init__(filepath, namespace=namespace)
         self._connection = self._init_and_connect(connect_params)
 
     def _init_and_connect(
@@ -59,7 +59,7 @@ class SQLiteTokenStorage(FileTokenStorage):
         if not self.file_exists():
             with self.user_only_umask():
                 conn: sqlite3.Connection = sqlite3.connect(
-                    self.filename, **connect_params
+                    self.filepath, **connect_params
                 )
             conn.executescript(
                 textwrap.dedent(
@@ -97,7 +97,7 @@ class SQLiteTokenStorage(FileTokenStorage):
             )
             conn.commit()
         else:
-            conn = sqlite3.connect(self.filename, **connect_params)
+            conn = sqlite3.connect(self.filepath, **connect_params)
         return conn
 
     def close(self) -> None:
@@ -111,7 +111,7 @@ class SQLiteTokenStorage(FileTokenStorage):
     ) -> None:
         """
         Given a dict of token data indexed by resource server, convert the data into
-        JSON dicts and write it to ``self.filename`` under the current namespace
+        JSON dicts and write it to ``self.filepath`` under the current namespace
 
         :param token_data_by_resource_server: a ``dict`` of ``TokenData`` objects
             indexed by their ``resource_server``.

--- a/tests/functional/tokenstorage_v2/test_sqlite_token_storage.py
+++ b/tests/functional/tokenstorage_v2/test_sqlite_token_storage.py
@@ -21,7 +21,7 @@ def adapters_to_close():
 @pytest.fixture
 def make_adapter(adapters_to_close, db_file):
     def func(*args, **kwargs):
-        if len(args) == 0 and "filename" not in kwargs:
+        if len(args) == 0 and "filepath" not in kwargs:
             args = (db_file,)
         ret = SQLiteTokenStorage(*args, **kwargs)
         adapters_to_close.add(ret)

--- a/tests/unit/experimental/globus_app/test_globus_app.py
+++ b/tests/unit/experimental/globus_app/test_globus_app.py
@@ -92,8 +92,8 @@ def test_user_app_login_client():
 
 def test_user_app_no_client_or_id():
     msg = (
-        "Could not to set up a globus login client. One of client_id or "
-        "login_client is required."
+        "Could not set up a globus login client. One of client_id or login_client is "
+        "required."
     )
     with pytest.raises(GlobusSDKUsageError, match=msg):
         UserApp("test-app")
@@ -127,10 +127,10 @@ def test_user_app_default_token_storage():
         # on the windows-latest run this was
         # C:\Users\runneradmin\AppData\Roaming\globus\app\mock_client_id\test-app\tokens.json
         expected = "\\globus\\app\\mock_client_id\\test-app\\tokens.json"
-        assert expected in token_storage.filename
+        assert token_storage.filepath.endswith(expected)
     else:
         expected = "~/.globus/app/mock_client_id/test-app/tokens.json"
-        assert token_storage.filename == os.path.expanduser(expected)
+        assert token_storage.filepath == os.path.expanduser(expected)
 
 
 class CustomMemoryTokenStorage(MemoryTokenStorage):

--- a/tests/unit/experimental/globus_app/test_globus_app.py
+++ b/tests/unit/experimental/globus_app/test_globus_app.py
@@ -89,20 +89,18 @@ def test_user_app_login_client():
 
 
 def test_user_app_no_client_or_id():
-    with pytest.raises(GlobusSDKUsageError) as exc:
+    msg = (
+        "Could not to set up a globus login client. One of client_id or "
+        "login_client is required."
+    )
+    with pytest.raises(GlobusSDKUsageError, match=msg):
         UserApp("test-app")
-    assert str(exc.value) == "One of either client_id or login_client is required."
 
 
 def test_user_app_both_client_and_id():
-    client_id = "mock_client_id"
-    mock_client = mock.Mock()
-
-    with pytest.raises(GlobusSDKUsageError) as exc:
-        UserApp("test-app", login_client=mock_client, client_id=client_id)
-
-    expected = "login_client is mutually exclusive with client_id and client_secret."
-    assert str(exc.value) == expected
+    msg = "Mutually exclusive parameters: client_id and login_client."
+    with pytest.raises(GlobusSDKUsageError, match=msg):
+        UserApp("test-app", login_client=mock.Mock(), client_id="client_id")
 
 
 def test_user_app_login_client_environment_mismatch():
@@ -214,12 +212,9 @@ def test_client_app():
 def test_client_app_no_secret():
     client_id = "mock_client_id"
 
-    with pytest.raises(GlobusSDKUsageError) as exc:
+    msg = "A ClientApp requires a client_secret to initialize its own login client"
+    with pytest.raises(GlobusSDKUsageError, match=msg):
         ClientApp("test-app", client_id=client_id)
-    assert (
-        str(exc.value)
-        == "Either login_client or both client_id and client_secret are required"
-    )
 
 
 def test_add_scope_requirements_and_auth_params_with_required_scopes():

--- a/tests/unit/experimental/globus_app/test_globus_app.py
+++ b/tests/unit/experimental/globus_app/test_globus_app.py
@@ -87,6 +87,7 @@ def test_user_app_login_client():
 
     assert user_app.app_name == "test-app"
     assert user_app._login_client == mock_client
+    assert user_app.client_id == "mock-client_id"
 
 
 def test_user_app_no_client_or_id():

--- a/tests/unit/experimental/test_token_storage.py
+++ b/tests/unit/experimental/test_token_storage.py
@@ -1,0 +1,51 @@
+import pytest
+
+from globus_sdk import GlobusSDKUsageError
+from globus_sdk.experimental.tokenstorage.base import _slugify_app_name
+
+
+@pytest.mark.parametrize(
+    "app_name, expected_slug",
+    (
+        ("Globus CLI v3.30.0", "globus-cli-v3-30-0"),
+        ("my-cool-app", "my-cool-app"),
+        ("jonathan", "jonathan"),
+    ),
+)
+def test_app_name_slugification_of_basic_app_names(app_name, expected_slug):
+    actual_slug = _slugify_app_name(app_name)
+    assert actual_slug == expected_slug
+
+
+def test_app_name_slugification_replaces_reserved_characters():
+    app_name = 'glob<>:"/\\|?*us'
+    expected = "glob+++++++++us"
+    actual_slug = _slugify_app_name(app_name)
+    assert actual_slug == expected
+
+
+def test_app_name_slugification_removes_control_characters():
+    app_name = "glob\0\n\t\rus"
+    expected = "globus"
+    actual_slug = _slugify_app_name(app_name)
+    assert actual_slug == expected
+
+
+def test_app_name_slugification_rejects_empty_name():
+    with pytest.raises(GlobusSDKUsageError):
+        _slugify_app_name("\n\t\r")
+
+
+@pytest.mark.parametrize("app_name", ("CON", "PRN\n", "nul", "LPT9", "COM1"))
+def test_app_name_slugification_rejects_reserved_names(app_name):
+    # # https://stackoverflow.com/a/31976060
+    with pytest.raises(GlobusSDKUsageError):
+        _slugify_app_name(app_name)
+
+
+def test_app_name_allows_reserved_name_prefixes():
+    # Prefix of app name ("CON") is reserved, but the slugified name is not.
+    app_name = "Continuous Deployment App"
+    expected = "continuous-deployment-app"
+    actual_slug = _slugify_app_name(app_name)
+    assert actual_slug == expected

--- a/tests/unit/experimental/test_token_storage.py
+++ b/tests/unit/experimental/test_token_storage.py
@@ -32,14 +32,14 @@ def test_app_name_slugification_removes_control_characters():
 
 
 def test_app_name_slugification_rejects_empty_name():
-    with pytest.raises(GlobusSDKUsageError):
+    with pytest.raises(GlobusSDKUsageError, match="name is empty"):
         _slugify_app_name("\n\t\r")
 
 
 @pytest.mark.parametrize("app_name", ("CON", "PRN\n", "nul", "LPT9", "COM1"))
 def test_app_name_slugification_rejects_reserved_names(app_name):
     # # https://stackoverflow.com/a/31976060
-    with pytest.raises(GlobusSDKUsageError):
+    with pytest.raises(GlobusSDKUsageError, match="reserved filename"):
         _slugify_app_name(app_name)
 
 

--- a/tests/unit/experimental/test_token_storage.py
+++ b/tests/unit/experimental/test_token_storage.py
@@ -32,7 +32,7 @@ def test_app_name_slugification_removes_control_characters():
 
 
 def test_app_name_slugification_rejects_empty_name():
-    with pytest.raises(GlobusSDKUsageError, match="name is empty"):
+    with pytest.raises(GlobusSDKUsageError, match="name results in the empty string"):
         _slugify_app_name("\n\t\r")
 
 


### PR DESCRIPTION

Made some changes to the way token storage is handled to improve cross-script usage & expanded the config interface to make specifying the correct tokenstorage easier.

## Changes

-   ``app_name`` is no longer required (defaults to "DEFAULT")

-   Token storage now defaults to including the client id in the path.

    -   Old (unix) : ``~/.globus/app/{app_name}/tokens.json``

    -   New (unix): ``~/.globus/app/{client_id}/{app_name}/tokens.json``

    -   Old (win): ``~\AppData\Local\globus\app\{app_name}\tokens.json``

    -   New (win): ``~\AppData\Local\globus\app\{client_id}\{app_name}\tokens.json``

-   ``GlobusAppConfig.token_storage`` now accepts shorthand string references:
     ``"json"`` to use a ``JSONTokenStorage``, ``"sqlite"`` to use a
     ``SQLiteTokenStorage`` and ``"memory"`` to use a ``MemoryTokenStorage``.

-   ``GlobusAppConfig.token_storage`` also now accepts a ``TokenStorageProvidable``,
     a class with a ``for_globus_app(...) -> TokenStorage`` class method.

<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1017.org.readthedocs.build/en/1017/

<!-- readthedocs-preview globus-sdk-python end -->