### PR TITLE
Update RTD config to use 'uv' for faster builds

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,9 +11,9 @@ build:
   # use 'uv pip install' to apply build customization in a pip-compatible way
   # see: https://docs.readthedocs.io/en/stable/build-customization.html#install-dependencies-with-uv
   commands:
-    - bash ./scripts/rtd-pre-sphinx-build.sh
     - asdf plugin add uv
     - asdf install uv latest
     - asdf global uv latest
     - uv pip install . -r "requirements/py3.11/docs.txt"
+    - bash ./scripts/rtd-pre-sphinx-build.sh
     - uv run -m sphinx -T -b html -d docs/_build/doctrees -D language=en docs $READTHEDOCS_OUTPUT/html

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,6 +14,7 @@ build:
     - asdf plugin add uv
     - asdf install uv latest
     - asdf global uv latest
+    - uv venv
     - uv pip install . -r "requirements/py3.11/docs.txt"
     - bash ./scripts/rtd-pre-sphinx-build.sh
     - uv run -m sphinx -T -b html -d docs/_build/doctrees -D language=en docs $READTHEDOCS_OUTPUT/html

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,12 +8,12 @@ build:
   os: "ubuntu-22.04"
   tools:
     python: "3.11"
-  jobs:
-    pre_build:
-      - bash ./scripts/rtd-pre-sphinx-build.sh
-
-python:
-  install:
-    - method: pip
-      path: .
-    - requirements: "requirements/py3.11/docs.txt"
+  # use 'uv pip install' to apply build customization in a pip-compatible way
+  # see: https://docs.readthedocs.io/en/stable/build-customization.html#install-dependencies-with-uv
+  commands:
+    - bash ./scripts/rtd-pre-sphinx-build.sh
+    - asdf plugin add uv
+    - asdf install uv latest
+    - asdf global uv latest
+    - uv pip install . -r "requirements/py3.11/docs.txt"
+    - uv run -m sphinx -T -b html -d docs/_build/doctrees -D language=en docs $READTHEDOCS_OUTPUT/html

--- a/scripts/rtd-pre-sphinx-build.sh
+++ b/scripts/rtd-pre-sphinx-build.sh
@@ -39,4 +39,4 @@ if [ -z "$(find changelog.d -name '*.rst')" ]; then
     exit 0
 fi
 
-scriv collect --keep --version "$VERSION" -v DEBUG
+uv run scriv collect --keep --version "$VERSION" -v DEBUG


### PR DESCRIPTION
This PR is an initial exploration of ways in which we can safely drop `uv` into our existing process without any requisite changes to the local dev experience.
RTD is chosen because
- it is simple
- it is well isolated from the rest of our work
- we should be able to measure build times (impact) trivially

---

Using `build.commands`, we completely override the build process for RTD. Per their documentation (linked in a comment), this is the way to convert a doc build to use `uv`.

The install is done using the `uv pip` interface, which has a few advantages:
- it can be treated as a plug-in replacement for `pip ...`
- it supports `-r` options (so we don't need to change how we're locking dependencies here)
- it ensures that we don't see any surprising new semantics from the uv lockfile (which could be hard to troubleshoot locally)

Because we're now using `build.commands`, there's no point in keeping `jobs.pre_build` as separate config. Simply inline the relevant command into our overridden process.


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1101.org.readthedocs.build/en/1101/

<!-- readthedocs-preview globus-sdk-python end -->