### PR TITLE
Support `version` field in `SearchClient.post_search()`

### DIFF
--- a/changelog.d/20241011_113822_8730430+m1yag1_sc_35200_version_field_post_search.rst
+++ b/changelog.d/20241011_113822_8730430+m1yag1_sc_35200_version_field_post_search.rst
@@ -1,0 +1,6 @@
+Development
+~~~~~~~~~~~
+
+- ``SearchQueryV1`` is a new class for submitting complex queries replacing
+the legacy ``SearchQuery`` class. A deprecation warning has been added to the
+``SearchQuery`` class. (:pr:`1079`)

--- a/changelog.d/20241011_113822_8730430+m1yag1_sc_35200_version_field_post_search.rst
+++ b/changelog.d/20241011_113822_8730430+m1yag1_sc_35200_version_field_post_search.rst
@@ -1,5 +1,5 @@
-Development
-~~~~~~~~~~~
+Added
+~~~~~
 
 - ``SearchQueryV1`` is a new class for submitting complex queries replacing
 the legacy ``SearchQuery`` class. A deprecation warning has been added to the

--- a/changelog.d/20241011_113822_8730430+m1yag1_sc_35200_version_field_post_search.rst
+++ b/changelog.d/20241011_113822_8730430+m1yag1_sc_35200_version_field_post_search.rst
@@ -2,5 +2,5 @@ Added
 ~~~~~
 
 - ``SearchQueryV1`` is a new class for submitting complex queries replacing
-the legacy ``SearchQuery`` class. A deprecation warning has been added to the
-``SearchQuery`` class. (:pr:`1079`)
+  the legacy ``SearchQuery`` class. A deprecation warning has been added to the
+  ``SearchQuery`` class. (:pr:`1079`)

--- a/docs/services/search.rst
+++ b/docs/services/search.rst
@@ -25,6 +25,10 @@ only to document the methods it provides to its subclasses.
    :members:
    :show-inheritance:
 
