### PR TITLE
Only call token_validation_error_handler once

### DIFF
--- a/changelog.d/20240923_150125_derek_only_call_token_validation_error_handler_once.rst
+++ b/changelog.d/20240923_150125_derek_only_call_token_validation_error_handler_once.rst
@@ -1,0 +1,7 @@
+
+Changed
+~~~~~~~
+
+-   Added a contextmanager to ensure that the call to ``GlobusApp.get_authorizer(...)``
+    only ever calls the registered ``token_validation_error_handler`` once, even if
+    nested calls happen as a part of the method invocation. (:pr:`NUMBER`)

--- a/changelog.d/20240923_150125_derek_only_call_token_validation_error_handler_once.rst
+++ b/changelog.d/20240923_150125_derek_only_call_token_validation_error_handler_once.rst
@@ -5,3 +5,9 @@ Changed
 -   Added a contextmanager to ensure that the call to ``GlobusApp.get_authorizer(...)``
     only ever calls the registered ``token_validation_error_handler`` once, even if
     nested calls happen as a part of the method invocation. (:pr:`NUMBER`)
+
+Removed
+~~~~~~~
+
+-   Removed the ``skip_error_handling`` optional kwarg from the method interface
+    ``GlobusApp.get_authorizer(...)``. (:pr:`NUMBER`)

--- a/changelog.d/20240923_150125_derek_only_call_token_validation_error_handler_once.rst
+++ b/changelog.d/20240923_150125_derek_only_call_token_validation_error_handler_once.rst
@@ -1,10 +1,9 @@
 
-Changed
-~~~~~~~
+Fixed
+~~~~~
 
--   Added a contextmanager to ensure that the call to ``GlobusApp.get_authorizer(...)``
-    only ever calls the registered ``token_validation_error_handler`` once, even if
-    nested calls happen as a part of the method invocation. (:pr:`NUMBER`)
+-   Fixed a bug where upgrading from access token to refresh token mode in a
+    ``GlobusApp`` could result in multiple login prompts. (:pr:`NUMBER`)
 
 Removed
 ~~~~~~~

--- a/src/globus_sdk/experimental/globus_app/app.py
+++ b/src/globus_sdk/experimental/globus_app/app.py
@@ -357,7 +357,7 @@ class GlobusApp(metaclass=abc.ABCMeta):
             raise e
 
     @contextlib.contextmanager
-    def _disabled_token_validation_error_handler(self) -> t.ContextManager[None]:
+    def _disabled_token_validation_error_handler(self) -> t.Iterator[None]:
         """
         Context manager to disable token validation error handling (as a default)
         for the duration of the context.

--- a/src/globus_sdk/experimental/globus_app/app.py
+++ b/src/globus_sdk/experimental/globus_app/app.py
@@ -337,7 +337,7 @@ class GlobusApp(metaclass=abc.ABCMeta):
         error_handling_enabled = self._token_validation_error_handling_enabled
 
         try:
-            # Disable token validation error handling while try to get an authorizer.
+            # Disable token validation error handling for nested calls.
             # This will ultimately ensure that the error handler is only called once
             # by the root `get_authorizer` invocation.
             with self._disabled_token_validation_error_handler():


### PR DESCRIPTION
## Changes

1. Fixed a bug where upgrading from access token to refresh token mode in a `GlobusApp` could result in multiple login prompts.
2. Removed the `skip_error_handling` optional kwarg from the method interface `GlobusApp.get_authorizer(...)`.


## Testing

Ran a script that requires dependent scopes twice, once with request_refresh_tokens set to false, once with it set to true. Observed a single login both invocations.

First script run:
  * Before fix: one login prompt
  * After fix: one login prompt

```py
from globus_sdk import TransferClient
from globus_sdk.experimental.globus_app import UserApp, GlobusAppConfig

app = UserApp(
    "refresh-tokens-with-consents",
    client_id="<client-id>",
    config=GlobusAppConfig(request_refresh_tokens=False),
)
transfer = TransferClient(app=app)

TUTORIAL_COLLECTION = "6c54cade-bde5-45c1-bdea-f4bd71dba2cc"
transfer.add_app_data_access_scope(TUTORIAL_COLLECTION)

ls_result = transfer.operation_ls(TUTORIAL_COLLECTION, "/")
print(ls_result)
# Results were printed
```


Second script run:
 * Before fix: two login prompts
 * After fix: one login prompt

```py
from globus_sdk import TransferClient
from globus_sdk.experimental.globus_app import UserApp, GlobusAppConfig

app = UserApp(
    "refresh-tokens-with-consents",
    client_id="<client-id>",
    config=GlobusAppConfig(request_refresh_tokens=True),
)
transfer = TransferClient(app=app)

TUTORIAL_COLLECTION = "6c54cade-bde5-45c1-bdea-f4bd71dba2cc"
transfer.add_app_data_access_scope(TUTORIAL_COLLECTION)

ls_result = transfer.operation_ls(TUTORIAL_COLLECTION, "/")
print(ls_result)
# Results were printed
```




<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1060.org.readthedocs.build/en/1060/

<!-- readthedocs-preview globus-sdk-python end -->