### PR TITLE
Improve typing-time lazy import behaviors to expose attribute errors to type checkers

### DIFF
--- a/changelog.d/20240917_134528_sirosen_improve_lazy_import_typing.rst
+++ b/changelog.d/20240917_134528_sirosen_improve_lazy_import_typing.rst
@@ -1,0 +1,5 @@
+Fixed
+~~~~~
+
+- Fix the typing-time attributes of ``globus_sdk`` so that ``mypy`` and other
+  type checkers won't erroneously suppress errors about missing attributes. (:pr:`NUMBER`)

--- a/requirements/py3.10/test.txt
+++ b/requirements/py3.10/test.txt
@@ -4,19 +4,19 @@
 #
 #    tox p -m freezedeps
 #
-certifi==2024.7.4
+certifi==2024.8.30
     # via requests
 charset-normalizer==3.3.2
     # via requests
-coverage==7.5.4
+coverage==7.6.1
     # via -r test.in
-exceptiongroup==1.2.1
+exceptiongroup==1.2.2
     # via pytest
 execnet==2.1.1
     # via pytest-xdist
 flaky==3.8.1
     # via -r test.in
-idna==3.7
+idna==3.10
     # via requests
 iniconfig==2.0.0
     # via pytest
@@ -24,7 +24,7 @@ packaging==24.1
     # via pytest
 pluggy==1.5.0
     # via pytest
-pytest==8.2.2
+pytest==8.3.3
     # via
     #   -r test.in
     #   pytest-randomly
@@ -33,7 +33,7 @@ pytest-randomly==3.15.0
     # via -r test.in
 pytest-xdist==3.6.1
     # via -r test.in
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via responses
 requests==2.32.3
     # via responses
@@ -41,7 +41,7 @@ responses==0.25.3
     # via -r test.in
 tomli==2.0.1
     # via pytest
-urllib3==2.2.2
+urllib3==2.2.3
     # via
     #   requests
     #   responses

--- a/requirements/py3.10/typing.txt
+++ b/requirements/py3.10/typing.txt
@@ -4,17 +4,17 @@
 #
 #    tox p -m freezedeps
 #
-certifi==2024.7.4
+certifi==2024.8.30
     # via requests
 charset-normalizer==3.3.2
     # via requests
-idna==3.7
+idna==3.10
     # via requests
-mypy==1.10.1
+mypy==1.11.2
     # via -r typing.in
 mypy-extensions==1.0.0
     # via mypy
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via responses
 requests==2.32.3
     # via responses
@@ -24,17 +24,17 @@ tomli==2.0.1
     # via mypy
 types-cryptography==3.3.23.2
     # via types-jwt
-types-docutils==0.21.0.20240708
+types-docutils==0.21.0.20240907
     # via -r typing.in
 types-jwt==0.1.3
     # via -r typing.in
-types-requests==2.32.0.20240622
+types-requests==2.32.0.20240914
     # via -r typing.in
 typing-extensions==4.12.2
     # via
     #   -r typing.in
     #   mypy
-urllib3==2.2.2
+urllib3==2.2.3
     # via
     #   requests
     #   responses

--- a/requirements/py3.11/docs.txt
+++ b/requirements/py3.11/docs.txt
@@ -4,21 +4,21 @@
 #
 #    tox p -m freezedeps
 #
-alabaster==0.7.16
+alabaster==1.0.0
     # via sphinx
-babel==2.15.0
+babel==2.16.0
     # via sphinx
 beautifulsoup4==4.12.3
     # via furo
-certifi==2024.7.4
+certifi==2024.8.30
     # via requests
 charset-normalizer==3.3.2
     # via requests
 docutils==0.21.2
     # via sphinx
-furo==2024.5.6
+furo==2024.8.6
     # via -r docs.in
-idna==3.7
+idna==3.10
     # via requests
 imagesize==1.4.1
     # via sphinx
@@ -32,7 +32,7 @@ pygments==2.18.0
     # via
     #   furo
     #   sphinx
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via responses
 requests==2.32.3
     # via
@@ -42,9 +42,9 @@ responses==0.25.3
     # via -r docs.in
 snowballstemmer==2.2.0
     # via sphinx
-soupsieve==2.5
+soupsieve==2.6
     # via beautifulsoup4