+.. autoclass:: SearchQueryV1
+    :members:
+    :show-inheritance:
+
 .. autoclass:: SearchScrollQuery
    :members:
    :show-inheritance:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ testpaths = ["tests"]
 norecursedirs = ["tests/non-pytest"]
 filterwarnings = [
     "error",
+    "ignore:'SearchQuery'*:DeprecationWarning",
 ]
 
 [tool.scriv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,6 @@ testpaths = ["tests"]
 norecursedirs = ["tests/non-pytest"]
 filterwarnings = [
     "error",
-    "ignore:'SearchQuery'*:DeprecationWarning",
 ]
 
 [tool.scriv]

--- a/src/globus_sdk/__init__.py
+++ b/src/globus_sdk/__init__.py
@@ -126,6 +126,7 @@ _LAZY_IMPORT_TABLE = {
         "SearchAPIError",
         "SearchClient",
         "SearchQuery",
+        "SearchQueryV1",
         "SearchScrollQuery",
     },
     "services.timers": {
@@ -245,6 +246,7 @@ if t.TYPE_CHECKING:
     from .services.search import SearchAPIError
     from .services.search import SearchClient
     from .services.search import SearchQuery
+    from .services.search import SearchQueryV1
     from .services.search import SearchScrollQuery
     from .services.timers import TimersAPIError
     from .services.timers import TimersClient
@@ -386,6 +388,7 @@ __all__ = (
     "SearchAPIError",
     "SearchClient",
     "SearchQuery",
+    "SearchQueryV1",
     "SearchScrollQuery",
     "SpecificFlowClient",
     "StorageGatewayDocument",

--- a/src/globus_sdk/_generate_init.py
+++ b/src/globus_sdk/_generate_init.py
@@ -202,7 +202,9 @@ _LAZY_IMPORT_TABLE: list[tuple[str, tuple[str, ...]]] = [
         (
             "SearchAPIError",
             "SearchClient",
+            # legacy class (remove in the future)
             "SearchQuery",
+            "SearchQueryV1",
             "SearchScrollQuery",
         ),
     ),

--- a/src/globus_sdk/services/search/__init__.py
+++ b/src/globus_sdk/services/search/__init__.py
@@ -1,5 +1,11 @@
 from .client import SearchClient
-from .data import SearchQuery, SearchScrollQuery
+from .data import SearchQuery, SearchQueryV1, SearchScrollQuery
 from .errors import SearchAPIError
 
-__all__ = ("SearchClient", "SearchQuery", "SearchScrollQuery", "SearchAPIError")
+__all__ = (
+    "SearchClient",
+    "SearchQuery",
+    "SearchQueryV1",
+    "SearchScrollQuery",
+    "SearchAPIError",
+)

--- a/src/globus_sdk/services/search/data.py
+++ b/src/globus_sdk/services/search/data.py
@@ -115,9 +115,7 @@ class SearchQuery(SearchQueryBase):
         additional_fields: dict[str, t.Any] | None = None,
     ):
         super().__init__()
-        exc.warn_deprecated(
-            "'SearchQuery' is a deprecated name. Use 'SearchQueryV1' instead."
-        )
+        exc.warn_deprecated("'SearchQuery' is deprecated. Use 'SearchQueryV1' instead.")
         if q is not None:
             self["q"] = q
         if limit is not None:
@@ -240,12 +238,17 @@ class SearchQueryV1(utils.PayloadWrapper):
 
     def __init__(
         self,
-        q: str | None = None,
         *,
+        q: str | None = None,
         limit: int | None = None,
         offset: int | None = None,
         advanced: bool | None = None,
         additional_fields: dict[str, t.Any] | None = None,
+        filters: list[dict[str, t.Any]] | utils.MissingType = utils.MISSING,
+        facets: list[dict[str, t.Any]] | utils.MissingType = utils.MISSING,
+        post_facet_filters: list[dict[str, t.Any]] | utils.MissingType = utils.MISSING,
+        boosts: list[dict[str, t.Any]] | utils.MissingType = utils.MISSING,
+        sorts: list[dict[str, t.Any]] | utils.MissingType = utils.MISSING,
     ):
         super().__init__()
         self["@version"] = "query#1.0.0"
@@ -260,11 +263,11 @@ class SearchQueryV1(utils.PayloadWrapper):
         if additional_fields is not None:
             self.update(additional_fields)
 
-        self["filters"] = []
-        self["facets"] = []
-        self["post_facet_filters"] = []
-        self["boosts"] = []
-        self["sorts"] = []
+        self["filters"] = filters
+        self["facets"] = facets
+        self["post_facet_filters"] = post_facet_filters
+        self["boosts"] = boosts
+        self["sorts"] = sorts
 
 
 class SearchScrollQuery(SearchQueryBase):

--- a/src/globus_sdk/services/search/data.py
+++ b/src/globus_sdk/services/search/data.py
@@ -238,6 +238,7 @@ class SearchQueryV1(utils.PayloadWrapper):
     :param post_facet_filters: a list of filters to apply after facet
         results are returned
     :param boosts: a list of boosts to apply to the query
+    :param sort: a list of fields to sort results
     :param additional_fields: additional data to include in the query document
     """
 

--- a/src/globus_sdk/services/search/data.py
+++ b/src/globus_sdk/services/search/data.py
@@ -233,6 +233,11 @@ class SearchQueryV1(utils.PayloadWrapper):
     :param advanced: Whether to enable (``True``) or not to enable (``False``) advanced
         parsing of query strings. The default of ``False`` is robust and guarantees that
         the query will not error with "bad query string" errors
+    :param filters: a list of filters to apply to the query
+    :param facets: a list of facets to apply to the query
+    :param post_facet_filters: a list of filters to apply after facet
+        results are returned
+    :param boosts: a list of boosts to apply to the query
     :param additional_fields: additional data to include in the query document
     """
 
@@ -243,12 +248,12 @@ class SearchQueryV1(utils.PayloadWrapper):
         limit: int | utils.MissingType = utils.MISSING,
         offset: int | utils.MissingType = utils.MISSING,
         advanced: bool | utils.MissingType = utils.MISSING,
-        additional_fields: dict[str, t.Any] | utils.MissingType = utils.MISSING,
         filters: list[dict[str, t.Any]] | utils.MissingType = utils.MISSING,
         facets: list[dict[str, t.Any]] | utils.MissingType = utils.MISSING,
         post_facet_filters: list[dict[str, t.Any]] | utils.MissingType = utils.MISSING,
         boosts: list[dict[str, t.Any]] | utils.MissingType = utils.MISSING,
         sorts: list[dict[str, t.Any]] | utils.MissingType = utils.MISSING,
+        additional_fields: dict[str, t.Any] | utils.MissingType = utils.MISSING,
     ):
         super().__init__()
         self["@version"] = "query#1.0.0"

--- a/src/globus_sdk/services/search/data.py
+++ b/src/globus_sdk/services/search/data.py
@@ -239,11 +239,11 @@ class SearchQueryV1(utils.PayloadWrapper):
     def __init__(
         self,
         *,
-        q: str | None = None,
-        limit: int | None = None,
-        offset: int | None = None,
-        advanced: bool | None = None,
-        additional_fields: dict[str, t.Any] | None = None,
+        q: str | utils.MissingType = utils.MISSING,
+        limit: int | utils.MissingType = utils.MISSING,
+        offset: int | utils.MissingType = utils.MISSING,
+        advanced: bool | utils.MissingType = utils.MISSING,
+        additional_fields: dict[str, t.Any] | utils.MissingType = utils.MISSING,
         filters: list[dict[str, t.Any]] | utils.MissingType = utils.MISSING,
         facets: list[dict[str, t.Any]] | utils.MissingType = utils.MISSING,
         post_facet_filters: list[dict[str, t.Any]] | utils.MissingType = utils.MISSING,
@@ -252,15 +252,15 @@ class SearchQueryV1(utils.PayloadWrapper):
     ):
         super().__init__()
         self["@version"] = "query#1.0.0"
-        if q is not None:
+        if q is not utils.MISSING:
             self["q"] = q
-        if limit is not None:
+        if limit is not utils.MISSING:
             self["limit"] = limit
-        if offset is not None:
+        if offset is not utils.MISSING:
             self["offset"] = offset
-        if advanced is not None:
+        if advanced is not utils.MISSING:
             self["advanced"] = advanced
-        if additional_fields is not None:
+        if additional_fields is not utils.MISSING:
             self.update(additional_fields)
 
         self["filters"] = filters

--- a/src/globus_sdk/services/search/data.py
+++ b/src/globus_sdk/services/search/data.py
@@ -252,7 +252,7 @@ class SearchQueryV1(utils.PayloadWrapper):
         facets: list[dict[str, t.Any]] | utils.MissingType = utils.MISSING,
         post_facet_filters: list[dict[str, t.Any]] | utils.MissingType = utils.MISSING,
         boosts: list[dict[str, t.Any]] | utils.MissingType = utils.MISSING,
-        sorts: list[dict[str, t.Any]] | utils.MissingType = utils.MISSING,
+        sort: list[dict[str, t.Any]] | utils.MissingType = utils.MISSING,
         additional_fields: dict[str, t.Any] | utils.MissingType = utils.MISSING,
     ):
         super().__init__()
