### PR TITLE
Remove the redundant tox `skip_missing_interpreters` setting

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,6 @@ envlist =
     py38-mindeps
     coverage_report
     docs
-skip_missing_interpreters = true
 minversion = 4.0.0
 labels =
     freezedeps = freezedeps-py{313,312,311,310,39,38}


### PR DESCRIPTION

This PR removes the redundant tox `skip_missing_interpreters` setting in `tox.ini`.
This codifies the recently-discovered fact that it's true by default.


<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>

<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1064.org.readthedocs.build/en/1064/

<!-- readthedocs-preview globus-sdk-python end -->