### PR TITLE
Add a pre-build scriv step to RTD builds

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,6 +8,9 @@ build:
   os: "ubuntu-22.04"
   tools:
     python: "3.11"
+  jobs:
+    pre_build:
+      - bash ./scripts/rtd-pre-sphinx-build.sh
 
 python:
   install:

--- a/requirements/docs.in
+++ b/requirements/docs.in
@@ -6,3 +6,6 @@ sphinx-design
 
 # required for testing modules to load
 responses
+
+# required for the PR pre-build step in RTD
+scriv

--- a/requirements/py3.10/test.txt
+++ b/requirements/py3.10/test.txt
@@ -6,9 +6,9 @@
 #
 certifi==2024.8.30
     # via requests
-charset-normalizer==3.3.2
+charset-normalizer==3.4.0
     # via requests
-coverage==7.6.1
+coverage==7.6.3
     # via -r test.in
 exceptiongroup==1.2.2
     # via pytest
@@ -39,7 +39,7 @@ requests==2.32.3
     # via responses
 responses==0.25.3
     # via -r test.in
-tomli==2.0.1
+tomli==2.0.2
     # via pytest
 urllib3==2.2.3
     # via

--- a/requirements/py3.10/typing.txt
+++ b/requirements/py3.10/typing.txt
@@ -6,11 +6,11 @@
 #
 certifi==2024.8.30
     # via requests
-charset-normalizer==3.3.2
+charset-normalizer==3.4.0
     # via requests
 idna==3.10
     # via requests
-mypy==1.11.2
+mypy==1.12.0
     # via -r typing.in
 mypy-extensions==1.0.0
     # via mypy
@@ -20,11 +20,11 @@ requests==2.32.3
     # via responses
 responses==0.25.3
     # via -r typing.in
-tomli==2.0.1
+tomli==2.0.2
     # via mypy
 types-cryptography==3.3.23.2
     # via types-jwt
-types-docutils==0.21.0.20240907
+types-docutils==0.21.0.20241005
     # via -r typing.in
 types-jwt==0.1.3
     # via -r typing.in

--- a/requirements/py3.11/docs.txt
+++ b/requirements/py3.11/docs.txt
@@ -6,14 +6,22 @@
 #
 alabaster==1.0.0
     # via sphinx
+attrs==24.2.0
+    # via scriv
 babel==2.16.0
     # via sphinx
 beautifulsoup4==4.12.3
     # via furo
 certifi==2024.8.30
     # via requests
-charset-normalizer==3.3.2
+charset-normalizer==3.4.0
     # via requests
+click==8.1.7
+    # via
+    #   click-log
+    #   scriv
+click-log==0.4.0
+    # via scriv
 docutils==0.21.2
     # via sphinx
 furo==2024.8.6
@@ -23,9 +31,15 @@ idna==3.10
 imagesize==1.4.1
     # via sphinx
 jinja2==3.1.4
-    # via sphinx
-markupsafe==2.1.5
+    # via
+    #   scriv
+    #   sphinx
+markdown-it-py==3.0.0
+    # via scriv
+markupsafe==3.0.1
     # via jinja2
+mdurl==0.1.2
+    # via markdown-it-py
 packaging==24.1
     # via sphinx
 pygments==2.18.0
@@ -37,14 +51,17 @@ pyyaml==6.0.2
 requests==2.32.3
     # via
     #   responses
+    #   scriv
     #   sphinx
 responses==0.25.3
+    # via -r docs.in
+scriv==1.5.1
     # via -r docs.in
 snowballstemmer==2.2.0
     # via sphinx
 soupsieve==2.6
     # via beautifulsoup4
-sphinx==8.0.2
+sphinx==8.1.3
     # via
     #   -r docs.in
     #   furo
@@ -58,7 +75,7 @@ sphinx-copybutton==0.5.2
     # via -r docs.in
 sphinx-design==0.6.1
     # via -r docs.in
-sphinx-issues==4.1.0
+sphinx-issues==5.0.0
     # via -r docs.in
 sphinxcontrib-applehelp==2.0.0
     # via sphinx

--- a/requirements/py3.11/test.txt
+++ b/requirements/py3.11/test.txt
@@ -6,9 +6,9 @@
 #
 certifi==2024.8.30
     # via requests
-charset-normalizer==3.3.2
+charset-normalizer==3.4.0
     # via requests
