### PR TITLE
Make `GlobusApp.token_store` public and documented

### DIFF
--- a/changelog.d/20240904_123201_sirosen_expose_app_token_storage.rst
+++ b/changelog.d/20240904_123201_sirosen_expose_app_token_storage.rst
@@ -1,0 +1,8 @@
+Changed
+~~~~~~~
+
+.. rubric:: Experimental
+
+- ``GlobusApp.token_storage`` is now a public property, allowing users
+  direct access to the ``ValidatingTokenStorage`` used by the app to build
+  authorizers. (:pr:`NUMBER`)

--- a/src/globus_sdk/experimental/globus_app/client_app.py
+++ b/src/globus_sdk/experimental/globus_app/client_app.py
@@ -87,7 +87,7 @@ class ClientApp(GlobusApp):
 
     def _initialize_authorizer_factory(self) -> None:
         self._authorizer_factory = ClientCredentialsAuthorizerFactory(
-            token_storage=self._validating_token_storage,
+            token_storage=self.token_storage,
             confidential_client=self._login_client,
         )
 

--- a/src/globus_sdk/experimental/globus_app/user_app.py
+++ b/src/globus_sdk/experimental/globus_app/user_app.py
@@ -132,12 +132,11 @@ class UserApp(GlobusApp):
     def _initialize_authorizer_factory(self) -> None:
         if self.config.request_refresh_tokens:
             self._authorizer_factory = RefreshTokenAuthorizerFactory(
-                token_storage=self._validating_token_storage,
-                auth_login_client=self._login_client,
+                token_storage=self.token_storage, auth_login_client=self._login_client
             )
         else:
             self._authorizer_factory = AccessTokenAuthorizerFactory(
-                token_storage=self._validating_token_storage,
+                token_storage=self.token_storage
             )
 
     def run_login_flow(

--- a/tests/unit/experimental/globus_app/test_globus_app.py
+++ b/tests/unit/experimental/globus_app/test_globus_app.py
@@ -161,7 +161,7 @@ def test_user_app_creates_consent_client():
     client_id = "mock_client_id"
     user_app = UserApp("test-app", client_id=client_id)
 
-    assert user_app._validating_token_storage._consent_client is not None
+    assert user_app.token_storage._consent_client is not None
 
 
 class MockLoginFlowManager(LoginFlowManager):


### PR DESCRIPTION
In service of this, the docstrings for GlobusApp needed to be fixed.
The `__init__` docstring is not used in our sphinx configuration, and
is therefore moved into the class docstring, where it will be properly
loaded and used for parameter doc. This allows the renamed attr to be
documented as an instance var.


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1040.org.readthedocs.build/en/1040/

<!-- readthedocs-preview globus-sdk-python end -->