### PR TITLE
Release v3.47.0

### DIFF
--- a/changelog.d/20241004_152509_sirosen_timers_client_scope_helper.rst
+++ b/changelog.d/20241004_152509_sirosen_timers_client_scope_helper.rst
@@ -1,7 +1,0 @@
-Added
-~~~~~
-
-- Add ``TimersClient.add_app_transfer_data_access_scope`` for ``TimersClient``
-  instances which are integrated with ``GlobusApp``. This method registers the
-  nested scope dependency for a ``data_access`` requirement for a transfer
-  timer. (:pr:`1074`)

--- a/changelog.d/20241011_113822_8730430+m1yag1_sc_35200_version_field_post_search.rst
+++ b/changelog.d/20241011_113822_8730430+m1yag1_sc_35200_version_field_post_search.rst
@@ -1,6 +1,0 @@
-Added
-~~~~~
-
-- ``SearchQueryV1`` is a new class for submitting complex queries replacing
-  the legacy ``SearchQuery`` class. A deprecation warning has been added to the
-  ``SearchQuery`` class. (:pr:`1079`)

--- a/changelog.d/20241023_134132_30907815+rjmello_modify_compute_client_reg_func.rst
+++ b/changelog.d/20241023_134132_30907815+rjmello_modify_compute_client_reg_func.rst
@@ -1,6 +1,0 @@
-Deprecated
-~~~~~~~~~~
-
-- Deprecated the ``ComputeFunctionDocument`` and ``ComputeFunctionMetadata`` classes.
-  This change reflects an early design adjustment to better align with the existing
-  Globus Compute SDK. (:pr:`1092`)

--- a/changelog.d/20241024_113828_chris_command_line_login_flow_manager_catch_eof.rst
+++ b/changelog.d/20241024_113828_chris_command_line_login_flow_manager_catch_eof.rst
@@ -1,5 +1,0 @@
-Changed
-~~~~~~~
-
-- Improved error messaging around EOF errors when prompting for code during a command
-  line login flow (:pr:`1093`)

--- a/changelog.d/20241031_151930_30907815+rjmello_versioned_compute_clients.rst
+++ b/changelog.d/20241031_151930_30907815+rjmello_versioned_compute_clients.rst
@@ -1,6 +1,0 @@
-Added
-~~~~~
-
-- Created ``ComputeClientV2`` and ``ComputeClientV3`` classes to support Globus Compute
-  API versions 2 and 3, respectively. The canonical ``ComputeClient`` is now a subclass
-  of ``ComputeClientV2``, preserving backward compatibility. (:pr:`1096`)

--- a/changelog.d/20241031_183742_sirosen_cleanup_tox_build.rst
+++ b/changelog.d/20241031_183742_sirosen_cleanup_tox_build.rst
@@ -1,4 +1,0 @@
-Development
-~~~~~~~~~~~
-
-- Introduce a ``toxfile.py`` to ensure clean builds during development. (:pr:`1098`)

--- a/changelog.d/20241107_160041_30907815+rjmello_compute_client_task_methods.rst
+++ b/changelog.d/20241107_160041_30907815+rjmello_compute_client_task_methods.rst
@@ -1,6 +1,0 @@
-Added
-~~~~~
-
-- Added the ``ComputeClientV3.submit()``, ``ComputeClientV2.submit()``,
-  ``ComputeClientV2.get_task()``, ``ComputeClientV2.get_task_batch()``,
-  and ``ComputeClientV2.get_task_group()`` methods. (:pr:`1094`)

--- a/changelog.rst
+++ b/changelog.rst
@@ -12,6 +12,52 @@ to a major new version of the SDK.
 
 .. scriv-insert-here
 
+.. _changelog-3.47.0:
+
+v3.47.0 (2024-11-08)
+--------------------
+
+Added
+~~~~~
+
+- Add ``TimersClient.add_app_transfer_data_access_scope`` for ``TimersClient``
+  instances which are integrated with ``GlobusApp``. This method registers the
+  nested scope dependency for a ``data_access`` requirement for a transfer
+  timer. (:pr:`1074`)
+
+- ``SearchQueryV1`` is a new class for submitting complex queries replacing
+  the legacy ``SearchQuery`` class. A deprecation warning has been added to the
+  ``SearchQuery`` class. (:pr:`1079`)
+
+- Created ``ComputeClientV2`` and ``ComputeClientV3`` classes to support Globus Compute
+  API versions 2 and 3, respectively. The canonical ``ComputeClient`` is now a subclass
+  of ``ComputeClientV2``, preserving backward compatibility. (:pr:`1096`)
+
+- Added the ``ComputeClientV3.submit()``, ``ComputeClientV2.submit()``,
+  ``ComputeClientV2.get_task()``, ``ComputeClientV2.get_task_batch()``,
+  and ``ComputeClientV2.get_task_group()`` methods. (:pr:`1094`)
+
+Changed
+~~~~~~~
+
+- Improved error messaging around EOF errors when prompting for code during a command
+  line login flow (:pr:`1093`)
+
+Deprecated
+~~~~~~~~~~
+
+- Deprecated the ``ComputeFunctionDocument`` and ``ComputeFunctionMetadata`` classes.
+  This change reflects an early design adjustment to better align with the existing
+  Globus Compute SDK. (:pr:`1092`)
+
+Development
+~~~~~~~~~~~
+
+- Introduce a ``toxfile.py`` to ensure clean builds during development. (:pr:`1098`)
+
+- The lazy importer used for the top-level ``globus_sdk`` module has been rewritten.
+  It produces identical results to the previous system. (:pr:`1100`)
+
 .. _changelog-3.46.0:
 
 v3.46.0 (2024-10-15)

--- a/src/globus_sdk/version.py
+++ b/src/globus_sdk/version.py
@@ -1,3 +1,3 @@
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "3.46.0"
+__version__ = "3.47.0"


### PR DESCRIPTION
Added
-----

- Add ``TimersClient.add_app_transfer_data_access_scope`` for ``TimersClient``
  instances which are integrated with ``GlobusApp``. This method registers the
  nested scope dependency for a ``data_access`` requirement for a transfer
  timer. (:pr:`1074`)

- ``SearchQueryV1`` is a new class for submitting complex queries replacing
  the legacy ``SearchQuery`` class. A deprecation warning has been added to the
  ``SearchQuery`` class. (:pr:`1079`)

- Created ``ComputeClientV2`` and ``ComputeClientV3`` classes to support Globus Compute
  API versions 2 and 3, respectively. The canonical ``ComputeClient`` is now a subclass
  of ``ComputeClientV2``, preserving backward compatibility. (:pr:`1096`)

- Added the ``ComputeClientV3.submit()``, ``ComputeClientV2.submit()``,
  ``ComputeClientV2.get_task()``, ``ComputeClientV2.get_task_batch()``,
  and ``ComputeClientV2.get_task_group()`` methods. (:pr:`1094`)

Changed
-------

- Improved error messaging around EOF errors when prompting for code during a command
  line login flow (:pr:`1093`)

Deprecated
----------

- Deprecated the ``ComputeFunctionDocument`` and ``ComputeFunctionMetadata`` classes.
  This change reflects an early design adjustment to better align with the existing
  Globus Compute SDK. (:pr:`1092`)

Development
-----------

- Introduce a ``toxfile.py`` to ensure clean builds during development. (:pr:`1098`)


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1103.org.readthedocs.build/en/1103/

<!-- readthedocs-preview globus-sdk-python end -->