### PR TITLE
Bugfix: allow_domains vs allowed_domains

### DIFF
--- a/changelog.d/20241217_142634_sirosen_fix_sgw_allowed_domains.rst
+++ b/changelog.d/20241217_142634_sirosen_fix_sgw_allowed_domains.rst
@@ -1,0 +1,6 @@
+Fixed
+~~~~~
+
+- Fix a bug in ``StorageGatewayDocument`` which stored any ``allowed_domains``
+  argument under an ``"allow_domains"`` key instead of the correct key,
+  ``"allowed_domains"``. (:pr:`NUMBER`)

--- a/src/globus_sdk/services/gcs/data/storage_gateway.py
+++ b/src/globus_sdk/services/gcs/data/storage_gateway.py
@@ -78,7 +78,7 @@ class StorageGatewayDocument(utils.PayloadWrapper):
             root=root,
         )
         self._set_optstrlists(
-            allow_domains=allowed_domains,
+            allowed_domains=allowed_domains,
             users_allow=users_allow,
             users_deny=users_deny,
         )


### PR DESCRIPTION
I've confirmed with the team that this was always incorrect -- there
was never a version which accepted `allow_domains`.


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1120.org.readthedocs.build/en/1120/

<!-- readthedocs-preview globus-sdk-python end -->