### PR TITLE
Fix a changelog which didn't get a number

### DIFF
--- a/changelog.d/20241004_135423_sirosen.rst
+++ b/changelog.d/20241004_135423_sirosen.rst
@@ -1,4 +1,4 @@
 Added
 ~~~~~
 
-- Add ``TransferClient.set_subscription_id`` (:pr:`NUMBER`)
+- Add ``TransferClient.set_subscription_id`` (:pr:`1073`)


### PR DESCRIPTION
There's a CI job which is supposed to assign these correctly, but
clearly it didn't run or failed.


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1082.org.readthedocs.build/en/1082/

<!-- readthedocs-preview globus-sdk-python end -->