### PR TITLE
Promote `gare` from `experimental`

### DIFF
--- a/changelog.d/20240916_102235_sirosen_move_consents.rst
+++ b/changelog.d/20240916_102235_sirosen_move_consents.rst
@@ -1,0 +1,6 @@
+Changed
+~~~~~~~
+
+- Globus Auth Requirements errors are no longer ``experimental``. They have
+  been moved to the ``globus_sdk.gare`` module and the primary document type
+  has been renamed from ``GlobusAuthRequirementsError`` to ``GARE``. (:pr:`NUMBER`)

--- a/changelog.d/20240916_102235_sirosen_move_consents.rst
+++ b/changelog.d/20240916_102235_sirosen_move_consents.rst
@@ -1,6 +1,0 @@
-Changed
-~~~~~~~
-
-- Globus Auth Requirements errors are no longer ``experimental``. They have
-  been moved to the ``globus_sdk.gare`` module and the primary document type
-  has been renamed from ``GlobusAuthRequirementsError`` to ``GARE``. (:pr:`NUMBER`)

--- a/changelog.d/20240916_102235_sirosen_move_gare.rst
+++ b/changelog.d/20240916_102235_sirosen_move_gare.rst
@@ -1,0 +1,11 @@
+Changed
+~~~~~~~
+
+- Globus Auth Requirements errors are no longer ``experimental``. They have
+  been moved to the ``globus_sdk.gare`` module and the primary document type
+  has been renamed from ``GlobusAuthRequirementsError`` to ``GARE``. (:pr:`NUMBER`)
+
+  - The functions provided by this interface have also been renamed to use
+    ``gare`` in their naming: ``to_gare``, ``is_gare``, ``has_gares``, and
+    ``to_gares`` are now all available. The older names are available as
+    aliases from the ``experimental`` namespace.

--- a/docs/authorization/gare.rst
+++ b/docs/authorization/gare.rst
@@ -1,29 +1,29 @@
 Auth Requirements Errors
 ========================
 
-Globus Auth Requirements Error is a response format that conveys to a client any
+'Globus Auth Requirements Error' is a response format that conveys to a client any
 modifications to a session (i.e., "boosting") that will be required
 to complete a particular request.
 
-The ``globus_sdk.experimental.auth_requirements_error`` module provides a
-number of tools to make it easier to identify and handle these errors when they occur.
+The ``globus_sdk.gare`` module provides a number of tools to make it easier to
+identify and handle these errors when they occur.
 
-GlobusAuthRequirementsError
----------------------------
+GARE
+----
 
-The ``GlobusAuthRequirementsError`` class provides a model for working with Globus
-Auth Requirements Error responses.
+The ``GARE`` class provides a model for working with Globus Auth Requirements Error
+responses.
 
 Services in the Globus ecosystem may need to communicate authorization requirements
 to their consumers. For example, a service may need to instruct clients to have the user
-consent to an additional scope, ``"foo"``. In such a case, ``GlobusAuthRequirementsError``
-can provide serialization into the well-known Globus Auth Requirements Error format:
+consent to an additional scope, ``"foo"``. In such a case, ``GARE`` can provide
+serialization into the well-known Globus Auth Requirements Error format:
 
 .. code-block:: python
 
-    from globus_sdk.experimental.auth_requirements_error import GlobusAuthRequirementsError
+    from globus_sdk.gare import GARE
 
