### PR TITLE
Enforce more lazy imports of `requests`

### DIFF
--- a/src/globus_sdk/login_flows/command_line_login_flow_manager.py
+++ b/src/globus_sdk/login_flows/command_line_login_flow_manager.py
@@ -3,12 +3,7 @@ from __future__ import annotations
 import textwrap
 import typing as t
 
-from globus_sdk import (
-    AuthLoginClient,
-    ConfidentialAppAuthClient,
-    GlobusSDKUsageError,
-    OAuthTokenResponse,
-)
+import globus_sdk
 from globus_sdk.gare import GlobusAuthorizationParameters
 from globus_sdk.utils import get_nice_hostname
 
@@ -40,7 +35,7 @@ class CommandLineLoginFlowManager(LoginFlowManager):
 
     def __init__(
         self,
-        login_client: AuthLoginClient,
+        login_client: globus_sdk.AuthLoginClient,
         *,
         redirect_uri: str | None = None,
         request_refresh_tokens: bool = False,
@@ -54,9 +49,9 @@ class CommandLineLoginFlowManager(LoginFlowManager):
 
         if redirect_uri is None:
             # Confidential clients must always define their own custom redirect URI.
-            if isinstance(login_client, ConfidentialAppAuthClient):
+            if isinstance(login_client, globus_sdk.ConfidentialAppAuthClient):
                 msg = "Use of a Confidential client requires an explicit redirect_uri."
-                raise GlobusSDKUsageError(msg)
+                raise globus_sdk.GlobusSDKUsageError(msg)
 
             # Native clients may infer the globus-provided helper page if omitted.
             redirect_uri = login_client.base_url + "v2/web/auth-code"
@@ -64,7 +59,10 @@ class CommandLineLoginFlowManager(LoginFlowManager):
 
     @classmethod
     def for_globus_app(
-        cls, app_name: str, login_client: AuthLoginClient, config: GlobusAppConfig
+        cls,
+        app_name: str,
+        login_client: globus_sdk.AuthLoginClient,
+        config: GlobusAppConfig,
     ) -> CommandLineLoginFlowManager:
         """
         Create a ``CommandLineLoginFlowManager`` for use in a GlobusApp.
@@ -91,7 +89,7 @@ class CommandLineLoginFlowManager(LoginFlowManager):
     def run_login_flow(
         self,
         auth_parameters: GlobusAuthorizationParameters,
-    ) -> OAuthTokenResponse:
+    ) -> globus_sdk.OAuthTokenResponse:
         """
         Run an interactive login flow on the command line to get tokens for the user.
 

--- a/src/globus_sdk/login_flows/local_server_login_flow_manager/local_server.py
+++ b/src/globus_sdk/login_flows/local_server_login_flow_manager/local_server.py
@@ -18,14 +18,13 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 from string import Template
 from urllib.parse import parse_qsl, urlparse
 
+from . import html_files
 from .errors import LocalServerLoginError
 
 if sys.version_info >= (3, 9):
     import importlib.resources as importlib_resources
 else:  # Python < 3.9
     import importlib_resources
-
-import globus_sdk.login_flows.local_server_login_flow_manager.html_files as html_files  # noqa: E501
 
 _IS_WINDOWS = os.name == "nt"
 

--- a/src/globus_sdk/login_flows/local_server_login_flow_manager/local_server_login_flow_manager.py
+++ b/src/globus_sdk/login_flows/local_server_login_flow_manager/local_server_login_flow_manager.py
@@ -7,12 +7,7 @@ import webbrowser
 from contextlib import contextmanager
 from string import Template
 
-from globus_sdk import (
-    AuthLoginClient,
-    GlobusSDKUsageError,
-    NativeAppAuthClient,
-    OAuthTokenResponse,
-)
+import globus_sdk
 from globus_sdk.gare import GlobusAuthorizationParameters
 from globus_sdk.login_flows.login_flow_manager import LoginFlowManager
 from globus_sdk.utils import get_nice_hostname
@@ -97,7 +92,7 @@ class LocalServerLoginFlowManager(LoginFlowManager):
 
     def __init__(
         self,
-        login_client: AuthLoginClient,
+        login_client: globus_sdk.AuthLoginClient,
         *,
         request_refresh_tokens: bool = False,
         native_prefill_named_grant: str | None = None,
@@ -114,7 +109,10 @@ class LocalServerLoginFlowManager(LoginFlowManager):
 
     @classmethod
     def for_globus_app(
-        cls, app_name: str, login_client: AuthLoginClient, config: GlobusAppConfig
+        cls,
+        app_name: str,
+        login_client: globus_sdk.AuthLoginClient,
+        config: GlobusAppConfig,
     ) -> LocalServerLoginFlowManager:
         """
         Create a ``LocalServerLoginFlowManager`` for use in a GlobusApp.
@@ -128,14 +126,14 @@ class LocalServerLoginFlowManager(LoginFlowManager):
             # A "local server" relies on the user being redirected back to the server
             # running on the local machine, so it can't use a custom redirect URI.
             msg = "Cannot define a custom redirect_uri for LocalServerLoginFlowManager."
-            raise GlobusSDKUsageError(msg)
-        if not isinstance(login_client, NativeAppAuthClient):
+            raise globus_sdk.GlobusSDKUsageError(msg)
+        if not isinstance(login_client, globus_sdk.NativeAppAuthClient):
             # Globus Auth has special provisions for native clients which allow implicit
             # redirect url grant to localhost:<any-port>. This is required for the
             # LocalServerLoginFlowManager to work and is not reproducible in
             # confidential clients.
             msg = "LocalServerLoginFlowManager is only supported for Native Apps."
-            raise GlobusSDKUsageError(msg)
+            raise globus_sdk.GlobusSDKUsageError(msg)
 
         hostname = get_nice_hostname()
         if hostname:
@@ -152,7 +150,7 @@ class LocalServerLoginFlowManager(LoginFlowManager):
     def run_login_flow(
         self,
         auth_parameters: GlobusAuthorizationParameters,
-    ) -> OAuthTokenResponse:
+    ) -> globus_sdk.OAuthTokenResponse:
         """
         Run an interactive login flow using a locally hosted server to get tokens
         for the user.

--- a/src/globus_sdk/login_flows/login_flow_manager.py
+++ b/src/globus_sdk/login_flows/login_flow_manager.py
@@ -29,9 +29,7 @@ class LoginFlowManager(metaclass=abc.ABCMeta):
         request_refresh_tokens: bool = False,
         native_prefill_named_grant: str | None = None,
     ) -> None:
-        if not isinstance(
-            login_client, globus_sdk.NativeAppAuthClient
-        ) and not isinstance(login_client, globus_sdk.ConfidentialAppAuthClient):
+        if not isinstance(login_client, (globus_sdk.NativeAppAuthClient, globus_sdk.ConfidentialAppAuthClient)):
             raise globus_sdk.GlobusSDKUsageError(
                 f"{type(self).__name__} requires a NativeAppAuthClient or "
                 f"ConfidentialAppAuthClient, but got a {type(login_client).__name__}."

--- a/src/globus_sdk/login_flows/login_flow_manager.py
+++ b/src/globus_sdk/login_flows/login_flow_manager.py
@@ -2,13 +2,7 @@ from __future__ import annotations
 
 import abc
 
-from globus_sdk import (
-    AuthLoginClient,
-    ConfidentialAppAuthClient,
-    GlobusSDKUsageError,
-    NativeAppAuthClient,
-    OAuthTokenResponse,
-)
+import globus_sdk
 from globus_sdk.gare import GlobusAuthorizationParameters
 
 
@@ -30,15 +24,15 @@ class LoginFlowManager(metaclass=abc.ABCMeta):
 
     def __init__(
         self,
-        login_client: AuthLoginClient,
+        login_client: globus_sdk.AuthLoginClient,
         *,
         request_refresh_tokens: bool = False,
         native_prefill_named_grant: str | None = None,
     ) -> None:
-        if not isinstance(login_client, NativeAppAuthClient) and not isinstance(
-            login_client, ConfidentialAppAuthClient
-        ):
-            raise GlobusSDKUsageError(
+        if not isinstance(
+            login_client, globus_sdk.NativeAppAuthClient
+        ) and not isinstance(login_client, globus_sdk.ConfidentialAppAuthClient):
+            raise globus_sdk.GlobusSDKUsageError(
                 f"{type(self).__name__} requires a NativeAppAuthClient or "
                 f"ConfidentialAppAuthClient, but got a {type(login_client).__name__}."
             )
@@ -76,14 +70,14 @@ class LoginFlowManager(metaclass=abc.ABCMeta):
         requested_scopes = auth_parameters.required_scopes
         # Native and Confidential App clients have different signatures for this method,
         # so they must be type checked & called independently.
-        if isinstance(login_client, NativeAppAuthClient):
+        if isinstance(login_client, globus_sdk.NativeAppAuthClient):
             login_client.oauth2_start_flow(
                 requested_scopes,
                 redirect_uri=redirect_uri,
                 refresh_tokens=self.request_refresh_tokens,
                 prefill_named_grant=self.native_prefill_named_grant,
             )
-        elif isinstance(login_client, ConfidentialAppAuthClient):
+        elif isinstance(login_client, globus_sdk.ConfidentialAppAuthClient):
             login_client.oauth2_start_flow(
                 redirect_uri,
                 requested_scopes,
@@ -94,7 +88,7 @@ class LoginFlowManager(metaclass=abc.ABCMeta):
     def run_login_flow(
         self,
         auth_parameters: GlobusAuthorizationParameters,
-    ) -> OAuthTokenResponse:
+    ) -> globus_sdk.OAuthTokenResponse:
         """
         Run a login flow to get tokens for a user.
 

--- a/src/globus_sdk/login_flows/login_flow_manager.py
+++ b/src/globus_sdk/login_flows/login_flow_manager.py
@@ -29,7 +29,10 @@ class LoginFlowManager(metaclass=abc.ABCMeta):
         request_refresh_tokens: bool = False,
         native_prefill_named_grant: str | None = None,
     ) -> None:
-        if not isinstance(login_client, (globus_sdk.NativeAppAuthClient, globus_sdk.ConfidentialAppAuthClient)):
+        if not isinstance(
+            login_client,
+            (globus_sdk.NativeAppAuthClient, globus_sdk.ConfidentialAppAuthClient),
+        ):
             raise globus_sdk.GlobusSDKUsageError(
                 f"{type(self).__name__} requires a NativeAppAuthClient or "
                 f"ConfidentialAppAuthClient, but got a {type(login_client).__name__}."

--- a/src/globus_sdk/response.py
+++ b/src/globus_sdk/response.py
@@ -5,13 +5,13 @@ import json
 import logging
 import typing as t
 
-from requests import Response
-
 from globus_sdk import _guards
 
 log = logging.getLogger(__name__)
 
 if t.TYPE_CHECKING:
+    from requests import Response
+
     import globus_sdk
 
 __all__ = (

--- a/src/globus_sdk/tokenstorage/v1/base.py
+++ b/src/globus_sdk/tokenstorage/v1/base.py
@@ -5,12 +5,12 @@ import contextlib
 import os
 import typing as t
 
-from globus_sdk.services.auth import OAuthTokenResponse
+import globus_sdk
 
 
 class StorageAdapter(metaclass=abc.ABCMeta):
     @abc.abstractmethod
-    def store(self, token_response: OAuthTokenResponse) -> None:
+    def store(self, token_response: globus_sdk.OAuthTokenResponse) -> None:
         """
         Store an `OAuthTokenResponse` in the underlying storage for this adapter.
 
@@ -30,7 +30,7 @@ class StorageAdapter(metaclass=abc.ABCMeta):
             token data to retriever from storage
         """
 
-    def on_refresh(self, token_response: OAuthTokenResponse) -> None:
+    def on_refresh(self, token_response: globus_sdk.OAuthTokenResponse) -> None:
         """
         By default, the on_refresh handler for a token storage adapter simply
         stores the token response.

--- a/src/globus_sdk/tokenstorage/v1/file_adapters.py
+++ b/src/globus_sdk/tokenstorage/v1/file_adapters.py
@@ -4,9 +4,10 @@ import json
 import pathlib
 import typing as t
 
-from globus_sdk.services.auth import OAuthTokenResponse
-from globus_sdk.tokenstorage.v1.base import FileAdapter
+import globus_sdk
 from globus_sdk.version import __version__
+
+from .base import FileAdapter
 
 # use the non-annotation form of TypedDict to apply a non-identifier key
 _JSONFileData_0 = t.TypedDict("_JSONFileData_0", {"globus-sdk.version": str})
@@ -103,7 +104,7 @@ class SimpleJSONFileAdapter(FileAdapter):
             }
         return self._handle_formats(data)
 
-    def store(self, token_response: OAuthTokenResponse) -> None:
+    def store(self, token_response: globus_sdk.OAuthTokenResponse) -> None:
         """
         By default, ``self.on_refresh`` is just an alias for this function.
 

--- a/src/globus_sdk/tokenstorage/v1/memory_adapter.py
+++ b/src/globus_sdk/tokenstorage/v1/memory_adapter.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import typing as t
 
-from globus_sdk.services.auth import OAuthTokenResponse
-from globus_sdk.tokenstorage.v1.base import StorageAdapter
+import globus_sdk
+
+from .base import StorageAdapter
 
 
 class MemoryAdapter(StorageAdapter):
@@ -16,7 +17,7 @@ class MemoryAdapter(StorageAdapter):
     def __init__(self) -> None:
         self._tokens: dict[str, dict[str, t.Any]] = {}
 
-    def store(self, token_response: OAuthTokenResponse) -> None:
+    def store(self, token_response: globus_sdk.OAuthTokenResponse) -> None:
         self._tokens.update(token_response.by_resource_server)
 
     def get_token_data(self, resource_server: str) -> dict[str, t.Any] | None:

--- a/src/globus_sdk/tokenstorage/v1/sqlite_adapter.py
+++ b/src/globus_sdk/tokenstorage/v1/sqlite_adapter.py
@@ -5,9 +5,10 @@ import pathlib
 import sqlite3
 import typing as t
 
-from globus_sdk.services.auth import OAuthTokenResponse
-from globus_sdk.tokenstorage.v1.base import FileAdapter
+import globus_sdk
 from globus_sdk.version import __version__
+
+from .base import FileAdapter
 
 
 class SQLiteAdapter(FileAdapter):
@@ -164,7 +165,7 @@ CREATE TABLE sdk_storage_adapter_internal (
         self._connection.commit()
         return rowcount != 0
 
-    def store(self, token_response: OAuthTokenResponse) -> None:
+    def store(self, token_response: globus_sdk.OAuthTokenResponse) -> None:
         """
         :param token_response: a globus_sdk.OAuthTokenResponse object containing token
                                data to store

--- a/src/globus_sdk/tokenstorage/v2/base.py
+++ b/src/globus_sdk/tokenstorage/v2/base.py
@@ -8,9 +8,8 @@ import re
 import sys
 import typing as t
 
-from globus_sdk import GlobusSDKUsageError
+import globus_sdk
 from globus_sdk._types import UUIDLike
-from globus_sdk.services.auth import OAuthDependentTokenResponse, OAuthTokenResponse
 
 from .token_data import TokenStorageData
 
@@ -68,7 +67,9 @@ class TokenStorage(metaclass=abc.ABCMeta):
         :returns: True if token data was deleted, False if none was found to delete.
         """
 
-    def store_token_response(self, token_response: OAuthTokenResponse) -> None:
+    def store_token_response(
+        self, token_response: globus_sdk.OAuthTokenResponse
+    ) -> None:
         """
         Store token data from an :class:`OAuthTokenResponse` in the current namespace.
 
@@ -90,7 +91,9 @@ class TokenStorage(metaclass=abc.ABCMeta):
             )
         self.store_token_data_by_resource_server(token_data_by_resource_server)
 
-    def _extract_identity_id(self, token_response: OAuthTokenResponse) -> str | None:
+    def _extract_identity_id(
+        self, token_response: globus_sdk.OAuthTokenResponse
+    ) -> str | None:
         """
         Get identity_id from id_token if available.
 
@@ -105,7 +108,7 @@ class TokenStorage(metaclass=abc.ABCMeta):
         """
         # dependent token responses cannot contain an `id_token` field, as the
         # top-level data is an array
-        if isinstance(token_response, OAuthDependentTokenResponse):
+        if isinstance(token_response, globus_sdk.OAuthDependentTokenResponse):
             return None
 
         if token_response.get("id_token"):
@@ -268,10 +271,10 @@ def _slugify_app_name(app_name: str) -> str:
             f'App name results in a reserved filename ("{app_name}"). '
             "Please choose a different name."
         )
