### PR TITLE
Refine and fix the container types in GlobusApp

### DIFF
--- a/changelog.d/20240829_121419_sirosen_fix_typing_bug.rst
+++ b/changelog.d/20240829_121419_sirosen_fix_typing_bug.rst
@@ -1,0 +1,8 @@
+Fixed
+~~~~~
+
+.. rubric:: Experimental
+
+- Container types in ``GlobusApp`` function argument annotations are now
+  generally covariant collections like ``Mapping`` rather than invariant
+  types like ``dict``. (:pr:`NUMBER`)

--- a/src/globus_sdk/experimental/globus_app/_validating_token_storage.py
+++ b/src/globus_sdk/experimental/globus_app/_validating_token_storage.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import typing as t
+
 from globus_sdk import AuthClient, Scope
 from globus_sdk.experimental.consents import ConsentForest
 from globus_sdk.experimental.tokenstorage import TokenData, TokenStorage
@@ -14,7 +16,7 @@ from .errors import (
 
 
 def _get_identity_id_from_token_data_by_resource_server(
-    token_data_by_resource_server: dict[str, TokenData]
+    token_data_by_resource_server: t.Mapping[str, TokenData]
 ) -> str | None:
     """
     Get the identity_id attribute from all TokenData objects by resource server
@@ -62,7 +64,7 @@ class ValidatingTokenStorage(TokenStorage):
         scope_requirements: dict[str, list[Scope]],
         *,
         consent_client: AuthClient | None = None,
-    ):
+    ) -> None:
         """
         :param token_storage: The token storage being wrapped.
         :param scope_requirements: A collection of resource-server keyed scope
@@ -103,7 +105,7 @@ class ValidatingTokenStorage(TokenStorage):
         self._consent_client = consent_client
 
     def store_token_data_by_resource_server(
-        self, token_data_by_resource_server: dict[str, TokenData]
+        self, token_data_by_resource_server: t.Mapping[str, TokenData]
     ) -> None:
         """
         :param token_data_by_resource_server: A dict of TokenData objects indexed by
@@ -168,7 +170,7 @@ class ValidatingTokenStorage(TokenStorage):
         return self._token_storage.remove_token_data(resource_server)
 
     def _validate_token_data_by_resource_server_meets_identity_requirements(
-        self, token_data_by_resource_server: dict[str, TokenData]
+        self, token_data_by_resource_server: t.Mapping[str, TokenData]
     ) -> None:
         """
         Validate that the identity info in the token data matches the stored identity

--- a/src/globus_sdk/experimental/globus_app/app.py
+++ b/src/globus_sdk/experimental/globus_app/app.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import abc
+import typing as t
 
 from globus_sdk import AuthClient, AuthLoginClient, GlobusSDKUsageError, Scope
 from globus_sdk._types import ScopeCollectionType, UUIDLike
@@ -43,7 +44,7 @@ class GlobusApp(metaclass=abc.ABCMeta):
         login_client: AuthLoginClient | None = None,
         client_id: UUIDLike | None = None,
         client_secret: str | None = None,
-        scope_requirements: dict[str, ScopeCollectionType] | None = None,
+        scope_requirements: t.Mapping[str, ScopeCollectionType] | None = None,
         config: GlobusAppConfig = DEFAULT_CONFIG,
     ):
         """
@@ -99,7 +100,7 @@ class GlobusApp(metaclass=abc.ABCMeta):
         self._validating_token_storage.set_consent_client(consent_client)
 
     def _resolve_scope_requirements(
-        self, scope_requirements: dict[str, ScopeCollectionType] | None
+        self, scope_requirements: t.Mapping[str, ScopeCollectionType] | None
     ) -> dict[str, list[Scope]]:
         if scope_requirements is None:
             return {}
@@ -278,7 +279,7 @@ class GlobusApp(metaclass=abc.ABCMeta):
             raise e
 
     def add_scope_requirements(
-        self, scope_requirements: dict[str, ScopeCollectionType]
+        self, scope_requirements: t.Mapping[str, ScopeCollectionType]
     ) -> None:
         """
         Add given scope requirements to the app's scope requirements. Any duplicate

