### PR TITLE
Replace MANIFEST.in with pyproject settings

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,0 @@
-include src/globus_sdk/experimental/login_flow_manager/local_server_login_flow_manager/html_files/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ namespaces = false
 
 [tool.setuptools.package-data]
 globus_sdk = ["py.typed"]
+"globus_sdk.experimental.login_flow_manager.local_server_login_flow_manager.html_files" = ["*.html"]
 
 [tool.setuptools.dynamic.version]
 attr = "globus_sdk.__version__"

--- a/tests/unit/experimental/test_local_server.py
+++ b/tests/unit/experimental/test_local_server.py
@@ -10,6 +10,13 @@ from globus_sdk.experimental.login_flow_manager.local_server_login_flow_manager.
 )
 
 
+def test_default_html_template_contains_expected_text():
+    # basic integrity test
+    assert "<h1>Globus Login Result</h1>" in DEFAULT_HTML_TEMPLATE.substitute(
+        post_login_message="", login_result="Login successful"
+    )
+
+
 @pytest.mark.parametrize(
     "url,expected_result",
     [


### PR DESCRIPTION
The manifest file specified inclusion of HTML files in a specific package dir.

Add a sanity test which ensures that the file is in the built distribution, then replace this with pyproject.toml configuration.

<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1049.org.readthedocs.build/en/1049/

<!-- readthedocs-preview globus-sdk-python end -->