### PR TITLE
Update pre-commit hooks & apply

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,12 +8,12 @@ repos:
     - id: check-merge-conflict
     - id: trailing-whitespace
 - repo: https://github.com/python-jsonschema/check-jsonschema
-  rev: 0.29.3
+  rev: 0.30.0
   hooks:
     - id: check-github-workflows
     - id: check-readthedocs
 - repo: https://github.com/asottile/pyupgrade
-  rev: v3.17.0
+  rev: v3.19.1
   hooks:
     - id: pyupgrade
       args: ["--py37-plus"]
@@ -23,19 +23,19 @@ repos:
     - id: black
       name: "Autoformat python files"
 - repo: https://github.com/adamchainz/blacken-docs
-  rev: 1.18.0
+  rev: 1.19.1
   hooks:
     - id: blacken-docs
-      additional_dependencies: ['black==23.9.1']
+      additional_dependencies: ['black==24.10.0']
 - repo: https://github.com/PyCQA/flake8
   rev: 7.1.1
   hooks:
     - id: flake8
       name: "Lint python files"
       additional_dependencies:
-        - 'flake8-bugbear==24.8.19'
-        - 'flake8-comprehensions==3.15.0'
-        - 'flake8-typing-as-t==0.0.3'
+        - 'flake8-bugbear==24.12.12'
+        - 'flake8-comprehensions==3.16.0'
+        - 'flake8-typing-as-t==1.0.0'
 - repo: https://github.com/PyCQA/isort
   rev: 5.13.2
   hooks:
@@ -46,7 +46,7 @@ repos:
   hooks:
     - id: bad-backticks
 - repo: https://github.com/sirosen/slyp
-  rev: 0.7.1
+  rev: 0.8.1
   hooks:
     - id: slyp
 - repo: https://github.com/codespell-project/codespell
@@ -55,7 +55,7 @@ repos:
     - id: codespell
       args: ["--ignore-regex", "https://[^\\s]*"]
 - repo: https://github.com/sirosen/texthooks
-  rev: 0.6.7
+  rev: 0.6.8
   hooks:
     - id: alphabetize-codeowners
 - repo: https://github.com/rhysd/actionlint

--- a/src/globus_sdk/_lazy_import.py
+++ b/src/globus_sdk/_lazy_import.py
@@ -162,7 +162,7 @@ class _ParsedPYIData:
             cls._CACHE[(module_name, pyi_filename)] = cls(module_name, pyi_filename)
         return cls._CACHE[(module_name, pyi_filename)]
 
-    def __init__(self, module_name: str, pyi_filename: str):
+    def __init__(self, module_name: str, pyi_filename: str) -> None:
         self.module_name = module_name
         self.pyi_filename = pyi_filename
         self._ast = _parse_pyi_ast(module_name, pyi_filename)

--- a/src/globus_sdk/_testing/models.py
+++ b/src/globus_sdk/_testing/models.py
@@ -150,7 +150,7 @@ class ResponseList:
         self,
         *data: RegisteredResponse,
         metadata: dict[str, t.Any] | None = None,
-    ):
+    ) -> None:
         self.responses = list(data)
         self._metadata = metadata
         self.parent: ResponseSet | None = None

