### PR TITLE
Allow specifying base_url as a BaseClient class attribute

### DIFF
--- a/changelog.d/20250109_142954_derek_client_class_base_url_sc_38541.rst
+++ b/changelog.d/20250109_142954_derek_client_class_base_url_sc_38541.rst
@@ -1,0 +1,7 @@
+
+Added
+~~~~~
+
+- Subclasses of ``BaseClient`` may now specify ``base_url`` as class attribute. (:pr:`NUMBER`)
+
+


### PR DESCRIPTION
Allow definition of client classes in the form

```python
class FacebookClient(BaseClient):
  base_url = "https://facebook.com"
```

(Before this value to come through the constructor)

<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1125.org.readthedocs.build/en/1125/

<!-- readthedocs-preview globus-sdk-python end -->