### PR TITLE
Update pyupgrade lower bound to 3.8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
   rev: v3.19.1
   hooks:
     - id: pyupgrade
-      args: ["--py37-plus"]
+      args: ["--py38-plus"]
 - repo: https://github.com/psf/black-pre-commit-mirror
   rev: 24.10.0
   hooks:

--- a/src/globus_sdk/_testing/models.py
+++ b/src/globus_sdk/_testing/models.py
@@ -1,17 +1,11 @@
 from __future__ import annotations
 
-import sys
 import types
 import typing as t
 
 import responses
 
 from ..utils import slash_join
-
-if sys.version_info < (3, 8):
-    from typing_extensions import Literal
-else:
-    from typing import Literal
 
 
 class RegisteredResponse:
@@ -63,7 +57,7 @@ class RegisteredResponse:
         # in `responses`, these are just `url`
         path: str,
         service: (
-            Literal[
+            t.Literal[
                 "auth",
                 "nexus",
                 "transfer",
@@ -78,7 +72,7 @@ class RegisteredResponse:
         ) = None,
         # method will be passed through to `responses.Response`, so we
         # support all of the values which it supports
-        method: Literal[
+        method: t.Literal[
             "GET",
             "PUT",
             "POST",
@@ -152,7 +146,7 @@ class RegisteredResponse:
 
     def _add_or_replace(
         self,
-        method: Literal["add", "replace"],
+        method: t.Literal["add", "replace"],
         *,
         requests_mock: responses.RequestsMock | None = None,
     ) -> RegisteredResponse:

--- a/src/globus_sdk/_types.py
+++ b/src/globus_sdk/_types.py
@@ -1,14 +1,8 @@
 from __future__ import annotations
 
 import datetime
-import sys
 import typing as t
 import uuid
-
-if sys.version_info < (3, 8):
-    from typing_extensions import Protocol
-else:
-    from typing import Protocol
 
 if t.TYPE_CHECKING:
     from globus_sdk.scopes import MutableScope, Scope
@@ -27,7 +21,7 @@ ScopeCollectionType = t.Union[
 ]
 
 
-class ResponseLike(Protocol):
+class ResponseLike(t.Protocol):
     @property
     def http_status(self) -> int: ...
 

--- a/src/globus_sdk/gare/_variants.py
+++ b/src/globus_sdk/gare/_variants.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import sys
 import typing as t
 
 from globus_sdk import exc
@@ -9,15 +8,10 @@ from globus_sdk._serializable import Serializable
 
 from ._auth_requirements_error import GARE, GlobusAuthorizationParameters
 
-if sys.version_info >= (3, 8):
-    from typing import Literal, Protocol
-else:
-    from typing_extensions import Literal, Protocol
-
 V = t.TypeVar("V", bound="LegacyAuthRequirementsErrorVariant")
 
 
-class LegacyAuthRequirementsErrorVariant(Protocol):
+class LegacyAuthRequirementsErrorVariant(t.Protocol):
     """
     Protocol for errors which can be converted to a Globus Auth Requirements Error.
     """
@@ -37,7 +31,7 @@ class LegacyConsentRequiredTransferError(Serializable):
     def __init__(
         self,
         *,
-        code: Literal["ConsentRequired"],
+        code: t.Literal["ConsentRequired"],
         required_scopes: list[str],
         extra: dict[str, t.Any] | None = None,
     ) -> None:
@@ -68,7 +62,7 @@ class LegacyConsentRequiredAPError(Serializable):
     def __init__(
         self,
         *,
-        code: Literal["ConsentRequired"],
+        code: t.Literal["ConsentRequired"],
         required_scope: str,
         extra: dict[str, t.Any] | None,
     ) -> None:
@@ -110,7 +104,7 @@ class LegacyAuthorizationParameters(Serializable):
         session_required_policies: str | list[str] | None = None,
         session_required_single_domain: str | list[str] | None = None,
         session_required_mfa: bool | None = None,
-        prompt: Literal["login"] | None = None,
+        prompt: t.Literal["login"] | None = None,
         extra: dict[str, t.Any] | None = None,
     ) -> None:
         self.session_message = validators.opt_str("session_message", session_message)
@@ -193,7 +187,7 @@ class LegacyAuthorizationParametersError(Serializable):
 
 def _validate_consent_required_literal(
     name: str, value: t.Any
-) -> Literal["ConsentRequired"]:
+) -> t.Literal["ConsentRequired"]:
     if value == "ConsentRequired":
         return "ConsentRequired"
     raise exc.ValidationError(f"'{name}' must be the string 'ConsentRequired'")

--- a/src/globus_sdk/globus_app/protocols.py
+++ b/src/globus_sdk/globus_app/protocols.py
@@ -1,17 +1,11 @@
 from __future__ import annotations
 
-import sys
 import typing as t
 
 from globus_sdk import AuthLoginClient
 from globus_sdk._types import UUIDLike
 from globus_sdk.login_flows import LoginFlowManager
 from globus_sdk.tokenstorage import TokenStorage
-
-if sys.version_info < (3, 8):
-    from typing_extensions import Protocol, runtime_checkable
-else:
-    from typing import Protocol, runtime_checkable
 
 if t.TYPE_CHECKING:
     from globus_sdk.tokenstorage import TokenValidationError
@@ -20,8 +14,8 @@ if t.TYPE_CHECKING:
     from .config import GlobusAppConfig
 
 
-@runtime_checkable
-class TokenStorageProvider(Protocol):
+@t.runtime_checkable
+class TokenStorageProvider(t.Protocol):
     """
     A protocol for a factory which can create ``TokenStorages``.
 
@@ -47,8 +41,8 @@ class TokenStorageProvider(Protocol):
         """
 
 
-@runtime_checkable
-class LoginFlowManagerProvider(Protocol):
+@t.runtime_checkable
+class LoginFlowManagerProvider(t.Protocol):
     """
     A protocol for a factory which can create ``LoginFlowManagers``.
 
@@ -68,7 +62,7 @@ class LoginFlowManagerProvider(Protocol):
         """
 
 
-class TokenValidationErrorHandler(Protocol):
+class TokenValidationErrorHandler(t.Protocol):
     """
     A handler invoked when a :class:`TokenValidationError` is raised during a
     service client call.

--- a/src/globus_sdk/services/auth/_common.py
+++ b/src/globus_sdk/services/auth/_common.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 import logging
-import sys
 import typing as t
 
 import jwt
@@ -13,11 +12,6 @@ from globus_sdk.exc import GlobusSDKUsageError
 from globus_sdk.exc.warnings import warn_deprecated
 from globus_sdk.response import GlobusHTTPResponse
 from globus_sdk.scopes import AuthScopes, TransferScopes, scopes_to_str
-
-if sys.version_info >= (3, 8):
-    from typing import Literal, Protocol, runtime_checkable
-else:
-    from typing_extensions import Literal, Protocol, runtime_checkable
 
 log = logging.getLogger(__name__)
 
@@ -47,7 +41,7 @@ def stringify_requested_scopes(requested_scopes: ScopeCollectionType | None) -> 
     return requested_scopes_string
 
 
-class _JWKGetCallbackProto(Protocol):
+class _JWKGetCallbackProto(t.Protocol):
     def __call__(
         self,
         path: str,
@@ -91,8 +85,8 @@ def pem_decode_jwk_data(
     return jwk_as_pem
 
 
-@runtime_checkable
-class SupportsJWKMethods(Protocol):
+@t.runtime_checkable
+class SupportsJWKMethods(t.Protocol):
     client_id: str | None
 
     def get_openid_configuration(self) -> GlobusHTTPResponse: ...
@@ -102,7 +96,7 @@ class SupportsJWKMethods(Protocol):
         self,
         openid_configuration: None | GlobusHTTPResponse | dict[str, t.Any],
         *,
-        as_pem: Literal[True],
+        as_pem: t.Literal[True],
     ) -> RSAPublicKey: ...
 
     @t.overload
@@ -110,7 +104,7 @@ class SupportsJWKMethods(Protocol):
         self,
         openid_configuration: None | GlobusHTTPResponse | dict[str, t.Any],
         *,
-        as_pem: Literal[False],
+        as_pem: t.Literal[False],
     ) -> dict[str, t.Any]: ...
 
     def get_jwk(

--- a/src/globus_sdk/services/auth/client/base_login_client.py
+++ b/src/globus_sdk/services/auth/client/base_login_client.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import sys
 import typing as t
 
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
@@ -20,11 +19,6 @@ from ..response import (
     OAuthRefreshTokenResponse,
     OAuthTokenResponse,
 )
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 log = logging.getLogger(__name__)
 
@@ -103,7 +97,7 @@ class AuthLoginClient(client.BaseClient):
         self,
         openid_configuration: None | GlobusHTTPResponse | dict[str, t.Any],
         *,
-        as_pem: Literal[True],
+        as_pem: t.Literal[True],
     ) -> RSAPublicKey: ...
 
     @t.overload
@@ -111,7 +105,7 @@ class AuthLoginClient(client.BaseClient):
         self,
         openid_configuration: None | GlobusHTTPResponse | dict[str, t.Any],
         *,
-        as_pem: Literal[False],
+        as_pem: t.Literal[False],
     ) -> dict[str, t.Any]: ...
 
     # FYI: this get_jwk method is duplicated in AuthClient
@@ -151,7 +145,7 @@ class AuthLoginClient(client.BaseClient):
         session_required_single_domain: str | t.Iterable[str] | None = None,
         session_required_policies: UUIDLike | t.Iterable[UUIDLike] | None = None,
         session_required_mfa: bool | None = None,
-        prompt: Literal["login"] | None = None,
+        prompt: t.Literal["login"] | None = None,
         query_params: dict[str, t.Any] | None = None,
     ) -> str:
         """

--- a/src/globus_sdk/services/auth/client/service_client.py
+++ b/src/globus_sdk/services/auth/client/service_client.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import functools
 import logging
-import sys
 import typing as t
 
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
@@ -29,11 +28,6 @@ from ..response import (
     GetProjectsResponse,
     GetScopesResponse,
 )
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 log = logging.getLogger(__name__)
 
@@ -178,7 +172,7 @@ class AuthClient(client.BaseClient):
         self,
         openid_configuration: None | GlobusHTTPResponse | dict[str, t.Any],
         *,
-        as_pem: Literal[True],
+        as_pem: t.Literal[True],
     ) -> RSAPublicKey: ...
 
     @t.overload
@@ -186,7 +180,7 @@ class AuthClient(client.BaseClient):
         self,
         openid_configuration: None | GlobusHTTPResponse | dict[str, t.Any],
         *,
-        as_pem: Literal[False],
+        as_pem: t.Literal[False],
     ) -> dict[str, t.Any]: ...
 
     # FYI: this get_jwk method is duplicated in AuthLoginBaseClient

