### PR TITLE
Add a new tox plugin setting to do `rm -r`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -69,18 +69,16 @@ commands = pyright src/ {posargs}
 # readthedocs doc build
 basepython = python3.11
 deps = -r requirements/py{py_dot_ver}/docs.txt
-allowlist_externals = rm
-changedir = docs/
 # clean the build dir before rebuilding
-commands_pre = rm -rf _build/
+globus_sdk_rmtree = docs/_build
+changedir = docs/
 commands = sphinx-build -j auto -d _build/doctrees -b html -W . _build/html {posargs}
 
 [testenv:twine-check]
 skip_install = true
 deps = build
        twine!=5.1.0
-allowlist_externals = rm
-commands_pre = rm -rf dist/
+globus_sdk_rmtree = dist
 # check that twine validating package data works
 commands = python -m build
            twine check --strict dist/*
@@ -89,8 +87,7 @@ commands = python -m build
 skip_install = true
 deps = poetry
 # remove the dist dir because it can lead to (confusing) spurious failures
-allowlist_externals = rm
-commands_pre = rm -rf dist/
+globus_sdk_rmtree = dist
 # use `poetry lock` to ensure that poetry can parse our dependencies
 changedir = tests/non-pytest/poetry-lock-test
 commands = poetry lock

--- a/toxfile.py
+++ b/toxfile.py
@@ -11,6 +11,7 @@ We only implement hooks which we need.
 
 from __future__ import annotations
 
+import logging
 import pathlib
 import shutil
 import typing as t
@@ -18,7 +19,11 @@ import typing as t
 from tox.plugin import impl
 
 if t.TYPE_CHECKING:
+    from tox.config.sets import EnvConfigSet
+    from tox.session.state import State
     from tox.tox_env.api import ToxEnv
+
+log = logging.getLogger(__name__)
 
 REPO_ROOT = pathlib.Path(__file__).parent
 BUILD_DIR = REPO_ROOT / "build"
@@ -33,3 +38,23 @@ def tox_on_install(
         return
     if BUILD_DIR.exists():
         shutil.rmtree(BUILD_DIR)
+
+
+@impl
+def tox_add_env_config(env_conf: EnvConfigSet, state: State) -> None:
+    env_conf.add_config(
+        keys=["globus_sdk_rmtree"],
+        of_type=list[str],
+        default=[],
+        desc="A dir tree to remove before running the environment commands",
+    )
+
+
+@impl
+def tox_before_run_commands(tox_env: ToxEnv) -> None:
+    sdk_rmtree = tox_env.conf.load("globus_sdk_rmtree")
+    for name in sdk_rmtree:
+        path = pathlib.Path(name)
+        if path.exists():
+            log.warning(f"globus_sdk_rmtree: {path}")
+            shutil.rmtree(path)


### PR DESCRIPTION
_Experimental PR:_ I decided to see if I could solve this problem, and what the tradeoffs would be.
We should be quick to reject it if we don't like the result, after a discussion.

The basic questions I wanted to answer were:
- how hard is it to implement "custom commands" as part of tox config via the plugin file?
- can we do better on the *very common* pattern of invoking `rm`, specifically?

Something non-obvious about this from just seeing the PR is that it took ~1 hour to implement these very modest changes.
The tox docs for the plugin hooks and objects are lagging a bit behind best-in-class tools like `pytest`, so it took some trial-and-error + reading up on existing plugins (like `tox-docker`) to see what they're doing.

---

Replace uses of `rm` in tox.ini with custom `rmtree` config setting, provided by the toxfile.py plugin.

Advantages over using `rm`:
- more concise, without the risk of forgetting `allowlist_externals`
- more portable -- works on Windows

Some projects have historically made themselves more portable by embedding `python -c ...` invocations in their tox config. This solves the problem of "how to do that cleanly".
