### PR TITLE
Add minimal ComputeClient

### DIFF
--- a/changelog.d/20241002_125030_30907815+rjmello_compute_client.rst
+++ b/changelog.d/20241002_125030_30907815+rjmello_compute_client.rst
@@ -1,0 +1,11 @@
+Added
+~~~~~
+
+-   Added an initial Globus Compute client class, ``globus_sdk.ComputeClient``. (:pr:`NUMBER`)
+
+    -   ``globus_sdk.ComputeAPIError`` is the error class for this client.
+
+    -   ``ComputeClient.get_function`` is a method to get information about a registered function.
+
+    -   Users can access scopes for the Globus Compute API via ``globus_sdk.scopes.ComputeScopes``
+        or ``globus_sdk.ComputeClient.scopes``.

--- a/docs/authorization/scopes_and_consents/scopes.rst
+++ b/docs/authorization/scopes_and_consents/scopes.rst
@@ -232,6 +232,9 @@ ScopeBuilder Constants
 .. autodata:: globus_sdk.scopes.data.AuthScopes
     :annotation:
 
+.. autodata:: globus_sdk.scopes.data.ComputeScopes
+    :annotation:
+
 .. autodata:: globus_sdk.scopes.data.FlowsScopes
     :annotation:
 

--- a/docs/services/compute.rst
+++ b/docs/services/compute.rst
@@ -1,0 +1,24 @@
+Globus Compute
+==============
+
+.. currentmodule:: globus_sdk
+
+..  autoclass:: ComputeClient
+    :members:
+    :member-order: bysource
+    :show-inheritance:
+    :exclude-members: error_class, scopes
+
+    ..  attribute:: scopes
+
+        ..  listknownscopes:: globus_sdk.scopes.ComputeScopes
+            :base_name: ComputeClient.scopes
+
+Client Errors
+-------------
+
+When an error occurs, a :class:`ComputeClient` will raise a ``ComputeAPIError``.
+
+.. autoclass:: ComputeAPIError
+   :members:
+   :show-inheritance:

--- a/docs/services/index.rst
+++ b/docs/services/index.rst
@@ -41,6 +41,7 @@ very simply::
     :maxdepth: 1
 
     auth
+    compute
     flows
     groups
     search

--- a/src/globus_sdk/__init__.py
+++ b/src/globus_sdk/__init__.py
@@ -68,6 +68,10 @@ _LAZY_IMPORT_TABLE = {
         "OAuthTokenResponse",
         "DependentScopeSpec",
     },
