### PR TITLE
Replace app requirement exploration method

### DIFF
--- a/changelog.d/20240905_134232_derek_better_app_scope_inspection.rst
+++ b/changelog.d/20240905_134232_derek_better_app_scope_inspection.rst
@@ -1,0 +1,9 @@
+
+Changed
+~~~~~~~
+
+-   The experimental ``GlobusApp`` construct's scope exploration interface has changed
+    from ``app.get_scope_requirements(resource_server: str) -> tuple[Scope]`` to
+    ``app.scope_requirements``. The new property will return a deep copy of the internal
+    requirements dictionary mapping resource server to a list of Scopes. (:pr:`NUMBER`)
+

--- a/src/globus_sdk/experimental/globus_app/app.py
+++ b/src/globus_sdk/experimental/globus_app/app.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import abc
+import copy
 import typing as t
 
 from globus_sdk import AuthClient, AuthLoginClient, GlobusSDKUsageError, Scope
@@ -294,11 +295,14 @@ class GlobusApp(metaclass=abc.ABCMeta):
 
         self._authorizer_factory.clear_cache(*scope_requirements.keys())
 
-    def get_scope_requirements(self, resource_server: str) -> tuple[Scope, ...]:
+    @property
+    def scope_requirements(self) -> dict[str, list[Scope]]:
         """
-        Get an immutable copy of the collection scope requirements currently defined
-        on a resource server.
+        Access a copy of scope requirements defined for this service.
 
-        :param resource_server: the resource server to get scope requirements for
+        Modifying the returned dict will not affect the app's scope requirements.
+        To add scope requirements, please use ``GlobusApp.add_scope_requirements()``
+            instead.
         """
-        return tuple(self._scope_requirements.get(resource_server, []))
+        # Scopes are mutable objects so we return a deepcopy
+        return copy.deepcopy(self._scope_requirements)

--- a/src/globus_sdk/experimental/globus_app/app.py
+++ b/src/globus_sdk/experimental/globus_app/app.py
@@ -298,11 +298,10 @@ class GlobusApp(metaclass=abc.ABCMeta):
     @property
     def scope_requirements(self) -> dict[str, list[Scope]]:
         """
-        Access a copy of scope requirements defined for this service.
+        Access a copy of app's aggregate scope requirements.
 
         Modifying the returned dict will not affect the app's scope requirements.
-        To add scope requirements, please use ``GlobusApp.add_scope_requirements()``
-            instead.
+        To add scope requirements, use ``GlobusApp.add_scope_requirements()``.
         """
         # Scopes are mutable objects so we return a deepcopy
         return copy.deepcopy(self._scope_requirements)