-sphinx==7.3.7
+sphinx==8.0.2
     # via
     #   -r docs.in
     #   furo
@@ -56,23 +56,23 @@ sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
     # via -r docs.in
-sphinx-design==0.6.0
+sphinx-design==0.6.1
     # via -r docs.in
 sphinx-issues==4.1.0
     # via -r docs.in
-sphinxcontrib-applehelp==1.0.8
+sphinxcontrib-applehelp==2.0.0
     # via sphinx
-sphinxcontrib-devhelp==1.0.6
+sphinxcontrib-devhelp==2.0.0
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.5
+sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.7
+sphinxcontrib-qthelp==2.0.0
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.10
+sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-urllib3==2.2.2
+urllib3==2.2.3
     # via
     #   requests
     #   responses

--- a/requirements/py3.11/test.txt
+++ b/requirements/py3.11/test.txt
@@ -4,17 +4,17 @@
 #
 #    tox p -m freezedeps
 #
-certifi==2024.7.4
+certifi==2024.8.30
     # via requests
 charset-normalizer==3.3.2
     # via requests
-coverage==7.5.4
+coverage==7.6.1
     # via -r test.in
 execnet==2.1.1
     # via pytest-xdist
 flaky==3.8.1
     # via -r test.in
-idna==3.7
+idna==3.10
     # via requests
 iniconfig==2.0.0
     # via pytest
@@ -22,7 +22,7 @@ packaging==24.1
     # via pytest
 pluggy==1.5.0
     # via pytest
-pytest==8.2.2
+pytest==8.3.3
     # via
     #   -r test.in
     #   pytest-randomly
@@ -31,13 +31,13 @@ pytest-randomly==3.15.0
     # via -r test.in
 pytest-xdist==3.6.1
     # via -r test.in
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via responses
 requests==2.32.3
     # via responses
 responses==0.25.3
     # via -r test.in
-urllib3==2.2.2
+urllib3==2.2.3
     # via
     #   requests
     #   responses

--- a/requirements/py3.11/typing.txt
+++ b/requirements/py3.11/typing.txt
@@ -4,17 +4,17 @@
 #
 #    tox p -m freezedeps
 #
-certifi==2024.7.4
+certifi==2024.8.30
     # via requests
 charset-normalizer==3.3.2
     # via requests
-idna==3.7
+idna==3.10
     # via requests
-mypy==1.10.1
+mypy==1.11.2
     # via -r typing.in
 mypy-extensions==1.0.0
     # via mypy
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via responses
 requests==2.32.3
     # via responses
@@ -22,17 +22,17 @@ responses==0.25.3
     # via -r typing.in
 types-cryptography==3.3.23.2
     # via types-jwt
-types-docutils==0.21.0.20240708
+types-docutils==0.21.0.20240907
     # via -r typing.in
 types-jwt==0.1.3
     # via -r typing.in
-types-requests==2.32.0.20240622
+types-requests==2.32.0.20240914
     # via -r typing.in
 typing-extensions==4.12.2
     # via
     #   -r typing.in
     #   mypy
-urllib3==2.2.2
+urllib3==2.2.3
     # via
     #   requests
     #   responses

--- a/requirements/py3.12/test.txt
+++ b/requirements/py3.12/test.txt
@@ -4,17 +4,17 @@
 #
 #    tox p -m freezedeps
 #
-certifi==2024.7.4
+certifi==2024.8.30
     # via requests
 charset-normalizer==3.3.2
     # via requests
-coverage==7.5.4
+coverage==7.6.1
     # via -r test.in
 execnet==2.1.1
     # via pytest-xdist
 flaky==3.8.1
     # via -r test.in
-idna==3.7
+idna==3.10
     # via requests
 iniconfig==2.0.0
     # via pytest
@@ -22,7 +22,7 @@ packaging==24.1
     # via pytest
 pluggy==1.5.0
     # via pytest
-pytest==8.2.2
+pytest==8.3.3
     # via
     #   -r test.in
     #   pytest-randomly
@@ -31,13 +31,13 @@ pytest-randomly==3.15.0
     # via -r test.in
 pytest-xdist==3.6.1
     # via -r test.in
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via responses
 requests==2.32.3
     # via responses
 responses==0.25.3
     # via -r test.in