-        raise GlobusSDKUsageError(msg)
+        raise globus_sdk.GlobusSDKUsageError(msg)
 
     if not app_name:
         msg = "App name results in the empty string. Please choose a different name."
-        raise GlobusSDKUsageError(msg)
+        raise globus_sdk.GlobusSDKUsageError(msg)
 
     return app_name

--- a/tests/non-pytest/lazy-imports/test_modules_do_not_require_requests.py
+++ b/tests/non-pytest/lazy-imports/test_modules_do_not_require_requests.py
@@ -17,17 +17,26 @@ PYTHON_BINARY = os.environ.get("GLOBUS_TEST_PY", sys.executable)
 @pytest.mark.parametrize(
     "module_name",
     (
-        # experimental modules
-        "experimental",
-        "experimental.scope_parser",
-        # parts which are expected to be standalone
-        "scopes",
-        "gare",
+        # most of the SDK should not pull in 'requests', making the parts which do
+        # not handle request sending easy to use without the perf penalty from
+        # requests/urllib3
+        "authorizers",
         "config",
+        "gare",
+        "local_endpoint",
+        "login_flows",
+        "paging",
+        "response",
+        "scopes",
+        "tokenstorage",
         # the top-level of the 'exc' subpackage (but not necessarily its contents)
+        # should similarly be standalone, for exception handlers
         "exc",
-        # internal bits and bobs
+        # internal components and utilities are a special case:
+        # failing to ensure that these avoid 'requests' can make it more difficult
+        # to ensure that the main parts (above) do not transitively pick it up
         "_guards",
+        "_serializable",
         "_types",
         "utils",
         "version",


### PR DESCRIPTION
The benefits of this change are twofold:

- it ensures that the lazy import semantics provided by the SDK's
  top-level `__init__` are preserved when a greater variety of symbols
  are imported from it

- it pushes for a more uniform import style, in which the SDK itself
  demonstrates the best practice of importing the package and then
  accessing its members -- this avoids eagerly doing an import when a
  module is loaded and is especially valuable when modules only need
  an SDK symbol for type annotations

The change was made first by expanding and reorganizing the list of
modules which are tested for lazy imports, and then making any
necessary src/ changes to satisfy the test.


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1072.org.readthedocs.build/en/1072/

<!-- readthedocs-preview globus-sdk-python end -->