### PR TITLE
Document auto-login disabling

### DIFF
--- a/changelog.d/20250114_150601_derek_fix_app_config_doc_ivar.rst
+++ b/changelog.d/20250114_150601_derek_fix_app_config_doc_ivar.rst
@@ -1,0 +1,6 @@
+
+Documentation
+~~~~~~~~~~~~~
+
+- Updated GlobusAppConfig docs to explain how to disable auto-login. (:pr:`NUMBER`)
+

--- a/src/globus_sdk/globus_app/config.py
+++ b/src/globus_sdk/globus_app/config.py
@@ -95,8 +95,9 @@ class GlobusAppConfig:
             Explicit values must be pre-registered on your client
             `here <https://app.globus.org/settings/developers>`_.
 
-    :ivar ``TokenValidationErrorHandler`` token_validation_error_handler: A handler
-        invoked to resolve errors raised during token validation.
+    :ivar ``TokenValidationErrorHandler`` | None token_validation_error_handler: A
+        handler invoked to resolve errors raised during token validation. Set this to
+        ``None`` to disable auto-login on service token validation errors.
         Default: ``resolve_by_login_flow`` (runs a login flow, storing the resulting
         tokens).
 


### PR DESCRIPTION
* Documentation didn't explain what happened if `GlobusAppConfig.token_validation_error_handler` was set to None (or explain that it could be set to None). Added that explanation.

<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1127.org.readthedocs.build/en/1127/

<!-- readthedocs-preview globus-sdk-python end -->