### PR TITLE
Fix prefill_named_grant when set via GlobusApp

### DIFF
--- a/changelog.d/20241004_164201_sirosen_fix_prefill_named_grant.rst
+++ b/changelog.d/20241004_164201_sirosen_fix_prefill_named_grant.rst
@@ -1,0 +1,6 @@
+Fixed
+~~~~~
+
+- ``LoginFlowManager``\s built with ``GlobusApp`` now generate a more
+  appropriate value for ``prefill_named_grant``, using the current
+  hostname if possible. (:pr:`NUMBER`)

--- a/src/globus_sdk/login_flows/command_line_login_flow_manager.py
+++ b/src/globus_sdk/login_flows/command_line_login_flow_manager.py
@@ -10,6 +10,7 @@ from globus_sdk import (
     OAuthTokenResponse,
 )
 from globus_sdk.gare import GlobusAuthorizationParameters
+from globus_sdk.utils import get_nice_hostname
 
 from .login_flow_manager import LoginFlowManager
 
@@ -74,11 +75,17 @@ class CommandLineLoginFlowManager(LoginFlowManager):
         :raises GlobusSDKUsageError: if login_redirect_uri is not set on the config
             but a ConfidentialAppAuthClient is supplied.
         """
+        hostname = get_nice_hostname()
+        if hostname:
+            prefill = f"{app_name} on {hostname}"
+        else:
+            prefill = app_name
+
         return cls(
             login_client,
             redirect_uri=config.login_redirect_uri,
             request_refresh_tokens=config.request_refresh_tokens,
-            native_prefill_named_grant=app_name,
+            native_prefill_named_grant=prefill,
         )
 
     def run_login_flow(

--- a/src/globus_sdk/login_flows/local_server_login_flow_manager/local_server_login_flow_manager.py
+++ b/src/globus_sdk/login_flows/local_server_login_flow_manager/local_server_login_flow_manager.py
@@ -15,6 +15,7 @@ from globus_sdk import (
 )
 from globus_sdk.gare import GlobusAuthorizationParameters
 from globus_sdk.login_flows.login_flow_manager import LoginFlowManager
+from globus_sdk.utils import get_nice_hostname
 
 from .errors import LocalServerEnvironmentalLoginError, LocalServerLoginError
 from .local_server import DEFAULT_HTML_TEMPLATE, RedirectHandler, RedirectHTTPServer
@@ -136,10 +137,16 @@ class LocalServerLoginFlowManager(LoginFlowManager):
             msg = "LocalServerLoginFlowManager is only supported for Native Apps."
             raise GlobusSDKUsageError(msg)
 
+        hostname = get_nice_hostname()
+        if hostname:
+            prefill = f"{app_name} on {hostname}"
+        else:
+            prefill = app_name
+
         return cls(
             login_client,
             request_refresh_tokens=config.request_refresh_tokens,
-            native_prefill_named_grant=app_name,
+            native_prefill_named_grant=prefill,
         )
 
     def run_login_flow(

--- a/src/globus_sdk/utils.py
+++ b/src/globus_sdk/utils.py
@@ -4,6 +4,7 @@ import collections
 import collections.abc
 import hashlib
 import os
+import platform
 import sys
 import typing as t
 import uuid
@@ -68,6 +69,21 @@ def sha256_string(s: str) -> str:
 
 def b64str(s: str) -> str:
     return b64encode(s.encode("utf-8")).decode("utf-8")
+
+
+def get_nice_hostname() -> str | None:
+    """
+    Get the current hostname, with the following added behavior:
+
+    - if it ends in '.local', strip that suffix, as this is a frequent macOS behavior
+      'DereksCoolMacbook.local' -> 'DereksCoolMacbook'
+
+    - if the hostname is undiscoverable, return None
+    """
+    name = platform.node()
+    if name.endswith(".local"):
+        return name[: -len(".local")]
+    return name or None
 
 
 def slash_join(a: str, b: str | None) -> str:

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -27,6 +27,25 @@ def test_sha256string():
 
 
 @pytest.mark.parametrize(
+    "platform_value, result",
+    (
+        # platform.node() can return '' when it doesn't know the hostname
+        # turn this into None
+        pytest.param("", None, id="empty-is-none"),
+        # macOS adds '.local' to the user's chosen machine name
+        pytest.param(
+            "VeryCoolMacbook.local", "VeryCoolMacbook", id="remove-local-suffix"
+        ),
+        # the "boring" case is when we do no extra work
+        pytest.param("linux-workstation", "linux-workstation", id="boring"),
+    ),
+)
+def test_get_nice_hostname(platform_value, result, monkeypatch):
+    monkeypatch.setattr("platform.node", lambda: platform_value)
+    assert utils.get_nice_hostname() == result
+
+
+@pytest.mark.parametrize(
     "a, b",
     [(a, b) for a in ["a", "a/"] for b in ["b", "/b"]]
     + [("a/b", c) for c in ["", None]],  # type: ignore


### PR DESCRIPTION
This uses a "nice" format of `<app> on <host>`. e.g.,

    sample-script on porgy-and-bess

Where `app_name="sample-script"` and the hostname is
`"porgy-and-bess"`.


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1075.org.readthedocs.build/en/1075/

<!-- readthedocs-preview globus-sdk-python end -->