### PR TITLE
Create versioned Compute clients

### DIFF
--- a/changelog.d/20241031_151930_30907815+rjmello_versioned_compute_clients.rst
+++ b/changelog.d/20241031_151930_30907815+rjmello_versioned_compute_clients.rst
@@ -1,0 +1,6 @@
+Added
+~~~~~
+
+- Created ``ComputeClientV2`` and ``ComputeClientV3`` classes to support Globus Compute
+  API versions 2 and 3, respectively. The canonical ``ComputeClient`` is now a subclass
+  of ``ComputeClientV2``, preserving backward compatibility. (:pr:`NUMBER`)

--- a/docs/services/compute.rst
+++ b/docs/services/compute.rst
@@ -3,7 +3,25 @@ Globus Compute
 
 .. currentmodule:: globus_sdk
 
+The standard way to interact with the Globus Compute service is through the
+`Globus Compute SDK <https://globus-compute.readthedocs.io/en/stable/sdk.html>`_,
+a separate, specialized toolkit that offers enhanced functionality for Globus Compute.
+Under the hood, the Globus Compute SDK uses the following clients to interact with
+the Globus Compute API. Advanced users may choose to work directly with these clients
+for custom implementations.
+
+The canonical :class:`ComputeClient` is a subclass of :class:`ComputeClientV2`,
+which supports version 2 of the Globus Compute API. When feasible, new projects
+should use :class:`ComputeClientV3`, which supports version 3 and includes the
+latest API features and improvements.
+
 ..  autoclass:: ComputeClient
+    :members:
+    :member-order: bysource
+    :show-inheritance:
+    :exclude-members: error_class, scopes
+
+..  autoclass:: ComputeClientV2
     :members:
     :member-order: bysource
     :show-inheritance:
@@ -13,6 +31,18 @@ Globus Compute
 
         ..  listknownscopes:: globus_sdk.scopes.ComputeScopes
             :base_name: ComputeClient.scopes
+
+..  autoclass:: ComputeClientV3
+    :members:
+    :member-order: bysource
+    :show-inheritance:
+    :exclude-members: error_class, scopes
+
+    ..  attribute:: scopes
+
+        ..  listknownscopes:: globus_sdk.scopes.ComputeScopes
+            :base_name: ComputeClient.scopes
+
 
 Client Errors
 -------------