+    "services.compute": {
+        "ComputeClient",
+        "ComputeAPIError",
+    },
     "services.gcs": {
         "CollectionDocument",
         "GCSAPIError",
@@ -192,6 +196,8 @@ if t.TYPE_CHECKING:
     from .services.auth import OAuthRefreshTokenResponse
     from .services.auth import OAuthTokenResponse
     from .services.auth import DependentScopeSpec
+    from .services.compute import ComputeClient
+    from .services.compute import ComputeAPIError
     from .services.gcs import CollectionDocument
     from .services.gcs import GCSAPIError
     from .services.gcs import GCSClient
@@ -308,6 +314,8 @@ __all__ = (
     "ClientCredentialsAuthorizer",
     "CollectionDocument",
     "CollectionPolicies",
+    "ComputeAPIError",
+    "ComputeClient",
     "ConfidentialAppAuthClient",
     "ConnectorTable",
     "DeleteData",

--- a/src/globus_sdk/_generate_init.py
+++ b/src/globus_sdk/_generate_init.py
@@ -132,6 +132,13 @@ _LAZY_IMPORT_TABLE: list[tuple[str, tuple[str, ...]]] = [
         ),
     ),
     (
+        "services.compute",
+        (
+            "ComputeClient",
+            "ComputeAPIError",
+        ),
+    ),
+    (
         "services.gcs",
         (
             "CollectionDocument",

--- a/src/globus_sdk/_sphinxext.py
+++ b/src/globus_sdk/_sphinxext.py
@@ -212,6 +212,8 @@ def _derive_doc_url_base(service: str | None) -> str:
         return "https://docs.globus.org/globus-connect-server/v5/api"
     elif service == "flows":
         return "https://globusonline.github.io/globus-flows#tag"
+    elif service == "compute":
+        return "https://compute.api.globus.org/redoc#tag"
     else:
         raise ValueError(f"Unsupported extdoclink service '{service}'")
 

--- a/src/globus_sdk/_testing/data/compute/_common.py
+++ b/src/globus_sdk/_testing/data/compute/_common.py
@@ -1,0 +1,5 @@
+import uuid
+
+FUNCTION_ID = str(uuid.uuid1())
+FUNCTION_NAME = "howdy_world"
+FUNCTION_CODE = "410\n10\n04\n:gASVQAAAAAAAAACMC2hvd2R5X3dvc ..."

--- a/src/globus_sdk/_testing/data/compute/get_function.py
+++ b/src/globus_sdk/_testing/data/compute/get_function.py
@@ -1,0 +1,24 @@
+from globus_sdk._testing.models import RegisteredResponse, ResponseSet
+
+from ._common import FUNCTION_CODE, FUNCTION_ID, FUNCTION_NAME
+
+FUNCTION_DOC = {
+    "function_uuid": FUNCTION_ID,
+    "function_name": FUNCTION_NAME,
+    "function_code": FUNCTION_CODE,
+    "description": "I just wanted to say hello.",
+    "metadata": {"python_version": "3.12.6", "sdk_version": "2.28.1"},
+}
+
+RESPONSES = ResponseSet(
+    metadata={
+        "function_id": FUNCTION_ID,
+        "function_name": FUNCTION_NAME,
+        "function_code": FUNCTION_CODE,
+    },
+    default=RegisteredResponse(
+        service="compute",
+        path=f"/v2/functions/{FUNCTION_ID}",
+        json=FUNCTION_DOC,
+    ),
+)

--- a/src/globus_sdk/_testing/models.py
+++ b/src/globus_sdk/_testing/models.py
@@ -30,6 +30,7 @@ class RegisteredResponse:
         "groups": "https://groups.api.globus.org/v2/",
         "timer": "https://timer.automate.globus.org/",
         "flows": "https://flows.automate.globus.org/",
+        "compute": "https://compute.api.globus.org/",
     }
     _base_path_map = {
         "transfer": "/v0.10/",

--- a/src/globus_sdk/scopes/__init__.py
+++ b/src/globus_sdk/scopes/__init__.py
@@ -5,6 +5,7 @@ from ._normalize import scopes_to_scope_list, scopes_to_str
 from .builder import ScopeBuilder
 from .data import (
     AuthScopes,
+    ComputeScopes,
     FlowsScopes,
     GCSCollectionScopeBuilder,
     GCSEndpointScopeBuilder,
@@ -28,6 +29,7 @@ __all__ = (
     "GCSCollectionScopeBuilder",
     "GCSEndpointScopeBuilder",
     "AuthScopes",
+    "ComputeScopes",
     "FlowsScopes",
     "SpecificFlowScopeBuilder",
     "GroupsScopes",

--- a/src/globus_sdk/scopes/data/__init__.py
+++ b/src/globus_sdk/scopes/data/__init__.py
@@ -1,4 +1,5 @@
 from .auth import AuthScopes
+from .compute import ComputeScopes
 from .flows import FlowsScopes, SpecificFlowScopeBuilder
 from .gcs import GCSCollectionScopeBuilder, GCSEndpointScopeBuilder
 from .groups import GroupsScopes, NexusScopes
@@ -8,6 +9,7 @@ from .transfer import TransferScopes
 
 __all__ = (
     "AuthScopes",
+    "ComputeScopes",
     "FlowsScopes",
     "SpecificFlowScopeBuilder",
     "GCSEndpointScopeBuilder",

--- a/src/globus_sdk/scopes/data/compute.py
+++ b/src/globus_sdk/scopes/data/compute.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from ..builder import ScopeBuilder, ScopeBuilderScopes
+
+
+class _ComputeScopeBuilder(ScopeBuilder):
+    """
+    The Compute service breaks the scopes/resource server convention: its resource
+    server is a service name and its scopes are built around the client ID.
+
+    Given that there isn't a simple way to support this more generally (and we
+    shouldn't encourage supporting this more generally), this class serves to
+    build out the scopes specifically for Compute.
+    """
+
+    def __init__(
+        self,
+        resource_server: str,
+        client_id: str,
+        known_scopes: ScopeBuilderScopes = None,
+        known_url_scopes: ScopeBuilderScopes = None,
+    ) -> None:
+        self._client_id = client_id
+        super().__init__(
+            resource_server,
+            known_scopes=known_scopes,
+            known_url_scopes=known_url_scopes,
+        )
+
+    def urn_scope_string(self, scope_name: str) -> str:
+        return f"urn:globus:auth:scope:{self._client_id}:{scope_name}"
+
+    def url_scope_string(self, scope_name: str) -> str:
+        return f"https://auth.globus.org/scopes/{self._client_id}/{scope_name}"
+
+
+ComputeScopes = _ComputeScopeBuilder(
+    "funcx_service",
+    "facd7ccc-c5f4-42aa-916b-a0e270e2c2a9",
+    known_url_scopes=["all"],
+)
+"""Compute scopes.
+
+.. listknownscopes:: globus_sdk.scopes.ComputeScopes
+"""

--- a/src/globus_sdk/scopes/data/compute.py
+++ b/src/globus_sdk/scopes/data/compute.py
@@ -4,13 +4,8 @@ from ..builder import ScopeBuilder, ScopeBuilderScopes
 
 
 class _ComputeScopeBuilder(ScopeBuilder):
-    """
-    The Compute service breaks the scopes/resource server convention: its resource
+    """The Compute service breaks the scopes/resource server convention: its resource
     server is a service name and its scopes are built around the client ID.
-
-    Given that there isn't a simple way to support this more generally (and we
-    shouldn't encourage supporting this more generally), this class serves to
-    build out the scopes specifically for Compute.
     """
 
     def __init__(

--- a/src/globus_sdk/services/compute/__init__.py
+++ b/src/globus_sdk/services/compute/__init__.py
@@ -1,0 +1,7 @@
+from .client import ComputeClient
+from .errors import ComputeAPIError
+
+__all__ = (
+    "ComputeAPIError",
+    "ComputeClient",
+)

--- a/src/globus_sdk/services/compute/client.py
+++ b/src/globus_sdk/services/compute/client.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import logging
+
+from globus_sdk import GlobusHTTPResponse, client
+from globus_sdk._types import UUIDLike
+from globus_sdk.scopes import ComputeScopes, Scope
+
+from .errors import ComputeAPIError
+
+log = logging.getLogger(__name__)
+
+
+class ComputeClient(client.BaseClient):
+    r"""
+    Client for the Globus Compute API.
+
+    .. automethodlist:: globus_sdk.ComputeClient
+    """
+
+    error_class = ComputeAPIError
+    service_name = "compute"
+    scopes = ComputeScopes
+    default_scope_requirements = [Scope(ComputeScopes.all)]
+
+    def get_function(self, function_id: UUIDLike) -> GlobusHTTPResponse:
+        """Get information about a registered function.
+
+        :param function_id: The ID of the function.
+
+        .. tab-set::
+
+            .. tab-item:: API Info
+
+                .. extdoclink:: Get Function
+                    :service: compute
+                    :ref: Functions/operation/get_function_v2_functions__function_uuid__get
+        """  # noqa: E501
+        return self.get(f"/v2/functions/{function_id}")

--- a/src/globus_sdk/services/compute/errors.py
+++ b/src/globus_sdk/services/compute/errors.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from globus_sdk.exc import GlobusAPIError
+
+
+class ComputeAPIError(GlobusAPIError):
+    pass

--- a/tests/functional/services/compute/conftest.py
+++ b/tests/functional/services/compute/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+
+import globus_sdk
+
+
+@pytest.fixture
+def compute_client(no_retry_transport):
+    class CustomComputeClient(globus_sdk.ComputeClient):
+        transport_class = no_retry_transport
+
+    return CustomComputeClient()

--- a/tests/functional/services/compute/test_get_function.py
+++ b/tests/functional/services/compute/test_get_function.py
@@ -1,0 +1,11 @@
+import globus_sdk
+from globus_sdk._testing import load_response
+
+
+def test_get_function(compute_client: globus_sdk.ComputeClient):
+    meta = load_response(compute_client.get_function).metadata
+    res = compute_client.get_function(function_id=meta["function_id"])
+    assert res.http_status == 200
+    assert res.data["function_uuid"] == meta["function_id"]
+    assert res.data["function_name"] == meta["function_name"]
+    assert res.data["function_code"] == meta["function_code"]

--- a/tests/unit/scopes/test_scope_builder.py
+++ b/tests/unit/scopes/test_scope_builder.py
@@ -1,6 +1,6 @@
 import uuid
 
-from globus_sdk.scopes import FlowsScopes, ScopeBuilder
+from globus_sdk.scopes import ComputeScopes, FlowsScopes, ScopeBuilder
 
 
 def test_url_scope_string():
@@ -93,6 +93,14 @@ def test_flows_scopes_creation():
     assert (
         FlowsScopes.run
         == "https://auth.globus.org/scopes/eec9b274-0c81-4334-bdc2-54e90e689b9a/run"
+    )
+
+
+def test_compute_scopes_creation():
+    assert ComputeScopes.resource_server == "funcx_service"
+    assert (
+        ComputeScopes.all
+        == "https://auth.globus.org/scopes/facd7ccc-c5f4-42aa-916b-a0e270e2c2a9/all"
     )
 
 


### PR DESCRIPTION
In the interest of limiting the scope of this PR, I've created a minimal `ComputeClient` class with a single `.get_function(...)` method to get information about registered functions from the Compute API. Additional methods will be added in subsequent PRs.

Similar to Flows, Compute requires a custom `ComputeScopesBuilder` class because its resource server is a service name and its scopes are built around the client ID.

<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1071.org.readthedocs.build/en/1071/

<!-- readthedocs-preview globus-sdk-python end -->