### PR TITLE
Add response subtypes for different oauth2 grants

### DIFF
--- a/changelog.d/20240917_121333_sirosen_add_token_response_classes.rst
+++ b/changelog.d/20240917_121333_sirosen_add_token_response_classes.rst
@@ -1,0 +1,17 @@
+Changed
+~~~~~~~
+
+- The response types for different OAuth2 token grants now vary by the grant
+  type. For example, a ``refresh_token`` grant will now produce a
+  ``RefreshTokenResponse``. This allows code handling responses to identify
+  which grant type was used to produce a response. (:pr:`NUMBER`)
+
+  - The following new types have been introduced:
+    ``globus_sdk.RefreshTokenResponse``,
+    ``globus_sdk.AuthorizationCodeTokenResponse``,
+    ``globus_sdk.ClientCredentialsTokenResponse``.
+
+  - The ``RenewingAuthorizer`` class is now a generic over the response type
+    which it handles, and the subtypes of authorizers are specialized for their
+    types of responses. e.g.,
+    ``class RefreshTokenAuthorizer(RenewingAuthorizer[RefreshTokenResponse])``.

--- a/changelog.d/20240917_121333_sirosen_add_token_response_classes.rst
+++ b/changelog.d/20240917_121333_sirosen_add_token_response_classes.rst
@@ -3,15 +3,15 @@ Changed
 
 - The response types for different OAuth2 token grants now vary by the grant
   type. For example, a ``refresh_token`` grant will now produce a
-  ``RefreshTokenResponse``. This allows code handling responses to identify
+  ``OAuthRefreshTokenResponse``. This allows code handling responses to identify
   which grant type was used to produce a response. (:pr:`NUMBER`)
 
   - The following new types have been introduced:
-    ``globus_sdk.RefreshTokenResponse``,
-    ``globus_sdk.AuthorizationCodeTokenResponse``,
-    ``globus_sdk.ClientCredentialsTokenResponse``.
+    ``globus_sdk.OAuthRefreshTokenResponse``,
+    ``globus_sdk.OAuthAuthorizationCodeResponse``,
+    ``globus_sdk.OAuthClientCredentialsResponse``.
 
   - The ``RenewingAuthorizer`` class is now a generic over the response type
     which it handles, and the subtypes of authorizers are specialized for their
     types of responses. e.g.,
-    ``class RefreshTokenAuthorizer(RenewingAuthorizer[RefreshTokenResponse])``.
+    ``class RefreshTokenAuthorizer(RenewingAuthorizer[OAuthRefreshTokenResponse])``.

--- a/docs/services/auth.rst
+++ b/docs/services/auth.rst
@@ -61,10 +61,6 @@ Auth Responses
    :members:
    :show-inheritance:
 
-.. autoclass:: OAuthDependentTokenResponse
-   :members:
-   :show-inheritance:
-
 .. autoclass:: AuthorizationCodeTokenResponse
    :members:
    :show-inheritance:
@@ -74,6 +70,10 @@ Auth Responses
    :show-inheritance:
 
 .. autoclass:: ClientCredentialsTokenResponse
+   :members:
+   :show-inheritance:
+
+.. autoclass:: OAuthDependentTokenResponse
    :members:
    :show-inheritance:
 

--- a/docs/services/auth.rst
+++ b/docs/services/auth.rst
@@ -61,15 +61,15 @@ Auth Responses
    :members:
    :show-inheritance:
 
-.. autoclass:: AuthorizationCodeTokenResponse
+.. autoclass:: OAuthAuthorizationCodeResponse
    :members:
    :show-inheritance:
 
-.. autoclass:: RefreshTokenResponse
+.. autoclass:: OAuthRefreshTokenResponse
    :members:
    :show-inheritance:
 
-.. autoclass:: ClientCredentialsTokenResponse
+.. autoclass:: OAuthClientCredentialsResponse
    :members:
    :show-inheritance:
 

--- a/docs/services/auth.rst
+++ b/docs/services/auth.rst
@@ -65,6 +65,18 @@ Auth Responses
    :members:
    :show-inheritance:
 
+.. autoclass:: AuthorizationCodeTokenResponse
+   :members:
+   :show-inheritance:
+
+.. autoclass:: RefreshTokenResponse
+   :members:
+   :show-inheritance:
+
+.. autoclass:: ClientCredentialsTokenResponse
+   :members:
+   :show-inheritance:
+
 .. autoclass:: GetConsentsResponse
    :members:
    :show-inheritance:

