### PR TITLE
Deprecate Compute function data classes

### DIFF
--- a/changelog.d/20241023_134132_30907815+rjmello_modify_compute_client_reg_func.rst
+++ b/changelog.d/20241023_134132_30907815+rjmello_modify_compute_client_reg_func.rst
@@ -1,0 +1,6 @@
+Deprecated
+~~~~~~~~~~
+
+- Deprecated the ``ComputeFunctionDocument`` and ``ComputeFunctionMetadata`` classes.
+  This change reflects an early design adjustment to better align with the existing
+  Globus Compute SDK. (:pr:`NUMBER`)

--- a/docs/services/compute.rst
+++ b/docs/services/compute.rst
@@ -14,17 +14,6 @@ Globus Compute
         ..  listknownscopes:: globus_sdk.scopes.ComputeScopes
             :base_name: ComputeClient.scopes
 
-Helper Objects
---------------
-
-.. autoclass:: ComputeFunctionDocument
-   :members:
-   :show-inheritance:
-
-.. autoclass:: ComputeFunctionMetadata
-   :members:
-   :show-inheritance:
-
 Client Errors
 -------------
 

--- a/scripts/ensure_exports_are_documented.py
+++ b/scripts/ensure_exports_are_documented.py
@@ -24,6 +24,8 @@ PACKAGE_LOCS_TO_SCAN = (
 )
 
 DEPRECATED_NAMES = {
+    "ComputeFunctionDocument",
+    "ComputeFunctionMetadata",
     "TimerAPIError",
     "TimerClient",
     "TimerScopes",

--- a/src/globus_sdk/services/compute/client.py
+++ b/src/globus_sdk/services/compute/client.py
@@ -7,7 +7,6 @@ from globus_sdk import GlobusHTTPResponse, client
 from globus_sdk._types import UUIDLike
 from globus_sdk.scopes import ComputeScopes, Scope
 
-from .data import ComputeFunctionDocument
 from .errors import ComputeAPIError
 
 log = logging.getLogger(__name__)
@@ -27,7 +26,7 @@ class ComputeClient(client.BaseClient):
 
     def register_function(
         self,
-        function_data: ComputeFunctionDocument | dict[str, t.Any],
+        function_data: dict[str, t.Any],
     ) -> GlobusHTTPResponse:
         """Register a new function.
 

--- a/src/globus_sdk/services/compute/data.py
+++ b/src/globus_sdk/services/compute/data.py
@@ -2,11 +2,17 @@ from __future__ import annotations
 
 from globus_sdk import utils
 from globus_sdk._types import UUIDLike
+from globus_sdk.exc import warn_deprecated
 from globus_sdk.utils import MISSING, MissingType
 
 
 class ComputeFunctionMetadata(utils.PayloadWrapper):
-    """A wrapper for function metadata.
+    """
+    .. warning::
+
+        This class is deprecated.
+
+    A wrapper for function metadata.
 
     :param python_version: The Python version used to serialize the function.
     :param sdk_version: The Globus Compute SDK version used to serialize the function.
@@ -18,13 +24,19 @@ class ComputeFunctionMetadata(utils.PayloadWrapper):
         python_version: str | MissingType = MISSING,
         sdk_version: str | MissingType = MISSING,
     ):
+        warn_deprecated("ComputeFunctionMetadata is deprecated.")
         super().__init__()
         self["python_version"] = python_version
         self["sdk_version"] = sdk_version
 
 
 class ComputeFunctionDocument(utils.PayloadWrapper):
-    """A function registration document.
+    """
+    .. warning::
+
+        This class is deprecated.
+
+    A function registration document.
 
     :param function_name: The name of the function.
     :param function_code: The serialized function source code.
@@ -44,6 +56,7 @@ class ComputeFunctionDocument(utils.PayloadWrapper):
         group: UUIDLike | MissingType = MISSING,
         public: bool = False,
     ):
+        warn_deprecated("ComputeFunctionDocument is deprecated.")
         super().__init__()
         self["function_name"] = function_name
         self["function_code"] = function_code

--- a/tests/functional/services/compute/test_register_function.py
+++ b/tests/functional/services/compute/test_register_function.py
@@ -1,13 +1,13 @@
 import globus_sdk
 from globus_sdk._testing import load_response
-from globus_sdk.services.compute import ComputeFunctionDocument
 
 
 def test_register_function(compute_client: globus_sdk.ComputeClient):
     meta = load_response(compute_client.register_function).metadata
-    function_doc = ComputeFunctionDocument(
-        function_name=meta["function_name"], function_code=meta["function_code"]
-    )
-    res = compute_client.register_function(function_doc)
+    registration_doc = {
+        "function_name": meta["function_name"],
+        "function_code": meta["function_code"],
+    }
+    res = compute_client.register_function(function_data=registration_doc)
     assert res.http_status == 200
     assert res.data["function_uuid"] == meta["function_id"]

--- a/tests/unit/services/compute/test_deprecated_data.py
+++ b/tests/unit/services/compute/test_deprecated_data.py
@@ -1,0 +1,21 @@
+import pytest
+
+from globus_sdk.exc import RemovedInV4Warning
+from globus_sdk.services.compute.data import (
+    ComputeFunctionDocument,
+    ComputeFunctionMetadata,
+)
+
+
+def test_compute_function_metadata_deprecated():
+    with pytest.warns(
+        RemovedInV4Warning, match="ComputeFunctionMetadata is deprecated."
+    ):
+        ComputeFunctionMetadata()
+
+
+def test_compute_function_document_deprecated():
+    with pytest.warns(
+        RemovedInV4Warning, match="ComputeFunctionDocument is deprecated."
+    ):
+        ComputeFunctionDocument(function_name="foo", function_code="bar")


### PR DESCRIPTION
Marked the `ComputeFunctionDocument` and `ComputeFunctionMetadata` classes for deprecation. This change reflects an early design adjustment to better align with the existing Globus Compute SDK.

<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1092.org.readthedocs.build/en/1092/

<!-- readthedocs-preview globus-sdk-python end -->