-urllib3==2.2.2
+urllib3==2.2.3
     # via
     #   requests
     #   responses

--- a/requirements/py3.12/typing.txt
+++ b/requirements/py3.12/typing.txt
@@ -4,17 +4,17 @@
 #
 #    tox p -m freezedeps
 #
-certifi==2024.7.4
+certifi==2024.8.30
     # via requests
 charset-normalizer==3.3.2
     # via requests
-idna==3.7
+idna==3.10
     # via requests
-mypy==1.10.1
+mypy==1.11.2
     # via -r typing.in
 mypy-extensions==1.0.0
     # via mypy
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via responses
 requests==2.32.3
     # via responses
@@ -22,17 +22,17 @@ responses==0.25.3
     # via -r typing.in
 types-cryptography==3.3.23.2
     # via types-jwt
-types-docutils==0.21.0.20240708
+types-docutils==0.21.0.20240907
     # via -r typing.in
 types-jwt==0.1.3
     # via -r typing.in
-types-requests==2.32.0.20240622
+types-requests==2.32.0.20240914
     # via -r typing.in
 typing-extensions==4.12.2
     # via
     #   -r typing.in
     #   mypy
-urllib3==2.2.2
+urllib3==2.2.3
     # via
     #   requests
     #   responses

--- a/requirements/py3.8/test-mindeps.txt
+++ b/requirements/py3.8/test-mindeps.txt
@@ -4,17 +4,17 @@
 #
 #    tox p -m freezedeps
 #
-certifi==2024.7.4
+certifi==2024.8.30
     # via requests
-cffi==1.16.0
+cffi==1.17.1
     # via cryptography
 chardet==3.0.4
     # via requests
-coverage==7.5.4
+coverage==7.6.1
     # via -r test.in
 cryptography==3.3.1
     # via -r test-mindeps.in
-exceptiongroup==1.2.1
+exceptiongroup==1.2.2
     # via pytest
 execnet==2.1.1
     # via pytest-xdist
@@ -22,7 +22,7 @@ flaky==3.8.1
     # via -r test.in
 idna==2.8
     # via requests
-importlib-metadata==8.0.0
+importlib-metadata==8.5.0
     # via pytest-randomly
 iniconfig==2.0.0
     # via pytest
@@ -34,7 +34,7 @@ pycparser==2.22
     # via cffi
 pyjwt==2.0.0
     # via -r test-mindeps.in
-pytest==8.2.2
+pytest==8.3.3
     # via
     #   -r test.in
     #   pytest-randomly
@@ -43,7 +43,7 @@ pytest-randomly==3.15.0
     # via -r test.in
 pytest-xdist==3.6.1
     # via -r test.in
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via responses
 requests==2.22.0
     # via
@@ -55,7 +55,7 @@ six==1.16.0
     # via cryptography
 tomli==2.0.1
     # via pytest
-types-pyyaml==6.0.12.20240311
+types-pyyaml==6.0.12.20240917
     # via responses
 typing-extensions==4.0.0
     # via -r test-mindeps.in
@@ -63,5 +63,5 @@ urllib3==1.25.11
     # via
     #   requests
     #   responses
-zipp==3.19.2
+zipp==3.20.2
     # via importlib-metadata

--- a/requirements/py3.8/test.txt
+++ b/requirements/py3.8/test.txt
@@ -4,21 +4,21 @@
 #
 #    tox p -m freezedeps
 #
-certifi==2024.7.4
+certifi==2024.8.30
     # via requests
 charset-normalizer==3.3.2
     # via requests
-coverage==7.5.4
+coverage==7.6.1
     # via -r test.in
-exceptiongroup==1.2.1
+exceptiongroup==1.2.2
     # via pytest
 execnet==2.1.1
     # via pytest-xdist
 flaky==3.8.1
     # via -r test.in
-idna==3.7
+idna==3.10
     # via requests
-importlib-metadata==8.0.0
+importlib-metadata==8.5.0
     # via pytest-randomly
 iniconfig==2.0.0
     # via pytest
@@ -26,7 +26,7 @@ packaging==24.1
     # via pytest
 pluggy==1.5.0
     # via pytest
-pytest==8.2.2
+pytest==8.3.3
     # via
     #   -r test.in
     #   pytest-randomly
