### PR TITLE
Update an HTTP link to the SDK docs, and others

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-# http://editorconfig.org
+# https://editorconfig.org/
 
 root = true
 

--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,7 @@ guide for detail.
 
 Links
 -----
-| Full Documentation: http://globus-sdk-python.readthedocs.io/
+| Full Documentation: https://globus-sdk-python.readthedocs.io/
 | Source Code: https://github.com/globus/globus-sdk-python
 | API Documentation: https://docs.globus.org/api/
 | Release History + Changelog: https://github.com/globus/globus-sdk-python/releases

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -4,7 +4,7 @@ Installation
 The Globus SDK requires `Python 3 <https://www.python.org/>`_.
 If a supported version of Python is not already installed on your system, see
 this `Python installation guide \
-<http://docs.python-guide.org/en/latest/starting/installation/>`_.
+<https://docs.python-guide.org/starting/installation/>`_.
 
 The simplest way to install the Globus SDK is using the ``pip`` package manager
 (https://pypi.python.org/pypi/pip), which is included in most Python


### PR DESCRIPTION
Found while reviewing the latest release on PyPI.

Other HTTP links have also been updated as appropriate, and redirects followed.

<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1105.org.readthedocs.build/en/1105/

<!-- readthedocs-preview globus-sdk-python end -->