--- a/tests/unit/experimental/globus_app/test_globus_app.py
+++ b/tests/unit/experimental/globus_app/test_globus_app.py
@@ -313,8 +313,30 @@ def test_constructor_scope_requirements_accepts_different_scope_types(scope_coll
     assert _sorted_auth_scope_str(user_app) == "email openid"
 
 
+def test_scope_requirements_returns_copies_scopes():
+    user_app = UserApp("test-app", client_id="mock_client_id")
+    foo_scope = Scope("foo:all").add_dependency(Scope("bar:all"))
+    user_app.add_scope_requirements({"foo": [foo_scope]})
+
+    real_requirements = user_app._scope_requirements
+    real_openid = real_requirements["auth.globus.org"][0]
+    real_foo = real_requirements["foo"][0]
+
+    copied_requirements = user_app.scope_requirements
+    copied_openid = copied_requirements["auth.globus.org"][0]
+    copied_foo = copied_requirements["foo"][0]
+
+    assert real_requirements is not copied_requirements
+
+    # Copied requirements mirror the originals but are distinct objects.
+    assert real_openid is not copied_openid
+    assert real_foo is not copied_foo
+    assert str(real_openid) == str(copied_openid)
+    assert str(real_foo) == str(copied_foo)
+
+
 def _sorted_auth_scope_str(user_app: UserApp) -> str:
-    scope_list = user_app.get_scope_requirements("auth.globus.org")
+    scope_list = user_app.scope_requirements["auth.globus.org"]
     return " ".join(sorted(str(scope) for scope in scope_list))
 
 

--- a/tests/unit/experimental/test_client_integration.py
+++ b/tests/unit/experimental/test_client_integration.py
@@ -38,7 +38,7 @@ def test_client_environment_does_not_match_the_globus_app_environment():
 def test_transfer_client_default_scopes(app):
     globus_sdk.TransferClient(app=app)
 
-    assert [str(s) for s in app.get_scope_requirements("transfer.api.globus.org")] == [
+    assert [str(s) for s in app.scope_requirements["transfer.api.globus.org"]] == [
         "urn:globus:auth:scope:transfer.api.globus.org:all"
     ]
 
@@ -48,7 +48,7 @@ def test_transfer_client_add_app_data_access_scope(app):
 
     collection_id = str(uuid.UUID(int=0))
     client.add_app_data_access_scope(collection_id)
-    str_list = [str(s) for s in app.get_scope_requirements("transfer.api.globus.org")]
+    str_list = [str(s) for s in app.scope_requirements["transfer.api.globus.org"]]
     expected = f"urn:globus:auth:scope:transfer.api.globus.org:all[*https://auth.globus.org/scopes/{collection_id}/data_access]"  # noqa: E501
     assert expected in str_list
 
@@ -62,7 +62,7 @@ def test_transfer_client_add_app_data_access_scope_chaining(app):
         .add_app_data_access_scope(collection_id_2)
     )
 
-    str_list = [str(s) for s in app.get_scope_requirements("transfer.api.globus.org")]
+    str_list = [str(s) for s in app.scope_requirements["transfer.api.globus.org"]]
     expected_1 = f"urn:globus:auth:scope:transfer.api.globus.org:all[*https://auth.globus.org/scopes/{collection_id_1}/data_access]"  # noqa: E501
     expected_2 = f"urn:globus:auth:scope:transfer.api.globus.org:all[*https://auth.globus.org/scopes/{collection_id_2}/data_access]"  # noqa: E501
     assert expected_1 in str_list
@@ -80,7 +80,7 @@ def test_transfer_client_add_app_data_access_scope_in_iterable(app):
     expected_2 = f"https://auth.globus.org/scopes/{collection_id_2}/data_access"
 
     transfer_dependencies = []
-    for scope in app.get_scope_requirements("transfer.api.globus.org"):
+    for scope in app.scope_requirements["transfer.api.globus.org"]:
         if scope.scope_string != globus_sdk.TransferClient.scopes.all:
             continue
         for dep in scope.dependencies:
@@ -106,7 +106,7 @@ def test_transfer_client_add_app_data_access_scope_catches_bad_uuid_in_iterable(
 def test_auth_client_default_scopes(app):
     globus_sdk.AuthClient(app=app)
 
-    str_list = [str(s) for s in app.get_scope_requirements("auth.globus.org")]
+    str_list = [str(s) for s in app.scope_requirements["auth.globus.org"]]
     assert "openid" in str_list
     assert "profile" in str_list
     assert "email" in str_list
@@ -115,7 +115,7 @@ def test_auth_client_default_scopes(app):
 def test_groups_client_default_scopes(app):
     globus_sdk.GroupsClient(app=app)
 
-    assert [str(s) for s in app.get_scope_requirements("groups.api.globus.org")] == [
+    assert [str(s) for s in app.scope_requirements["groups.api.globus.org"]] == [
         "urn:globus:auth:scope:groups.api.globus.org:view_my_groups_and_memberships"
     ]
 
@@ -123,7 +123,7 @@ def test_groups_client_default_scopes(app):
 def test_search_client_default_scopes(app):
     globus_sdk.SearchClient(app=app)
 
-    assert [str(s) for s in app.get_scope_requirements("search.api.globus.org")] == [
+    assert [str(s) for s in app.scope_requirements["search.api.globus.org"]] == [
         "urn:globus:auth:scope:search.api.globus.org:search"
     ]
 
@@ -132,7 +132,7 @@ def test_timer_client_default_scopes(app):
     globus_sdk.TimersClient(app=app)
 
     timer_client_id = "524230d7-ea86-4a52-8312-86065a9e0417"
-    str_list = [str(s) for s in app.get_scope_requirements(timer_client_id)]
+    str_list = [str(s) for s in app.scope_requirements[timer_client_id]]
     assert str_list == [f"https://auth.globus.org/scopes/{timer_client_id}/timer"]
 
 
@@ -140,7 +140,7 @@ def test_flows_client_default_scopes(app):
     globus_sdk.FlowsClient(app=app)
 
     flows_client_id = "eec9b274-0c81-4334-bdc2-54e90e689b9a"
-    str_list = [str(s) for s in app.get_scope_requirements("flows.globus.org")]
+    str_list = [str(s) for s in app.scope_requirements["flows.globus.org"]]
     assert len(str_list) == 1
     assert str_list == [f"https://auth.globus.org/scopes/{flows_client_id}/all"]
 
@@ -148,7 +148,7 @@ def test_flows_client_default_scopes(app):
 def test_specific_flow_client_default_scopes(app):
     globus_sdk.SpecificFlowClient("flow_id", app=app)
 
-    assert [str(s) for s in app.get_scope_requirements("flow_id")] == [
+    assert [str(s) for s in app.scope_requirements["flow_id"]] == [
         "https://auth.globus.org/scopes/flow_id/flow_flow_id_user"
     ]
 
@@ -160,6 +160,6 @@ def test_gcs_client_default_scopes(app):
 
     globus_sdk.GCSClient(domain_name, app=app)
 
-    assert [str(s) for s in app.get_scope_requirements(endpoint_client_id)] == [
+    assert [str(s) for s in app.scope_requirements[endpoint_client_id]] == [
         f"urn:globus:auth:scope:{endpoint_client_id}:manage_collections"
     ]

--- a/tests/unit/test_base_client.py
+++ b/tests/unit/test_base_client.py
@@ -226,7 +226,7 @@ def test_app_integration(base_client_class):
     assert c.app_name == "SDK Test"
 
     # confirm default_required_scopes were automatically added
-    assert [str(s) for s in app.get_scope_requirements(c.resource_server)] == [
+    assert [str(s) for s in app.scope_requirements[c.resource_server]] == [
         TransferScopes.all
     ]
 
@@ -244,7 +244,7 @@ def test_app_scopes(base_client_class):
     c = base_client_class(app=app, app_scopes=[Scope("foo")])
 
     # confirm app_scopes were added and default_required_scopes were not
-    assert [str(s) for s in app.get_scope_requirements(c.resource_server)] == ["foo"]
+    assert [str(s) for s in app.scope_requirements[c.resource_server]] == ["foo"]
 
 
 def test_add_app_scope(base_client_class):
@@ -252,7 +252,7 @@ def test_add_app_scope(base_client_class):
     c = base_client_class(app=app)
 
     c.add_app_scope("foo")
-    str_list = [str(s) for s in app.get_scope_requirements(c.resource_server)]
+    str_list = [str(s) for s in app.scope_requirements[c.resource_server]]
     assert len(str_list) == 2
     assert TransferScopes.all in str_list
     assert "foo" in str_list
@@ -261,7 +261,7 @@ def test_add_app_scope(base_client_class):
 def test_add_app_scope_chaining(base_client_class):
     app = UserApp("SDK Test", client_id="client_id")
     c = base_client_class(app=app).add_app_scope("foo").add_app_scope("bar")
-    str_list = [str(s) for s in app.get_scope_requirements(c.resource_server)]
+    str_list = [str(s) for s in app.scope_requirements[c.resource_server]]
     assert len(str_list) == 3
     assert TransferScopes.all in str_list
     assert "foo" in str_list


### PR DESCRIPTION

## What?
Replace `app.get_scope_requirements(resource_server: str) -> tuple[Scope]` with the @property method `app.scope_requirements` which will create and return a deep copy of the internal scope requirements.

## Why?
`app.get_scope_requirements(...)` was added to give developers a lens into the aggregate requirements registered on a GlobusApp. By making resource_server a required parameter however, we mandated that a developer have foreknowledge of the scopes they are exploring which, at least in part, defeats the purpose of supporting exploration.

This new approach allows for iteration over all resource servers and leverages deepcopy to ensure that users don't retrieve and modify their scope requirements outside of the App defined interfaces (`app.add_scope_requirements(...)`)

<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1042.org.readthedocs.build/en/1042/

<!-- readthedocs-preview globus-sdk-python end -->