### PR TITLE
Mark certain changes non-Experimental

### DIFF
--- a/changelog.d/20240918_224616_sirosen_control_tokenstorage_identity_id_extraction.rst
+++ b/changelog.d/20240918_224616_sirosen_control_tokenstorage_identity_id_extraction.rst
@@ -1,8 +1,6 @@
 Fixed
 ~~~~~
 
-.. rubric:: Experimental
-
 - Fix the handling of Dependent Token and Refresh Token responses in
-  ``TokenStorage`` and ``GlobusApp``'s internal ``ValidatingTokenStorage`` in
-  order to ensure that ``id_token`` is only parsed when appropriate. (:pr:`1055`)
+  ``TokenStorage`` and ``ValidatingTokenStorage`` in order to ensure
+  that ``id_token`` is only parsed when appropriate. (:pr:`1055`)

--- a/changelog.d/20240924_225530_sirosen_refactor_token_validation.rst
+++ b/changelog.d/20240924_225530_sirosen_refactor_token_validation.rst
@@ -1,8 +1,6 @@
 Changed
 ~~~~~~~
 
-.. rubric:: Experimental
-
 - The mechanisms of token data validation inside of ``GlobusApp`` are now more
   modular and extensible. The ``ValidatingTokenStorage`` class does not define
   built-in validation behaviors, but instead contains a list of validator


### PR DESCRIPTION
These were noted as Experimental before the relevant components moved
from the `.experimental` subpackage. Now that they've moved, the
rubric is not appropriate.


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1081.org.readthedocs.build/en/1081/

<!-- readthedocs-preview globus-sdk-python end -->