--- a/src/globus_sdk/authorizers/access_token.py
+++ b/src/globus_sdk/authorizers/access_token.py
@@ -16,7 +16,7 @@ class AccessTokenAuthorizer(StaticGlobusAuthorizer):
     :param access_token: An access token for Globus Auth
     """
 
-    def __init__(self, access_token: str):
+    def __init__(self, access_token: str) -> None:
         log.info(
             "Setting up an AccessTokenAuthorizer. It will use an "
             "auth type of Bearer and cannot handle 401s."

--- a/src/globus_sdk/authorizers/client_credentials.py
+++ b/src/globus_sdk/authorizers/client_credentials.py
@@ -65,7 +65,7 @@ class ClientCredentialsAuthorizer(
         on_refresh: (
             None | t.Callable[[globus_sdk.OAuthClientCredentialsResponse], t.Any]
         ) = None,
-    ):
+    ) -> None:
         # values for _get_token_data
         self.confidential_client = confidential_client
         self.scopes = scopes_to_str(scopes)

--- a/src/globus_sdk/authorizers/refresh_token.py
+++ b/src/globus_sdk/authorizers/refresh_token.py
@@ -58,7 +58,7 @@ class RefreshTokenAuthorizer(
         on_refresh: (
             None | t.Callable[[globus_sdk.OAuthRefreshTokenResponse], t.Any]
         ) = None,
-    ):
+    ) -> None:
         log.info(
             "Setting up RefreshTokenAuthorizer with auth_client="
             f"[instance:{id(auth_client)}]"

--- a/src/globus_sdk/client.py
+++ b/src/globus_sdk/client.py
@@ -74,7 +74,7 @@ class BaseClient:
         authorizer: GlobusAuthorizer | None = None,
         app_name: str | None = None,
         transport_params: dict[str, t.Any] | None = None,
-    ):
+    ) -> None:
         # Determine the client's environment.
         if app is not None:
             # If we're using a GlobusApp, the client's environment must either match the

--- a/src/globus_sdk/exc/api.py
+++ b/src/globus_sdk/exc/api.py
@@ -41,7 +41,7 @@ class GlobusAPIError(GlobusError):
     MESSAGE_FIELDS = ["message", "detail", "title"]
     RECOGNIZED_AUTHZ_SCHEMES = ["bearer", "basic", "globus-goauthtoken"]
 
-    def __init__(self, r: requests.Response, *args: t.Any, **kwargs: t.Any):
+    def __init__(self, r: requests.Response, *args: t.Any, **kwargs: t.Any) -> None:
         self._cached_raw_json: t.Any = _CACHE_SENTINEL
 
         self.http_status = r.status_code

--- a/src/globus_sdk/exc/convert.py
+++ b/src/globus_sdk/exc/convert.py
@@ -18,7 +18,7 @@ class NetworkError(GlobusError):
     to explain potentially confusing or inconsistent exceptions passed to us
     """
 
-    def __init__(self, msg: str, exc: Exception, *args: t.Any, **kwargs: t.Any):
+    def __init__(self, msg: str, exc: Exception, *args: t.Any, **kwargs: t.Any) -> None:
         super().__init__(msg)
         self.underlying_exception = exc
 

--- a/src/globus_sdk/exc/err_info.py
+++ b/src/globus_sdk/exc/err_info.py
@@ -65,7 +65,7 @@ class AuthorizationParameterInfo(ErrorInfo):
     >>>     print("got authz params:", authz_params)
     """
 
-    def __init__(self, error_data: dict[str, t.Any]):
+    def __init__(self, error_data: dict[str, t.Any]) -> None:
         # data is there if this key is present and it is a dict
         self._has_data = isinstance(error_data.get("authorization_parameters"), dict)
         data = t.cast(

--- a/src/globus_sdk/gare/_auth_requirements_error.py
+++ b/src/globus_sdk/gare/_auth_requirements_error.py
@@ -56,7 +56,7 @@ class GlobusAuthorizationParameters(Serializable):
         required_scopes: list[str] | None = None,
         prompt: str | None = None,
         extra: dict[str, t.Any] | None = None,
-    ):
+    ) -> None:
         self.session_message = validators.opt_str("session_message", session_message)
         self.session_required_identities = validators.opt_str_list(
             "session_required_identities", session_required_identities
@@ -103,7 +103,7 @@ class GARE(Serializable):
         authorization_parameters: dict[str, t.Any] | GlobusAuthorizationParameters,
         *,
         extra: dict[str, t.Any] | None = None,
-    ):
+    ) -> None:
         self.code = validators.str_("code", code)
         self.authorization_parameters = validators.instance_or_dict(
             "authorization_parameters",

--- a/src/globus_sdk/gare/_variants.py
+++ b/src/globus_sdk/gare/_variants.py
@@ -40,7 +40,7 @@ class LegacyConsentRequiredTransferError(Serializable):
         code: Literal["ConsentRequired"],
         required_scopes: list[str],
         extra: dict[str, t.Any] | None = None,
-    ):
+    ) -> None:
         self.code = _validate_consent_required_literal("code", code)
         self.required_scopes = validators.str_list("required_scopes", required_scopes)
         self.extra = extra or {}
@@ -71,7 +71,7 @@ class LegacyConsentRequiredAPError(Serializable):
         code: Literal["ConsentRequired"],
         required_scope: str,
         extra: dict[str, t.Any] | None,
-    ):
+    ) -> None:
         self.code = _validate_consent_required_literal("code", code)
         self.required_scope = validators.str_("required_scope", required_scope)
         self.extra = extra or {}
@@ -112,7 +112,7 @@ class LegacyAuthorizationParameters(Serializable):
         session_required_mfa: bool | None = None,
         prompt: Literal["login"] | None = None,
         extra: dict[str, t.Any] | None = None,
-    ):
+    ) -> None:
         self.session_message = validators.opt_str("session_message", session_message)
         self.session_required_identities = validators.opt_str_list(
             "session_required_identities", session_required_identities
@@ -167,7 +167,7 @@ class LegacyAuthorizationParametersError(Serializable):
         authorization_parameters: dict[str, t.Any] | LegacyAuthorizationParameters,
         code: str | None = None,
         extra: dict[str, t.Any] | None = None,
-    ):
+    ) -> None:
         # Apply default, if necessary
         self.code = validators.str_("code", code or self.DEFAULT_CODE)
         self.authorization_parameters = validators.instance_or_dict(

--- a/src/globus_sdk/globus_app/authorizer_factory.py
+++ b/src/globus_sdk/globus_app/authorizer_factory.py
@@ -224,7 +224,7 @@ class ClientCredentialsAuthorizerFactory(
         token_storage: ValidatingTokenStorage,
         confidential_client: globus_sdk.ConfidentialAppAuthClient,
         scope_requirements: dict[str, list[globus_sdk.Scope]],
-    ):
+    ) -> None:
         """
         :param token_storage: The ``ValidatingTokenStorage`` used
         for defining and validating the set of authorization requirements that

