### PR TITLE
Use `scriv[toml]` in `tox -e prepare-release`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -123,7 +123,7 @@ commands = python scripts/ensure_min_python_is_tested.py
 
 [testenv:prepare-release]
 skip_install = true
-deps = scriv
+deps = scriv[toml]
 commands =
     python changelog.d/check-version-is-new.py
     scriv collect


### PR DESCRIPTION
If the developer's default python interpreter is <3.11, they will need
the `tomli` dep in order for `scriv collect` to succeed. Without this,
there's an error about not being able to read pyproject.toml data.


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1025.org.readthedocs.build/en/1025/

<!-- readthedocs-preview globus-sdk-python end -->