### PR TITLE
Remove identity ID consistency validation from ClientApp

### DIFF
--- a/changelog.d/20241121_133309_derek_client_app_expired_token_bug.rst
+++ b/changelog.d/20241121_133309_derek_client_app_expired_token_bug.rst
@@ -2,7 +2,7 @@
 Changed
 ~~~~~~~
 
--   Removed identity id validation from ``ClientApps``. (:pr:`NUMBER`)
+-   Removed identity ID consistency validation from ``ClientApp``. (:pr:`NUMBER`)
 
 Fixed
 ~~~~~

--- a/changelog.d/20241121_133309_derek_client_app_expired_token_bug.rst
+++ b/changelog.d/20241121_133309_derek_client_app_expired_token_bug.rst
@@ -1,0 +1,10 @@
+
+Changed
+~~~~~~~
+
+-   Removed identity id validation from ``ClientApps``. (:pr:`NUMBER`)
+
+Fixed
+~~~~~
+
+-   Fixed a bug that would cause ``ClientApp`` token refreshes to fail. (:pr:`NUMBER`)

--- a/src/globus_sdk/globus_app/app.py
+++ b/src/globus_sdk/globus_app/app.py
@@ -192,7 +192,7 @@ class GlobusApp(metaclass=abc.ABCMeta):
         # our initial scope requirements
         scope_validator = ScopeRequirementsValidator(scope_requirements, consent_client)
 
-        # use validators to enforce invariants about scopes and identity ID
+        # use validators to enforce invariants about scopes
         validating_token_storage.validators.append(scope_validator)
 
         return validating_token_storage

--- a/src/globus_sdk/globus_app/app.py
+++ b/src/globus_sdk/globus_app/app.py
@@ -14,7 +14,6 @@ from globus_sdk.tokenstorage import (
     ScopeRequirementsValidator,
     TokenStorage,
     TokenValidationError,
-    UnchangingIdentityIDValidator,
     ValidatingTokenStorage,
 )
 
@@ -92,7 +91,7 @@ class GlobusApp(metaclass=abc.ABCMeta):
 
         # create the requisite token storage for the app, with validation based on
         # the provided parameters