--- a/src/globus_sdk/paging/base.py
+++ b/src/globus_sdk/paging/base.py
@@ -59,7 +59,7 @@ class Paginator(t.Iterable[PageT], metaclass=abc.ABCMeta):
         # the Base paginator must accept arbitrary additional kwargs to indicate that
         # its child classes could define and use additional kwargs
         **kwargs: t.Any,
-    ):
+    ) -> None:
         self.method = method
         self.items_key = items_key
         self.client_args = client_args

--- a/src/globus_sdk/paging/last_key.py
+++ b/src/globus_sdk/paging/last_key.py
@@ -15,7 +15,7 @@ class LastKeyPaginator(Paginator[PageT]):
         items_key: str | None = None,
         client_args: tuple[t.Any, ...],
         client_kwargs: dict[str, t.Any],
-    ):
+    ) -> None:
         super().__init__(
             method,
             items_key=items_key,

--- a/src/globus_sdk/paging/limit_offset.py
+++ b/src/globus_sdk/paging/limit_offset.py
@@ -18,7 +18,7 @@ class _LimitOffsetBasedPaginator(Paginator[PageT]):  # pylint: disable=abstract-
         page_size: int,
         client_args: tuple[t.Any, ...],
         client_kwargs: dict[str, t.Any],
-    ):
+    ) -> None:
         super().__init__(
             method,
             items_key=items_key,

--- a/src/globus_sdk/paging/marker.py
+++ b/src/globus_sdk/paging/marker.py
@@ -23,7 +23,7 @@ class MarkerPaginator(Paginator[PageT]):
         marker_key: str = "marker",
         client_args: tuple[t.Any, ...],
         client_kwargs: dict[str, t.Any],
-    ):
+    ) -> None:
         super().__init__(
             method,
             items_key=items_key,

--- a/src/globus_sdk/paging/next_token.py
+++ b/src/globus_sdk/paging/next_token.py
@@ -23,7 +23,7 @@ class NextTokenPaginator(Paginator[PageT]):
         items_key: str | None = None,
         client_args: tuple[t.Any, ...],
         client_kwargs: dict[str, t.Any],
-    ):
+    ) -> None:
         super().__init__(
             method,
             items_key=items_key,

--- a/src/globus_sdk/paging/table.py
+++ b/src/globus_sdk/paging/table.py
@@ -36,7 +36,7 @@ class PaginatorTable:
     Creation of ``PaginatorTable`` objects is considered a private API.
     """
 
-    def __init__(self, client: t.Any):
+    def __init__(self, client: t.Any) -> None:
         self._client = client
         # _bindings is a lazily loaded table of names -> callables which
         # return paginators

--- a/src/globus_sdk/response.py
+++ b/src/globus_sdk/response.py
@@ -45,7 +45,7 @@ class GlobusHTTPResponse:
         self,
         response: Response | GlobusHTTPResponse,
         client: globus_sdk.BaseClient | None = None,
-    ):
+    ) -> None:
         # init on a GlobusHTTPResponse: we are wrapping this data
         # the _response is None
         if isinstance(response, GlobusHTTPResponse):

--- a/src/globus_sdk/scopes/consents/_errors.py
+++ b/src/globus_sdk/scopes/consents/_errors.py
@@ -9,7 +9,7 @@ if t.TYPE_CHECKING:
 class ConsentParseError(Exception):
     """An error raised if consent parsing/loading fails."""
 
-    def __init__(self, message: str, raw_consent: dict[str, t.Any]):
+    def __init__(self, message: str, raw_consent: dict[str, t.Any]) -> None:
         super().__init__(message)
         self.raw_consent = raw_consent
 
@@ -17,6 +17,6 @@ class ConsentParseError(Exception):
 class ConsentTreeConstructionError(Exception):
     """An error raised if consent tree construction fails."""
 
-    def __init__(self, message: str, consents: list[Consent]):
+    def __init__(self, message: str, consents: list[Consent]) -> None:
         super().__init__(message)
         self.consents = consents

--- a/src/globus_sdk/scopes/consents/_model.py
+++ b/src/globus_sdk/scopes/consents/_model.py
@@ -139,7 +139,7 @@ class ConsentForest:
                                  [Scope: <collection2>:data_access]
     """
 
-    def __init__(self, consents: t.Iterable[t.Mapping[str, t.Any] | Consent]):
+    def __init__(self, consents: t.Iterable[t.Mapping[str, t.Any] | Consent]) -> None:
         """
         :param consents: An iterable of consent data objects. Typically, this will be
             a ConsentForestResponse retrieved via `auth_client.get_consents(identity)`.
@@ -225,7 +225,7 @@ class ConsentTree:
        consent dependencies.
     """
 
-    def __init__(self, root_id: int, forest: ConsentForest):
+    def __init__(self, root_id: int, forest: ConsentForest) -> None:
         self.root = forest.get_node(root_id)
         self.nodes = [self.root]
         self._node_by_id = {root_id: self.root}

--- a/src/globus_sdk/services/auth/flow_managers/authorization_code.py
+++ b/src/globus_sdk/services/auth/flow_managers/authorization_code.py
@@ -53,7 +53,7 @@ class GlobusAuthorizationCodeFlowManager(GlobusOAuthFlowManager):
         requested_scopes: ScopeCollectionType | None = None,
         state: str = "_default",
         refresh_tokens: bool = False,
-    ):
+    ) -> None:
         # convert a scope object or iterable to string immediately on load
         # and default to the default requested scopes
         self.requested_scopes: str = stringify_requested_scopes(requested_scopes)