@@ -266,7 +266,7 @@ class SearchQueryV1(utils.PayloadWrapper):
         self["facets"] = facets
         self["post_facet_filters"] = post_facet_filters
         self["boosts"] = boosts
-        self["sorts"] = sorts
+        self["sort"] = sort
 
         if not isinstance(additional_fields, utils.MissingType):
             self.update(additional_fields)

--- a/src/globus_sdk/services/search/data.py
+++ b/src/globus_sdk/services/search/data.py
@@ -252,22 +252,19 @@ class SearchQueryV1(utils.PayloadWrapper):
     ):
         super().__init__()
         self["@version"] = "query#1.0.0"
-        if q is not utils.MISSING:
-            self["q"] = q
-        if limit is not utils.MISSING:
-            self["limit"] = limit
-        if offset is not utils.MISSING:
-            self["offset"] = offset
-        if advanced is not utils.MISSING:
-            self["advanced"] = advanced
-        if additional_fields is not utils.MISSING:
-            self.update(additional_fields)
 
+        self["q"] = q
+        self["limit"] = limit
+        self["offset"] = offset
+        self["advanced"] = advanced
         self["filters"] = filters
         self["facets"] = facets
         self["post_facet_filters"] = post_facet_filters
         self["boosts"] = boosts
         self["sorts"] = sorts
+
+        if not isinstance(additional_fields, utils.MissingType):
+            self.update(additional_fields)
 
 
 class SearchScrollQuery(SearchQueryBase):

--- a/src/globus_sdk/services/search/data.py
+++ b/src/globus_sdk/services/search/data.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import typing as t
 
-from globus_sdk import utils
+from globus_sdk import exc, utils
 
 # workaround for absence of Self type
 # for the workaround and some background, see:
@@ -115,6 +115,9 @@ class SearchQuery(SearchQueryBase):
         additional_fields: dict[str, t.Any] | None = None,
     ):
         super().__init__()
+        exc.warn_deprecated(
+            "'SearchQuery' is a deprecated name. Use 'SearchQueryV1' instead."
+        )
         if q is not None:
             self["q"] = q
         if limit is not None:
