### PR TITLE
docs(services): change num_results argument to limit

### DIFF
--- a/docs/services/index.rst
+++ b/docs/services/index.rst
@@ -24,7 +24,7 @@ very simply::
 
     print("My Last 25 Tasks:")
     # `filter` to get Delete Tasks (default is just Transfer Tasks)
-    for task in tc.task_list(num_results=25, filter="type:TRANSFER,DELETE"):
+    for task in tc.task_list(limit=25, filter="type:TRANSFER,DELETE"):
         print(task["task_id"], task["type"], task["status"])
 
 .. note:: Multi-Thread and Multi-Process Safety


### PR DESCRIPTION
This will fix the following error:

```
    for task in tc.task_list(num_results=25, filter="type:TRANSFER,DELETE"):
TypeError: task_list() got an unexpected keyword argument 'num_results'
```

<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1107.org.readthedocs.build/en/1107/

<!-- readthedocs-preview globus-sdk-python end -->