### PR TITLE
Fix flaky tests + add __str__ of ConsentForest

### DIFF
--- a/src/globus_sdk/experimental/consents/_model.py
+++ b/src/globus_sdk/experimental/consents/_model.py
@@ -25,6 +25,7 @@ The resources defined herein are:
 
 from __future__ import annotations
 
+import textwrap
 import typing as t
 from dataclasses import dataclass
 from datetime import datetime
@@ -154,6 +155,12 @@ class ConsentForest:
 
         self.edges = self._compute_edges()
         self.trees = self._build_trees()
+
+    def __str__(self) -> str:
+        # indent 4 for inner elements, so that we can put their headings at 2 indent
+        trees = textwrap.indent("\n".join(str(t) for t in self.trees), "    ")
+        nodes = textwrap.indent("\n".join(str(n) for n in self.nodes), "    ")
+        return f"ConsentForest\n  nodes\n{nodes}\n  trees\n{trees}"
 
     def _compute_edges(self) -> dict[int, set[int]]:
         """

--- a/tests/common/consents.py
+++ b/tests/common/consents.py
@@ -4,7 +4,6 @@ import uuid
 from collections import defaultdict, namedtuple
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
-from random import randint
 
 from globus_sdk import Scope
 from globus_sdk._types import UUIDLike
@@ -25,7 +24,7 @@ class ConsentTest(Consent):
     client: UUIDLike
     scope: UUIDLike
     scope_name: str
-    id: int = field(default_factory=lambda: randint(1, 10000))
+    id: int = field(default_factory=lambda: uuid.uuid1().int)
     effective_identity: UUIDLike = str(uuid.uuid4())
     dependency_path: list[int] = field(default_factory=list)
     created: datetime = field(


### PR DESCRIPTION
We experienced rare test failures in CI which were reproducible by
reusing the pytest-randomly seed. In order to diagnose the cause, a
`__str__` method was added to the ConsentForest class to stringify its
primary elements (consent nodes and consent trees).

The node and tree classes already define `__str__`, and
`ConsentTree.__str__` is formatted and indented data in some cases.
So the container's string form is also newline separated and uses
`textwrap.indent` for nice presentation.

Inspection of the stringified consent data in a failing case revealed
non-unique node IDs in the test data. Tracking down the production of
these IDs, we find a `random.randint()` usage which *can* collide in
rare cases. To rectify, simply replace the fully random data with the
integer form of UUIDs -- this guarantees uniqueness with minimal code
complexity cost.


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1038.org.readthedocs.build/en/1038/

<!-- readthedocs-preview globus-sdk-python end -->