### PR TITLE
Fix `ComputeClient.get_task_batch` URL path

### DIFF
--- a/changelog.d/20241209_223301_30907815+rjmello.rst
+++ b/changelog.d/20241209_223301_30907815+rjmello.rst
@@ -1,0 +1,5 @@
+Fixed
+~~~~~
+
+- Fixed an incorrect URL path in ``ComputeClient.get_task_batch``. (:pr:`NUMBER`)
+

--- a/src/globus_sdk/_testing/data/compute/v2/get_task_batch.py
+++ b/src/globus_sdk/_testing/data/compute/v2/get_task_batch.py
@@ -13,7 +13,7 @@ RESPONSES = ResponseSet(
     metadata={"task_id": TASK_ID},
     default=RegisteredResponse(
         service="compute",
-        path="/v2/tasks/batch",
+        path="/v2/batch_status",
         method="POST",
         json=TASK_BATCH_DOC,
         # Ensure task_ids is a list

--- a/src/globus_sdk/services/compute/client.py
+++ b/src/globus_sdk/services/compute/client.py
@@ -221,7 +221,7 @@ class ComputeClientV2(client.BaseClient):
                     :ref: Root/operation/get_batch_status_v2_batch_status_post
         """
         task_ids = list(utils.safe_strseq_iter(task_ids))
-        return self.post("/v2/tasks/batch", data={"task_ids": task_ids})
+        return self.post("/v2/batch_status", data={"task_ids": task_ids})
 
     def get_task_group(self, task_group_id: UUIDLike) -> GlobusHTTPResponse:
         """Get a list of task IDs associated with a task group.


### PR DESCRIPTION
Fixed an incorrect URL path in `ComputeClient.get_task_batch`.

<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1117.org.readthedocs.build/en/1117/

<!-- readthedocs-preview globus-sdk-python end -->