--- a/src/globus_sdk/services/auth/flow_managers/native_app.py
+++ b/src/globus_sdk/services/auth/flow_managers/native_app.py
@@ -107,7 +107,7 @@ class GlobusNativeAppFlowManager(GlobusOAuthFlowManager):
         verifier: str | None = None,
         refresh_tokens: bool = False,
         prefill_named_grant: str | None = None,
-    ):
+    ) -> None:
         self.auth_client = auth_client
 
         # set client_id, then check for validity

--- a/src/globus_sdk/services/auth/identity_map.py
+++ b/src/globus_sdk/services/auth/identity_map.py
@@ -136,7 +136,7 @@ class IdentityMap:
         *,
         id_batch_size: int | None = None,
         cache: None | t.MutableMapping[str, dict[str, t.Any]] = None,
-    ):
+    ) -> None:
         self.auth_client = auth_client
         self.id_batch_size = id_batch_size or self._default_id_batch_size
 

--- a/src/globus_sdk/services/compute/data.py
+++ b/src/globus_sdk/services/compute/data.py
@@ -23,7 +23,7 @@ class ComputeFunctionMetadata(utils.PayloadWrapper):
         *,
         python_version: str | MissingType = MISSING,
         sdk_version: str | MissingType = MISSING,
-    ):
+    ) -> None:
         warn_deprecated("ComputeFunctionMetadata is deprecated.")
         super().__init__()
         self["python_version"] = python_version
