### PR TITLE
Use `all` in default_scope_requirements for Flows

### DIFF
--- a/changelog.d/20240809_155147_sirosen_use_flows_all_scope.rst
+++ b/changelog.d/20240809_155147_sirosen_use_flows_all_scope.rst
@@ -1,0 +1,7 @@
+Changed
+~~~~~~~
+
+.. rubric:: Experimental
+
+- The ``default_scope_requirements`` for ``globus_sdk.FlowsClient`` has been
+  updated to list the Flows ``all`` scope. (:pr:`NUMBER`)

--- a/src/globus_sdk/services/flows/client.py
+++ b/src/globus_sdk/services/flows/client.py
@@ -31,10 +31,7 @@ class FlowsClient(client.BaseClient):
     error_class = FlowsAPIError
     service_name = "flows"
     scopes = FlowsScopes
-    default_scope_requirements = [
-        Scope(FlowsScopes.view_flows),
-        Scope(FlowsScopes.run_status),
-    ]
+    default_scope_requirements = [Scope(FlowsScopes.all)]
 
     def create_flow(
         self,

--- a/tests/unit/experimental/test_client_integration.py
+++ b/tests/unit/experimental/test_client_integration.py
@@ -107,9 +107,8 @@ def test_flows_client_default_scopes(app):
 
     flows_client_id = "eec9b274-0c81-4334-bdc2-54e90e689b9a"
     str_list = [str(s) for s in app.get_scope_requirements("flows.globus.org")]
-    assert len(str_list) == 2
-    assert f"https://auth.globus.org/scopes/{flows_client_id}/view_flows" in str_list
-    assert f"https://auth.globus.org/scopes/{flows_client_id}/run_status" in str_list
+    assert len(str_list) == 1
+    assert str_list == [f"https://auth.globus.org/scopes/{flows_client_id}/all"]
 
 
 def test_specific_flow_client_default_scopes(app):


### PR DESCRIPTION
Update the `default_scope_requirements` field for `FlowsClient` to
list (only) the `all` scope. This increases the capabilities of a
default-built FlowsClient to include creation of a Flow.

This appears to have been a minor oversight in the initial
`default_scope_requirements` build-out, not an intentional decision to
limit capabilities. The `all` scope is newer than
`default_scope_requirements` and is the most appropriate choice now.


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1029.org.readthedocs.build/en/1029/

<!-- readthedocs-preview globus-sdk-python end -->