### PR TITLE
Minor test cleanup

### DIFF
--- a/tests/functional/services/search/test_search.py
+++ b/tests/functional/services/search/test_search.py
@@ -91,13 +91,10 @@ def test_search_post_query_simple_with_v1_helper(search_client):
     assert req_body == {"@version": "query#1.0.0", "q": "foo"}
 
 
-@pytest.mark.parametrize(
-    "query_doc",
-    [{"q": "foo", "limit": 10, "offset": 0}],
-)
-def test_search_post_query_arg_overrides(search_client, query_doc):
+def test_search_post_query_arg_overrides(search_client):
     meta = load_response(search_client.post_search).metadata
 
+    query_doc = {"q": "foo", "limit": 10, "offset": 0}
     res = search_client.post_search(meta["index_id"], query_doc, limit=100, offset=150)
     assert res.http_status == 200
 

--- a/tests/functional/services/search/test_search.py
+++ b/tests/functional/services/search/test_search.py
@@ -56,10 +56,12 @@ def test_search_post_query_simple(search_client, query_doc):
     assert req_body == dict(query_doc)
 
 
-@pytest.mark.filterwarnings("ignore:'SearchQuery'*:DeprecationWarning")
 def test_search_post_query_with_legacy_helper(search_client):
     meta = load_response(search_client.post_search).metadata
-    query_doc = globus_sdk.SearchQuery("foo")
+    with pytest.warns(
+        globus_sdk.exc.RemovedInV4Warning, match="'SearchQuery' is deprecated"
+    ):
+        query_doc = globus_sdk.SearchQuery("foo")
 
     res = search_client.post_search(meta["index_id"], query_doc)
     assert res.http_status == 200
@@ -114,10 +116,12 @@ def test_search_post_query_arg_overrides(search_client):
     assert query_doc["offset"] == 0
 
 
-@pytest.mark.filterwarnings("ignore:'SearchQuery'*:DeprecationWarning")
 def test_search_post_query_arg_overrides_with_legacy_helper(search_client):
     meta = load_response(search_client.post_search).metadata
-    query_doc = globus_sdk.SearchQuery("foo", limit=10, offset=0)
+    with pytest.warns(
+        globus_sdk.exc.RemovedInV4Warning, match="'SearchQuery' is deprecated"
+    ):
+        query_doc = globus_sdk.SearchQuery("foo", limit=10, offset=0)
 
     res = search_client.post_search(meta["index_id"], query_doc, limit=100, offset=150)
     assert res.http_status == 200

--- a/tests/functional/services/search/test_search.py
+++ b/tests/functional/services/search/test_search.py
@@ -59,7 +59,7 @@ def test_search_post_query_simple(search_client, query_doc):
 def test_search_post_query_with_legacy_helper(search_client):
     meta = load_response(search_client.post_search).metadata
     with pytest.warns(
-        globus_sdk.exc.RemovedInV4Warning, match="'SearchQuery' is deprecated"
+        globus_sdk.RemovedInV4Warning, match="'SearchQuery' is deprecated"
     ):
         query_doc = globus_sdk.SearchQuery("foo")
 
@@ -119,7 +119,7 @@ def test_search_post_query_arg_overrides(search_client):
 def test_search_post_query_arg_overrides_with_legacy_helper(search_client):
     meta = load_response(search_client.post_search).metadata
     with pytest.warns(
-        globus_sdk.exc.RemovedInV4Warning, match="'SearchQuery' is deprecated"
+        globus_sdk.RemovedInV4Warning, match="'SearchQuery' is deprecated"
     ):
         query_doc = globus_sdk.SearchQuery("foo", limit=10, offset=0)
 

--- a/tests/unit/helpers/test_search.py
+++ b/tests/unit/helpers/test_search.py
@@ -4,29 +4,28 @@ Unit tests for globus_sdk.SearchQuery
 
 import pytest
 
-import globus_sdk
-from globus_sdk import SearchQuery, SearchQueryV1, utils
-from globus_sdk.exc.warnings import RemovedInV4Warning
+from globus_sdk import RemovedInV4Warning, SearchQuery, SearchQueryV1, utils
 
 
 def test_init_legacy():
-    """Creates SearchQuery and verifies results"""
-    with pytest.warns(
-        globus_sdk.exc.RemovedInV4Warning, match="'SearchQuery' is deprecated"
-    ):
+    params = {"q": "foo", "limit": 10, "offset": 0, "advanced": False}
+    with pytest.warns(RemovedInV4Warning, match="'SearchQuery' is deprecated"):
+        param_query = SearchQuery(**params)
+    for par in params:
+        assert param_query[par] == params[par]
+
+
+def test_init_legacy_no_args():
+    with pytest.warns(RemovedInV4Warning, match="'SearchQuery' is deprecated"):
         query = SearchQuery()
 
     assert len(query) == 0
 
-    # init with supported fields
-    params = {"q": "foo", "limit": 10, "offset": 0, "advanced": False}
-    param_query = SearchQuery(**params)
-    for par in params:
-        assert param_query[par] == params[par]
 
-    # init with additional_fields
+def test_init_legacy_additional_fields():
     add_params = {"param1": "value1", "param2": "value2"}
-    param_query = SearchQuery(additional_fields=add_params)
+    with pytest.warns(RemovedInV4Warning, match="'SearchQuery' is deprecated"):
+        param_query = SearchQuery(additional_fields=add_params)
     for par in add_params:
         assert param_query[par] == add_params[par]
 
@@ -64,9 +63,7 @@ def test_init_v1():
 
 @pytest.mark.parametrize("attrname", ["q", "limit", "offset", "advanced"])
 def test_set_method(attrname):