@@ -55,7 +55,7 @@ class ComputeFunctionDocument(utils.PayloadWrapper):
         metadata: ComputeFunctionMetadata | MissingType = MISSING,
         group: UUIDLike | MissingType = MISSING,
         public: bool = False,
-    ):
+    ) -> None:
         warn_deprecated("ComputeFunctionDocument is deprecated.")
         super().__init__()
         self["function_name"] = function_name

--- a/src/globus_sdk/services/flows/client.py
+++ b/src/globus_sdk/services/flows/client.py
@@ -852,7 +852,7 @@ class SpecificFlowClient(client.BaseClient):
         authorizer: GlobusAuthorizer | None = None,
         app_name: str | None = None,
         transport_params: dict[str, t.Any] | None = None,
-    ):
+    ) -> None:
         self._flow_id = flow_id
         self.scopes = SpecificFlowScopeBuilder(flow_id)
         super().__init__(

--- a/src/globus_sdk/services/gcs/client.py
+++ b/src/globus_sdk/services/gcs/client.py
@@ -53,7 +53,7 @@ class GCSClient(client.BaseClient):
         authorizer: GlobusAuthorizer | None = None,
         app_name: str | None = None,
         transport_params: dict[str, t.Any] | None = None,
-    ):
+    ) -> None:
         # check if the provided address was a DNS name or an HTTPS URL
         if not gcs_address.startswith("https://"):
             # if it's a DNS name format it accordingly

--- a/src/globus_sdk/services/gcs/data/endpoint.py
+++ b/src/globus_sdk/services/gcs/data/endpoint.py
@@ -115,7 +115,7 @@ class EndpointDocument(utils.PayloadWrapper):
         gridftp_control_channel_port: int | None | MissingType = MISSING,
         # additional fields
         additional_fields: dict[str, t.Any] | MissingType = MISSING,
-    ):
+    ) -> None:
         super().__init__()
         self["DATA_TYPE"] = data_type
         self["contact_email"] = contact_email

--- a/src/globus_sdk/services/gcs/response.py
+++ b/src/globus_sdk/services/gcs/response.py
@@ -57,7 +57,7 @@ class UnpackingGCSResponse(GlobusHTTPResponse):
         self,
         response: GlobusHTTPResponse,
         match: str | t.Callable[[dict[str, t.Any]], bool],
-    ):
+    ) -> None:
         super().__init__(response)
 
         if callable(match):

--- a/src/globus_sdk/services/groups/data.py
+++ b/src/globus_sdk/services/groups/data.py
@@ -294,7 +294,7 @@ class GroupPolicies(utils.PayloadWrapper):
         authentication_assurance_timeout: (
             int | None | utils.MissingType
         ) = utils.MISSING,
-    ):
+    ) -> None:
         super().__init__()
         self["is_high_assurance"] = is_high_assurance
         self["group_visibility"] = group_visibility

--- a/src/globus_sdk/services/search/data.py
+++ b/src/globus_sdk/services/search/data.py
@@ -113,7 +113,7 @@ class SearchQuery(SearchQueryBase):
         offset: int | None = None,
         advanced: bool | None = None,
         additional_fields: dict[str, t.Any] | None = None,
-    ):
+    ) -> None:
         super().__init__()
         exc.warn_deprecated("'SearchQuery' is deprecated. Use 'SearchQueryV1' instead.")
         if q is not None:
@@ -255,7 +255,7 @@ class SearchQueryV1(utils.PayloadWrapper):
         boosts: list[dict[str, t.Any]] | utils.MissingType = utils.MISSING,
         sort: list[dict[str, t.Any]] | utils.MissingType = utils.MISSING,
         additional_fields: dict[str, t.Any] | utils.MissingType = utils.MISSING,
-    ):
+    ) -> None:
         super().__init__()
         self["@version"] = "query#1.0.0"
 
