### PR TITLE
Remove literal type alias to help sphinx render

### DIFF
--- a/src/globus_sdk/services/transfer/data/transfer_data.py
+++ b/src/globus_sdk/services/transfer/data/transfer_data.py
@@ -11,8 +11,7 @@ if t.TYPE_CHECKING:
     import globus_sdk
 
 log = logging.getLogger(__name__)
-_StrSyncLevel = t.Literal["exists", "size", "mtime", "checksum"]
-_sync_level_dict: dict[_StrSyncLevel, int] = {
+_sync_level_dict: dict[t.Literal["exists", "size", "mtime", "checksum"], int] = {
     "exists": 0,
     "size": 1,
     "mtime": 2,
@@ -20,7 +19,9 @@ _sync_level_dict: dict[_StrSyncLevel, int] = {
 }
 
 
-def _parse_sync_level(sync_level: _StrSyncLevel | int) -> int:
+def _parse_sync_level(
+    sync_level: t.Literal["exists", "size", "mtime", "checksum"] | int
+) -> int:
     """
     Map sync_level strings to known int values
 
@@ -168,7 +169,9 @@ class TransferData(utils.PayloadWrapper):
         *,
         label: str | None = None,
         submission_id: UUIDLike | None = None,
-        sync_level: _StrSyncLevel | int | None = None,
+        sync_level: (
+            int | None | t.Literal["exists", "size", "mtime", "checksum"]
+        ) = None,
         verify_checksum: bool = False,
         preserve_timestamp: bool = False,
         encrypt_data: bool = False,


### PR DESCRIPTION
This type alias is used in 3 locations (two of which are internal), but sphinx autodoc does not render it as desired or expected. It seems that there's something more complex going wrong with the docstring for this class, but it may also be related to some outstanding sphinx bugs related to type aliases and literals, specifically.

For now, switch off of the alias and use the literal verbatim in `TransferData.__init__` to get a rendering which is much closer to being correct.

----

Here's the original render:
![image](https://github.com/user-attachments/assets/3fdd803b-39aa-4b8b-874a-425227295c49)

Here's the fix:
![image](https://github.com/user-attachments/assets/c1b167ee-463e-4357-8bdd-480c2940b4d8)

I burned a good chunk of time playing with sphinx autodoc settings to try to fix this, and I don't think that's the issue. I think it's something to do with the exact content of that file -- maybe a missing escape or other incorrect bit of RST in the docstring. For now, I'm satisfied with the fix as being loads better than what we're publishing today, but I'd like to come back to this and fully fix it at some point.

<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1129.org.readthedocs.build/en/1129/

<!-- readthedocs-preview globus-sdk-python end -->