### PR TITLE
Update experimental provider protocols to require keyword-only arguments

### DIFF
--- a/changelog.d/20240802_175848_sirosen_harmonize_globus_app_protocols.rst
+++ b/changelog.d/20240802_175848_sirosen_harmonize_globus_app_protocols.rst
@@ -1,0 +1,7 @@
+Changed
+~~~~~~~
+
+- The experimental ``TokenStorageProvider`` and ``LoginFlowManagerProvider``
+  protocols have been updated to require keyword-only arguments for their
+  ``for_globus_app`` methods. This protects against potential ordering
+  confusion for their arguments. (:pr:`NUMBER`)

--- a/src/globus_sdk/experimental/globus_app/_types.py
+++ b/src/globus_sdk/experimental/globus_app/_types.py
@@ -23,7 +23,12 @@ if t.TYPE_CHECKING:
 class TokenStorageProvider(Protocol):
     @classmethod
     def for_globus_app(
-        cls, client_id: UUIDLike, app_name: str, config: GlobusAppConfig, namespace: str
+        cls,
+        *,
+        app_name: str,
+        config: GlobusAppConfig,
+        client_id: UUIDLike,
+        namespace: str,
     ) -> TokenStorage: ...
 
 
@@ -31,7 +36,7 @@ class TokenStorageProvider(Protocol):
 class LoginFlowManagerProvider(Protocol):
     @classmethod
     def for_globus_app(
-        cls, app_name: str, login_client: AuthLoginClient, config: GlobusAppConfig
+        cls, *, app_name: str, config: GlobusAppConfig, login_client: AuthLoginClient
     ) -> LoginFlowManager: ...
 
 

--- a/src/globus_sdk/experimental/globus_app/app.py
+++ b/src/globus_sdk/experimental/globus_app/app.py
@@ -195,11 +195,21 @@ class GlobusApp(metaclass=abc.ABCMeta):
             return token_storage
 
         elif isinstance(token_storage, TokenStorageProvider):
-            return token_storage.for_globus_app(client_id, app_name, config, namespace)
+            return token_storage.for_globus_app(
+                app_name=app_name,
+                config=config,
+                client_id=client_id,
+                namespace=namespace,
+            )
 
         elif token_storage in KNOWN_TOKEN_STORAGES:
             provider = KNOWN_TOKEN_STORAGES[token_storage]
-            return provider.for_globus_app(client_id, app_name, config, namespace)
+            return provider.for_globus_app(
+                app_name=app_name,
+                config=config,
+                client_id=client_id,
+                namespace=namespace,
+            )
 
         raise GlobusSDKUsageError(
             f"Unsupported token_storage value: {token_storage}. Must be a "

--- a/src/globus_sdk/experimental/globus_app/user_app.py
+++ b/src/globus_sdk/experimental/globus_app/user_app.py
@@ -102,7 +102,9 @@ class UserApp(GlobusApp):
                 f"<LoginFlowManager>."
             )
 
-        return provider.for_globus_app(app_name, login_client, config)
+        return provider.for_globus_app(
+            app_name=app_name, config=config, login_client=login_client
+        )
 
     def _initialize_login_client(
         self,


### PR DESCRIPTION
These experimental protocols are here updated to use keyword-only arguments. This protects against ordering bugs, in which argument order is accidentally reversed when positional arguments are used.

The protocol methods are also updated to list their common arguments -- `app_name` and `config` -- first, and their non-common arguments -- `client_id`, `namespace`, `login_client` -- afterwards. Although it makes no semantic difference to the now-order-independent protocols, it makes it easier to see what they have in common and what they do not, as protocols used in nearby/related contexts.