-        self.token_storage = _build_default_validating_token_storage(
+        self.token_storage = self._initialize_validating_token_storage(
             token_storage=self._token_storage,
             consent_client=consent_client,
             scope_requirements=self._scope_requirements,
@@ -177,6 +176,26 @@ class GlobusApp(metaclass=abc.ABCMeta):
         """
         Initializes and returns an AuthLoginClient to be used in authorization requests.
         """
+
+    def _initialize_validating_token_storage(
+        self,
+        token_storage: TokenStorage,
+        consent_client: AuthClient,
+        scope_requirements: t.Mapping[str, t.Sequence[Scope]],
+    ) -> ValidatingTokenStorage:
+        """
+        Initializes the validating token storage for the app.
+        """
+        validating_token_storage = ValidatingTokenStorage(token_storage)
+
+        # construct ValidatingTokenStorage around the TokenStorage and
+        # our initial scope requirements
+        scope_validator = ScopeRequirementsValidator(scope_requirements, consent_client)
+
+        # use validators to enforce invariants about scopes and identity ID
+        validating_token_storage.validators.append(scope_validator)
+
+        return validating_token_storage
 
     def _resolve_token_storage(
         self, app_name: str, client_id: UUIDLike, config: GlobusAppConfig
@@ -391,36 +410,3 @@ class GlobusApp(metaclass=abc.ABCMeta):
         """
         # Scopes are mutable objects so we return a deepcopy
         return copy.deepcopy(self._scope_requirements)
-
-
-def _build_default_validating_token_storage(
-    *,
-    token_storage: TokenStorage,
-    consent_client: AuthClient,
-    scope_requirements: t.Mapping[str, t.Sequence[Scope]],
-) -> ValidatingTokenStorage:
-    """
-    Given the appropriate configuration data, build the default
-    ValidatingTokenStorage for use within GlobusApp.
-
-    :param token_storage: The token storage to wrap in a ValidatingTokenStorage.
-    :param consent_client: The app's internal AuthClient instance which is used
-        to fetch consent information.
-    :param scope_requirements: The scope requirements for the app.
-    """
-    validating_token_storage = ValidatingTokenStorage(token_storage)
-
-    # construct ValidatingTokenStorage around the TokenStorage and
-    # our initial scope requirements
-    scope_validator = ScopeRequirementsValidator(scope_requirements, consent_client)
-    identity_id_validator = UnchangingIdentityIDValidator()
-
-    # use validators to enforce invariants about scopes and identity ID
-    validating_token_storage.validators.extend(
-        (
-            scope_validator,
-            identity_id_validator,
-        )
-    )
-
-    return validating_token_storage

--- a/tests/unit/globus_app/test_globus_app.py
+++ b/tests/unit/globus_app/test_globus_app.py
@@ -50,7 +50,7 @@ def _mock_token_data_by_rs(
     expiration_delta: int = 300,
 ):
     return {
-        "auth.globus.org": TokenStorageData(
+        resource_server: TokenStorageData(
             resource_server=resource_server,
             identity_id="mock_identity_id",
             scope=scope,
@@ -486,12 +486,16 @@ def test_client_app_expired_token_is_auto_resolved():
     client_app = ClientApp("test-app", **client_creds, config=config)
 
     transfer = TransferClient(app=client_app, app_scopes=[Scope(meta["scope"])])
-
     load_response(transfer.task_list)
+
+    starting_token = memory_storage.get_token_data(meta["resource_server"]).access_token
+    assert starting_token == token_data[meta["resource_server"]].access_token
+
     transfer.task_list()
 
-    access_token = memory_storage.get_token_data(meta["resource_server"]).access_token
-    assert access_token == meta["access_token"]
+    ending_token = memory_storage.get_token_data(meta["resource_server"]).access_token
+    assert starting_token != ending_token
+    assert ending_token == meta["access_token"]
 
 
 def test_client_app_get_authorizer():

--- a/tests/unit/globus_app/test_globus_app.py
+++ b/tests/unit/globus_app/test_globus_app.py
@@ -462,7 +462,6 @@ def test_user_app_expired_token_triggers_login():
     assert login_flow_manager.counter == 1
 
 
-@pytest.mark.xfail(reason="Identified Bug")
 def test_client_app_expired_token_is_auto_resolved():
     """
     This test exercises ClientApp token grant behavior.
@@ -488,7 +487,11 @@ def test_client_app_expired_token_is_auto_resolved():
 
     transfer = TransferClient(app=client_app, app_scopes=[Scope(meta["scope"])])
 
+    load_response(transfer.task_list)
     transfer.task_list()
+
+    access_token = memory_storage.get_token_data(meta["resource_server"]).access_token
+    assert access_token == meta["access_token"]
 
 
 def test_client_app_get_authorizer():

--- a/tests/unit/globus_app/test_globus_app.py
+++ b/tests/unit/globus_app/test_globus_app.py
@@ -15,6 +15,7 @@ from globus_sdk import (
     GlobusAppConfig,
     NativeAppAuthClient,
     RefreshTokenAuthorizer,
+    TransferClient,
     UserApp,
 )
 from globus_sdk._testing import load_response
@@ -42,15 +43,20 @@ from globus_sdk.tokenstorage import (
 )
 
 
-def _mock_token_data_by_rs():
+def _mock_token_data_by_rs(
+    resource_server: str = "auth.globus.org",
+    scope: str = "openid",
+    refresh_token: str | None = "mock_refresh_token",
+    expiration_delta: int = 300,
+):
     return {
         "auth.globus.org": TokenStorageData(
-            resource_server="auth.globus.org",
+            resource_server=resource_server,
             identity_id="mock_identity_id",
-            scope="openid",
+            scope=scope,
             access_token="mock_access_token",
-            refresh_token="mock_refresh_token",
-            expires_at_seconds=int(time.time() + 300),
+            refresh_token=refresh_token,
+            expires_at_seconds=int(time.time() + expiration_delta),
             token_type="Bearer",
         )
     }
@@ -434,13 +440,14 @@ class RaisingLoginFlowManagerCounter(LoginFlowManager):
         raise CustomExitException("mock login attempt")
 
 
-def test_user_app_expired_authorizer_triggers_login():
+def test_user_app_expired_token_triggers_login():
     # Set up token data with an expired access token and no refresh token
     client_id = "mock_client_id"
     memory_storage = MemoryTokenStorage()
-    token_data = _mock_token_data_by_rs()
-    token_data["auth.globus.org"].expires_at_seconds = int(time.time() - 3600)
-    token_data["auth.globus.org"].refresh_token = None
+    token_data = _mock_token_data_by_rs(
+        refresh_token=None,
+        expiration_delta=-3600,  # Expired by 1 hour
+    )
     memory_storage.store_token_data_by_resource_server(token_data)
 
     login_flow_manager = RaisingLoginFlowManagerCounter()
@@ -453,6 +460,35 @@ def test_user_app_expired_authorizer_triggers_login():
         user_app.get_authorizer("auth.globus.org")
 
     assert login_flow_manager.counter == 1
+
+
+@pytest.mark.xfail(reason="Identified Bug")
+def test_client_app_expired_token_is_auto_resolved():
+    """
+    This test exercises ClientApp token grant behavior.
+    ClientApps may request updated tokens outside the normal token authorization flow.
+    """
+    client_creds = {
+        "client_id": "mock_client_id",
+        "client_secret": "mock_client_secret",
+    }
+    meta = load_response("auth.oauth2_client_credentials_tokens").metadata
+
+    memory_storage = MemoryTokenStorage()
+    token_data = _mock_token_data_by_rs(
+        resource_server=meta["resource_server"],
+        scope=meta["scope"],
+        refresh_token=None,
+        expiration_delta=-3600,  # Expired by 1 hour
+    )
+    memory_storage.store_token_data_by_resource_server(token_data)
+
+    config = GlobusAppConfig(token_storage=memory_storage)
+    client_app = ClientApp("test-app", **client_creds, config=config)
+
+    transfer = TransferClient(app=client_app, app_scopes=[Scope(meta["scope"])])
+
+    transfer.task_list()
 
 
 def test_client_app_get_authorizer():


### PR DESCRIPTION
## What?
* Remove identity id consistency validation from ClientApps (UserApps are unaffected).


## Why?
1. ClientApps don't have the same token refresh erganomics as UserApps.
   * If an access token is expired in a UserApp, it will raise an error which can be by the app and initiate a login flow.
   * If an access token is expired in a ClientApp, it will still return a ClientCredentialAuthorizer expecting that the access token will be refreshed by that authorizer down the line.
1. ClientCredentialAuthorizers exclusively request one token at a time.

Because of these two facts, a refresh initiated by a ClientCredentialAuthorizer will only ever contain identity info if it's refreshing specifically an globus auth token because that identity info only comes if you specify the special auth-managed "openid" scope.

Because this is a pretty widespread bug (any usage of a ClientApp), I advocate that we simply remove identity id consistency validation from ClientApps (thank you @rjmello for this suggestion) while planning to move off of `ClientCredntialAuthorizer` in the future.

## Testing
1. Added a unit test that recreates a scenario users reported. Verified it failed before the fix & succeeded after it.
2. Simulated a client app token expiry scenario locally & observed that the groups token was successfully refreshed.