@@ -301,7 +301,7 @@ class SearchScrollQuery(SearchQueryBase):
         advanced: bool | None = None,
         marker: str | None = None,
         additional_fields: dict[str, t.Any] | None = None,
-    ):
+    ) -> None:
         super().__init__()
         if q is not None:
             self["q"] = q

--- a/src/globus_sdk/tokenstorage/v1/file_adapters.py
+++ b/src/globus_sdk/tokenstorage/v1/file_adapters.py
@@ -35,7 +35,7 @@ class SimpleJSONFileAdapter(FileAdapter):
     # the supported versions (data not in these versions causes an error)
     supported_versions = ("1.0",)
 
-    def __init__(self, filename: pathlib.Path | str):
+    def __init__(self, filename: pathlib.Path | str) -> None:
         self.filename = str(filename)
 
     def _invalid(self, msg: str) -> t.NoReturn:

--- a/src/globus_sdk/tokenstorage/v1/sqlite_adapter.py
+++ b/src/globus_sdk/tokenstorage/v1/sqlite_adapter.py
@@ -46,7 +46,7 @@ class SQLiteAdapter(FileAdapter):
         *,
         namespace: str = "DEFAULT",
         connect_params: dict[str, t.Any] | None = None,
-    ):
+    ) -> None:
         self.filename = self.dbname = str(dbname)
         self.namespace = namespace
         self._connection = self._init_and_connect(connect_params)

--- a/src/globus_sdk/tokenstorage/v2/base.py
+++ b/src/globus_sdk/tokenstorage/v2/base.py
@@ -135,7 +135,9 @@ class FileTokenStorage(TokenStorage, metaclass=abc.ABCMeta):
     # File suffix associated with files of this type (e.g., "csv")
     file_format: str = "_UNSET_"  # must be overridden by subclasses
 
-    def __init__(self, filepath: pathlib.Path | str, *, namespace: str = "DEFAULT"):
+    def __init__(
+        self, filepath: pathlib.Path | str, *, namespace: str = "DEFAULT"
+    ) -> None:
         """
         :param filepath: the name of the file to write to and read from
         :param namespace: A user-supplied namespace for partitioning token data

--- a/src/globus_sdk/transport/requests.py
+++ b/src/globus_sdk/transport/requests.py
@@ -110,7 +110,7 @@ class RequestsTransport:
         retry_checks: list[RetryCheck] | None = None,
         max_sleep: float | int = 10,
         max_retries: int | None = None,
-    ):
+    ) -> None:
         self.session = requests.Session()
         self.verify_ssl = config.get_ssl_verify(verify_ssl)
         self.http_timeout = config.get_http_timeout(http_timeout)

--- a/src/globus_sdk/transport/retry.py
+++ b/src/globus_sdk/transport/retry.py
@@ -36,7 +36,7 @@ class RetryContext:
         authorizer: GlobusAuthorizer | None = None,
         response: requests.Response | None = None,
         exception: Exception | None = None,
-    ):
+    ) -> None:
         # retry attempt number
         self.attempt = attempt
         # if there is an authorizer for the request, it will be available in the context
@@ -116,7 +116,7 @@ class RetryCheckRunner:
 
     # check configs: a list of pairs, (check, flags)
     # a check without flags is assumed to have flags=NONE
-    def __init__(self, checks: list[RetryCheck]):
+    def __init__(self, checks: list[RetryCheck]) -> None:
         self._checks: list[RetryCheck] = []
         self._check_data: dict[RetryCheck, dict[str, t.Any]] = {}
         for check in checks:

--- a/tests/common/response_mock.py
+++ b/tests/common/response_mock.py
@@ -28,7 +28,7 @@ class PickleableMockResponse(mock.NonCallableMock):
 
     def __init__(
         self, status_code, json_body=None, text=None, headers=None, *args, **kwargs
-    ):
+    ) -> None:
         kwargs["spec"] = requests.Response
         super().__init__(*args, **kwargs)
         self.__class__ = PickleableMockResponse

--- a/tests/functional/login_flows/test_login_flow_manager.py
+++ b/tests/functional/login_flows/test_login_flow_manager.py
@@ -124,7 +124,7 @@ def test_command_line_login_flow_manager_eof_error(monkeypatch, capsys):
 
 
 class MockRedirectServer:
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         self.socket = Mock()
         self.socket.getsockname.return_value = ("", 0)
 

--- a/tests/functional/services/auth/service_client/test_get_identities.py
+++ b/tests/functional/services/auth/service_client/test_get_identities.py
@@ -9,7 +9,7 @@ from globus_sdk._testing import get_last_request, load_response
 class StringWrapper:
     """Simple test object to be a non-string obj wrapping a string"""
 
-    def __init__(self, s):
+    def __init__(self, s) -> None:
         self.s = s
 
     def __str__(self):

--- a/tests/unit/authorizers/test_renewing_authorizer.py
+++ b/tests/unit/authorizers/test_renewing_authorizer.py
@@ -13,7 +13,7 @@ class MockRenewer(RenewingAuthorizer):
     _extract_token_data can return known values for testing
     """
 
