### PR TITLE
Update experimental root docs

### DIFF
--- a/docs/experimental/index.rst
+++ b/docs/experimental/index.rst
@@ -1,16 +1,14 @@
-.. warning::
-
-    The ``experimental`` subpackage contains new interfaces that should be considered
-    unstable. While we will make an effort to provide deprecation warnings for code
-    that is graduating to an official module, the contents of this subpackage *may*
-    change at any time or be removed entirely.
-
-    **Use at your own risk.**
-
 .. experimental_root:
 
 Globus SDK Experimental Components
 ==================================
+
+.. warning::
+
+    The ``experimental`` module contains new "unstable" interfaces. These interfaces
+    are subject to breaking changes.
+
+    **Use at your own risk.**
 
 .. toctree::
     :caption: Contents
@@ -20,3 +18,17 @@ Globus SDK Experimental Components
     scope_parser
     consents
     globus_app
+
+
+Experimental Construct Lifecycle
+--------------------------------
+
+A construct is added in the ``experimental`` module when we, the maintainers,
+are not sufficiently confident that it represents the best possible interface for the
+underlying functionality. This frequently occurs when we have a design which shows
+promise but would like to solicit feedback from the community before committing to it.
+
+Once an interface has been evaluated and proven to be sufficiently coherent, we will
+"stabilize" it, moving it to an appropriate section in the main module and leaving
+behind an alias in the requisite experimental module to minimize import breakage. These
+aliases will persist until the next major version release of the SDK (e.g., v3 -> v4).


### PR DESCRIPTION
Updated the experimental root documentation to establish a policy of leaving behind aliases in the experimental module whenever constructs are brought over into the main module.

<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1033.org.readthedocs.build/en/1033/

<!-- readthedocs-preview globus-sdk-python end -->