--- a/src/globus_sdk/__init__.py
+++ b/src/globus_sdk/__init__.py
@@ -70,6 +70,8 @@ _LAZY_IMPORT_TABLE = {
     },
     "services.compute": {
         "ComputeClient",
+        "ComputeClientV2",
+        "ComputeClientV3",
         "ComputeAPIError",
         "ComputeFunctionDocument",
         "ComputeFunctionMetadata",
@@ -206,6 +208,8 @@ if t.TYPE_CHECKING:
     from .services.auth import OAuthTokenResponse
     from .services.auth import DependentScopeSpec
     from .services.compute import ComputeClient
+    from .services.compute import ComputeClientV2
+    from .services.compute import ComputeClientV3
     from .services.compute import ComputeAPIError
     from .services.compute import ComputeFunctionDocument
     from .services.compute import ComputeFunctionMetadata
@@ -333,6 +337,8 @@ __all__ = (
     "CollectionPolicies",
     "ComputeAPIError",
     "ComputeClient",
+    "ComputeClientV2",
+    "ComputeClientV3",
     "ComputeFunctionDocument",
     "ComputeFunctionMetadata",
     "ConfidentialAppAuthClient",

--- a/src/globus_sdk/_generate_init.py
+++ b/src/globus_sdk/_generate_init.py
@@ -135,6 +135,8 @@ _LAZY_IMPORT_TABLE: list[tuple[str, tuple[str, ...]]] = [
         "services.compute",
         (
             "ComputeClient",
+            "ComputeClientV2",
+            "ComputeClientV3",
             "ComputeAPIError",
             "ComputeFunctionDocument",
             "ComputeFunctionMetadata",

--- a/src/globus_sdk/_testing/data/compute/v2/delete_function.py
+++ b/src/globus_sdk/_testing/data/compute/v2/delete_function.py
@@ -1,6 +1,6 @@
 from globus_sdk._testing.models import RegisteredResponse, ResponseSet
 
-from ._common import FUNCTION_ID
+from .._common import FUNCTION_ID
 
 RESPONSES = ResponseSet(
     metadata={"function_id": FUNCTION_ID},

--- a/src/globus_sdk/_testing/data/compute/v2/get_function.py
+++ b/src/globus_sdk/_testing/data/compute/v2/get_function.py
@@ -1,6 +1,6 @@
 from globus_sdk._testing.models import RegisteredResponse, ResponseSet
 
-from ._common import FUNCTION_CODE, FUNCTION_ID, FUNCTION_NAME
+from .._common import FUNCTION_CODE, FUNCTION_ID, FUNCTION_NAME
 
 FUNCTION_DOC = {
     "function_uuid": FUNCTION_ID,

--- a/src/globus_sdk/_testing/data/compute/v2/register_function.py
+++ b/src/globus_sdk/_testing/data/compute/v2/register_function.py
@@ -1,6 +1,6 @@
 from globus_sdk._testing.models import RegisteredResponse, ResponseSet
 
-from ._common import FUNCTION_CODE, FUNCTION_ID, FUNCTION_NAME
+from .._common import FUNCTION_CODE, FUNCTION_ID, FUNCTION_NAME
 
 RESPONSES = ResponseSet(
     metadata={

--- a/src/globus_sdk/services/compute/__init__.py
+++ b/src/globus_sdk/services/compute/__init__.py
@@ -1,10 +1,12 @@
-from .client import ComputeClient
+from .client import ComputeClient, ComputeClientV2, ComputeClientV3
 from .data import ComputeFunctionDocument, ComputeFunctionMetadata
 from .errors import ComputeAPIError
 
 __all__ = (
     "ComputeAPIError",
     "ComputeClient",
+    "ComputeClientV2",
+    "ComputeClientV3",
     "ComputeFunctionDocument",
     "ComputeFunctionMetadata",
 )

--- a/src/globus_sdk/services/compute/client.py
+++ b/src/globus_sdk/services/compute/client.py
@@ -12,11 +12,11 @@ from .errors import ComputeAPIError
 log = logging.getLogger(__name__)
 
 
-class ComputeClient(client.BaseClient):
+class ComputeClientV2(client.BaseClient):
     r"""
-    Client for the Globus Compute API.
+    Client for the Globus Compute API, version 2.
 
-    .. automethodlist:: globus_sdk.ComputeClient
+    .. automethodlist:: globus_sdk.ComputeClientV2
     """
 
     error_class = ComputeAPIError
@@ -71,3 +71,25 @@ class ComputeClient(client.BaseClient):
                     :ref: Functions/operation/delete_function_v2_functions__function_uuid__delete
         """  # noqa: E501
         return self.delete(f"/v2/functions/{function_id}")
+
+
+class ComputeClientV3(client.BaseClient):
+    r"""
+    Client for the Globus Compute API, version 3.
+
+    .. automethodlist:: globus_sdk.ComputeClientV3
+    """
+
+    error_class = ComputeAPIError
+    service_name = "compute"
+    scopes = ComputeScopes
+    default_scope_requirements = [Scope(ComputeScopes.all)]
+
+
+class ComputeClient(ComputeClientV2):
+    r"""
+    Canonical client for the Globus Compute API, with support exclusively for
+    API version 2.
+
+    .. automethodlist:: globus_sdk.ComputeClient
+    """

--- a/tests/functional/services/compute/conftest.py
+++ b/tests/functional/services/compute/conftest.py
@@ -4,8 +4,8 @@ import globus_sdk
 
 
 @pytest.fixture
-def compute_client(no_retry_transport):
-    class CustomComputeClient(globus_sdk.ComputeClient):
+def compute_client_v2(no_retry_transport):
+    class CustomComputeClientV2(globus_sdk.ComputeClientV2):
         transport_class = no_retry_transport
 
-    return CustomComputeClient()
+    return CustomComputeClientV2()

--- a/tests/functional/services/compute/test_delete_function.py
+++ b/tests/functional/services/compute/test_delete_function.py
@@ -1,9 +1,0 @@
-import globus_sdk
-from globus_sdk._testing import load_response
-
-
-def test_delete_function(compute_client: globus_sdk.ComputeClient):
-    meta = load_response(compute_client.delete_function).metadata
-    res = compute_client.delete_function(function_id=meta["function_id"])
-    assert res.http_status == 200
-    assert res.data == {"result": 302}

--- a/tests/functional/services/compute/v2/test_delete_function.py
+++ b/tests/functional/services/compute/v2/test_delete_function.py
@@ -1,0 +1,9 @@
+import globus_sdk
+from globus_sdk._testing import load_response
+
+
+def test_delete_function(compute_client_v2: globus_sdk.ComputeClientV2):
+    meta = load_response(compute_client_v2.delete_function).metadata
+    res = compute_client_v2.delete_function(function_id=meta["function_id"])
+    assert res.http_status == 200
+    assert res.data == {"result": 302}

--- a/tests/functional/services/compute/v2/test_get_function.py
+++ b/tests/functional/services/compute/v2/test_get_function.py
@@ -2,9 +2,9 @@ import globus_sdk
 from globus_sdk._testing import load_response
 
 
-def test_get_function(compute_client: globus_sdk.ComputeClient):
-    meta = load_response(compute_client.get_function).metadata
-    res = compute_client.get_function(function_id=meta["function_id"])
+def test_get_function(compute_client_v2: globus_sdk.ComputeClientV2):
+    meta = load_response(compute_client_v2.get_function).metadata
+    res = compute_client_v2.get_function(function_id=meta["function_id"])
     assert res.http_status == 200
     assert res.data["function_uuid"] == meta["function_id"]
     assert res.data["function_name"] == meta["function_name"]

--- a/tests/functional/services/compute/v2/test_register_function.py
+++ b/tests/functional/services/compute/v2/test_register_function.py
@@ -2,12 +2,12 @@ import globus_sdk
 from globus_sdk._testing import load_response
 
 
-def test_register_function(compute_client: globus_sdk.ComputeClient):
-    meta = load_response(compute_client.register_function).metadata
+def test_register_function(compute_client_v2: globus_sdk.ComputeClientV2):
+    meta = load_response(compute_client_v2.register_function).metadata
     registration_doc = {
         "function_name": meta["function_name"],
         "function_code": meta["function_code"],
     }
-    res = compute_client.register_function(function_data=registration_doc)
+    res = compute_client_v2.register_function(function_data=registration_doc)
     assert res.http_status == 200
     assert res.data["function_uuid"] == meta["function_id"]

--- a/tests/unit/services/compute/test_canononical_client.py
+++ b/tests/unit/services/compute/test_canononical_client.py
@@ -1,0 +1,6 @@
+from globus_sdk.services.compute.client import ComputeClient, ComputeClientV2
+
+
+def test_canonical_client_is_v2():
+    client = ComputeClient()
+    assert isinstance(client, ComputeClientV2)


### PR DESCRIPTION
Created `ComputeClientV2` and `ComputeClientV3` classes to support Globus Compute API versions 2 and 3, respectively. The canonical `ComputeClient` is now a subclass of `ComputeClientV2`, preserving backward compatibility.

<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1096.org.readthedocs.build/en/1096/

<!-- readthedocs-preview globus-sdk-python end -->