--- a/src/globus_sdk/services/gcs/data/_common.py
+++ b/src/globus_sdk/services/gcs/data/_common.py
@@ -1,22 +1,15 @@
 from __future__ import annotations
 
-import sys
 import typing as t
 
 from globus_sdk.utils import MISSING
-
-if sys.version_info < (3, 8):
-    from typing_extensions import Protocol
-else:
-    from typing import Protocol
-
 
 VersionTuple = t.Tuple[int, int, int]
 
 DatatypeCallback = t.Callable[["DocumentWithInducedDatatype"], t.Optional[VersionTuple]]
 
 
-class DocumentWithInducedDatatype(Protocol):
+class DocumentWithInducedDatatype(t.Protocol):
     DATATYPE_BASE: str
     DATATYPE_VERSION_IMPLICATIONS: dict[str, VersionTuple]
     DATATYPE_VERSION_CALLBACKS: tuple[DatatypeCallback, ...]

--- a/src/globus_sdk/services/groups/data.py
+++ b/src/globus_sdk/services/groups/data.py
@@ -1,18 +1,10 @@
 from __future__ import annotations
 
 import enum
-import sys
 import typing as t
 
 from globus_sdk import utils
 from globus_sdk._types import UUIDLike
-
-if sys.version_info < (3, 8):
-    from typing_extensions import Literal
-    from typing_extensions import get_args as typing_get_args
-else:
-    from typing import Literal
-    from typing import get_args as typing_get_args
 
 T = t.TypeVar("T")
 