@@ -219,6 +222,49 @@ class SearchQuery(SearchQueryBase):
             sort["order"] = order
         self["sort"].append(sort)
         return self
+
+
+class SearchQueryV1(utils.PayloadWrapper):
+    """
+    A specialized dict which has helpers for creating and modifying a Search
+    Query document. Replaces the usage of ``SearchQuery``.
+
+    :param q: The query string. Required unless filters are used.
+    :param limit: A limit on the number of results returned in a single page
+    :param offset: An offset into the set of all results for the query
+    :param advanced: Whether to enable (``True``) or not to enable (``False``) advanced
+        parsing of query strings. The default of ``False`` is robust and guarantees that
+        the query will not error with "bad query string" errors
+    :param additional_fields: additional data to include in the query document
+    """
+
+    def __init__(
+        self,
+        q: str | None = None,
+        *,
+        limit: int | None = None,
+        offset: int | None = None,
+        advanced: bool | None = None,
+        additional_fields: dict[str, t.Any] | None = None,
+    ):
+        super().__init__()
+        self["@version"] = "query#1.0.0"
+        if q is not None:
+            self["q"] = q
+        if limit is not None:
+            self["limit"] = limit
+        if offset is not None:
+            self["offset"] = offset
+        if advanced is not None:
+            self["advanced"] = advanced
+        if additional_fields is not None:
+            self.update(additional_fields)
+
+        self["filters"] = []
+        self["facets"] = []
+        self["post_facet_filters"] = []
+        self["boosts"] = []
+        self["sorts"] = []
 
 
 class SearchScrollQuery(SearchQueryBase):

--- a/tests/functional/services/search/test_search.py
+++ b/tests/functional/services/search/test_search.py
@@ -45,6 +45,7 @@ def test_search_query_simple(search_client):
         {"q": "foo"},
         {"q": "foo", "limit": 10},
         globus_sdk.SearchQuery("foo"),
+        globus_sdk.SearchQueryV1("foo"),
     ],
 )
 def test_search_post_query_simple(search_client, query_doc):

--- a/tests/functional/services/search/test_search.py
+++ b/tests/functional/services/search/test_search.py
@@ -41,12 +41,7 @@ def test_search_query_simple(search_client):
 
 @pytest.mark.parametrize(
     "query_doc",
-    [
-        {"q": "foo"},
-        {"q": "foo", "limit": 10},
-        globus_sdk.SearchQuery("foo"),
-        globus_sdk.SearchQueryV1("foo"),
-    ],
+    [{"q": "foo"}, {"q": "foo", "limit": 10}, globus_sdk.SearchQuery("foo")],
 )
 def test_search_post_query_simple(search_client, query_doc):
     meta = load_response(search_client.post_search).metadata
@@ -62,6 +57,23 @@ def test_search_post_query_simple(search_client, query_doc):
     assert req.body is not None
     req_body = json.loads(req.body)
     assert req_body == dict(query_doc)
+
+
+def test_search_post_v1_query_simple(search_client):
+    query_doc = globus_sdk.SearchQueryV1(q="foo")
+    meta = load_response(search_client.post_search).metadata
+
+    res = search_client.post_search(meta["index_id"], query_doc)
+    assert res.http_status == 200
+
+    data = res.data
+    assert isinstance(data, dict)
+    assert data["gmeta"][0]["entries"][0]["content"]["foo"] == "bar"
+
+    req = get_last_request()
+    assert req.body is not None
+    req_body = json.loads(req.body)
+    assert req_body == {"@version": "query#1.0.0", "q": "foo"}
 
 
 @pytest.mark.parametrize(

--- a/tests/functional/services/search/test_search.py
+++ b/tests/functional/services/search/test_search.py
@@ -39,10 +39,7 @@ def test_search_query_simple(search_client):
     }
 
 
-@pytest.mark.parametrize(
-    "query_doc",
-    [{"q": "foo"}, {"q": "foo", "limit": 10}, globus_sdk.SearchQuery("foo")],
-)
+@pytest.mark.parametrize("query_doc", [{"q": "foo"}, {"q": "foo", "limit": 10}])
 def test_search_post_query_simple(search_client, query_doc):
     meta = load_response(search_client.post_search).metadata
 
@@ -59,7 +56,25 @@ def test_search_post_query_simple(search_client, query_doc):
     assert req_body == dict(query_doc)
 
 