--- a/src/globus_sdk/experimental/globus_app/authorizer_factory.py
+++ b/src/globus_sdk/experimental/globus_app/authorizer_factory.py
@@ -32,7 +32,7 @@ class AuthorizerFactory(
     re-used until its ``store_token_response`` method is called.
     """
 
-    def __init__(self, token_storage: ValidatingTokenStorage):
+    def __init__(self, token_storage: ValidatingTokenStorage) -> None:
         """
         :param token_storage: The ``ValidatingTokenStorage`` used
         for defining and validating the set of authorization requirements that
@@ -107,7 +107,7 @@ class AccessTokenAuthorizerFactory(AuthorizerFactory[AccessTokenAuthorizer]):
     An ``AuthorizerFactory`` that constructs ``AccessTokenAuthorizer``.
     """
 
-    def __init__(self, token_storage: ValidatingTokenStorage):
+    def __init__(self, token_storage: ValidatingTokenStorage) -> None:
         super().__init__(token_storage)
         self._cached_authorizer_expiration: dict[str, int] = {}
 
@@ -176,7 +176,7 @@ class RefreshTokenAuthorizerFactory(AuthorizerFactory[RefreshTokenAuthorizer]):
         self,
         token_storage: ValidatingTokenStorage,
         auth_login_client: AuthLoginClient,
-    ):
+    ) -> None:
         """
         :param token_storage: The ``ValidatingTokenStorage`` used
         for defining and validating the set of authorization requirements that

--- a/src/globus_sdk/experimental/globus_app/client_app.py
+++ b/src/globus_sdk/experimental/globus_app/client_app.py
@@ -47,7 +47,7 @@ class ClientApp(GlobusApp):
         client_secret: str | None = None,
         scope_requirements: dict[str, ScopeCollectionType] | None = None,
         config: GlobusAppConfig = DEFAULT_CONFIG,
-    ):
+    ) -> None:
         if config.login_flow_manager is not None:
             raise GlobusSDKUsageError("A ClientApp cannot use a login_flow_manager")
 

--- a/src/globus_sdk/experimental/globus_app/errors.py
+++ b/src/globus_sdk/experimental/globus_app/errors.py
@@ -24,7 +24,7 @@ class MissingIdentityError(IdentityValidationError):
 class IdentityMismatchError(IdentityValidationError):
     """The identity in a token response did not match the expected identity."""
 
-    def __init__(self, message: str, stored_id: UUIDLike, new_id: UUIDLike):
+    def __init__(self, message: str, stored_id: UUIDLike, new_id: UUIDLike) -> None:
         super().__init__(message)
         self.stored_id = stored_id
         self.new_id = new_id
@@ -33,7 +33,7 @@ class IdentityMismatchError(IdentityValidationError):
 class MissingTokenError(TokenValidationError):
     """No token stored for a given resource server."""
 
-    def __init__(self, message: str, resource_server: str):
+    def __init__(self, message: str, resource_server: str) -> None:
         super().__init__(message)
         self.resource_server = resource_server
 
@@ -41,7 +41,7 @@ class MissingTokenError(TokenValidationError):
 class ExpiredTokenError(TokenValidationError):
     """The token stored for a given resource server has expired."""
 
-    def __init__(self, expires_at_seconds: int):
+    def __init__(self, expires_at_seconds: int) -> None:
         expiration = datetime.fromtimestamp(expires_at_seconds)
         super().__init__(f"Token expired at {expiration.isoformat()}")
         self.expiration = expiration
@@ -50,7 +50,9 @@ class ExpiredTokenError(TokenValidationError):
 class UnmetScopeRequirementsError(TokenValidationError):
     """The token stored for a given resource server is missing required scopes."""
 
