### PR TITLE
Add ConnectorTable.extend() method

### DIFF
--- a/changelog.d/20250221_095128_sirosen_connector_table_extend.rst
+++ b/changelog.d/20250221_095128_sirosen_connector_table_extend.rst
@@ -1,0 +1,6 @@
+Added
+~~~~~
+
+- ``ConnectorTable`` has a new classmethod, ``extend`` which allows users to
+  add new connectors to the mapping. ``ConnectorTable.extend()`` returns a new
+  connector table subclass and does not modify the original. (:pr:`NUMBER`)

--- a/tests/unit/helpers/gcs/test_connector_table.py
+++ b/tests/unit/helpers/gcs/test_connector_table.py
@@ -90,3 +90,51 @@ def test_all_connector_attributes_are_assigned():
     for attribute in annotated_attributes:
         instance = getattr(ConnectorTable, attribute)
         assert isinstance(instance, GlobusConnectServerConnector)
+
+
+def test_table_can_be_extended_with_simple_item():
+    # don't think too hard about the ethical implications of transporter clones
+    connector_name = "Star Trek Transporter"
+    connector_id = uuid.uuid1()
+
+    ExtendedTable = ConnectorTable.extend(
+        connector_name=connector_name, connector_id=connector_id
+    )
+
+    # we get a new subclass named 'ExtendedConnectorTable'
+    assert issubclass(ExtendedTable, ConnectorTable)
+    assert ExtendedTable.__name__ == "ExtendedConnectorTable"
+
+    # access via name, attribute, and ID all resolve to the same object
+    data_object = ExtendedTable.lookup(connector_id)
+    assert isinstance(data_object, GlobusConnectServerConnector)
+    assert ExtendedTable.STAR_TREK_TRANSPORTER is data_object
+    assert ExtendedTable.lookup(connector_name) is data_object
+
+
+def test_table_extended_twice():
+    connector_id1 = uuid.uuid1()
+    connector_id2 = uuid.uuid1()
+
+    ExtendedTable1 = ConnectorTable.extend(
+        connector_name="Star Trek Transporter", connector_id=connector_id1
+    )
+    ExtendedTable2 = ExtendedTable1.extend(
+        connector_name="Battlestar Galactica FTL", connector_id=connector_id2
+    )
+
+    # we get new subclasses named 'ExtendedConnectorTable'
+    assert issubclass(ExtendedTable1, ConnectorTable)
+    assert ExtendedTable1.__name__ == "ExtendedConnectorTable"
+    assert issubclass(ExtendedTable2, ExtendedTable1)
+    assert ExtendedTable2.__name__ == "ExtendedConnectorTable"
+
+    # both tables get the same object for connector1
+    # only table2 has connector2
+    data_object = ExtendedTable1.lookup(connector_id1)
+    assert isinstance(data_object, GlobusConnectServerConnector)
+    assert ExtendedTable2.lookup(connector_id1) is data_object
+
+    assert ExtendedTable1.lookup(connector_id2) is None
+    data_object2 = ExtendedTable2.lookup(connector_id2)
+    assert isinstance(data_object2, GlobusConnectServerConnector)


### PR DESCRIPTION
This method allows ConnectorTable consumers to extend the class with an additional connector (or, if they chain calls, multiple connectors). The new connector is written into the new subclass as a part of its `_connectors` tuple and as an attribute.

The base ConnectorTable class is left unmodified, meaning that callers who extend the table cannot conflict.

---

The motivation for this work is for usages in primarily internal applications like the GCS CLI, where new connectors are sometimes supported for testing before they are generally available. Additionally, users beta testing such connectors may want SDK support.

At time of writing, there is at least one internal connector under development which cannot be added to the SDK yet.

<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1021.org.readthedocs.build/en/1021/

<!-- readthedocs-preview globus-sdk-python end -->