### PR TITLE
'add_app_data_access_scope' accepts iterables

### DIFF
--- a/changelog.d/20240829_113235_sirosen_accept_iterable_data_access.rst
+++ b/changelog.d/20240829_113235_sirosen_accept_iterable_data_access.rst
@@ -1,0 +1,5 @@
+Added
+~~~~~
+
+- ``TransferClient.add_app_data_access_scope`` now accepts iterables of
+  collection IDs as an alternative to individual collection IDs. (:pr:`NUMBER`)

--- a/tests/unit/experimental/test_client_integration.py
+++ b/tests/unit/experimental/test_client_integration.py
@@ -91,13 +91,13 @@ def test_transfer_client_add_app_data_access_scope_in_iterable(app):
 
 
 def test_transfer_client_add_app_data_access_scope_catches_bad_uuid(app):
-    with pytest.raises(ValueError, match="'collection_id' must be a valid UUID"):
+    with pytest.raises(ValueError, match="'collection_ids' must be a valid UUID"):
         globus_sdk.TransferClient(app=app).add_app_data_access_scope("foo")
 
 
 def test_transfer_client_add_app_data_access_scope_catches_bad_uuid_in_iterable(app):
     collection_id_1 = str(uuid.UUID(int=1))
-    with pytest.raises(ValueError, match=r"'collection_id\[1\]' must be a valid UUID"):
+    with pytest.raises(ValueError, match=r"'collection_ids\[1\]' must be a valid UUID"):
         globus_sdk.TransferClient(app=app).add_app_data_access_scope(
             [collection_id_1, "foo"]
         )

--- a/tests/unit/experimental/test_client_integration.py
+++ b/tests/unit/experimental/test_client_integration.py
@@ -69,6 +69,40 @@ def test_transfer_client_add_app_data_access_scope_chaining(app):
     assert expected_2 in str_list
 
 
+def test_transfer_client_add_app_data_access_scope_in_iterable(app):
+    collection_id_1 = str(uuid.UUID(int=1))
+    collection_id_2 = str(uuid.UUID(int=2))
+    globus_sdk.TransferClient(app=app).add_app_data_access_scope(
+        (collection_id_1, collection_id_2)
+    )
+
+    expected_1 = f"https://auth.globus.org/scopes/{collection_id_1}/data_access"
+    expected_2 = f"https://auth.globus.org/scopes/{collection_id_2}/data_access"
+
+    transfer_dependencies = []
+    for scope in app.get_scope_requirements("transfer.api.globus.org"):
+        if scope.scope_string != globus_sdk.TransferClient.scopes.all:
+            continue
+        for dep in scope.dependencies:
+            transfer_dependencies.append((dep.scope_string, dep.optional))
+
+    assert (expected_1, True) in transfer_dependencies
+    assert (expected_2, True) in transfer_dependencies
+
+
+def test_transfer_client_add_app_data_access_scope_catches_bad_uuid(app):
+    with pytest.raises(ValueError, match="'collection_id' must be a valid UUID"):
+        globus_sdk.TransferClient(app=app).add_app_data_access_scope("foo")
+
+
+def test_transfer_client_add_app_data_access_scope_catches_bad_uuid_in_iterable(app):
+    collection_id_1 = str(uuid.UUID(int=1))
+    with pytest.raises(ValueError, match=r"'collection_id\[1\]' must be a valid UUID"):
+        globus_sdk.TransferClient(app=app).add_app_data_access_scope(
+            [collection_id_1, "foo"]
+        )
+
+
 def test_auth_client_default_scopes(app):
     globus_sdk.AuthClient(app=app)
 


### PR DESCRIPTION
`collection_id: UUIDLike` has been converted to
`collection_id: UUIDLike | Iterable[UUIDLike]`

All other changes here serve to instrument, document, and test this
change. The helper now iterates over collection IDs as appropriate.
We still check that the input is valid UUID data in order to helpfully
error earlier on malformed data.

---

This change was made in response to feedback about the typical usage around Transfer submission.
It's typical to have an iterable of standard mapped collections, which can contain 0, 1, or 2 elements.
Allowing for an iterable (and potentially an empty one at that) makes such usages simpler.


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1034.org.readthedocs.build/en/1034/

<!-- readthedocs-preview globus-sdk-python end -->