### PR TITLE
Fix doc build to use 'html', not 'dirhtml'

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -74,7 +74,7 @@ allowlist_externals = rm
 changedir = docs/
 # clean the build dir before rebuilding
 commands_pre = rm -rf _build/
-commands = sphinx-build -j auto -d _build/doctrees -b dirhtml -W . _build/dirhtml {posargs}
+commands = sphinx-build -j auto -d _build/doctrees -b html -W . _build/html {posargs}
 
 [testenv:twine-check]
 skip_install = true


### PR DESCRIPTION
RTD builds are using 'html', so we aren't able to simulate the exact
same behaviors unless we fix this discrepancy.


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1045.org.readthedocs.build/en/1045/

<!-- readthedocs-preview globus-sdk-python end -->