-    error = GlobusAuthRequirementsError(
+    error_doc = GARE(
         code="ConsentRequired",
         authorization_parameters=GlobusAuthorizationParameters(
             required_scopes=["foo"],
@@ -42,9 +42,9 @@ by specifying ``include_extra=True`` when calling ``to_dict()``.
 
 .. code-block:: python
 
-    from globus_sdk.experimental.auth_requirements_error import GlobusAuthRequirementsError
+    from globus_sdk.gare import GARE
 
-    error = GlobusAuthRequirementsError(
+    error = GARE(
         code="ConsentRequired",
         authorization_parameters=GlobusAuthorizationParameters(
             required_scopes=["foo"],
@@ -61,8 +61,8 @@ by specifying ``include_extra=True`` when calling ``to_dict()``.
     # Render a dictionary with extra fields
     error.to_dict(include_extra=True)
 
-These fields are stored by both the ``GlobusAuthRequirementsError`` and
-``GlobusAuthenticationParameters`` classes in an ``extra`` attribute.
+These fields are stored by both the ``GARE`` and ``GlobusAuthenticationParameters``
+classes in an ``extra`` attribute.
 
 .. note::
 
@@ -75,9 +75,8 @@ These fields are stored by both the ``GlobusAuthRequirementsError`` and
 Parsing Responses
 -----------------
 
-If you are writing a client to a Globus API, the ``auth_requirements_error`` subpackage
-provides utilities to detect legacy Globus Auth requirements error response
-formats and normalize them.
+If you are writing a client to a Globus API, the ``gare`` subpackage provides utilities
+to detect legacy Globus Auth requirements error response formats and normalize them.
 
 To detect if a ``GlobusAPIError``, ``ErrorSubdocument``, or JSON response
 dictionary represents an error that can be converted to a Globus Auth
@@ -85,27 +84,25 @@ Requirements Error, you can use, e.g.,:
 
 .. code-block:: python
 
-    from globus_sdk.experimental import auth_requirements_error
+    from globus_sdk import gare
 
     error_dict = {
         "code": "ConsentRequired",
         "message": "Missing required foo consent",
     }
     # The dict is not a Globus Auth Requirements Error, so `False` is returned.
-    auth_requirements_error.utils.is_auth_requirements_error(error_dict)
+    gare.is_auth_requirements_error(error_dict)
 
     # The dict is not a Globus Auth Requirements Error and cannot be converted.
-    auth_requirements_error.utils.to_auth_requirements_error(error_dict)  # None
+    gare.to_auth_requirements_error(error_dict)  # None
 
     error_dict = {
         "code": "ConsentRequired",
         "message": "Missing required foo consent",
         "required_scopes": ["urn:globus:auth:scope:transfer.api.globus.org:all[*foo]"],
     }
-    auth_requirements_error.utils.is_auth_requirements_error(error_dict)  # True
-    auth_requirements_error.utils.to_auth_requirements_error(
-        error_dict
-    )  # GlobusAuthRequirementsError
+    gare.is_auth_requirements_error(error_dict)  # True
+    gare.to_auth_requirements_error(error_dict)  # GARE
 
 .. note::
 
@@ -118,22 +115,38 @@ Requirements Error, you can use, e.g.,:
 
 .. code-block:: python
 
-    auth_requirements_error.utils.to_auth_requirements_error(
-        other_error
-    )  # GlobusAuthRequirementsError
-    auth_requirements_error.utils.to_auth_requirements_errors(
-        [other_error]
-    )  # [GlobusAuthRequirementsError, ...]
+    gare.to_auth_requirements_error(other_error)  # GARE
+    gare.to_auth_requirements_errors([other_error])  # [GARE, ...]
 
 Notes
 -----
 
-``GlobusAuthRequirementsError`` enforces types strictly when parsing a Globus
-Auth Requirements Error response dictionary, and will raise a ``ValueError`` if a
+``GARE`` enforces types strictly when parsing a Globus Auth Requirements Error
+response dictionary, and will raise a :class:`globus_sdk.ValidationError` if a
 supported field is supplied with a value of the wrong type.
 
-``GlobusAuthRequirementsError`` does not attempt to mimic or itself enforce
-any logic specific to the Globus Auth service with regard to what represents a valid
-combination of fields (e.g., ``session_required_mfa`` requires either
-``session_required_identities`` or ``session_required_single_domain``
-in order to be properly handled).
+``GARE`` does not attempt to mimic or itself enforce any logic specific to the
+Globus Auth service with regard to what represents a valid combination of fields
+(e.g., ``session_required_mfa`` requires either ``session_required_identities`` or
+``session_required_single_domain`` in order to be properly handled).
+
+Reference
+---------
+
+.. currentmodule:: globus_sdk.gare
+
+.. autoclass:: GARE
+    :members:
+    :inherited-members:
+
+.. autoclass:: GlobusAuthorizationParameters
+    :members:
+    :inherited-members:
+
+.. autofunction:: to_auth_requirements_error
+
+.. autofunction:: to_auth_requirements_errors
+
+.. autofunction:: is_auth_requirements_error
+
+.. autofunction:: has_auth_requirements_errors

--- a/docs/authorization/gare.rst
+++ b/docs/authorization/gare.rst
@@ -1,5 +1,5 @@
-Auth Requirements Errors
-========================
+Globus Auth Requirements Errors (GAREs)
+=======================================
 
 'Globus Auth Requirements Error' is a response format that conveys to a client any
 modifications to a session (i.e., "boosting") that will be required
@@ -143,10 +143,10 @@ Reference
     :members:
     :inherited-members:
 
-.. autofunction:: to_auth_requirements_error
+.. autofunction:: to_gare
 
-.. autofunction:: to_auth_requirements_errors
+.. autofunction:: to_gares
 
-.. autofunction:: is_auth_requirements_error
+.. autofunction:: is_gare
 
-.. autofunction:: has_auth_requirements_errors
+.. autofunction:: has_gares

--- a/docs/authorization/index.rst
+++ b/docs/authorization/index.rst
@@ -8,3 +8,4 @@ Components of the Globus SDK which handle application authorization.
 
     globus_authorizers
     scopes_and_consents/index
+    gare

--- a/docs/experimental/index.rst
+++ b/docs/experimental/index.rst
@@ -14,7 +14,6 @@ Globus SDK Experimental Components
     :caption: Contents
     :maxdepth: 1
 
-    auth_requirements_errors
     scope_parser
     consents
     globus_app

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "cryptography>=3.3.1,!=3.4.0",
     # depend on the latest version of typing-extensions on python versions which do
     # not have all of the typing features we use
-    'typing_extensions>=4.0; python_version<"3.10"',
+    'typing_extensions>=4.0; python_version<"3.11"',
     # python versions older than 3.9 don't have importlib.resources
     'importlib_resources>=5.12.0; python_version<"3.9"',
 ]

--- a/src/globus_sdk/_serializable.py
+++ b/src/globus_sdk/_serializable.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
 import inspect
+import sys
 import typing as t
 
-T = t.TypeVar("T", bound="Serializable")
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 
 class Serializable:
@@ -30,7 +34,7 @@ class Serializable:
         ]
 
     @classmethod
-    def from_dict(cls: type[T], data: dict[str, t.Any]) -> T:
+    def from_dict(cls, data: dict[str, t.Any]) -> Self:
         """
         Instantiate from a dictionary.
 

--- a/src/globus_sdk/experimental/auth_requirements_error.py
+++ b/src/globus_sdk/experimental/auth_requirements_error.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import sys
+import typing as t
+
+__all__ = (
+    "GlobusAuthRequirementsError",
+    "GlobusAuthorizationParameters",
+    "to_auth_requirements_error",
+    "to_auth_requirements_errors",
+    "is_auth_requirements_error",
+    "has_auth_requirements_errors",
+)
+
+# legacy aliases
+# (when accessed, these will emit deprecation warnings)
+if t.TYPE_CHECKING:
+    from globus_sdk.gare import GARE as GlobusAuthRequirementsError
+    from globus_sdk.gare import (
+        GlobusAuthorizationParameters,
+        has_auth_requirements_errors,
+        is_auth_requirements_error,
+        to_auth_requirements_error,
+        to_auth_requirements_errors,
+    )
+else:
+
+    def __getattr__(name: str) -> t.Any:
+        import globus_sdk.gare as gare_module
+        from globus_sdk.exc import warn_deprecated
+
+        warn_deprecated(
+            "'globus_sdk.experimental.auth_requirements_error' has been renamed to "
+            "'globus_sdk.gare'. "
+            f"Importing '{name}' from `globus_sdk.experimental` is deprecated."
+        )
+
+        # rename GlobusAuthRequirementsError -> GARE
+        if name == "GlobusAuthRequirementsError":
+            name = "GARE"
+
+        value = getattr(gare_module, name, None)
+        if value is None:
+            raise AttributeError(f"module {__name__} has no attribute {name}")
+        setattr(sys.modules[__name__], name, value)
+        return value

--- a/src/globus_sdk/experimental/auth_requirements_error.py
+++ b/src/globus_sdk/experimental/auth_requirements_error.py
@@ -16,13 +16,11 @@ __all__ = (
 # (when accessed, these will emit deprecation warnings)
 if t.TYPE_CHECKING:
     from globus_sdk.gare import GARE as GlobusAuthRequirementsError
-    from globus_sdk.gare import (
-        GlobusAuthorizationParameters,
-        has_auth_requirements_errors,
-        is_auth_requirements_error,
-        to_auth_requirements_error,
-        to_auth_requirements_errors,
-    )
+    from globus_sdk.gare import GlobusAuthorizationParameters
+    from globus_sdk.gare import has_gares as has_auth_requirements_errors
+    from globus_sdk.gare import is_gare as is_auth_requirements_error
+    from globus_sdk.gare import to_gare as to_auth_requirements_error
+    from globus_sdk.gare import to_gares as to_auth_requirements_errors
 else:
 
     _RENAMES = {

--- a/src/globus_sdk/experimental/auth_requirements_error.py
+++ b/src/globus_sdk/experimental/auth_requirements_error.py
@@ -25,21 +25,28 @@ if t.TYPE_CHECKING:
     )
 else:
 
+    _RENAMES = {
+        "GlobusAuthRequirementsError": "GARE",
+        "to_auth_requirements_error": "to_gare",
+        "to_auth_requirements_errors": "to_gares",
+        "is_auth_requirements_error": "is_gare",
+        "has_auth_requirements_errors": "has_gares",
+    }
+
     def __getattr__(name: str) -> t.Any:
         import globus_sdk.gare as gare_module
         from globus_sdk.exc import warn_deprecated
 
+        new_name = _RENAMES.get(name, name)
+
         warn_deprecated(
             "'globus_sdk.experimental.auth_requirements_error' has been renamed to "
             "'globus_sdk.gare'. "
-            f"Importing '{name}' from `globus_sdk.experimental` is deprecated."
+            f"Importing '{name}' from `globus_sdk.experimental` is deprecated. "
+            f"Use `globus_sdk.gare.{new_name}` instead."
         )
 
-        # rename GlobusAuthRequirementsError -> GARE
-        if name == "GlobusAuthRequirementsError":
-            name = "GARE"
-
-        value = getattr(gare_module, name, None)
+        value = getattr(gare_module, new_name, None)
         if value is None:
             raise AttributeError(f"module {__name__} has no attribute {name}")
         setattr(sys.modules[__name__], name, value)

--- a/src/globus_sdk/experimental/globus_app/app.py
+++ b/src/globus_sdk/experimental/globus_app/app.py
@@ -7,10 +7,8 @@ import typing as t
 from globus_sdk import AuthClient, AuthLoginClient, GlobusSDKUsageError, Scope
 from globus_sdk._types import ScopeCollectionType, UUIDLike
 from globus_sdk.authorizers import GlobusAuthorizer
-from globus_sdk.experimental.auth_requirements_error import (
-    GlobusAuthorizationParameters,
-)
 from globus_sdk.experimental.tokenstorage import TokenStorage
+from globus_sdk.gare import GlobusAuthorizationParameters
 from globus_sdk.scopes import AuthScopes, scopes_to_scope_list
 
 from ._types import TokenStorageProvider

--- a/src/globus_sdk/experimental/globus_app/client_app.py
+++ b/src/globus_sdk/experimental/globus_app/client_app.py
@@ -2,9 +2,7 @@ from __future__ import annotations
 
 from globus_sdk import AuthLoginClient, ConfidentialAppAuthClient, GlobusSDKUsageError
 from globus_sdk._types import ScopeCollectionType, UUIDLike
-from globus_sdk.experimental.auth_requirements_error import (
-    GlobusAuthorizationParameters,
-)
+from globus_sdk.gare import GlobusAuthorizationParameters
 
 from .app import GlobusApp
 from .authorizer_factory import ClientCredentialsAuthorizerFactory

--- a/src/globus_sdk/experimental/globus_app/user_app.py
+++ b/src/globus_sdk/experimental/globus_app/user_app.py
@@ -9,13 +9,11 @@ from globus_sdk import (
     NativeAppAuthClient,
 )
 from globus_sdk._types import ScopeCollectionType, UUIDLike
-from globus_sdk.experimental.auth_requirements_error import (
-    GlobusAuthorizationParameters,
-)
 from globus_sdk.experimental.login_flow_manager import (
     CommandLineLoginFlowManager,
     LoginFlowManager,
 )
+from globus_sdk.gare import GlobusAuthorizationParameters
 
 from ._types import LoginFlowManagerProvider
 from .app import GlobusApp

--- a/src/globus_sdk/experimental/login_flow_manager/command_line_login_flow_manager.py
+++ b/src/globus_sdk/experimental/login_flow_manager/command_line_login_flow_manager.py
@@ -9,9 +9,7 @@ from globus_sdk import (
     GlobusSDKUsageError,
     OAuthTokenResponse,
 )
-from globus_sdk.experimental.auth_requirements_error import (
-    GlobusAuthorizationParameters,
-)
+from globus_sdk.gare import GlobusAuthorizationParameters
 
 from .login_flow_manager import LoginFlowManager
 

--- a/src/globus_sdk/experimental/login_flow_manager/local_server_login_flow_manager/local_server_login_flow_manager.py
+++ b/src/globus_sdk/experimental/login_flow_manager/local_server_login_flow_manager/local_server_login_flow_manager.py
@@ -8,12 +8,10 @@ from contextlib import contextmanager
 from string import Template
 
 from globus_sdk import AuthLoginClient, GlobusSDKUsageError, OAuthTokenResponse
-from globus_sdk.experimental.auth_requirements_error import (
-    GlobusAuthorizationParameters,
-)
 from globus_sdk.experimental.login_flow_manager.login_flow_manager import (
     LoginFlowManager,
 )
+from globus_sdk.gare import GlobusAuthorizationParameters
 
 from ._local_server import (
     DEFAULT_HTML_TEMPLATE,

--- a/src/globus_sdk/experimental/login_flow_manager/login_flow_manager.py
+++ b/src/globus_sdk/experimental/login_flow_manager/login_flow_manager.py
@@ -9,9 +9,7 @@ from globus_sdk import (
     NativeAppAuthClient,
     OAuthTokenResponse,
 )
-from globus_sdk.experimental.auth_requirements_error import (
-    GlobusAuthorizationParameters,
-)
+from globus_sdk.gare import GlobusAuthorizationParameters
 
 
 class LoginFlowManager(metaclass=abc.ABCMeta):

--- a/src/globus_sdk/gare/__init__.py
+++ b/src/globus_sdk/gare/__init__.py
@@ -1,16 +1,11 @@
 from ._auth_requirements_error import GARE, GlobusAuthorizationParameters
-from ._functional_api import (
-    has_auth_requirements_errors,
-    is_auth_requirements_error,
-    to_auth_requirements_error,
-    to_auth_requirements_errors,
-)
+from ._functional_api import has_gares, is_gare, to_gare, to_gares
 
-__all__ = [
+__all__ = (
     "GARE",
     "GlobusAuthorizationParameters",
-    "to_auth_requirements_error",
-    "to_auth_requirements_errors",
-    "is_auth_requirements_error",
-    "has_auth_requirements_errors",
-]
+    "to_gare",
+    "to_gares",
+    "is_gare",
+    "has_gares",
+)

--- a/src/globus_sdk/gare/__init__.py
+++ b/src/globus_sdk/gare/__init__.py
@@ -1,7 +1,4 @@
-from ._auth_requirements_error import (
-    GlobusAuthorizationParameters,
-    GlobusAuthRequirementsError,
-)
+from ._auth_requirements_error import GARE, GlobusAuthorizationParameters
 from ._functional_api import (
     has_auth_requirements_errors,
     is_auth_requirements_error,
@@ -10,7 +7,7 @@ from ._functional_api import (
 )
 
 __all__ = [
-    "GlobusAuthRequirementsError",
+    "GARE",
     "GlobusAuthorizationParameters",
     "to_auth_requirements_error",
     "to_auth_requirements_errors",

--- a/src/globus_sdk/gare/_auth_requirements_error.py
+++ b/src/globus_sdk/gare/_auth_requirements_error.py
@@ -11,7 +11,7 @@ class GlobusAuthorizationParameters(Serializable):
     Data class containing authorization parameters that can be passed during
     an authentication flow to control how the user will authenticate.
 
-    When used with a GARE  this represents the additional authorization
+    When used with a GARE this represents the additional authorization
     parameters needed in order to complete a request that had insufficient
     authorization state.
 

--- a/src/globus_sdk/gare/_auth_requirements_error.py
+++ b/src/globus_sdk/gare/_auth_requirements_error.py
@@ -11,9 +11,9 @@ class GlobusAuthorizationParameters(Serializable):
     Data class containing authorization parameters that can be passed during
     an authentication flow to control how the user will authenticate.
 
-    When used with a GlobusAuthRequirementsError this represents the additional
-    authorization parameters needed in order to complete a request that had
-    insufficient authorization state.
+    When used with a GARE  this represents the additional authorization
+    parameters needed in order to complete a request that had insufficient
+    authorization state.
 
     :ivar session_message: A message to be displayed to the user.
     :vartype session_message: str, optional
@@ -77,7 +77,7 @@ class GlobusAuthorizationParameters(Serializable):
         self.extra = extra or {}
 
 
-class GlobusAuthRequirementsError(Serializable):
+class GARE(Serializable):
     """
     Represents a Globus Auth Requirements Error.
 

--- a/src/globus_sdk/gare/_functional_api.py
+++ b/src/globus_sdk/gare/_functional_api.py
@@ -76,7 +76,7 @@ def to_gares(
 ) -> list[GARE]:
     """
     Converts a list of GlobusAPIErrors, ErrorSubdocuments, or dicts into a list of
-    GAREs  by attempting to match each error to GARE (preferred) or legacy variants.
+    GAREs by attempting to match each error to GARE (preferred) or legacy variants.
 
     .. note::
 

--- a/src/globus_sdk/gare/_functional_api.py
+++ b/src/globus_sdk/gare/_functional_api.py
@@ -16,7 +16,7 @@ from ._variants import (
 log = logging.getLogger(__name__)
 
 
-def to_auth_requirements_error(
+def to_gare(
     error: exc.GlobusAPIError | exc.ErrorSubdocument | dict[str, t.Any]
 ) -> GARE | None:
     """
@@ -40,7 +40,7 @@ def to_auth_requirements_error(
     if isinstance(error, GlobusAPIError):
         # Iterate over ErrorSubdocuments
         for subdoc in error.errors:
-            authreq_error = to_auth_requirements_error(subdoc)
+            authreq_error = to_gare(subdoc)
             if authreq_error is not None:
                 # Return only the first auth requirements error we encounter
                 return authreq_error
@@ -71,7 +71,7 @@ def to_auth_requirements_error(
     return None
 
 
-def to_auth_requirements_errors(
+def to_gares(
     errors: list[exc.GlobusAPIError | exc.ErrorSubdocument | dict[str, t.Any]]
 ) -> list[GARE]:
     """
@@ -98,13 +98,13 @@ def to_auth_requirements_errors(
             candidate_errors.append(error)
 
     # Try to convert all candidate errors to auth requirements errors
-    all_errors = [to_auth_requirements_error(error) for error in candidate_errors]
+    all_errors = [to_gare(error) for error in candidate_errors]
 
     # Remove any errors that did not resolve to a Globus Auth Requirements Error
     return [error for error in all_errors if error is not None]
 
 
-def is_auth_requirements_error(
+def is_gare(
     error: exc.GlobusAPIError | exc.ErrorSubdocument | dict[str, t.Any]
 ) -> bool:
     """
@@ -113,10 +113,10 @@ def is_auth_requirements_error(
 
     :param error: The error to check.
     """
-    return to_auth_requirements_error(error) is not None
+    return to_gare(error) is not None
 
 
-def has_auth_requirements_errors(
+def has_gares(
     errors: list[exc.GlobusAPIError | exc.ErrorSubdocument | dict[str, t.Any]]
 ) -> bool:
     """
@@ -125,4 +125,4 @@ def has_auth_requirements_errors(
 
     :param errors: The errors to check.
     """
-    return any(is_auth_requirements_error(error) for error in errors)
+    return any(is_gare(error) for error in errors)

--- a/src/globus_sdk/gare/_functional_api.py
+++ b/src/globus_sdk/gare/_functional_api.py
@@ -5,7 +5,7 @@ import typing as t
 
 from globus_sdk import exc
 
-from ._auth_requirements_error import GlobusAuthRequirementsError
+from ._auth_requirements_error import GARE
 from ._variants import (
     LegacyAuthorizationParametersError,
     LegacyAuthRequirementsErrorVariant,
@@ -13,25 +13,20 @@ from ._variants import (
     LegacyConsentRequiredTransferError,
 )
 
-if t.TYPE_CHECKING:
-    from globus_sdk.exc import ErrorSubdocument, GlobusAPIError
-
 log = logging.getLogger(__name__)
 
 
 def to_auth_requirements_error(
-    error: GlobusAPIError | ErrorSubdocument | dict[str, t.Any]
-) -> GlobusAuthRequirementsError | None:
+    error: exc.GlobusAPIError | exc.ErrorSubdocument | dict[str, t.Any]
+) -> GARE | None:
     """
     Converts a GlobusAPIError, ErrorSubdocument, or dict into a
-    GlobusAuthRequirementsError by attempting to match to
-    GlobusAuthRequirementsError (preferred) or legacy variants.
+    GARE by attempting to match to GARE (preferred) or legacy variants.
 
     .. note::
 
         A GlobusAPIError may contain multiple errors, and in this case only a single
-        GlobusAuthRequirementsError is returned for the first error that matches
-        a known format.
+        GARE is returned for the first error that matches a known format.
 
 
     If the provided error does not match a known format, None is returned.
@@ -58,9 +53,9 @@ def to_auth_requirements_error(
 
     # Prefer a proper auth requirements error, if possible
     try:
-        return GlobusAuthRequirementsError.from_dict(error_dict)
+        return GARE.from_dict(error_dict)
     except exc.ValidationError as err:
-        log.debug(f"Failed to parse error as 'GlobusAuthRequirementsError' ({err})")
+        log.debug(f"Failed to parse error as 'GARE' ({err})")
 
     supported_variants: list[type[LegacyAuthRequirementsErrorVariant]] = [
         LegacyAuthorizationParametersError,
@@ -77,12 +72,11 @@ def to_auth_requirements_error(
 
 
 def to_auth_requirements_errors(
-    errors: list[GlobusAPIError | ErrorSubdocument | dict[str, t.Any]]
-) -> list[GlobusAuthRequirementsError]:
+    errors: list[exc.GlobusAPIError | exc.ErrorSubdocument | dict[str, t.Any]]
+) -> list[GARE]:
     """
     Converts a list of GlobusAPIErrors, ErrorSubdocuments, or dicts into a list of
-    GlobusAuthRequirementsErrors by attempting to match each error to
-    GlobusAuthRequirementsError (preferred) or legacy variants.
+    GAREs  by attempting to match each error to GARE (preferred) or legacy variants.
 
     .. note::
 
@@ -95,7 +89,7 @@ def to_auth_requirements_errors(
     """
     from globus_sdk.exc import GlobusAPIError
 
-    candidate_errors: list[ErrorSubdocument | dict[str, t.Any]] = []
+    candidate_errors: list[exc.ErrorSubdocument | dict[str, t.Any]] = []
     for error in errors:
         if isinstance(error, GlobusAPIError):
             # Use the ErrorSubdocuments
@@ -111,7 +105,7 @@ def to_auth_requirements_errors(
 
 
 def is_auth_requirements_error(
-    error: GlobusAPIError | ErrorSubdocument | dict[str, t.Any]
+    error: exc.GlobusAPIError | exc.ErrorSubdocument | dict[str, t.Any]
 ) -> bool:
     """
     Return True if the provided error matches a known
@@ -123,7 +117,7 @@ def is_auth_requirements_error(
 
 
 def has_auth_requirements_errors(
-    errors: list[GlobusAPIError | ErrorSubdocument | dict[str, t.Any]]
+    errors: list[exc.GlobusAPIError | exc.ErrorSubdocument | dict[str, t.Any]]
 ) -> bool:
     """
     Return True if any of the provided errors match a known

--- a/src/globus_sdk/gare/_variants.py
+++ b/src/globus_sdk/gare/_variants.py
@@ -7,10 +7,7 @@ from globus_sdk import exc
 from globus_sdk._guards import validators
 from globus_sdk._serializable import Serializable
 
-from ._auth_requirements_error import (
-    GlobusAuthorizationParameters,
-    GlobusAuthRequirementsError,
-)
+from ._auth_requirements_error import GARE, GlobusAuthorizationParameters
 
 if sys.version_info >= (3, 8):
     from typing import Literal, Protocol
@@ -29,7 +26,7 @@ class LegacyAuthRequirementsErrorVariant(Protocol):
     def from_dict(cls: type[V], data: dict[str, t.Any]) -> V:
         pass
 
-    def to_auth_requirements_error(self) -> GlobusAuthRequirementsError: ...
+    def to_auth_requirements_error(self) -> GARE: ...
 
 
 class LegacyConsentRequiredTransferError(Serializable):
@@ -48,11 +45,11 @@ class LegacyConsentRequiredTransferError(Serializable):
         self.required_scopes = validators.str_list("required_scopes", required_scopes)
         self.extra = extra or {}
 
-    def to_auth_requirements_error(self) -> GlobusAuthRequirementsError:
+    def to_auth_requirements_error(self) -> GARE:
         """
         Return a GlobusAuthRequirementsError representing this error.
         """
-        return GlobusAuthRequirementsError(
+        return GARE(
             code=self.code,
             authorization_parameters=GlobusAuthorizationParameters(
                 required_scopes=self.required_scopes,
@@ -79,14 +76,14 @@ class LegacyConsentRequiredAPError(Serializable):
         self.required_scope = validators.str_("required_scope", required_scope)
         self.extra = extra or {}
 
-    def to_auth_requirements_error(self) -> GlobusAuthRequirementsError:
+    def to_auth_requirements_error(self) -> GARE:
         """
         Return a GlobusAuthRequirementsError representing this error.
 
         Normalizes the required_scope field to a list and uses the description
         to set the session message.
         """
-        return GlobusAuthRequirementsError(
+        return GARE(
             code=self.code,
             authorization_parameters=GlobusAuthorizationParameters(
                 required_scopes=[self.required_scope],
@@ -180,14 +177,14 @@ class LegacyAuthorizationParametersError(Serializable):
         )
         self.extra = extra or {}
 
-    def to_auth_requirements_error(self) -> GlobusAuthRequirementsError:
+    def to_auth_requirements_error(self) -> GARE:
         """
         Return a GlobusAuthRequirementsError representing this error.
         """
         authorization_parameters = (
             self.authorization_parameters.to_authorization_parameters()
         )
-        return GlobusAuthRequirementsError(
+        return GARE(
             authorization_parameters=authorization_parameters,
             code=self.code,
             extra=self.extra,

--- a/tests/functional/test_login_manager.py
+++ b/tests/functional/test_login_manager.py
@@ -2,13 +2,11 @@ from unittest.mock import Mock, patch
 
 from globus_sdk import ConfidentialAppAuthClient, NativeAppAuthClient
 from globus_sdk._testing import load_response
-from globus_sdk.experimental.auth_requirements_error import (
-    GlobusAuthorizationParameters,
-)
 from globus_sdk.experimental.login_flow_manager import (
     CommandLineLoginFlowManager,
     LocalServerLoginFlowManager,
 )
+from globus_sdk.gare import GlobusAuthorizationParameters
 
 
 def _mock_input(s):

--- a/tests/non-pytest/lazy-imports/test_modules_do_not_require_requests.py
+++ b/tests/non-pytest/lazy-imports/test_modules_do_not_require_requests.py
@@ -19,10 +19,10 @@ PYTHON_BINARY = os.environ.get("GLOBUS_TEST_PY", sys.executable)
     (
         # experimental modules
         "experimental",
-        "experimental.auth_requirements_error",
         "experimental.scope_parser",
         # parts which are expected to be standalone
         "scopes",
+        "gare",
         "config",
         # the top-level of the 'exc' subpackage (but not necessarily its contents)
         "exc",

--- a/tests/unit/experimental/globus_app/test_globus_app.py
+++ b/tests/unit/experimental/globus_app/test_globus_app.py
@@ -16,9 +16,6 @@ from globus_sdk import (
 )
 from globus_sdk._testing import load_response
 from globus_sdk.exc import GlobusSDKUsageError
-from globus_sdk.experimental.auth_requirements_error import (
-    GlobusAuthorizationParameters,
-)
 from globus_sdk.experimental.globus_app import (
     AccessTokenAuthorizerFactory,
     ClientApp,
@@ -38,6 +35,7 @@ from globus_sdk.experimental.tokenstorage import (
     SQLiteTokenStorage,
     TokenData,
 )
+from globus_sdk.gare import GlobusAuthorizationParameters
 from globus_sdk.scopes import AuthScopes, Scope
 from globus_sdk.services.auth import OAuthTokenResponse
 

--- a/tests/unit/test_auth_requirements_error.py
+++ b/tests/unit/test_auth_requirements_error.py
@@ -1,16 +1,37 @@
 import pytest
 
 from globus_sdk._testing import construct_error
-from globus_sdk.exc import ErrorSubdocument
+from globus_sdk.exc import ErrorSubdocument, RemovedInV4Warning
 from globus_sdk.gare import (
     GARE,
     GlobusAuthorizationParameters,
     _variants,
-    has_auth_requirements_errors,
-    is_auth_requirements_error,
-    to_auth_requirements_error,
-    to_auth_requirements_errors,
+    has_gares,
+    is_gare,
+    to_gare,
+    to_gares,
 )
+
+
+@pytest.mark.parametrize(
+    "alias, value",
+    (
+        ("GlobusAuthorizationParameters", GlobusAuthorizationParameters),
+        ("GlobusAuthRequirementsError", GARE),
+        ("to_auth_requirements_error", to_gare),
+        ("to_auth_requirements_errors", to_gares),
+        ("has_auth_requirements_errors", has_gares),
+        ("is_auth_requirements_error", is_gare),
+    ),
+)
+def test_deprecated_experimental_alias(alias, value):
+    with pytest.warns(RemovedInV4Warning):
+        from globus_sdk.experimental import (
+            auth_requirements_error as experimental_module,
+        )
+
+        aliased_value = getattr(experimental_module, alias)
+    assert aliased_value is value
 
 
 @pytest.mark.parametrize(
@@ -51,14 +72,14 @@ def test_create_auth_requirements_error_from_consent_error(error_dict, status):
 
     for error in (error_dict, error_subdoc, api_error):
         # Test boolean utility functions
-        assert is_auth_requirements_error(error)
-        assert has_auth_requirements_errors([error])
+        assert is_gare(error)
+        assert has_gares([error])
 
         # Check that this only produces one error
-        assert len(to_auth_requirements_errors([error])) == 1
+        assert len(to_gares([error])) == 1
 
         # Create a Globus Auth requirements error from a Transfer format error
-        authreq_error = to_auth_requirements_error(error)
+        authreq_error = to_gare(error)
         assert isinstance(authreq_error, GARE)
         assert authreq_error.code == "ConsentRequired"
         assert authreq_error.authorization_parameters.required_scopes == [
@@ -115,15 +136,15 @@ def test_create_auth_requirements_error_from_authorization_error(
 
     for error in (error_dict, error_subdoc, api_error):
         # Test boolean utility functions
-        assert is_auth_requirements_error(error)
-        assert has_auth_requirements_errors([error])
+        assert is_gare(error)
+        assert has_gares([error])
 
         # Check that this only produces one error
-        assert len(to_auth_requirements_errors([error])) == 1
+        assert len(to_gares([error])) == 1
 
         # Create a Globus Auth requirements error from a legacy
         # authorization parameters format error
-        authreq_error = to_auth_requirements_error(error)
+        authreq_error = to_gare(error)
         assert isinstance(authreq_error, GARE)
 
         # Check that the default error code is set
@@ -175,15 +196,15 @@ def test_create_auth_requirements_error_from_authorization_error_csv(
 
     for error in (error_dict, error_subdoc, api_error):
         # Test boolean utility functions
-        assert is_auth_requirements_error(error)
-        assert has_auth_requirements_errors([error])
+        assert is_gare(error)
+        assert has_gares([error])
 
         # Check that this only produces one error
-        assert len(to_auth_requirements_errors([error])) == 1
+        assert len(to_gares([error])) == 1
 
         # Create a Globus Auth requirements error from a legacy
         # authorization parameters format error
-        authreq_error = to_auth_requirements_error(error)
+        authreq_error = to_gare(error)
         assert isinstance(authreq_error, GARE)
 
         # Check that the default error code is set
@@ -252,10 +273,10 @@ def test_create_auth_requirements_errors_from_multiple_errors():
     all_errors = [consent_errors, not_an_error, authorization_error]
 
     # Test boolean utility function
-    assert has_auth_requirements_errors(all_errors)
+    assert has_gares(all_errors)
 
     # Create auth requirements errors from a all errors
-    authreq_errors = to_auth_requirements_errors(all_errors)
+    authreq_errors = to_gares(all_errors)
     assert isinstance(authreq_errors, list)
     assert len(authreq_errors) == 3
 
@@ -313,15 +334,15 @@ def test_create_auth_requirements_error_from_legacy_authorization_error_with_cod
 
     for error in (error_dict, error_subdoc, api_error):
         # Test boolean utility functions
-        assert is_auth_requirements_error(error)
-        assert has_auth_requirements_errors([error])
+        assert is_gare(error)
+        assert has_gares([error])
 
         # Check that this only produces one error
-        assert len(to_auth_requirements_errors([error])) == 1
+        assert len(to_gares([error])) == 1
 
         # Create a Globus Auth requirements error from a legacy
         # authorization parameters format error
-        authreq_error = to_auth_requirements_error(error)
+        authreq_error = to_gare(error)
         assert isinstance(authreq_error, GARE)
 
         # Check that the custom error code is set
@@ -363,14 +384,14 @@ def test_backward_compatibility_consent_required_error():
     )
 
     # Test boolean utility functions
-    assert is_auth_requirements_error(error)
-    assert has_auth_requirements_errors([error])
+    assert is_gare(error)
+    assert has_gares([error])
 
     # Check that this only produces one error
-    assert len(to_auth_requirements_errors([error])) == 1
+    assert len(to_gares([error])) == 1
 
     # Create a Globus Auth requirements error
-    authreq_error = to_auth_requirements_error(error)
+    authreq_error = to_gare(error)
     assert isinstance(authreq_error, GARE)
     assert authreq_error.code == "ConsentRequired"
     assert authreq_error.authorization_parameters.required_scopes == [

--- a/tests/unit/test_auth_requirements_error.py
+++ b/tests/unit/test_auth_requirements_error.py
@@ -2,9 +2,9 @@ import pytest
 
 from globus_sdk._testing import construct_error
 from globus_sdk.exc import ErrorSubdocument
-from globus_sdk.experimental.auth_requirements_error import (
+from globus_sdk.gare import (
+    GARE,
     GlobusAuthorizationParameters,
-    GlobusAuthRequirementsError,
     _variants,
     has_auth_requirements_errors,
     is_auth_requirements_error,
@@ -59,7 +59,7 @@ def test_create_auth_requirements_error_from_consent_error(error_dict, status):
 
         # Create a Globus Auth requirements error from a Transfer format error
         authreq_error = to_auth_requirements_error(error)
-        assert isinstance(authreq_error, GlobusAuthRequirementsError)
+        assert isinstance(authreq_error, GARE)
         assert authreq_error.code == "ConsentRequired"
         assert authreq_error.authorization_parameters.required_scopes == [
             "urn:globus:auth:scope:transfer.api.globus.org:all[*foo *bar]"
@@ -124,7 +124,7 @@ def test_create_auth_requirements_error_from_authorization_error(
         # Create a Globus Auth requirements error from a legacy
         # authorization parameters format error
         authreq_error = to_auth_requirements_error(error)
-        assert isinstance(authreq_error, GlobusAuthRequirementsError)
+        assert isinstance(authreq_error, GARE)
 
         # Check that the default error code is set
         assert authreq_error.code == "AuthorizationRequired"
@@ -184,7 +184,7 @@ def test_create_auth_requirements_error_from_authorization_error_csv(
         # Create a Globus Auth requirements error from a legacy
         # authorization parameters format error
         authreq_error = to_auth_requirements_error(error)
-        assert isinstance(authreq_error, GlobusAuthRequirementsError)
+        assert isinstance(authreq_error, GARE)
 
         # Check that the default error code is set
         assert authreq_error.code == "AuthorizationRequired"
@@ -261,7 +261,7 @@ def test_create_auth_requirements_errors_from_multiple_errors():
 
     # Check that errors properly converted
     for authreq_error in authreq_errors:
-        assert isinstance(authreq_error, GlobusAuthRequirementsError)
+        assert isinstance(authreq_error, GARE)
 
     # Check that the proper auth requirements errors were produced
     assert authreq_errors[0].code == "ConsentRequired"
@@ -322,7 +322,7 @@ def test_create_auth_requirements_error_from_legacy_authorization_error_with_cod
         # Create a Globus Auth requirements error from a legacy
         # authorization parameters format error
         authreq_error = to_auth_requirements_error(error)
-        assert isinstance(authreq_error, GlobusAuthRequirementsError)
+        assert isinstance(authreq_error, GARE)
 
         # Check that the custom error code is set
         assert authreq_error.code == "UnsatisfiedPolicy"
@@ -371,7 +371,7 @@ def test_backward_compatibility_consent_required_error():
 
     # Create a Globus Auth requirements error
     authreq_error = to_auth_requirements_error(error)
-    assert isinstance(authreq_error, GlobusAuthRequirementsError)
+    assert isinstance(authreq_error, GARE)
     assert authreq_error.code == "ConsentRequired"
     assert authreq_error.authorization_parameters.required_scopes == [
         "urn:globus:auth:scope:transfer.api.globus.org:all[*baz]"
@@ -414,7 +414,7 @@ def test_backward_compatibility_consent_required_error():
     "target_class, data, expect_message",
     [
         (  # missing 'code'
-            GlobusAuthRequirementsError,
+            GARE,
             {"authorization_parameters": {"session_required_policies": "foo"}},
             "'code' must be a string",
         ),


### PR DESCRIPTION
The `auth_requirements_error` module is moved to `globus_sdk.gare` and docs and importts are updated.

Included in this change, `GlobusAuthRequirementsError` has been renamed to `GARE`, as the `Error` suffix to a name typically indicates that a class is an exception class.

Aliasing has been put in place from `experimental` to the new code location.

As a minor, related fix `_serializable.Serializable` now uses a `Self` type annotation, rather than a type var. This improves the doc rendering of the `from_dict` and `to_dict` methods, as they show the self-type rather than an unbound type variable T.

<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1048.org.readthedocs.build/en/1048/

<!-- readthedocs-preview globus-sdk-python end -->