-def test_search_post_v1_query_simple(search_client):
+@pytest.mark.filterwarnings("ignore:'SearchQuery'*:DeprecationWarning")
+def test_search_post_query_with_legacy_helper(search_client):
+    meta = load_response(search_client.post_search).metadata
+    query_doc = globus_sdk.SearchQuery("foo")
+
+    res = search_client.post_search(meta["index_id"], query_doc)
+    assert res.http_status == 200
+
+    data = res.data
+    assert isinstance(data, dict)
+    assert data["gmeta"][0]["entries"][0]["content"]["foo"] == "bar"
+
+    req = get_last_request()
+    assert req.body is not None
+    req_body = json.loads(req.body)
+    assert req_body == dict(query_doc)
+
+
+def test_search_post_query_simple_with_v1_helper(search_client):
     query_doc = globus_sdk.SearchQueryV1(q="foo")
     meta = load_response(search_client.post_search).metadata
 
@@ -78,13 +93,34 @@ def test_search_post_v1_query_simple(search_client):
 
 @pytest.mark.parametrize(
     "query_doc",
-    [
-        {"q": "foo", "limit": 10, "offset": 0},
-        globus_sdk.SearchQuery("foo", limit=10, offset=0),
-    ],
+    [{"q": "foo", "limit": 10, "offset": 0}],
 )
 def test_search_post_query_arg_overrides(search_client, query_doc):
     meta = load_response(search_client.post_search).metadata
+
+    res = search_client.post_search(meta["index_id"], query_doc, limit=100, offset=150)
+    assert res.http_status == 200
+
+    data = res.data
+    assert isinstance(data, dict)
+    assert data["gmeta"][0]["entries"][0]["content"]["foo"] == "bar"
+
+    req = get_last_request()
+    assert req.body is not None
+    req_body = json.loads(req.body)
+    assert req_body != dict(query_doc)
+    assert req_body["q"] == query_doc["q"]
+    assert req_body["limit"] == 100
+    assert req_body["offset"] == 150
+    # important! these should be unchanged (no side-effects)
+    assert query_doc["limit"] == 10
+    assert query_doc["offset"] == 0
+
+
+@pytest.mark.filterwarnings("ignore:'SearchQuery'*:DeprecationWarning")
+def test_search_post_query_arg_overrides_with_legacy_helper(search_client):
+    meta = load_response(search_client.post_search).metadata
+    query_doc = globus_sdk.SearchQuery("foo", limit=10, offset=0)
 
     res = search_client.post_search(meta["index_id"], query_doc, limit=100, offset=150)
     assert res.http_status == 200

--- a/tests/unit/helpers/test_search.py
+++ b/tests/unit/helpers/test_search.py
@@ -4,7 +4,8 @@ Unit tests for globus_sdk.SearchQuery
 
 import pytest
 
-from globus_sdk import SearchQuery, SearchQueryV1
+from globus_sdk import SearchQuery, SearchQueryV1, utils
+from globus_sdk.exc.warnings import RemovedInV4Warning
 
 
 def test_init_legacy():
@@ -28,8 +29,8 @@ def test_init_legacy():
 
 def test_init_legacy_deprecation_warning():
     with pytest.warns(
-        DeprecationWarning,
-        match="'SearchQuery' is a deprecated name. Use 'SearchQueryV1' instead.",
+        RemovedInV4Warning,
+        match="'SearchQuery' is deprecated. Use 'SearchQueryV1' instead.",
     ):
         SearchQuery()
 
@@ -42,7 +43,7 @@ def test_init_v1():
 
     # ensure key attributes initialize to empty lists
     for attribute in ["facets", "filters", "post_facet_filters", "sorts", "boosts"]:
-        assert query[attribute] == []
+        assert query[attribute] == utils.MISSING
 
     # init with supported fields
     params = {"q": "foo", "limit": 10, "offset": 0, "advanced": False}

--- a/tests/unit/helpers/test_search.py
+++ b/tests/unit/helpers/test_search.py
@@ -43,7 +43,7 @@ def test_init_v1():
     assert query["@version"] == "query#1.0.0"
 
     # ensure key attributes initialize to empty lists
-    for attribute in ["facets", "filters", "post_facet_filters", "sorts", "boosts"]:
+    for attribute in ["facets", "filters", "post_facet_filters", "sort", "boosts"]:
         assert query[attribute] == utils.MISSING
 
     # init with supported fields