@@ -35,7 +35,7 @@ pytest-randomly==3.15.0
     # via -r test.in
 pytest-xdist==3.6.1
     # via -r test.in
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via responses
 requests==2.32.3
     # via responses
@@ -43,9 +43,9 @@ responses==0.25.3
     # via -r test.in
 tomli==2.0.1
     # via pytest
-urllib3==2.2.2
+urllib3==2.2.3
     # via
     #   requests
     #   responses
-zipp==3.19.2
+zipp==3.20.2
     # via importlib-metadata

--- a/requirements/py3.8/typing.txt
+++ b/requirements/py3.8/typing.txt
@@ -4,17 +4,17 @@
 #
 #    tox p -m freezedeps
 #
-certifi==2024.7.4
+certifi==2024.8.30
     # via requests
 charset-normalizer==3.3.2
     # via requests
-idna==3.7
+idna==3.10
     # via requests
-mypy==1.10.1
+mypy==1.11.2
     # via -r typing.in
 mypy-extensions==1.0.0
     # via mypy
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via responses
 requests==2.32.3
     # via responses
@@ -24,17 +24,17 @@ tomli==2.0.1
     # via mypy
 types-cryptography==3.3.23.2
     # via types-jwt
-types-docutils==0.21.0.20240708
+types-docutils==0.21.0.20240907
     # via -r typing.in
 types-jwt==0.1.3
     # via -r typing.in
-types-requests==2.32.0.20240622
+types-requests==2.32.0.20240914
     # via -r typing.in
 typing-extensions==4.12.2
     # via
     #   -r typing.in
     #   mypy
-urllib3==2.2.2
+urllib3==2.2.3
     # via
     #   requests
     #   responses

--- a/requirements/py3.9/test.txt
+++ b/requirements/py3.9/test.txt
@@ -4,21 +4,21 @@
 #
 #    tox p -m freezedeps
 #
-certifi==2024.7.4
+certifi==2024.8.30
     # via requests
 charset-normalizer==3.3.2
     # via requests
-coverage==7.5.4
+coverage==7.6.1
     # via -r test.in
-exceptiongroup==1.2.1
+exceptiongroup==1.2.2
     # via pytest
 execnet==2.1.1
     # via pytest-xdist
 flaky==3.8.1
     # via -r test.in
-idna==3.7
+idna==3.10
     # via requests
-importlib-metadata==8.0.0
+importlib-metadata==8.5.0
     # via pytest-randomly
 iniconfig==2.0.0
     # via pytest
@@ -26,7 +26,7 @@ packaging==24.1
     # via pytest
 pluggy==1.5.0
     # via pytest
-pytest==8.2.2
+pytest==8.3.3
     # via
     #   -r test.in
     #   pytest-randomly
@@ -35,7 +35,7 @@ pytest-randomly==3.15.0
     # via -r test.in
 pytest-xdist==3.6.1
     # via -r test.in
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via responses
 requests==2.32.3
     # via responses
@@ -43,9 +43,9 @@ responses==0.25.3
     # via -r test.in
 tomli==2.0.1
     # via pytest
-urllib3==2.2.2
+urllib3==2.2.3
     # via
     #   requests
     #   responses
-zipp==3.19.2
+zipp==3.20.2
     # via importlib-metadata

--- a/requirements/py3.9/typing.txt
+++ b/requirements/py3.9/typing.txt
@@ -4,17 +4,17 @@
 #
 #    tox p -m freezedeps
 #
-certifi==2024.7.4
+certifi==2024.8.30
     # via requests
 charset-normalizer==3.3.2
     # via requests
-idna==3.7
+idna==3.10
     # via requests
-mypy==1.10.1
+mypy==1.11.2
     # via -r typing.in
 mypy-extensions==1.0.0
     # via mypy
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via responses
 requests==2.32.3
     # via responses
@@ -24,17 +24,17 @@ tomli==2.0.1
     # via mypy
 types-cryptography==3.3.23.2
     # via types-jwt
-types-docutils==0.21.0.20240708
+types-docutils==0.21.0.20240907
     # via -r typing.in
 types-jwt==0.1.3
     # via -r typing.in