-    def __init__(self, token_data, **kwargs):
+    def __init__(self, token_data, **kwargs) -> None:
         self.token_data = token_data
         self.token_response = mock.Mock()
         super().__init__(**kwargs)

--- a/tests/unit/globus_app/test_globus_app.py
+++ b/tests/unit/globus_app/test_globus_app.py
@@ -195,7 +195,7 @@ def test_user_app_without_refresh_tokens_sets_expected_validators():
 
 
 class MockLoginFlowManager(LoginFlowManager):
-    def __init__(self, login_client: AuthLoginClient | None = None):
+    def __init__(self, login_client: AuthLoginClient | None = None) -> None:
         login_client = login_client or mock.Mock(spec=NativeAppAuthClient)
         super().__init__(login_client)
 
@@ -429,7 +429,7 @@ class RaisingLoginFlowManagerCounter(LoginFlowManager):
     each login attempt.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(mock.Mock(spec=NativeAppAuthClient))
         self.counter = 0
 
@@ -594,7 +594,7 @@ def test_app_login_flows_can_be_forced(login_kwargs, expected_login, monkeypatch
 
 
 class CountingCommandLineLoginFlowManager(CommandLineLoginFlowManager):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.counter = 0
 

--- a/tests/unit/test_guards.py
+++ b/tests/unit/test_guards.py
@@ -185,7 +185,7 @@ def test_simple_validator_failing(validator, value, match_message):
 
 def test_instance_or_dict_validator_failing():
     class MyObj(_serializable.Serializable):
-        def __init__(self, *, extra=None):
+        def __init__(self, *, extra=None) -> None:
             pass
 
     with pytest.raises(
@@ -196,7 +196,7 @@ def test_instance_or_dict_validator_failing():
 
 def test_instance_or_dict_validator_pass_on_simple_instance():
     class MyObj(_serializable.Serializable):
-        def __init__(self, *, extra=None):
+        def __init__(self, *, extra=None) -> None:
             pass
 
     x = MyObj()
@@ -206,7 +206,7 @@ def test_instance_or_dict_validator_pass_on_simple_instance():
 
 def test_instance_or_dict_validator_pass_on_simple_dict():
     class MyObj(_serializable.Serializable):
-        def __init__(self, *, extra=None):
+        def __init__(self, *, extra=None) -> None:
             pass
 
     x = _guards.validators.instance_or_dict("foo", {}, MyObj)

--- a/tests/unit/test_paging.py
+++ b/tests/unit/test_paging.py
@@ -12,7 +12,7 @@ N = 25
 
 
 class PagingSimulator:
-    def __init__(self, n):
+    def __init__(self, n) -> None:
         self.n = n  # the number of simulated items
 
     def simulate_get(self, *args, **params):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -95,7 +95,7 @@ def test_classproperty_prefers_instance():
     class Foo:
         x = {"x": 1}
 
-        def __init__(self):
+        def __init__(self) -> None:
             self.x = {"x": 2}
 
         @utils.classproperty


### PR DESCRIPTION
Primarily, this applies the slyp-driven change to have a return type annotation of `None` on all initializers.

---

In #1121, I noticed that our hooks were a bit behind. Manually doing the update (rather than waiting for pre-commit.com) lets us apply the autofixing changes right away.