--- a/src/globus_sdk/__init__.py
+++ b/src/globus_sdk/__init__.py
@@ -63,6 +63,9 @@ _LAZY_IMPORT_TABLE = {
         "GetIdentitiesResponse",
         "OAuthDependentTokenResponse",
         "OAuthTokenResponse",
+        "AuthorizationCodeTokenResponse",
+        "ClientCredentialsTokenResponse",
+        "RefreshTokenResponse",
         "DependentScopeSpec",
     },
     "services.gcs": {
@@ -185,6 +188,9 @@ if t.TYPE_CHECKING:
     from .services.auth import GetIdentitiesResponse
     from .services.auth import OAuthDependentTokenResponse
     from .services.auth import OAuthTokenResponse
+    from .services.auth import AuthorizationCodeTokenResponse
+    from .services.auth import ClientCredentialsTokenResponse
+    from .services.auth import RefreshTokenResponse
     from .services.auth import DependentScopeSpec
     from .services.gcs import CollectionDocument
     from .services.gcs import GCSAPIError
@@ -292,6 +298,7 @@ __all__ = (
     "AuthAPIError",
     "AuthClient",
     "AuthLoginClient",
+    "AuthorizationCodeTokenResponse",
     "AzureBlobStoragePolicies",
     "BaseClient",
     "BasicAuthorizer",
@@ -300,6 +307,7 @@ __all__ = (
     "BoxStoragePolicies",
     "CephStoragePolicies",
     "ClientCredentialsAuthorizer",
+    "ClientCredentialsTokenResponse",
     "CollectionDocument",
     "CollectionPolicies",
     "ConfidentialAppAuthClient",
@@ -361,6 +369,7 @@ __all__ = (
     "POSIXStoragePolicies",
     "RecurringTimerSchedule",
     "RefreshTokenAuthorizer",
+    "RefreshTokenResponse",
     "RemovedInV4Warning",
     "S3StoragePolicies",
     "Scope",

--- a/src/globus_sdk/__init__.py
+++ b/src/globus_sdk/__init__.py
@@ -61,11 +61,11 @@ _LAZY_IMPORT_TABLE = {
         "IdentityMap",
         "GetConsentsResponse",
         "GetIdentitiesResponse",
+        "OAuthAuthorizationCodeResponse",
+        "OAuthClientCredentialsResponse",
         "OAuthDependentTokenResponse",
+        "OAuthRefreshTokenResponse",
         "OAuthTokenResponse",
-        "AuthorizationCodeTokenResponse",
-        "ClientCredentialsTokenResponse",
-        "RefreshTokenResponse",
         "DependentScopeSpec",
     },
     "services.gcs": {
@@ -186,11 +186,11 @@ if t.TYPE_CHECKING:
     from .services.auth import IdentityMap
     from .services.auth import GetConsentsResponse
     from .services.auth import GetIdentitiesResponse
+    from .services.auth import OAuthAuthorizationCodeResponse
+    from .services.auth import OAuthClientCredentialsResponse
     from .services.auth import OAuthDependentTokenResponse
+    from .services.auth import OAuthRefreshTokenResponse
     from .services.auth import OAuthTokenResponse
-    from .services.auth import AuthorizationCodeTokenResponse
-    from .services.auth import ClientCredentialsTokenResponse
-    from .services.auth import RefreshTokenResponse
     from .services.auth import DependentScopeSpec
     from .services.gcs import CollectionDocument
     from .services.gcs import GCSAPIError
@@ -298,7 +298,6 @@ __all__ = (
     "AuthAPIError",
     "AuthClient",
     "AuthLoginClient",
-    "AuthorizationCodeTokenResponse",
     "AzureBlobStoragePolicies",
     "BaseClient",
     "BasicAuthorizer",
@@ -307,7 +306,6 @@ __all__ = (
     "BoxStoragePolicies",
     "CephStoragePolicies",
     "ClientCredentialsAuthorizer",
-    "ClientCredentialsTokenResponse",
     "CollectionDocument",
     "CollectionPolicies",
     "ConfidentialAppAuthClient",
@@ -359,7 +357,10 @@ __all__ = (
     "NativeAppAuthClient",
     "NetworkError",
     "NullAuthorizer",
+    "OAuthAuthorizationCodeResponse",
+    "OAuthClientCredentialsResponse",
     "OAuthDependentTokenResponse",
+    "OAuthRefreshTokenResponse",
     "OAuthTokenResponse",
     "OnceTimerSchedule",
     "OneDriveStoragePolicies",
@@ -369,7 +370,6 @@ __all__ = (
     "POSIXStoragePolicies",
     "RecurringTimerSchedule",
     "RefreshTokenAuthorizer",
-    "RefreshTokenResponse",
     "RemovedInV4Warning",
     "S3StoragePolicies",
     "Scope",

--- a/src/globus_sdk/_generate_init.py
+++ b/src/globus_sdk/_generate_init.py
@@ -125,6 +125,9 @@ _LAZY_IMPORT_TABLE: list[tuple[str, tuple[str, ...]]] = [
             "GetIdentitiesResponse",
             "OAuthDependentTokenResponse",
             "OAuthTokenResponse",
+            "AuthorizationCodeTokenResponse",
+            "ClientCredentialsTokenResponse",
+            "RefreshTokenResponse",
             # API data helpers
             "DependentScopeSpec",
         ),

--- a/src/globus_sdk/_generate_init.py
+++ b/src/globus_sdk/_generate_init.py
@@ -123,11 +123,11 @@ _LAZY_IMPORT_TABLE: list[tuple[str, tuple[str, ...]]] = [
             # responses
             "GetConsentsResponse",
             "GetIdentitiesResponse",
+            "OAuthAuthorizationCodeResponse",
+            "OAuthClientCredentialsResponse",
             "OAuthDependentTokenResponse",
+            "OAuthRefreshTokenResponse",
             "OAuthTokenResponse",
-            "AuthorizationCodeTokenResponse",
-            "ClientCredentialsTokenResponse",
-            "RefreshTokenResponse",
             # API data helpers
             "DependentScopeSpec",
         ),

--- a/src/globus_sdk/authorizers/client_credentials.py
+++ b/src/globus_sdk/authorizers/client_credentials.py
@@ -13,7 +13,7 @@ log = logging.getLogger(__name__)
 
 
 class ClientCredentialsAuthorizer(
-    RenewingAuthorizer["globus_sdk.ClientCredentialsTokenResponse"]
+    RenewingAuthorizer["globus_sdk.OAuthClientCredentialsResponse"]
 ):
     r"""
     Implementation of a RenewingAuthorizer that renews confidential app client
@@ -47,7 +47,7 @@ class ClientCredentialsAuthorizer(
         POSIX timestamp (i.e. seconds since the epoch)
     :param on_refresh: A callback which is triggered any time this authorizer fetches a
         new access_token. The ``on_refresh`` callable is invoked on the
-        :class:`globus_sdk.ClientCredentialsTokenResponse` object resulting from the
+        :class:`globus_sdk.OAuthClientCredentialsResponse` object resulting from the
         token being refreshed. It should take only one positional argument, the token
         response object.
         This is useful for implementing storage for Access Tokens, as the
@@ -63,7 +63,7 @@ class ClientCredentialsAuthorizer(
         access_token: str | None = None,
         expires_at: int | None = None,
         on_refresh: (
-            None | t.Callable[[globus_sdk.ClientCredentialsTokenResponse], t.Any]
+            None | t.Callable[[globus_sdk.OAuthClientCredentialsResponse], t.Any]
         ) = None,
     ):
         # values for _get_token_data
@@ -77,7 +77,7 @@ class ClientCredentialsAuthorizer(
 
         super().__init__(access_token, expires_at, on_refresh)
 
-    def _get_token_response(self) -> globus_sdk.ClientCredentialsTokenResponse:
+    def _get_token_response(self) -> globus_sdk.OAuthClientCredentialsResponse:
         """
         Make a request for new tokens, using a 'client_credentials' grant.
         """
@@ -86,7 +86,7 @@ class ClientCredentialsAuthorizer(
         )
 
     def _extract_token_data(
-        self, res: globus_sdk.ClientCredentialsTokenResponse
+        self, res: globus_sdk.OAuthClientCredentialsResponse
     ) -> dict[str, t.Any]:
         """
         Get the tokens .by_resource_server,

--- a/src/globus_sdk/authorizers/client_credentials.py
+++ b/src/globus_sdk/authorizers/client_credentials.py
@@ -48,7 +48,7 @@ class ClientCredentialsAuthorizer(
     :param on_refresh: A callback which is triggered any time this authorizer fetches a
         new access_token. The ``on_refresh`` callable is invoked on the
         :class:`globus_sdk.ClientCredentialsTokenResponse` object resulting from the
-        token being refreshed. It should take only one argument, the token response
+        token being refreshed. It should take only one positional argument, the token response
         object.
         This is useful for implementing storage for Access Tokens, as the
         ``on_refresh`` callback can be used to update the Access Tokens and

--- a/src/globus_sdk/authorizers/client_credentials.py
+++ b/src/globus_sdk/authorizers/client_credentials.py
@@ -79,7 +79,7 @@ class ClientCredentialsAuthorizer(
 
     def _get_token_response(self) -> globus_sdk.ClientCredentialsTokenResponse:
         """
-        Make a client credentials request for new tokens.
+        Make a request for new client credentials tokens.
         """
         return self.confidential_client.oauth2_client_credentials_tokens(
             requested_scopes=self.scopes

--- a/src/globus_sdk/authorizers/client_credentials.py
+++ b/src/globus_sdk/authorizers/client_credentials.py
@@ -48,8 +48,8 @@ class ClientCredentialsAuthorizer(
     :param on_refresh: A callback which is triggered any time this authorizer fetches a
         new access_token. The ``on_refresh`` callable is invoked on the
         :class:`globus_sdk.ClientCredentialsTokenResponse` object resulting from the
-        token being refreshed. It should take only one positional argument, the token response
-        object.
+        token being refreshed. It should take only one positional argument, the token
+        response object.
         This is useful for implementing storage for Access Tokens, as the
         ``on_refresh`` callback can be used to update the Access Tokens and
         their expiration times.
@@ -79,7 +79,7 @@ class ClientCredentialsAuthorizer(
 
     def _get_token_response(self) -> globus_sdk.ClientCredentialsTokenResponse:
         """
-        Make a request for new client credentials tokens.
+        Make a request for new tokens, using a 'client_credentials' grant.
         """
         return self.confidential_client.oauth2_client_credentials_tokens(
             requested_scopes=self.scopes

--- a/src/globus_sdk/authorizers/client_credentials.py
+++ b/src/globus_sdk/authorizers/client_credentials.py
@@ -3,18 +3,18 @@ from __future__ import annotations
 import logging
 import typing as t
 
+import globus_sdk
 from globus_sdk._types import ScopeCollectionType
 from globus_sdk.scopes import scopes_to_str
 
 from .renewing import RenewingAuthorizer
 
-if t.TYPE_CHECKING:
-    from globus_sdk.services.auth import ConfidentialAppAuthClient, OAuthTokenResponse
-
 log = logging.getLogger(__name__)
 
 
-class ClientCredentialsAuthorizer(RenewingAuthorizer):
+class ClientCredentialsAuthorizer(
+    RenewingAuthorizer["globus_sdk.ClientCredentialsTokenResponse"]
+):
     r"""
     Implementation of a RenewingAuthorizer that renews confidential app client
     Access Tokens using a ConfidentialAppAuthClient and a set of scopes to
@@ -47,9 +47,9 @@ class ClientCredentialsAuthorizer(RenewingAuthorizer):
         POSIX timestamp (i.e. seconds since the epoch)
     :param on_refresh: A callback which is triggered any time this authorizer fetches a
         new access_token. The ``on_refresh`` callable is invoked on the
-        :class:`OAuthTokenResponse <globus_sdk.OAuthTokenResponse>`
-        object resulting from the token being refreshed. It should take only one
-        argument, the token response object.
+        :class:`globus_sdk.ClientCredentialsTokenResponse` object resulting from the
+        token being refreshed. It should take only one argument, the token response
+        object.
         This is useful for implementing storage for Access Tokens, as the
         ``on_refresh`` callback can be used to update the Access Tokens and
         their expiration times.
@@ -57,12 +57,14 @@ class ClientCredentialsAuthorizer(RenewingAuthorizer):
 
     def __init__(
         self,
-        confidential_client: ConfidentialAppAuthClient,
+        confidential_client: globus_sdk.ConfidentialAppAuthClient,
         scopes: ScopeCollectionType,
         *,
         access_token: str | None = None,
         expires_at: int | None = None,
-        on_refresh: None | t.Callable[[OAuthTokenResponse], t.Any] = None,
+        on_refresh: (
+            None | t.Callable[[globus_sdk.ClientCredentialsTokenResponse], t.Any]
+        ) = None,
     ):
         # values for _get_token_data
         self.confidential_client = confidential_client
@@ -75,15 +77,17 @@ class ClientCredentialsAuthorizer(RenewingAuthorizer):
 
         super().__init__(access_token, expires_at, on_refresh)
 
-    def _get_token_response(self) -> OAuthTokenResponse:
+    def _get_token_response(self) -> globus_sdk.ClientCredentialsTokenResponse:
         """
-        Make a client credentials grant
+        Make a client credentials request for new tokens.
         """
         return self.confidential_client.oauth2_client_credentials_tokens(
             requested_scopes=self.scopes
         )
 
-    def _extract_token_data(self, res: OAuthTokenResponse) -> dict[str, t.Any]:
+    def _extract_token_data(
+        self, res: globus_sdk.ClientCredentialsTokenResponse
+    ) -> dict[str, t.Any]:
         """
         Get the tokens .by_resource_server,
         Ensure that only one token was gotten, and return that token.

--- a/src/globus_sdk/authorizers/refresh_token.py
+++ b/src/globus_sdk/authorizers/refresh_token.py
@@ -10,7 +10,9 @@ from .renewing import RenewingAuthorizer
 log = logging.getLogger(__name__)
 
 
-class RefreshTokenAuthorizer(RenewingAuthorizer["globus_sdk.RefreshTokenResponse"]):
+class RefreshTokenAuthorizer(
+    RenewingAuthorizer["globus_sdk.OAuthRefreshTokenResponse"]
+):
     """
     Implements Authorization using a Refresh Token to periodically fetch
     renewed Access Tokens. It may be initialized with an Access Token, or it
@@ -39,7 +41,7 @@ class RefreshTokenAuthorizer(RenewingAuthorizer["globus_sdk.RefreshTokenResponse
         POSIX timestamp (i.e. seconds since the epoch)
     :param on_refresh: A callback which is triggered any time this authorizer fetches a
         new access_token. The ``on_refresh`` callable is invoked on the
-        :class:`globus_sdk.RefreshTokenResponse` object resulting from the token being
+        :class:`globus_sdk.OAuthRefreshTokenResponse` object resulting from the token being
         refreshed. It should take only one argument, the token response object.
         This is useful for implementing storage for Access Tokens, as the
         ``on_refresh`` callback can be used to update the Access Tokens and
@@ -53,7 +55,9 @@ class RefreshTokenAuthorizer(RenewingAuthorizer["globus_sdk.RefreshTokenResponse
         *,
         access_token: str | None = None,
         expires_at: int | None = None,
-        on_refresh: None | t.Callable[[globus_sdk.RefreshTokenResponse], t.Any] = None,
+        on_refresh: (
+            None | t.Callable[[globus_sdk.OAuthRefreshTokenResponse], t.Any]
+        ) = None,
     ):
         log.info(
             "Setting up RefreshTokenAuthorizer with auth_client="
@@ -77,14 +81,14 @@ class RefreshTokenAuthorizer(RenewingAuthorizer["globus_sdk.RefreshTokenResponse
 
         super().__init__(access_token, expires_at, on_refresh)
 
-    def _get_token_response(self) -> globus_sdk.RefreshTokenResponse:
+    def _get_token_response(self) -> globus_sdk.OAuthRefreshTokenResponse:
         """
         Make a refresh token grant
         """
         return self.auth_client.oauth2_refresh_token(self.refresh_token)
 
     def _extract_token_data(
-        self, res: globus_sdk.RefreshTokenResponse
+        self, res: globus_sdk.OAuthRefreshTokenResponse
     ) -> dict[str, t.Any]:
         """
         Get the tokens .by_resource_server,

--- a/src/globus_sdk/authorizers/refresh_token.py
+++ b/src/globus_sdk/authorizers/refresh_token.py
@@ -77,7 +77,7 @@ class RefreshTokenAuthorizer(RenewingAuthorizer["globus_sdk.RefreshTokenResponse
 
         super().__init__(access_token, expires_at, on_refresh)
 
-    def _get_token_response(self) -> globus_sdk.RfreshTokenResponse:
+    def _get_token_response(self) -> globus_sdk.RefreshTokenResponse:
         """
         Make a refresh token grant
         """

--- a/src/globus_sdk/authorizers/refresh_token.py
+++ b/src/globus_sdk/authorizers/refresh_token.py
@@ -10,7 +10,7 @@ from .renewing import RenewingAuthorizer
 log = logging.getLogger(__name__)
 
 
-class RefreshTokenAuthorizer(RenewingAuthorizer):
+class RefreshTokenAuthorizer(RenewingAuthorizer["globus_sdk.RefreshTokenResponse"]):
     """
     Implements Authorization using a Refresh Token to periodically fetch
     renewed Access Tokens. It may be initialized with an Access Token, or it
@@ -39,9 +39,8 @@ class RefreshTokenAuthorizer(RenewingAuthorizer):
         POSIX timestamp (i.e. seconds since the epoch)
     :param on_refresh: A callback which is triggered any time this authorizer fetches a
         new access_token. The ``on_refresh`` callable is invoked on the
-        :class:`OAuthTokenResponse <globus_sdk.OAuthTokenResponse>`
-        object resulting from the token being refreshed. It should take only one
-        argument, the token response object.
+        :class:`globus_sdk.RefreshTokenResponse` object resulting from the token being
+        refreshed. It should take only one argument, the token response object.
         This is useful for implementing storage for Access Tokens, as the
         ``on_refresh`` callback can be used to update the Access Tokens and
         their expiration times.
@@ -54,7 +53,7 @@ class RefreshTokenAuthorizer(RenewingAuthorizer):
         *,
         access_token: str | None = None,
         expires_at: int | None = None,
-        on_refresh: None | t.Callable[[globus_sdk.OAuthTokenResponse], t.Any] = None,
+        on_refresh: None | t.Callable[[globus_sdk.RefreshTokenResponse], t.Any] = None,
     ):
         log.info(
             "Setting up RefreshTokenAuthorizer with auth_client="
@@ -78,14 +77,14 @@ class RefreshTokenAuthorizer(RenewingAuthorizer):
 
         super().__init__(access_token, expires_at, on_refresh)
 
-    def _get_token_response(self) -> globus_sdk.OAuthTokenResponse:
+    def _get_token_response(self) -> globus_sdk.RfreshTokenResponse:
         """
         Make a refresh token grant
         """
         return self.auth_client.oauth2_refresh_token(self.refresh_token)
 
     def _extract_token_data(
-        self, res: globus_sdk.OAuthTokenResponse
+        self, res: globus_sdk.RefreshTokenResponse
     ) -> dict[str, t.Any]:
         """
         Get the tokens .by_resource_server,

--- a/src/globus_sdk/services/auth/__init__.py
+++ b/src/globus_sdk/services/auth/__init__.py
@@ -12,13 +12,13 @@ from .flow_managers import (
 )
 from .identity_map import IdentityMap
 from .response import (
-    AuthorizationCodeTokenResponse,
-    ClientCredentialsTokenResponse,
     GetConsentsResponse,
     GetIdentitiesResponse,
+    OAuthAuthorizationCodeResponse,
+    OAuthClientCredentialsResponse,
     OAuthDependentTokenResponse,
+    OAuthRefreshTokenResponse,
     OAuthTokenResponse,
-    RefreshTokenResponse,
 )
 
 __all__ = (
@@ -36,11 +36,11 @@ __all__ = (
     "GlobusNativeAppFlowManager",
     "GlobusAuthorizationCodeFlowManager",
     # responses
-    "AuthorizationCodeTokenResponse",
-    "ClientCredentialsTokenResponse",
     "GetConsentsResponse",
     "GetIdentitiesResponse",
+    "OAuthAuthorizationCodeResponse",
+    "OAuthClientCredentialsResponse",
     "OAuthDependentTokenResponse",
+    "OAuthRefreshTokenResponse",
     "OAuthTokenResponse",
-    "RefreshTokenResponse",
 )

--- a/src/globus_sdk/services/auth/__init__.py
+++ b/src/globus_sdk/services/auth/__init__.py
@@ -12,10 +12,13 @@ from .flow_managers import (
 )
 from .identity_map import IdentityMap
 from .response import (
+    AuthorizationCodeTokenResponse,
+    ClientCredentialsTokenResponse,
     GetConsentsResponse,
     GetIdentitiesResponse,
     OAuthDependentTokenResponse,
     OAuthTokenResponse,
+    RefreshTokenResponse,
 )
 
 __all__ = (
@@ -33,8 +36,11 @@ __all__ = (
     "GlobusNativeAppFlowManager",
     "GlobusAuthorizationCodeFlowManager",
     # responses
+    "AuthorizationCodeTokenResponse",
+    "ClientCredentialsTokenResponse",
     "GetConsentsResponse",
     "GetIdentitiesResponse",
     "OAuthDependentTokenResponse",
     "OAuthTokenResponse",
+    "RefreshTokenResponse",
 )

--- a/src/globus_sdk/services/auth/client/base_login_client.py
+++ b/src/globus_sdk/services/auth/client/base_login_client.py
@@ -15,7 +15,11 @@ from globus_sdk.scopes import AuthScopes, Scope
 from .._common import get_jwk_data, pem_decode_jwk_data
 from ..errors import AuthAPIError
 from ..flow_managers import GlobusOAuthFlowManager
-from ..response import OAuthTokenResponse
+from ..response import (
+    AuthorizationCodeTokenResponse,
+    OAuthTokenResponse,
+    RefreshTokenResponse,
+)
 
 if sys.version_info >= (3, 8):
     from typing import Literal
@@ -203,7 +207,9 @@ class AuthLoginClient(client.BaseClient):
         log.info(f"Got authorization URL: {auth_url}")
         return auth_url
 
-    def oauth2_exchange_code_for_tokens(self, auth_code: str) -> OAuthTokenResponse:
+    def oauth2_exchange_code_for_tokens(
+        self, auth_code: str
+    ) -> AuthorizationCodeTokenResponse:
         """
         Exchange an authorization code for a token or tokens.
 
@@ -231,7 +237,7 @@ class AuthLoginClient(client.BaseClient):
         refresh_token: str,
         *,
         body_params: dict[str, t.Any] | None = None,
-    ) -> OAuthTokenResponse:
+    ) -> RefreshTokenResponse:
         r"""
         Exchange a refresh token for a
         :class:`OAuthTokenResponse <.OAuthTokenResponse>`, containing
@@ -251,7 +257,9 @@ class AuthLoginClient(client.BaseClient):
         """
         log.info("Executing token refresh; typically requires client credentials")
         form_data = {"refresh_token": refresh_token, "grant_type": "refresh_token"}
-        return self.oauth2_token(form_data, body_params=body_params)
+        return self.oauth2_token(
+            form_data, body_params=body_params, response_class=RefreshTokenResponse
+        )
 
     def oauth2_validate_token(
         self,

--- a/src/globus_sdk/services/auth/client/base_login_client.py
+++ b/src/globus_sdk/services/auth/client/base_login_client.py
@@ -16,9 +16,9 @@ from .._common import get_jwk_data, pem_decode_jwk_data
 from ..errors import AuthAPIError
 from ..flow_managers import GlobusOAuthFlowManager
 from ..response import (
-    AuthorizationCodeTokenResponse,
+    OAuthAuthorizationCodeResponse,
+    OAuthRefreshTokenResponse,
     OAuthTokenResponse,
-    RefreshTokenResponse,
 )
 
 if sys.version_info >= (3, 8):
@@ -209,7 +209,7 @@ class AuthLoginClient(client.BaseClient):
 
     def oauth2_exchange_code_for_tokens(
         self, auth_code: str
-    ) -> AuthorizationCodeTokenResponse:
+    ) -> OAuthAuthorizationCodeResponse:
         """
         Exchange an authorization code for a token or tokens.
 
@@ -237,7 +237,7 @@ class AuthLoginClient(client.BaseClient):
         refresh_token: str,
         *,
         body_params: dict[str, t.Any] | None = None,
-    ) -> RefreshTokenResponse:
+    ) -> OAuthRefreshTokenResponse:
         r"""
         Exchange a refresh token for a
         :class:`OAuthTokenResponse <.OAuthTokenResponse>`, containing
@@ -258,7 +258,7 @@ class AuthLoginClient(client.BaseClient):
         log.info("Executing token refresh; typically requires client credentials")
         form_data = {"refresh_token": refresh_token, "grant_type": "refresh_token"}
         return self.oauth2_token(
-            form_data, body_params=body_params, response_class=RefreshTokenResponse
+            form_data, body_params=body_params, response_class=OAuthRefreshTokenResponse
         )
 
     def oauth2_validate_token(

--- a/src/globus_sdk/services/auth/client/confidential_client.py
+++ b/src/globus_sdk/services/auth/client/confidential_client.py
@@ -11,9 +11,9 @@ from globus_sdk.response import GlobusHTTPResponse
 from .._common import stringify_requested_scopes
 from ..flow_managers import GlobusAuthorizationCodeFlowManager
 from ..response import (
+    ClientCredentialsTokenResponse,
     GetIdentitiesResponse,
     OAuthDependentTokenResponse,
-    OAuthTokenResponse,
 )
 from .base_login_client import AuthLoginClient
 
@@ -109,7 +109,7 @@ class ConfidentialAppAuthClient(AuthLoginClient):
     def oauth2_client_credentials_tokens(
         self,
         requested_scopes: ScopeCollectionType | None = None,
-    ) -> OAuthTokenResponse:
+    ) -> ClientCredentialsTokenResponse:
         r"""
         Perform an OAuth2 Client Credentials Grant to get access tokens which
         directly represent your client and allow it to act on its own
@@ -132,7 +132,8 @@ class ConfidentialAppAuthClient(AuthLoginClient):
         log.info("Fetching token(s) using client credentials")
         requested_scopes_string = stringify_requested_scopes(requested_scopes)
         return self.oauth2_token(
-            {"grant_type": "client_credentials", "scope": requested_scopes_string}
+            {"grant_type": "client_credentials", "scope": requested_scopes_string},
+            response_class=ClientCredentialsTokenResponse,
         )
 
     def oauth2_start_flow(

--- a/src/globus_sdk/services/auth/client/confidential_client.py
+++ b/src/globus_sdk/services/auth/client/confidential_client.py
@@ -11,8 +11,8 @@ from globus_sdk.response import GlobusHTTPResponse
 from .._common import stringify_requested_scopes
 from ..flow_managers import GlobusAuthorizationCodeFlowManager
 from ..response import (
-    ClientCredentialsTokenResponse,
     GetIdentitiesResponse,
+    OAuthClientCredentialsResponse,
     OAuthDependentTokenResponse,
 )
 from .base_login_client import AuthLoginClient
@@ -109,7 +109,7 @@ class ConfidentialAppAuthClient(AuthLoginClient):
     def oauth2_client_credentials_tokens(
         self,
         requested_scopes: ScopeCollectionType | None = None,
-    ) -> ClientCredentialsTokenResponse:
+    ) -> OAuthClientCredentialsResponse:
         r"""
         Perform an OAuth2 Client Credentials Grant to get access tokens which
         directly represent your client and allow it to act on its own
@@ -133,7 +133,7 @@ class ConfidentialAppAuthClient(AuthLoginClient):
         requested_scopes_string = stringify_requested_scopes(requested_scopes)
         return self.oauth2_token(
             {"grant_type": "client_credentials", "scope": requested_scopes_string},
-            response_class=ClientCredentialsTokenResponse,
+            response_class=OAuthClientCredentialsResponse,
         )
 
     def oauth2_start_flow(

--- a/src/globus_sdk/services/auth/client/native_client.py
+++ b/src/globus_sdk/services/auth/client/native_client.py
@@ -8,7 +8,7 @@ from globus_sdk.authorizers import NullAuthorizer
 from globus_sdk.response import GlobusHTTPResponse
 
 from ..flow_managers import GlobusNativeAppFlowManager
-from ..response import RefreshTokenResponse
+from ..response import OAuthRefreshTokenResponse
 from .base_login_client import AuthLoginClient
 
 log = logging.getLogger(__name__)
@@ -115,7 +115,7 @@ class NativeAppAuthClient(AuthLoginClient):
         refresh_token: str,
         *,
         body_params: dict[str, t.Any] | None = None,
-    ) -> RefreshTokenResponse:
+    ) -> OAuthRefreshTokenResponse:
         """
         ``NativeAppAuthClient`` specializes the refresh token grant to include
         its client ID as a parameter in the POST body.
@@ -132,7 +132,7 @@ class NativeAppAuthClient(AuthLoginClient):
             "client_id": self.client_id,
         }
         return self.oauth2_token(
-            form_data, body_params=body_params, response_class=RefreshTokenResponse
+            form_data, body_params=body_params, response_class=OAuthRefreshTokenResponse
         )
 
     def create_native_app_instance(

--- a/src/globus_sdk/services/auth/client/native_client.py
+++ b/src/globus_sdk/services/auth/client/native_client.py
@@ -8,7 +8,7 @@ from globus_sdk.authorizers import NullAuthorizer
 from globus_sdk.response import GlobusHTTPResponse
 
 from ..flow_managers import GlobusNativeAppFlowManager
-from ..response import OAuthTokenResponse
+from ..response import RefreshTokenResponse
 from .base_login_client import AuthLoginClient
 
 log = logging.getLogger(__name__)
@@ -115,7 +115,7 @@ class NativeAppAuthClient(AuthLoginClient):
         refresh_token: str,
         *,
         body_params: dict[str, t.Any] | None = None,
-    ) -> OAuthTokenResponse:
+    ) -> RefreshTokenResponse:
         """
         ``NativeAppAuthClient`` specializes the refresh token grant to include
         its client ID as a parameter in the POST body.
@@ -131,7 +131,9 @@ class NativeAppAuthClient(AuthLoginClient):
             "grant_type": "refresh_token",
             "client_id": self.client_id,
         }
-        return self.oauth2_token(form_data, body_params=body_params)
+        return self.oauth2_token(
+            form_data, body_params=body_params, response_class=RefreshTokenResponse
+        )
 
     def create_native_app_instance(
         self,

--- a/src/globus_sdk/services/auth/flow_managers/authorization_code.py
+++ b/src/globus_sdk/services/auth/flow_managers/authorization_code.py
@@ -8,7 +8,7 @@ from globus_sdk import utils
 from globus_sdk._types import ScopeCollectionType
 
 from .._common import stringify_requested_scopes
-from ..response import AuthorizationCodeTokenResponse
+from ..response import OAuthAuthorizationCodeResponse
 from .base import GlobusOAuthFlowManager
 
 if t.TYPE_CHECKING:
@@ -107,7 +107,7 @@ class GlobusAuthorizationCodeFlowManager(GlobusOAuthFlowManager):
 
     def exchange_code_for_tokens(
         self, auth_code: str
-    ) -> AuthorizationCodeTokenResponse:
+    ) -> OAuthAuthorizationCodeResponse:
         """
         The second step of the Authorization Code flow, exchange an
         authorization code for access tokens (and refresh tokens if specified)
@@ -124,5 +124,5 @@ class GlobusAuthorizationCodeFlowManager(GlobusOAuthFlowManager):
                 "code": auth_code.encode("utf-8"),
                 "redirect_uri": self.redirect_uri,
             },
-            response_class=AuthorizationCodeTokenResponse,
+            response_class=OAuthAuthorizationCodeResponse,
         )

--- a/src/globus_sdk/services/auth/flow_managers/authorization_code.py
+++ b/src/globus_sdk/services/auth/flow_managers/authorization_code.py
@@ -8,7 +8,7 @@ from globus_sdk import utils
 from globus_sdk._types import ScopeCollectionType
 
 from .._common import stringify_requested_scopes
-from ..response import OAuthTokenResponse
+from ..response import AuthorizationCodeTokenResponse
 from .base import GlobusOAuthFlowManager
 
 if t.TYPE_CHECKING:
@@ -105,7 +105,9 @@ class GlobusAuthorizationCodeFlowManager(GlobusOAuthFlowManager):
         encoded_params = urllib.parse.urlencode(params)
         return f"{authorize_base_url}?{encoded_params}"
 
-    def exchange_code_for_tokens(self, auth_code: str) -> OAuthTokenResponse:
+    def exchange_code_for_tokens(
+        self, auth_code: str
+    ) -> AuthorizationCodeTokenResponse:
         """
         The second step of the Authorization Code flow, exchange an
         authorization code for access tokens (and refresh tokens if specified)
@@ -121,5 +123,6 @@ class GlobusAuthorizationCodeFlowManager(GlobusOAuthFlowManager):
                 "grant_type": "authorization_code",
                 "code": auth_code.encode("utf-8"),
                 "redirect_uri": self.redirect_uri,
-            }
+            },
+            response_class=AuthorizationCodeTokenResponse,
         )

--- a/src/globus_sdk/services/auth/flow_managers/base.py
+++ b/src/globus_sdk/services/auth/flow_managers/base.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import abc
 import typing as t
 
-from ..response import AuthorizationCodeTokenResponse
+from ..response import OAuthAuthorizationCodeResponse
 
 
 class GlobusOAuthFlowManager(abc.ABC):
@@ -43,7 +43,7 @@ class GlobusOAuthFlowManager(abc.ABC):
     @abc.abstractmethod
     def exchange_code_for_tokens(
         self, auth_code: str
-    ) -> AuthorizationCodeTokenResponse:
+    ) -> OAuthAuthorizationCodeResponse:
         """
         This method takes an auth_code and produces a response object
         containing one or more tokens.

--- a/src/globus_sdk/services/auth/flow_managers/base.py
+++ b/src/globus_sdk/services/auth/flow_managers/base.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import abc
 import typing as t
 
-from ..response import OAuthTokenResponse
+from ..response import AuthorizationCodeTokenResponse
 
 
 class GlobusOAuthFlowManager(abc.ABC):
@@ -41,7 +41,9 @@ class GlobusOAuthFlowManager(abc.ABC):
         """
 
     @abc.abstractmethod
-    def exchange_code_for_tokens(self, auth_code: str) -> OAuthTokenResponse:
+    def exchange_code_for_tokens(
+        self, auth_code: str
+    ) -> AuthorizationCodeTokenResponse:
         """
         This method takes an auth_code and produces a response object
         containing one or more tokens.

--- a/src/globus_sdk/services/auth/flow_managers/native_app.py
+++ b/src/globus_sdk/services/auth/flow_managers/native_app.py
@@ -13,7 +13,7 @@ from globus_sdk._types import ScopeCollectionType
 from globus_sdk.exc import GlobusSDKUsageError
 
 from .._common import stringify_requested_scopes
-from ..response import AuthorizationCodeTokenResponse
+from ..response import OAuthAuthorizationCodeResponse
 from .base import GlobusOAuthFlowManager
 
 if t.TYPE_CHECKING:
@@ -192,7 +192,7 @@ class GlobusNativeAppFlowManager(GlobusOAuthFlowManager):
 
     def exchange_code_for_tokens(
         self, auth_code: str
-    ) -> AuthorizationCodeTokenResponse:
+    ) -> OAuthAuthorizationCodeResponse:
         """
         The second step of the Native App flow, exchange an authorization code
         for access tokens (and refresh tokens if specified).
@@ -211,5 +211,5 @@ class GlobusNativeAppFlowManager(GlobusOAuthFlowManager):
                 "code_verifier": self.verifier,
                 "redirect_uri": self.redirect_uri,
             },
-            response_class=AuthorizationCodeTokenResponse,
+            response_class=OAuthAuthorizationCodeResponse,
         )

--- a/src/globus_sdk/services/auth/flow_managers/native_app.py
+++ b/src/globus_sdk/services/auth/flow_managers/native_app.py
@@ -13,7 +13,7 @@ from globus_sdk._types import ScopeCollectionType
 from globus_sdk.exc import GlobusSDKUsageError
 
 from .._common import stringify_requested_scopes
-from ..response import OAuthTokenResponse
+from ..response import AuthorizationCodeTokenResponse
 from .base import GlobusOAuthFlowManager
 
 if t.TYPE_CHECKING:
@@ -190,7 +190,9 @@ class GlobusNativeAppFlowManager(GlobusOAuthFlowManager):
         encoded_params = urllib.parse.urlencode(params)
         return f"{authorize_base_url}?{encoded_params}"
 
-    def exchange_code_for_tokens(self, auth_code: str) -> OAuthTokenResponse:
+    def exchange_code_for_tokens(
+        self, auth_code: str
+    ) -> AuthorizationCodeTokenResponse:
         """
         The second step of the Native App flow, exchange an authorization code
         for access tokens (and refresh tokens if specified).
@@ -208,5 +210,6 @@ class GlobusNativeAppFlowManager(GlobusOAuthFlowManager):
                 "code": auth_code.encode("utf-8"),
                 "code_verifier": self.verifier,
                 "redirect_uri": self.redirect_uri,
-            }
+            },
+            response_class=AuthorizationCodeTokenResponse,
         )

--- a/src/globus_sdk/services/auth/response/__init__.py
+++ b/src/globus_sdk/services/auth/response/__init__.py
@@ -2,7 +2,13 @@ from .clients import GetClientsResponse
 from .consents import GetConsentsResponse
 from .credentials import GetClientCredentialsResponse
 from .identities import GetIdentitiesResponse, GetIdentityProvidersResponse
-from .oauth import OAuthDependentTokenResponse, OAuthTokenResponse
+from .oauth import (
+    AuthorizationCodeTokenResponse,
+    ClientCredentialsTokenResponse,
+    OAuthDependentTokenResponse,
+    OAuthTokenResponse,
+    RefreshTokenResponse,
+)
 from .policies import GetPoliciesResponse
 from .projects import GetProjectsResponse
 from .scopes import GetScopesResponse
@@ -18,4 +24,7 @@ __all__ = (
     "GetScopesResponse",
     "OAuthTokenResponse",
     "OAuthDependentTokenResponse",
+    "AuthorizationCodeTokenResponse",
+    "RefreshTokenResponse",
+    "ClientCredentialsTokenResponse",
 )

--- a/src/globus_sdk/services/auth/response/__init__.py
+++ b/src/globus_sdk/services/auth/response/__init__.py
@@ -3,11 +3,11 @@ from .consents import GetConsentsResponse
 from .credentials import GetClientCredentialsResponse
 from .identities import GetIdentitiesResponse, GetIdentityProvidersResponse
 from .oauth import (
-    AuthorizationCodeTokenResponse,
-    ClientCredentialsTokenResponse,
+    OAuthAuthorizationCodeResponse,
+    OAuthClientCredentialsResponse,
     OAuthDependentTokenResponse,
+    OAuthRefreshTokenResponse,
     OAuthTokenResponse,
-    RefreshTokenResponse,
 )
 from .policies import GetPoliciesResponse
 from .projects import GetProjectsResponse
@@ -22,9 +22,9 @@ __all__ = (
     "GetPoliciesResponse",
     "GetProjectsResponse",
     "GetScopesResponse",
-    "OAuthTokenResponse",
+    "OAuthAuthorizationCodeResponse",
+    "OAuthClientCredentialsResponse",
     "OAuthDependentTokenResponse",
-    "AuthorizationCodeTokenResponse",
-    "RefreshTokenResponse",
-    "ClientCredentialsTokenResponse",
+    "OAuthRefreshTokenResponse",
+    "OAuthTokenResponse",
 )

--- a/src/globus_sdk/services/auth/response/oauth.py
+++ b/src/globus_sdk/services/auth/response/oauth.py
@@ -250,7 +250,7 @@ class OAuthTokenResponse(GlobusHTTPResponse):
         )
 
 
-class AuthorizationCodeTokenResponse(OAuthTokenResponse):
+class OAuthAuthorizationCodeResponse(OAuthTokenResponse):
     """
     Class for responses from the OAuth2 'authorization_code' grant.
 
@@ -259,11 +259,11 @@ class AuthorizationCodeTokenResponse(OAuthTokenResponse):
 
     For example,
     :meth:`globus_sdk.ConfidentialAppAuthClient.oauth2_exchange_code_for_tokens`
-    will return an ``AuthorizationCodeTokenResponse``.
+    will return an ``OAuthAuthorizationCodeResponse``.
     """
 
 
-class ClientCredentialsTokenResponse(OAuthTokenResponse):
+class OAuthClientCredentialsResponse(OAuthTokenResponse):
     """
     Class for responses from the OAuth2 'client_credentials' grant.
 
@@ -273,7 +273,7 @@ class ClientCredentialsTokenResponse(OAuthTokenResponse):
     """
 
 
-class RefreshTokenResponse(OAuthTokenResponse):
+class OAuthRefreshTokenResponse(OAuthTokenResponse):
     """
     Class for responses from the OAuth2 'refresh_token' grant.
 

--- a/src/globus_sdk/services/auth/response/oauth.py
+++ b/src/globus_sdk/services/auth/response/oauth.py
@@ -250,12 +250,49 @@ class OAuthTokenResponse(GlobusHTTPResponse):
         )
 
 
+class AuthorizationCodeTokenResponse(OAuthTokenResponse):
+    """
+    Class for responses from the OAuth2 'authorization_code' grant.
+
+    This class of response is returned by methods which get new tokens via a
+    code-exchange, as in 3-legged OAuth or PKCE.
+
+    For example,
+    :meth:`globus_sdk.ConfidentialAppAuthClient.oauth2_exchange_code_for_tokens`
+    will return an ``AuthorizationCodeTokenResponse``.
+    """
+
+
+class ClientCredentialsTokenResponse(OAuthTokenResponse):
+    """
+    Class for responses from the OAuth2 'client_credentials' grant.
+
+    This class of response is returned by methods which get new tokens by means of
+    client credentials, namely
+    :meth:`globus_sdk.ConfidentialAppAuthClient.oauth2_client_credentials_tokens`.
+    """
+
+
+class RefreshTokenResponse(OAuthTokenResponse):
+    """
+    Class for responses from the OAuth2 'refresh_token' grant.
+
+    This class of response is returned by methods which get new tokens from an
+    existing Refresh Token, e.g.,
+    :meth:`globus_sdk.NativeAppAuthClient.oauth2_refresh_token`.
+    """
+
+
 class OAuthDependentTokenResponse(OAuthTokenResponse):
     """
-    Class for responses from the OAuth2 code for tokens retrieved by the
-    OAuth2 Dependent Token Extension Grant. For more complete docs, see
+    Class for responses from the OAuth2
+    'urn:globus:auth:grant_type:dependent_token' grant.
+
+    This is an extension grant type defined by Globus.
+
     :meth:`oauth2_get_dependent_tokens \
     <globus_sdk.ConfidentialAppAuthClient.oauth2_get_dependent_tokens>`
+    provides this response, and includes some documentation on its proper usage.
     """
 
     def _init_rs_dict(self) -> None:


### PR DESCRIPTION
The initial goal of this work is to allow a function handling a token
response, e.g., in a tokenstorage interface, to determine the context
in which the original call was made. It is now possible to check

    if isinstance(response, OAuthRefreshTokenResponse): ...

in a generic token handler.

Additionally, this opens the way for distinct token response objects
to implement methods which vary based on the known properties of their
respective grant types. For example, OAuthRefreshTokenResponse could
raise a more informative error when `decode_id_token` is called and
no `id_token` is present.


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1051.org.readthedocs.build/en/1051/

<!-- readthedocs-preview globus-sdk-python end -->