-types-requests==2.32.0.20240622
+types-requests==2.32.0.20240914
     # via -r typing.in
 typing-extensions==4.12.2
     # via
     #   -r typing.in
     #   mypy
-urllib3==2.2.2
+urllib3==2.2.3
     # via
     #   requests
     #   responses

--- a/src/globus_sdk/__init__.py
+++ b/src/globus_sdk/__init__.py
@@ -254,32 +254,32 @@ if t.TYPE_CHECKING:
     from .utils import MISSING
     from .utils import MissingType
 
+else:
 
-def __dir__() -> t.List[str]:
-    # dir(globus_sdk) should include everything exported in __all__
-    # as well as some explicitly selected attributes from the default dir() output
-    # on a module
-    #
-    # see also:
-    # https://discuss.python.org/t/how-to-properly-extend-standard-dir-search-with-module-level-dir/4202
-    return list(__all__) + [
-        # __all__ itself can be inspected
-        "__all__",
-        # useful to figure out where a package is installed
-        "__file__",
-        "__path__",
-    ]
+    def __dir__() -> t.List[str]:
+        # dir(globus_sdk) should include everything exported in __all__
+        # as well as some explicitly selected attributes from the default dir() output
+        # on a module
+        #
+        # see also:
+        # https://discuss.python.org/t/how-to-properly-extend-standard-dir-search-with-module-level-dir/4202
+        return list(__all__) + [
+            # __all__ itself can be inspected
+            "__all__",
+            # useful to figure out where a package is installed
+            "__file__",
+            "__path__",
+        ]
 
+    def __getattr__(name: str) -> t.Any:
+        for modname, items in _LAZY_IMPORT_TABLE.items():
+            if name in items:
+                mod = importlib.import_module("." + modname, __name__)
+                value = getattr(mod, name)
+                setattr(sys.modules[__name__], name, value)
+                return value
 
-def __getattr__(name: str) -> t.Any:
-    for modname, items in _LAZY_IMPORT_TABLE.items():
-        if name in items:
-            mod = importlib.import_module("." + modname, __name__)
-            value = getattr(mod, name)
-            setattr(sys.modules[__name__], name, value)
-            return value
-
-    raise AttributeError(f"module {__name__} has no attribute {name}")
+        raise AttributeError(f"module {__name__} has no attribute {name}")
 
 
 __all__ = (

--- a/src/globus_sdk/_generate_init.py
+++ b/src/globus_sdk/_generate_init.py
@@ -36,7 +36,7 @@ FIXED_EPILOG = """
 logging.getLogger("globus_sdk").addHandler(logging.NullHandler())
 """
 
-FIXED_MODULE_METHODS = """
+FIXED_MODULE_METHODS = """\
 def __dir__() -> t.List[str]:
     # dir(globus_sdk) should include everything exported in __all__
     # as well as some explicitly selected attributes from the default dir() output
@@ -51,7 +51,6 @@ def __dir__() -> t.List[str]:
         "__file__",
         "__path__",
     ]
-
 
 def __getattr__(name: str) -> t.Any:
     for modname, items in _LAZY_IMPORT_TABLE.items():
@@ -279,7 +278,9 @@ def _init_pieces() -> t.Iterator[str]:
     yield "if t.TYPE_CHECKING:"
     yield from _generate_imports()
     yield ""
-    yield FIXED_MODULE_METHODS
+    yield "else:"
+    yield ""
+    yield textwrap.indent(FIXED_MODULE_METHODS, "    ")
     yield ""
     yield from _generate_all_tuple()
     yield ""

--- a/tests/non-pytest/mypy-ignore-tests/lazy_importer.py
+++ b/tests/non-pytest/mypy-ignore-tests/lazy_importer.py
@@ -1,0 +1,7 @@
+# test typing interactions with __getattr__-based lazy imports
+import globus_sdk
+
+# ensure that a valid name is treated as valid
+globus_sdk.TransferClient
+# but an invalid name is not!
+globus_sdk.TRansferClient  # type: ignore[attr-defined]


### PR DESCRIPTION
Basically, the three commits are:

- Run "tox -m freezedeps" to ensure we're on the latest `mypy` version
- Add a failing typing test
- Fix the lazy-importer at typing-time


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1052.org.readthedocs.build/en/1052/

<!-- readthedocs-preview globus-sdk-python end -->