-    def __init__(self, message: str, scope_requirements: dict[str, list[Scope]]):
+    def __init__(
+        self, message: str, scope_requirements: dict[str, list[Scope]]
+    ) -> None:
         super().__init__(message)
         # The full set of scope requirements which were evaluated.
         #   Notably this is not exclusively the unmet scope requirements.

--- a/src/globus_sdk/experimental/globus_app/user_app.py
+++ b/src/globus_sdk/experimental/globus_app/user_app.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import typing as t
+
 from globus_sdk import (
     AuthLoginClient,
     ConfidentialAppAuthClient,
@@ -63,9 +65,9 @@ class UserApp(GlobusApp):
         login_client: AuthLoginClient | None = None,
         client_id: UUIDLike | None = None,
         client_secret: str | None = None,
-        scope_requirements: dict[str, ScopeCollectionType] | None = None,
+        scope_requirements: t.Mapping[str, ScopeCollectionType] | None = None,
         config: GlobusAppConfig = DEFAULT_CONFIG,
-    ):
+    ) -> None:
         super().__init__(
             app_name,
             login_client=login_client,

--- a/src/globus_sdk/experimental/login_flow_manager/command_line_login_flow_manager.py
+++ b/src/globus_sdk/experimental/login_flow_manager/command_line_login_flow_manager.py
@@ -43,7 +43,7 @@ class CommandLineLoginFlowManager(LoginFlowManager):
         native_prefill_named_grant: str | None = None,
         login_prompt: str = "Please authenticate with Globus here:",
         code_prompt: str = "Enter the resulting Authorization Code here:",
-    ):
+    ) -> None:
         """
         :param login_client: The ``AuthLoginClient`` that will be making the Globus
             Auth API calls needed for the authentication flow. Note that this

--- a/src/globus_sdk/experimental/login_flow_manager/local_server_login_flow_manager/local_server_login_flow_manager.py
+++ b/src/globus_sdk/experimental/login_flow_manager/local_server_login_flow_manager/local_server_login_flow_manager.py
@@ -106,7 +106,7 @@ class LocalServerLoginFlowManager(LoginFlowManager):
         native_prefill_named_grant: str | None = None,
         server_address: tuple[str, int] = ("127.0.0.1", 0),
         html_template: Template = DEFAULT_HTML_TEMPLATE,
-    ):
+    ) -> None:
         """
         :param login_client: The ``AuthLoginClient`` that will be making the Globus
             Auth API calls needed for the authentication flow. Note that this

--- a/src/globus_sdk/experimental/login_flow_manager/login_flow_manager.py
+++ b/src/globus_sdk/experimental/login_flow_manager/login_flow_manager.py
@@ -27,7 +27,7 @@ class LoginFlowManager(metaclass=abc.ABCMeta):
         *,
         request_refresh_tokens: bool = False,
         native_prefill_named_grant: str | None = None,
-    ):
+    ) -> None:
         """
         :param login_client: The client to use for login flows.
         :param request_refresh_tokens: Control whether refresh tokens will be requested.

--- a/src/globus_sdk/experimental/tokenstorage/base.py
+++ b/src/globus_sdk/experimental/tokenstorage/base.py
@@ -37,7 +37,7 @@ class TokenStorage(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def store_token_data_by_resource_server(
-        self, token_data_by_resource_server: dict[str, TokenData]
+        self, token_data_by_resource_server: t.Mapping[str, TokenData]
     ) -> None:
         """
         Store token data in underlying storage partitioned by the resource server

