### PR TITLE
Enhance the 'ensure-exports-are-documented' lint

### DIFF
--- a/docs/authorization/scopes_and_consents/scopes.rst
+++ b/docs/authorization/scopes_and_consents/scopes.rst
@@ -195,6 +195,10 @@ Scope Reference
 
 .. autoclass:: ScopeCycleError
 
+.. autofunction:: scopes_to_str
+
+.. autofunction:: scopes_to_scope_list
+
 ScopeBuilders
 -------------
 

--- a/docs/authorization/scopes_and_consents/scopes.rst
+++ b/docs/authorization/scopes_and_consents/scopes.rst
@@ -195,6 +195,11 @@ Scope Reference
 
 .. autoclass:: ScopeCycleError
 
+.. rubric:: Utility Functions
+
+``globus_sdk.scopes`` also provides helper functions which are used to
+manipulate scope objects.
+
 .. autofunction:: scopes_to_str
 
 .. autofunction:: scopes_to_scope_list

--- a/scripts/ensure_exports_are_documented.py
+++ b/scripts/ensure_exports_are_documented.py
@@ -13,6 +13,11 @@ REPO_ROOT = pathlib.Path(__file__).parent.parent
 
 _ALL_NAME_PATTERN = re.compile(r'\s+"(\w+)",?')
 
+PACKAGE_DIRS_TO_SCAN = (
+    "globus_sdk",
+    "globus_sdk/scopes",
+)
+
 DEPRECATED_NAMES = {
     "TimerAPIError",
     "TimerClient",
@@ -85,13 +90,16 @@ def get_names_from_all_list(package_dir) -> list[str]:
 def ensure_exports_are_documented() -> bool:
     success = True
     used_deprecations = set()
-    for package_dir in ("globus_sdk", "globus_sdk/scopes"):
+    for package_dir in PACKAGE_DIRS_TO_SCAN:
         for name in get_names_from_all_list(package_dir):
             if name in DEPRECATED_NAMES:
                 used_deprecations.add(name)
                 continue
             if not is_documented(name):
-                print(f"{name} is not documented")
+                print(
+                    f"'src/{package_dir}/__init__.py::{name}' "
+                    "was not found in doc directives"
+                )
                 success = False
     if unused_deprecations := (DEPRECATED_NAMES - used_deprecations):
         print(f"unused deprecations: {unused_deprecations}")

--- a/src/globus_sdk/scopes/_normalize.py
+++ b/src/globus_sdk/scopes/_normalize.py
@@ -13,11 +13,17 @@ def scopes_to_str(scopes: ScopeCollectionType) -> str:
     """
     Normalize a scope collection to a space-separated scope string.
 
-    e.g., scopes_to_str(Scope("foo")) -> "foo"
-    e.g., scopes_to_str(Scope("foo"), "bar", MutableScope("qux")) -> "foo bar qux"
-
     :param scopes: A scope string or object, or an iterable of scope strings or objects.
     :returns: A space-separated scope string.
+
+    Example usage:
+
+    .. code-block:: pycon
+
+        >>> scopes_to_str(Scope("foo"))
+        'foo'
+        >>> scopes_to_str(Scope("foo"), "bar", MutableScope("qux"))
+        'foo bar qux'
     """
     scope_iter = _iter_scope_collection(scopes, split_root_scopes=False)
     return " ".join(str(scope) for scope in scope_iter)
@@ -27,12 +33,17 @@ def scopes_to_scope_list(scopes: ScopeCollectionType) -> list[Scope]:
     """
     Normalize a scope collection to a list of Scope objects.
 
-    e.g., scopes_to_scope_list(Scope("foo")) -> [Scope("foo")]
-    e.g., scopes_to_scope_list(Scope("foo"), "bar baz", MutableScope("qux"))
-            -> [Scope("foo"), Scope("bar"), Scope("baz"), Scope("qux")]
-
     :param scopes: A scope string or object, or an iterable of scope strings or objects.
     :returns: A list of Scope objects.
+
+    Example usage:
+
+    .. code-block:: pycon
+
+        >>> scopes_to_scope_list(Scope("foo"))
+        [Scope('foo')]
+        >>> scopes_to_scope_list(Scope("foo"), "bar baz", MutableScope("qux"))
+        [Scope('foo'), Scope('bar'), Scope('baz'), Scope('qux')]
     """
     scope_list: list[Scope] = []
     for scope in _iter_scope_collection(scopes):
@@ -54,20 +65,26 @@ def _iter_scope_collection(
     Provide an iterator over a scope collection type, flattening nested scope
     collections as encountered.
 
-    e.g., _iter_scope_collection("foo") -> generator("foo")
-    e.g., _iter_scope_collection(Scope.parse("foo bar"), "baz qux")
-            -> generator(Scope("foo"), Scope("bar"), "baz", "qux")
-
     Collections of scope representations are yielded one at a time.
     Individual scope representations are yielded as-is.
 
-    :obj: A scope collection or scope representation.
-    :iter_scope_strings: If True, scope strings with multiple root scopes are split.
-        This flag allows a caller to optimize, skipping a bfs operation if merging will
-        be done later purely with strings.
-        e.g., _iter_scope_collection("foo bar[baz qux]") -> "foo", "bar[baz qux]"
-        e.g., _iter_scope_collection("foo bar[baz qux]", split_root_scopes=False)
-            -> "foo bar[baz qux]"
+    :param obj: A scope collection or scope representation.
+    :param iter_scope_strings: If True, scope strings with multiple root scopes are
+        split. This flag allows a caller to optimize, skipping a bfs operation if
+        merging will be done later purely with strings.
+
+    Example usage:
+
+    .. code-block:: pycon
+
+        >>> list(_iter_scope_collection("foo"))
+        ['foo']
+        >>> list(_iter_scope_collection(Scope.parse("foo bar"), "baz qux"))
+        [Scope('foo'), Scope('bar'), 'baz', 'qux']
+        >>> list(_iter_scope_collection("foo bar[baz qux]"))
+        ['foo', 'bar[baz qux]']
+        >>> list(_iter_scope_collection("foo bar[baz qux]", split_root_scopes=False))
+        'foo bar[baz qux]'
     """
     if isinstance(obj, str):
         yield from _iter_scope_string(obj, split_root_scopes)


### PR DESCRIPTION
1.  Make the linter able to understand the relevant sphinx directives
    (via regex matching), looking for autoclass, py:data, etc

2.  Make the linter able to check additional public subpackage
    contents, starting with `globus_sdk.scopes`

2a. Document `scopes_to_str` and `scopes_to_scope_list` via
    `autofunction` directives. These are now considered public parts
    of `globus_sdk.scopes`.

    This was ambiguous before. Although we might not want to treat
    them as public in the future, there is an existing ambiguity.
    Because they are small and simple, simply committing to these
    public interfaces makes our policy clearer with minimal cost.

3.  Add support for listing deprecated names in the linter. This
    allows it to ignore deprecated `Timer*` names. If a deprecated
    name disappears from the __all__ lists, it will be treated as
    an error.

The lint is still imperfect -- it doesn't understand module context
(e.g. `.. currentmodule: ...`) and match names appropriately via
qualname or similar -- but it's sufficiently improved that it won't be
trivially fooled anymore.


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1063.org.readthedocs.build/en/1063/

<!-- readthedocs-preview globus-sdk-python end -->