-    with pytest.warns(
-        globus_sdk.exc.RemovedInV4Warning, match="'SearchQuery' is deprecated"
-    ):
+    with pytest.warns(RemovedInV4Warning, match="'SearchQuery' is deprecated"):
         query = SearchQuery()
     method = getattr(query, "set_{}".format("query" if attrname == "q" else attrname))
     # start absent
@@ -78,9 +75,7 @@ def test_set_method(attrname):
 
 
 def test_add_facet():
-    with pytest.warns(
-        globus_sdk.exc.RemovedInV4Warning, match="'SearchQuery' is deprecated"
-    ):
+    with pytest.warns(RemovedInV4Warning, match="'SearchQuery' is deprecated"):
         query = SearchQuery()
     assert "facets" not in query
 
@@ -136,9 +131,7 @@ def test_add_facet():
 
 
 def test_add_filter():
-    with pytest.warns(
-        globus_sdk.exc.RemovedInV4Warning, match="'SearchQuery' is deprecated"
-    ):
+    with pytest.warns(RemovedInV4Warning, match="'SearchQuery' is deprecated"):
         query = SearchQuery()
     assert "filters" not in query
 
@@ -179,9 +172,7 @@ def test_add_filter():
 
 
 def test_add_boost():
-    with pytest.warns(
-        globus_sdk.exc.RemovedInV4Warning, match="'SearchQuery' is deprecated"
-    ):
+    with pytest.warns(RemovedInV4Warning, match="'SearchQuery' is deprecated"):
         query = SearchQuery()
     assert "boosts" not in query
 
@@ -203,9 +194,7 @@ def test_add_boost():
 
 
 def test_add_sort():
-    with pytest.warns(
-        globus_sdk.exc.RemovedInV4Warning, match="'SearchQuery' is deprecated"
-    ):
+    with pytest.warns(RemovedInV4Warning, match="'SearchQuery' is deprecated"):
         query = SearchQuery()
     assert "sort" not in query
 

--- a/tests/unit/helpers/test_search.py
+++ b/tests/unit/helpers/test_search.py
@@ -4,14 +4,17 @@ Unit tests for globus_sdk.SearchQuery
 
 import pytest
 
+import globus_sdk
 from globus_sdk import SearchQuery, SearchQueryV1, utils
 from globus_sdk.exc.warnings import RemovedInV4Warning
 
 
-@pytest.mark.filterwarnings("ignore:'SearchQuery'*:DeprecationWarning")
 def test_init_legacy():
     """Creates SearchQuery and verifies results"""
-    query = SearchQuery()
+    with pytest.warns(
+        globus_sdk.exc.RemovedInV4Warning, match="'SearchQuery' is deprecated"
+    ):
+        query = SearchQuery()
 
     assert len(query) == 0
 
@@ -60,9 +63,11 @@ def test_init_v1():
 
 
 @pytest.mark.parametrize("attrname", ["q", "limit", "offset", "advanced"])
-@pytest.mark.filterwarnings("ignore:'SearchQuery'*:DeprecationWarning")
 def test_set_method(attrname):
-    query = SearchQuery()
+    with pytest.warns(
+        globus_sdk.exc.RemovedInV4Warning, match="'SearchQuery' is deprecated"
+    ):
+        query = SearchQuery()
     method = getattr(query, "set_{}".format("query" if attrname == "q" else attrname))
     # start absent
     assert attrname not in query
@@ -72,9 +77,11 @@ def test_set_method(attrname):
     assert query[attrname] == "foo"
 
 
-@pytest.mark.filterwarnings("ignore:'SearchQuery'*:DeprecationWarning")
 def test_add_facet():
-    query = SearchQuery()
+    with pytest.warns(
+        globus_sdk.exc.RemovedInV4Warning, match="'SearchQuery' is deprecated"
+    ):
+        query = SearchQuery()
     assert "facets" not in query
 
     # simple terms facet
@@ -128,9 +135,11 @@ def test_add_facet():
     }
 
 
-@pytest.mark.filterwarnings("ignore:'SearchQuery'*:DeprecationWarning")
 def test_add_filter():
-    query = SearchQuery()
+    with pytest.warns(
+        globus_sdk.exc.RemovedInV4Warning, match="'SearchQuery' is deprecated"
+    ):
+        query = SearchQuery()
     assert "filters" not in query
 
     # returns self
@@ -169,9 +178,11 @@ def test_add_filter():
     }
 
 
-@pytest.mark.filterwarnings("ignore:'SearchQuery'*:DeprecationWarning")
 def test_add_boost():
-    query = SearchQuery()
+    with pytest.warns(
+        globus_sdk.exc.RemovedInV4Warning, match="'SearchQuery' is deprecated"
+    ):
+        query = SearchQuery()
     assert "boosts" not in query
 
     # returns self
@@ -191,9 +202,11 @@ def test_add_boost():
     }
 
 
-@pytest.mark.filterwarnings("ignore:'SearchQuery'*:DeprecationWarning")
 def test_add_sort():
-    query = SearchQuery()
+    with pytest.warns(
+        globus_sdk.exc.RemovedInV4Warning, match="'SearchQuery' is deprecated"
+    ):
+        query = SearchQuery()
     assert "sort" not in query
 
     # returns self


### PR DESCRIPTION
- Do not use parametrize with single value
- Prefer scoped warning handlers (context manager + specific warning type)


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1090.org.readthedocs.build/en/1090/

<!-- readthedocs-preview globus-sdk-python end -->