### PR TITLE
Improve EOF error messaging during CLI login flows

### DIFF
--- a/changelog.d/20241024_113828_chris_command_line_login_flow_manager_catch_eof.rst
+++ b/changelog.d/20241024_113828_chris_command_line_login_flow_manager_catch_eof.rst
@@ -1,0 +1,5 @@
+Changed
+~~~~~~~
+
+- Improved error messaging around EOF errors when prompting for code during a command
+  line login flow (:pr:`NUMBER`)

--- a/docs/authorization/login_flows.rst
+++ b/docs/authorization/login_flows.rst
@@ -52,6 +52,9 @@ Example Code:
     :member-order: bysource
     :show-inheritance:
 
+
+.. autoexception:: CommandLineLoginFlowEOFError
+
 Local Server
 ------------
 

--- a/src/globus_sdk/login_flows/__init__.py
+++ b/src/globus_sdk/login_flows/__init__.py
@@ -1,4 +1,7 @@
-from .command_line_login_flow_manager import CommandLineLoginFlowManager
+from .command_line_login_flow_manager import (
+    CommandLineLoginFlowEOFError,
+    CommandLineLoginFlowManager,
+)
 from .local_server_login_flow_manager import (
     LocalServerEnvironmentalLoginError,
     LocalServerLoginError,
@@ -8,6 +11,7 @@ from .login_flow_manager import LoginFlowManager
 
 __all__ = (
     "CommandLineLoginFlowManager",
+    "CommandLineLoginFlowEOFError",
     "LocalServerLoginError",
     "LocalServerEnvironmentalLoginError",
     "LocalServerLoginFlowManager",


### PR DESCRIPTION
Motivated by observed issues in Compute - users can set up working Compute endpoints, change their setups slightly around access to STDIN, and then see cryptic EOF errors when they eventually need to re-auth.

NB: as of the time of this commit, Compute handles this by raising an error before running login flows if the current environment does not appear to be an interactive terminal. The goal of this commit is to move that behavior to a more centralized location.

<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1093.org.readthedocs.build/en/1093/

<!-- readthedocs-preview globus-sdk-python end -->