### PR TITLE
Minor tox.ini improvement: use `base = mypy`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -42,13 +42,13 @@ deps = pre-commit
 skip_install = true
 commands = pre-commit run --all-files
 
-[testenv:mypy{,-test}]
-commands_pre =
-deps =
-    -r requirements/py{py_dot_ver}/typing.txt
-commands =
-    !test: mypy src/ {posargs}
-    test: mypy --show-error-codes --warn-unused-ignores tests/non-pytest/mypy-ignore-tests/
+[testenv:mypy]
+deps = -r requirements/py{py_dot_ver}/typing.txt
+commands = mypy src/ {posargs}
+
+[testenv:mypy-test]
+base = mypy
+commands = mypy --show-error-codes --warn-unused-ignores tests/non-pytest/mypy-ignore-tests/
 
 [testenv:test-lazy-imports]
 deps = -r requirements/py{py_dot_ver}/test.txt


### PR DESCRIPTION
Declaring a `base` environment allows you to declare a parallel
environment to an existing one with some settings overridden. This
lets us avoid the generative environment listing syntax (slightly
obscure as a feature, not everyone knows about it) and having two
`commands` lists fully differentiated by a factor.

The config here is 100% equivalent to what we had before, but is
easier to read and understand for developers less immersed in tox.


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1119.org.readthedocs.build/en/1119/

<!-- readthedocs-preview globus-sdk-python end -->