### PR TITLE
Fix an RST syntax issue

### DIFF
--- a/src/globus_sdk/services/auth/client/service_client.py
+++ b/src/globus_sdk/services/auth/client/service_client.py
@@ -838,7 +838,7 @@ class AuthClient(client.BaseClient):
         :param domain_constraints_exclude: A list of domains that cannot satisfy the
             policy
 
-        .. note:
+        .. note::
 
             ``project_id``, ``display_name``, and ``description`` are all required
             arguments, although they are not declared as required in the function


### PR DESCRIPTION
Exactly what it says on the tin.

Discovered while reviewing Sphinx output with nitpick enabled.

<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1085.org.readthedocs.build/en/1085/

<!-- readthedocs-preview globus-sdk-python end -->