--- a/src/globus_sdk/experimental/tokenstorage/json.py
+++ b/src/globus_sdk/experimental/tokenstorage/json.py
@@ -116,7 +116,7 @@ class JSONTokenStorage(FileTokenStorage):
         return self._handle_formats(data)
 
     def store_token_data_by_resource_server(
-        self, token_data_by_resource_server: dict[str, TokenData]
+        self, token_data_by_resource_server: t.Mapping[str, TokenData]
     ) -> None:
         """
         Store token data as JSON data in ``self.filepath`` under the current namespace

--- a/src/globus_sdk/experimental/tokenstorage/memory.py
+++ b/src/globus_sdk/experimental/tokenstorage/memory.py
@@ -35,7 +35,7 @@ class MemoryTokenStorage(TokenStorage):
         return cls(namespace=namespace)
 
     def store_token_data_by_resource_server(
-        self, token_data_by_resource_server: dict[str, TokenData]
+        self, token_data_by_resource_server: t.Mapping[str, TokenData]
     ) -> None:
         if self.namespace not in self._tokens:
             self._tokens[self.namespace] = {}

--- a/src/globus_sdk/experimental/tokenstorage/sqlite.py
+++ b/src/globus_sdk/experimental/tokenstorage/sqlite.py
@@ -35,7 +35,7 @@ class SQLiteTokenStorage(FileTokenStorage):
         *,
         connect_params: dict[str, t.Any] | None = None,
         namespace: str = "DEFAULT",
-    ):
+    ) -> None:
         """
         :param filepath: The path of the DB file to write to and read from.
         :param connect_params: A pass-through dictionary for fine-tuning the SQLite
@@ -107,7 +107,7 @@ class SQLiteTokenStorage(FileTokenStorage):
         self._connection.close()
 
     def store_token_data_by_resource_server(
-        self, token_data_by_resource_server: dict[str, TokenData]
+        self, token_data_by_resource_server: t.Mapping[str, TokenData]
     ) -> None:
         """
         Given a dict of token data indexed by resource server, convert the data into

--- a/src/globus_sdk/experimental/tokenstorage/token_data.py
+++ b/src/globus_sdk/experimental/tokenstorage/token_data.py
@@ -49,7 +49,7 @@ class TokenData(_serializable.Serializable):
         expires_at_seconds: int,
         token_type: str | None,
         extra: dict[str, t.Any] | None = None,
-    ):
+    ) -> None:
         self.resource_server = _validators.str_("resource_server", resource_server)
         self.identity_id = _validators.opt_str("identity_id", identity_id)
         self.scope = _validators.str_("scope", scope)

--- a/tests/non-pytest/mypy-ignore-tests/app_scope_requirmeents.py
+++ b/tests/non-pytest/mypy-ignore-tests/app_scope_requirmeents.py
@@ -1,0 +1,12 @@
+from globus_sdk.experimental.globus_app import UserApp
+
+# declare scope data in the form of a subtype of the ScopeCollectionType (`list[str]`)
+# indexed in a dict, this is meant to be a subtype of the requirements data accepted
+# by `GlobusApp.add_scope_requirements`
+#
+# this is a regression test for that being annotated as `dict[str, ScopeCollectionType]`
+# which will reject the input type because `dict` is a mutable container, and therefore
+# invariant
+scopes: dict[str, list[str]] = {"foo": ["bar"]}
+my_app = UserApp("...", client_id="...")
+my_app.add_scope_requirements(scopes)


### PR DESCRIPTION
For user-input interfaces, we should generally declare types which
express our constraints vis-a-vis mutability of container types.
That is, if we can accept a `Mapping[K, V]`, we should declare that as
our input constraint, rather than `dict[K, V]` or
`MutableMapping[K, V]`.

The reason for this is that the variance of `K` and `V` over an
immutable mapping is more permissive. Immutable container types tend
to be covariant, whereas mutable containers are invariant.
Invariance can incorrectly penalize users by being overly strict,
rejecting subtypes of `K` and `V`.

Therefore, fix all of the input points for GlobusApp which
unnecessarily use `dict` to use `MutableMapping` instead.

Additionally, make `__init__` methods consistent in declaring a return
type of `None`. `mypy` is now lenient, allowing omission of the return
type on `__init__`, but it considers a no-arg unannotated init to be
untyped. This can lead to surprising behaviors -- for consistency,
`__init__` should always be annotated with a return type.

A typing regression test is included for the usage which first raised
this issue.


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1035.org.readthedocs.build/en/1035/

<!-- readthedocs-preview globus-sdk-python end -->