### PR TITLE
Configure mypy to cache to sqlite

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,6 +169,7 @@ known_first_party = ["tests", "globus_sdk"]
 
 [tool.mypy]
 strict = true
+sqlite_cache = true
 warn_unreachable = true
 warn_no_return = true
 


### PR DESCRIPTION

This PR introduces the following changes:

*   Configure mypy to use sqlite as its backend cache.

<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>

<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1095.org.readthedocs.build/en/1095/

<!-- readthedocs-preview globus-sdk-python end -->