-coverage==7.6.1
+coverage==7.6.3
     # via -r test.in
 execnet==2.1.1
     # via pytest-xdist

--- a/requirements/py3.11/typing.txt
+++ b/requirements/py3.11/typing.txt
@@ -6,11 +6,11 @@
 #
 certifi==2024.8.30
     # via requests
-charset-normalizer==3.3.2
+charset-normalizer==3.4.0
     # via requests
 idna==3.10
     # via requests
-mypy==1.11.2
+mypy==1.12.0
     # via -r typing.in
 mypy-extensions==1.0.0
     # via mypy
@@ -22,7 +22,7 @@ responses==0.25.3
     # via -r typing.in
 types-cryptography==3.3.23.2
     # via types-jwt
-types-docutils==0.21.0.20240907
+types-docutils==0.21.0.20241005
     # via -r typing.in
 types-jwt==0.1.3
     # via -r typing.in

--- a/requirements/py3.12/test.txt
+++ b/requirements/py3.12/test.txt
@@ -6,9 +6,9 @@
 #
 certifi==2024.8.30
     # via requests
-charset-normalizer==3.3.2
+charset-normalizer==3.4.0
     # via requests
-coverage==7.6.1
+coverage==7.6.3
     # via -r test.in
 execnet==2.1.1
     # via pytest-xdist

--- a/requirements/py3.12/typing.txt
+++ b/requirements/py3.12/typing.txt
@@ -6,11 +6,11 @@
 #
 certifi==2024.8.30
     # via requests
-charset-normalizer==3.3.2
+charset-normalizer==3.4.0
     # via requests
 idna==3.10
     # via requests
-mypy==1.11.2
+mypy==1.12.0
     # via -r typing.in
 mypy-extensions==1.0.0
     # via mypy
@@ -22,7 +22,7 @@ responses==0.25.3
     # via -r typing.in
 types-cryptography==3.3.23.2
     # via types-jwt
-types-docutils==0.21.0.20240907
+types-docutils==0.21.0.20241005
     # via -r typing.in
 types-jwt==0.1.3
     # via -r typing.in

--- a/requirements/py3.13/test.txt
+++ b/requirements/py3.13/test.txt
@@ -6,9 +6,9 @@
 #
 certifi==2024.8.30
     # via requests
-charset-normalizer==3.3.2
+charset-normalizer==3.4.0
     # via requests
-coverage==7.6.1
+coverage==7.6.3
     # via -r test.in
 execnet==2.1.1
     # via pytest-xdist

--- a/requirements/py3.13/typing.txt
+++ b/requirements/py3.13/typing.txt
@@ -6,11 +6,11 @@
 #
 certifi==2024.8.30
     # via requests
-charset-normalizer==3.3.2
+charset-normalizer==3.4.0
     # via requests
 idna==3.10
     # via requests
-mypy==1.11.2
+mypy==1.12.0
     # via -r typing.in
 mypy-extensions==1.0.0
     # via mypy
@@ -22,7 +22,7 @@ responses==0.25.3
     # via -r typing.in
 types-cryptography==3.3.23.2
     # via types-jwt
-types-docutils==0.21.0.20240907
+types-docutils==0.21.0.20241005
     # via -r typing.in
 types-jwt==0.1.3
     # via -r typing.in

--- a/requirements/py3.8/test-mindeps.txt
+++ b/requirements/py3.8/test-mindeps.txt
@@ -53,7 +53,7 @@ responses==0.23.1
     # via -r test.in
 six==1.16.0
     # via cryptography
-tomli==2.0.1
+tomli==2.0.2
     # via pytest
 types-pyyaml==6.0.12.20240917
     # via responses

--- a/requirements/py3.8/test.txt
+++ b/requirements/py3.8/test.txt
@@ -6,7 +6,7 @@
 #
 certifi==2024.8.30
     # via requests
-charset-normalizer==3.3.2
+charset-normalizer==3.4.0
     # via requests
 coverage==7.6.1
     # via -r test.in
@@ -41,7 +41,7 @@ requests==2.32.3
     # via responses
 responses==0.25.3
     # via -r test.in
-tomli==2.0.1
+tomli==2.0.2
     # via pytest
 urllib3==2.2.3
     # via

--- a/requirements/py3.8/typing.txt
+++ b/requirements/py3.8/typing.txt
@@ -6,11 +6,11 @@
 #
 certifi==2024.8.30
     # via requests
-charset-normalizer==3.3.2
+charset-normalizer==3.4.0
     # via requests
 idna==3.10
     # via requests