@@ -23,7 +15,7 @@ class GroupRole(enum.Enum):
     admin = "admin"
 
 
-_GROUP_ROLE_T = t.Union[GroupRole, Literal["member", "manager", "admin"]]
+_GROUP_ROLE_T = t.Union[GroupRole, t.Literal["member", "manager", "admin"]]
 
 
 class GroupMemberVisibility(enum.Enum):
@@ -32,7 +24,7 @@ class GroupMemberVisibility(enum.Enum):
 
 
 _GROUP_MEMBER_VISIBILITY_T = t.Union[
-    GroupMemberVisibility, Literal["members", "managers"]
+    GroupMemberVisibility, t.Literal["members", "managers"]
 ]
 
 
@@ -41,7 +33,7 @@ class GroupVisibility(enum.Enum):
     private = "private"
 
 
-_GROUP_VISIBILITY_T = t.Union[GroupVisibility, Literal["authenticated", "private"]]
+_GROUP_VISIBILITY_T = t.Union[GroupVisibility, t.Literal["authenticated", "private"]]
 
 
 class GroupRequiredSignupFields(enum.Enum):
@@ -61,7 +53,7 @@ class GroupRequiredSignupFields(enum.Enum):
 
 _GROUP_REQUIRED_SIGNUP_FIELDS_T = t.Union[
     GroupRequiredSignupFields,
-    Literal[
+    t.Literal[
         "institution",
         "current_project_name",
         "address",
@@ -85,7 +77,7 @@ def _typename(obj: t.Any) -> str:
 
 
 def _fmt_union(obj: t.Any) -> str:
-    return " | ".join(_typename(x) for x in typing_get_args(obj))
+    return " | ".join(_typename(x) for x in t.get_args(obj))
 
 
 def _docstring_fixer(cls: type[T]) -> type[T]:

--- a/src/globus_sdk/services/transfer/client.py
+++ b/src/globus_sdk/services/transfer/client.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import sys
 import time
 import typing as t
 import uuid
@@ -14,11 +13,6 @@ from .data import DeleteData, TransferData
 from .errors import TransferAPIError
 from .response import ActivationRequirementsResponse, IterableTransferResponse
 from .transport import TransferRequestsTransport
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 log = logging.getLogger(__name__)
 
@@ -279,7 +273,7 @@ class TransferClient(client.BaseClient):
     def set_subscription_id(
         self,
         collection_id: UUIDLike,
-        subscription_id: UUIDLike | Literal["DEFAULT"] | None,
+        subscription_id: UUIDLike | t.Literal["DEFAULT"] | None,
     ) -> response.GlobusHTTPResponse:
         """
         Set the ``subscription_id`` on a mapped collection.
@@ -393,7 +387,7 @@ class TransferClient(client.BaseClient):
         filter_host_endpoint: UUIDLike | None = None,
         filter_non_functional: bool | None = None,
         filter_entity_type: (
-            Literal[
+            t.Literal[
                 "GCP_mapped_collection",
                 "GCP_guest_collection",
                 "GCSv5_endpoint",
@@ -2195,7 +2189,7 @@ class TransferClient(client.BaseClient):
         filter_task_id: None | UUIDLike | t.Iterable[UUIDLike] = None,
         filter_owner_id: UUIDLike | None = None,
         filter_endpoint: UUIDLike | None = None,
-        filter_endpoint_use: Literal["source", "destination"] | None = None,
+        filter_endpoint_use: t.Literal["source", "destination"] | None = None,
         filter_is_paused: bool | None = None,
         filter_completion_time: None | str | tuple[DateLike, DateLike] = None,
         filter_min_faults: int | None = None,

--- a/src/globus_sdk/services/transfer/data/transfer_data.py
+++ b/src/globus_sdk/services/transfer/data/transfer_data.py
@@ -2,13 +2,7 @@ from __future__ import annotations
 
 import datetime
 import logging
-import sys
 import typing as t
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 from globus_sdk import exc, utils
 from globus_sdk._types import UUIDLike
@@ -17,7 +11,7 @@ if t.TYPE_CHECKING:
     import globus_sdk
 
 log = logging.getLogger(__name__)
-_StrSyncLevel = Literal["exists", "size", "mtime", "checksum"]
+_StrSyncLevel = t.Literal["exists", "size", "mtime", "checksum"]
 _sync_level_dict: dict[_StrSyncLevel, int] = {
     "exists": 0,
     "size": 1,
@@ -335,8 +329,10 @@ class TransferData(utils.PayloadWrapper):
         self,
         name: str,
         *,
-        method: Literal["include", "exclude"] = "exclude",
-        type: None | Literal["file", "dir"] = None,  # pylint: disable=redefined-builtin
+        method: t.Literal["include", "exclude"] = "exclude",
+        type: (  # pylint: disable=redefined-builtin
+            None | t.Literal["file", "dir"]
+        ) = None,
     ) -> None:
         """
         Add a filter rule to the transfer document.


### PR DESCRIPTION
This upgrades various version-dispatched imports of typing symbols, mostly Literal but also Protocol.

---

Noted in a previous PR; we missed this upgrade when the time was right.

(Personal note: I'd like to make `mddj` parse pyupgrade bounds from pre-commit config, to make it easy to lint against `RequiresPython`.)


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1128.org.readthedocs.build/en/1128/

<!-- readthedocs-preview globus-sdk-python end -->