### PR TITLE
Fix persistent `build/` dir with tox wheels

### DIFF
--- a/changelog.d/20241031_183742_sirosen_cleanup_tox_build.rst
+++ b/changelog.d/20241031_183742_sirosen_cleanup_tox_build.rst
@@ -1,0 +1,4 @@
+Development
+~~~~~~~~~~~
+
+- Introduce a ``toxfile.py`` to ensure clean builds during development. (:pr:`NUMBER`)

--- a/toxfile.py
+++ b/toxfile.py
@@ -1,0 +1,35 @@
+"""
+This is a very small 'tox' plugin.
+'toxfile.py' is a special name for auto-loading a plugin without defining package
+metadata.
+
+For full doc, see: https://tox.wiki/en/latest/plugins.html
+
+Methods decorated below with `tox.plugin.impl` are hook implementations.
+We only implement hooks which we need.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import shutil
+import typing as t
+
+from tox.plugin import impl
+
+if t.TYPE_CHECKING:
+    from tox.tox_env.api import ToxEnv
+
+REPO_ROOT = pathlib.Path(__file__).parent
+BUILD_DIR = REPO_ROOT / "build"
+
+
+@impl
+def tox_on_install(
+    tox_env: ToxEnv, arguments: t.Any, section: str, of_type: str
+) -> None:
+    # when setting up the wheel build, clear the 'build/' directory if present
+    if tox_env.name != "build_wheel":
+        return
+    if BUILD_DIR.exists():
+        shutil.rmtree(BUILD_DIR)


### PR DESCRIPTION
tox build_wheel has been producing a `build/` directory (setuptools)
which is not cleared between runs. This manifests as a very bad and
confusing developer experience when a module is renamed or moved, and
both the old and new files are present in the sdist and wheel for
testing. This can result in module name shadowing and other hard to
debug issues.

We have attempted to solve this in the past by means of custom
external packaging environments, but have never found a satisfactory
solution. This new approach is to "bite the bullet" and use tox's
plugin extension points. Via pluggy, tox is providing the same
architecture for extension which pytest is based around, meaning that
the 'toxfile.py' should be thought of as analogous to 'conftest.py'
(already familiar) and the hook decorator should be understood to be
similar to `@pytest.fixture` or definition of hook methods like
`pytest_configure`.

We only define one hook, which is invoked each time `tox` is
installing into an environment. We inspect the environment name and
abort if it's anything other than `"build_wheel"`. If and only if
we're running the install phase of `"build_wheel"`, we will remove the
`build/` directory if present.

For my final test runs of the new behavior, I ran tox, manually added
files to `build/`, then ran tox again. I was able to confirm that the
extra files in `build/` were removed. The same testing procedure fails
on `main`. I also confirmed that `tox p` was not measurably slower,
indicating that the build-once semantics are being preserved.


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1098.org.readthedocs.build/en/1098/

<!-- readthedocs-preview globus-sdk-python end -->