-mypy==1.11.2
+mypy==1.12.0
     # via -r typing.in
 mypy-extensions==1.0.0
     # via mypy
@@ -20,11 +20,11 @@ requests==2.32.3
     # via responses
 responses==0.25.3
     # via -r typing.in
-tomli==2.0.1
+tomli==2.0.2
     # via mypy
 types-cryptography==3.3.23.2
     # via types-jwt
-types-docutils==0.21.0.20240907
+types-docutils==0.21.0.20241005
     # via -r typing.in
 types-jwt==0.1.3
     # via -r typing.in

--- a/requirements/py3.9/test.txt
+++ b/requirements/py3.9/test.txt
@@ -6,9 +6,9 @@
 #
 certifi==2024.8.30
     # via requests
-charset-normalizer==3.3.2
+charset-normalizer==3.4.0
     # via requests
-coverage==7.6.1
+coverage==7.6.3
     # via -r test.in
 exceptiongroup==1.2.2
     # via pytest
@@ -41,7 +41,7 @@ requests==2.32.3
     # via responses
 responses==0.25.3
     # via -r test.in
-tomli==2.0.1
+tomli==2.0.2
     # via pytest
 urllib3==2.2.3
     # via

--- a/requirements/py3.9/typing.txt
+++ b/requirements/py3.9/typing.txt
@@ -6,11 +6,11 @@
 #
 certifi==2024.8.30
     # via requests
-charset-normalizer==3.3.2
+charset-normalizer==3.4.0
     # via requests
 idna==3.10
     # via requests
-mypy==1.11.2
+mypy==1.12.0
     # via -r typing.in
 mypy-extensions==1.0.0
     # via mypy
@@ -20,11 +20,11 @@ requests==2.32.3
     # via responses
 responses==0.25.3
     # via -r typing.in
-tomli==2.0.1
+tomli==2.0.2
     # via mypy
 types-cryptography==3.3.23.2
     # via types-jwt
-types-docutils==0.21.0.20240907
+types-docutils==0.21.0.20241005
     # via -r typing.in
 types-jwt==0.1.3
     # via -r typing.in

--- a/scripts/rtd-pre-sphinx-build.sh
+++ b/scripts/rtd-pre-sphinx-build.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+case "$READTHEDOCS_VERSION_TYPE" in
+    external)  # PR builds
+        ;;
+    branch | tag | unknown)
+        echo "not a PR build, exiting"
+        exit 0
+        ;;
+    *)
+        echo "unrecognized build type"
+        exit 1
+        ;;
+esac
+
+if [ -z "$(find changelog.d -name '*.rst')" ]; then
+    echo "no changes visible in changelog.d/"
+    echo "exiting without running 'scriv collect'"
+    exit 0
+fi
+
+SDK_VERSION=$(grep '^__version__' src/globus_sdk/version.py | cut -d '"' -f2)
+DEV_VERSION="${SDK_VERSION}-dev"
+
+scriv collect --keep --version "$DEV_VERSION"

--- a/scripts/rtd-pre-sphinx-build.sh
+++ b/scripts/rtd-pre-sphinx-build.sh
@@ -20,6 +20,6 @@ if [ -z "$(find changelog.d -name '*.rst')" ]; then
 fi
 
 SDK_VERSION=$(grep '^__version__' src/globus_sdk/version.py | cut -d '"' -f2)
-DEV_VERSION="${SDK_VERSION}-dev"
+DEV_VERSION="${SDK_VERSION}-pr-${READTHEDOCS_VERSION_NAME}"
 
-scriv collect --keep --version "$DEV_VERSION"
+scriv collect --keep --version "$DEV_VERSION" -v DEBUG


### PR DESCRIPTION
When running a readthedocs PR build, automatically run `scriv collect` if there are changelog fragments, with a `-dev` suffixed version number.
In support of this, install `scriv` into docs environments, so that it can be run by readthedocs. (Requires a run of `tox r -m freezedeps`.)

The end result is that PR builds will be able to see a preview of the changelog. It won't necessarily be "fully cleaned up" in cases where we want to make some edits at the time of the release, but it will be close and in many cases perfect.

---

This change is a bit of an experiment. I'm curious if it will work in the way I would like. The RTD build on *this* PR will be a good test.


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1080.org.readthedocs.build/en/1080/

<!-- readthedocs-preview globus-sdk-python end -->