### PR TITLE
Add ComputeClient methods to manage functions

### DIFF
--- a/changelog.d/20241008_214456_30907815+rjmello_compute_client_function_methods.rst
+++ b/changelog.d/20241008_214456_30907815+rjmello_compute_client_function_methods.rst
@@ -1,0 +1,8 @@
+Added
+~~~~~
+
+- Added ``ComputeClient.register_function()`` and ``ComputeClient.delete_function()``
+  methods. (:pr:`NUMBER`)
+
+- Added ``ComputeFunctionDocument`` and ``ComputeFunctionMetadata`` data classes for
+  use with the ``ComputeClient.register_function()`` method. (:pr:`NUMBER`)

--- a/docs/services/compute.rst
+++ b/docs/services/compute.rst
@@ -14,6 +14,17 @@ Globus Compute
         ..  listknownscopes:: globus_sdk.scopes.ComputeScopes
             :base_name: ComputeClient.scopes
 
+Helper Objects
+--------------
+
+.. autoclass:: ComputeFunctionDocument
+   :members:
+   :show-inheritance:
+
+.. autoclass:: ComputeFunctionMetadata
+   :members:
+   :show-inheritance:
+
 Client Errors
 -------------
 

--- a/src/globus_sdk/__init__.py
+++ b/src/globus_sdk/__init__.py
@@ -71,6 +71,8 @@ _LAZY_IMPORT_TABLE = {
     "services.compute": {
         "ComputeClient",
         "ComputeAPIError",
+        "ComputeFunctionDocument",
+        "ComputeFunctionMetadata",
     },
     "services.gcs": {
         "CollectionDocument",
@@ -198,6 +200,8 @@ if t.TYPE_CHECKING:
     from .services.auth import DependentScopeSpec
     from .services.compute import ComputeClient
     from .services.compute import ComputeAPIError
+    from .services.compute import ComputeFunctionDocument
+    from .services.compute import ComputeFunctionMetadata
     from .services.gcs import CollectionDocument
     from .services.gcs import GCSAPIError
     from .services.gcs import GCSClient
@@ -316,6 +320,8 @@ __all__ = (
     "CollectionPolicies",
     "ComputeAPIError",
     "ComputeClient",
+    "ComputeFunctionDocument",
+    "ComputeFunctionMetadata",
     "ConfidentialAppAuthClient",
     "ConnectorTable",
     "DeleteData",

--- a/src/globus_sdk/_generate_init.py
+++ b/src/globus_sdk/_generate_init.py
@@ -136,6 +136,8 @@ _LAZY_IMPORT_TABLE: list[tuple[str, tuple[str, ...]]] = [
         (
             "ComputeClient",
             "ComputeAPIError",
+            "ComputeFunctionDocument",
+            "ComputeFunctionMetadata",
         ),
     ),
     (

--- a/src/globus_sdk/_testing/data/compute/delete_function.py
+++ b/src/globus_sdk/_testing/data/compute/delete_function.py
@@ -1,0 +1,13 @@
+from globus_sdk._testing.models import RegisteredResponse, ResponseSet
+
+from ._common import FUNCTION_ID
+
+RESPONSES = ResponseSet(
+    metadata={"function_id": FUNCTION_ID},
+    default=RegisteredResponse(
+        service="compute",
+        path=f"/v2/functions/{FUNCTION_ID}",
+        method="DELETE",
+        json={"result": 302},
+    ),
+)

--- a/src/globus_sdk/_testing/data/compute/register_function.py
+++ b/src/globus_sdk/_testing/data/compute/register_function.py
@@ -2,14 +2,6 @@ from globus_sdk._testing.models import RegisteredResponse, ResponseSet
 
 from ._common import FUNCTION_CODE, FUNCTION_ID, FUNCTION_NAME
 
-FUNCTION_DOC = {
-    "function_uuid": FUNCTION_ID,
-    "function_name": FUNCTION_NAME,
-    "function_code": FUNCTION_CODE,
-    "description": "I just wanted to say hello.",
-    "metadata": {"python_version": "3.12.6", "sdk_version": "2.28.1"},
-}
-
 RESPONSES = ResponseSet(
     metadata={
         "function_id": FUNCTION_ID,
@@ -18,8 +10,8 @@ RESPONSES = ResponseSet(
     },
     default=RegisteredResponse(
         service="compute",
-        path=f"/v2/functions/{FUNCTION_ID}",
-        method="GET",
-        json=FUNCTION_DOC,
+        path="/v2/functions",
+        method="POST",
+        json={"function_uuid": FUNCTION_ID},
     ),
 )

--- a/src/globus_sdk/services/compute/__init__.py
+++ b/src/globus_sdk/services/compute/__init__.py
@@ -1,7 +1,10 @@
 from .client import ComputeClient
+from .data import ComputeFunctionDocument, ComputeFunctionMetadata
 from .errors import ComputeAPIError
 
 __all__ = (
     "ComputeAPIError",
     "ComputeClient",
+    "ComputeFunctionDocument",
+    "ComputeFunctionMetadata",
 )

--- a/src/globus_sdk/services/compute/client.py
+++ b/src/globus_sdk/services/compute/client.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import logging
+import typing as t
 
 from globus_sdk import GlobusHTTPResponse, client
 from globus_sdk._types import UUIDLike
 from globus_sdk.scopes import ComputeScopes, Scope
 
+from .data import ComputeFunctionDocument
 from .errors import ComputeAPIError
 
 log = logging.getLogger(__name__)
@@ -23,6 +25,24 @@ class ComputeClient(client.BaseClient):
     scopes = ComputeScopes
     default_scope_requirements = [Scope(ComputeScopes.all)]
 
+    def register_function(
+        self,
+        function_data: ComputeFunctionDocument | dict[str, t.Any],
+    ) -> GlobusHTTPResponse:
+        """Register a new function.
+
+        :param function_data: A function registration document.
+
+        .. tab-set::
+
+            .. tab-item:: API Info
+
+                .. extdoclink:: Register Function
+                    :service: compute
+                    :ref: Functions/operation/register_function_v2_functions_post
+        """  # noqa: E501
+        return self.post("/v2/functions", data=function_data)
+
     def get_function(self, function_id: UUIDLike) -> GlobusHTTPResponse:
         """Get information about a registered function.
 
@@ -37,3 +57,18 @@ class ComputeClient(client.BaseClient):
                     :ref: Functions/operation/get_function_v2_functions__function_uuid__get
         """  # noqa: E501
         return self.get(f"/v2/functions/{function_id}")
+
+    def delete_function(self, function_id: UUIDLike) -> GlobusHTTPResponse:
+        """Delete a registered function.
+
+        :param function_id: The ID of the function.
+
+        .. tab-set::
+
+            .. tab-item:: API Info
+
+                .. extdoclink:: Delete Function
+                    :service: compute
+                    :ref: Functions/operation/delete_function_v2_functions__function_uuid__delete
+        """  # noqa: E501
+        return self.delete(f"/v2/functions/{function_id}")

--- a/src/globus_sdk/services/compute/data.py
+++ b/src/globus_sdk/services/compute/data.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from globus_sdk import utils
+from globus_sdk._types import UUIDLike
+from globus_sdk.utils import MISSING, MissingType
+
+
+class ComputeFunctionMetadata(utils.PayloadWrapper):
+    """A wrapper for function metadata.
+
+    :param python_version: The Python version used to serialize the function.
+    :param sdk_version: The Globus Compute SDK version used to serialize the function.
+    """
+
+    def __init__(
+        self,
+        *,
+        python_version: str | MissingType = MISSING,
+        sdk_version: str | MissingType = MISSING,
+    ):
+        super().__init__()
+        self["python_version"] = python_version
+        self["sdk_version"] = sdk_version
+
+
+class ComputeFunctionDocument(utils.PayloadWrapper):
+    """A function registration document.
+
+    :param function_name: The name of the function.
+    :param function_code: The serialized function source code.
+    :param description: The description of the function.
+    :param metadata: The metadata of the function.
+    :param group: Restrict function access to members of this Globus group.
+    :param public: Indicates whether the function is public.
+    """
+
+    def __init__(
+        self,
+        *,
+        function_name: str,
+        function_code: str,
+        description: str | MissingType = MISSING,
+        metadata: ComputeFunctionMetadata | MissingType = MISSING,
+        group: UUIDLike | MissingType = MISSING,
+        public: bool = False,
+    ):
+        super().__init__()
+        self["function_name"] = function_name
+        self["function_code"] = function_code
+        self["description"] = description
+        self["metadata"] = metadata
+        self["group"] = group
+        self["public"] = public

--- a/tests/functional/services/compute/test_delete_function.py
+++ b/tests/functional/services/compute/test_delete_function.py
@@ -1,0 +1,9 @@
+import globus_sdk
+from globus_sdk._testing import load_response
+
+
+def test_delete_function(compute_client: globus_sdk.ComputeClient):
+    meta = load_response(compute_client.delete_function).metadata
+    res = compute_client.delete_function(function_id=meta["function_id"])
+    assert res.http_status == 200
+    assert res.data == {"result": 302}

--- a/tests/functional/services/compute/test_register_function.py
+++ b/tests/functional/services/compute/test_register_function.py
@@ -1,0 +1,13 @@
+import globus_sdk
+from globus_sdk._testing import load_response
+from globus_sdk.services.compute import ComputeFunctionDocument
+
+
+def test_register_function(compute_client: globus_sdk.ComputeClient):
+    meta = load_response(compute_client.register_function).metadata
+    function_doc = ComputeFunctionDocument(
+        function_name=meta["function_name"], function_code=meta["function_code"]
+    )
+    res = compute_client.register_function(function_doc)
+    assert res.http_status == 200
+    assert res.data["function_uuid"] == meta["function_id"]


### PR DESCRIPTION
Add `.register_function()` and `.delete_function()` methods to the `ComputeClient` class.

<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1078.org.readthedocs.build/en/1078/

<!-- readthedocs-preview globus-sdk-python end -->