--- a/tests/unit/helpers/test_search.py
+++ b/tests/unit/helpers/test_search.py
@@ -4,13 +4,13 @@ Unit tests for globus_sdk.SearchQuery
 
 import pytest
 
-from globus_sdk import SearchQuery
+from globus_sdk import SearchQuery, SearchQueryV1
 
 
-def test_init():
+def test_init_legacy():
     """Creates SearchQuery and verifies results"""
-    # default init
     query = SearchQuery()
+
     assert len(query) == 0
 
     # init with supported fields
@@ -22,6 +22,37 @@ def test_init():
     # init with additional_fields
     add_params = {"param1": "value1", "param2": "value2"}
     param_query = SearchQuery(additional_fields=add_params)
+    for par in add_params:
+        assert param_query[par] == add_params[par]
+
+
+def test_init_legacy_deprecation_warning():
+    with pytest.warns(
+        DeprecationWarning,
+        match="'SearchQuery' is a deprecated name. Use 'SearchQueryV1' instead.",
+    ):
+        SearchQuery()
+
+
+def test_init_v1():
+    query = SearchQueryV1()
+
+    # ensure the version is set to query#1.0.0
+    assert query["@version"] == "query#1.0.0"
+
+    # ensure key attributes initialize to empty lists
+    for attribute in ["facets", "filters", "post_facet_filters", "sorts", "boosts"]:
+        assert query[attribute] == []
+
+    # init with supported fields
+    params = {"q": "foo", "limit": 10, "offset": 0, "advanced": False}
+    param_query = SearchQueryV1(**params)
+    for par in params:
+        assert param_query[par] == params[par]
+
+    # init with additional_fields
+    add_params = {"param1": "value1", "param2": "value2"}
+    param_query = SearchQueryV1(additional_fields=add_params)
     for par in add_params:
         assert param_query[par] == add_params[par]
 

--- a/tests/unit/helpers/test_search.py
+++ b/tests/unit/helpers/test_search.py
@@ -8,6 +8,7 @@ from globus_sdk import SearchQuery, SearchQueryV1, utils
 from globus_sdk.exc.warnings import RemovedInV4Warning
 
 
+@pytest.mark.filterwarnings("ignore:'SearchQuery'*:DeprecationWarning")
 def test_init_legacy():
     """Creates SearchQuery and verifies results"""
     query = SearchQuery()
@@ -59,6 +60,7 @@ def test_init_v1():
 
 
 @pytest.mark.parametrize("attrname", ["q", "limit", "offset", "advanced"])
+@pytest.mark.filterwarnings("ignore:'SearchQuery'*:DeprecationWarning")
 def test_set_method(attrname):
     query = SearchQuery()
     method = getattr(query, "set_{}".format("query" if attrname == "q" else attrname))
@@ -70,6 +72,7 @@ def test_set_method(attrname):
     assert query[attrname] == "foo"
 
 
+@pytest.mark.filterwarnings("ignore:'SearchQuery'*:DeprecationWarning")
 def test_add_facet():
     query = SearchQuery()
     assert "facets" not in query
@@ -125,6 +128,7 @@ def test_add_facet():
     }
 
 
+@pytest.mark.filterwarnings("ignore:'SearchQuery'*:DeprecationWarning")
 def test_add_filter():
     query = SearchQuery()
     assert "filters" not in query
@@ -165,6 +169,7 @@ def test_add_filter():
     }
 
 
+@pytest.mark.filterwarnings("ignore:'SearchQuery'*:DeprecationWarning")
 def test_add_boost():
     query = SearchQuery()
     assert "boosts" not in query
@@ -186,6 +191,7 @@ def test_add_boost():
     }
 
 
+@pytest.mark.filterwarnings("ignore:'SearchQuery'*:DeprecationWarning")
 def test_add_sort():
     query = SearchQuery()
     assert "sort" not in query


### PR DESCRIPTION
https://app.shortcut.com/globus/story/35200/python-sdk-support-version-field-in-searchclient-post-search

## Summary of changes

* Added ignore for `SearchQuery` in pyproject.toml filterwarnings for pytest
* Updated SphinxDocs for `SearchQueryV1`
* Added `SearchQueryV1` to the _generate_init.py script
* Added `SearchQueryV1` class for new v1 search request version
* Added deprecation warning to the `SearchQuery` class during init
* Added unit and functional tests for `SearchQueryV1` and `SearchQuery` deprecation warnings.

<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1079.org.readthedocs.build/en/1079/

<!-- readthedocs-preview globus-sdk-python end -->