### PR TITLE
Fix the presentation of scope constants in docs

### DIFF
--- a/docs/authorization/scopes_and_consents/scopes.rst
+++ b/docs/authorization/scopes_and_consents/scopes.rst
@@ -229,30 +229,66 @@ ScopeBuilder Types
 ScopeBuilder Constants
 ~~~~~~~~~~~~~~~~~~~~~~
 
-.. autodata:: globus_sdk.scopes.data.AuthScopes
-    :annotation:
+.. py:data:: globus_sdk.scopes.data.AuthScopes
 
-.. autodata:: globus_sdk.scopes.data.ComputeScopes
-    :annotation:
+    Globus Auth scopes.
 
-.. autodata:: globus_sdk.scopes.data.FlowsScopes
-    :annotation:
+    .. listknownscopes:: globus_sdk.scopes.AuthScopes
+        :example_scope: view_identity_set
 
-.. autodata:: globus_sdk.scopes.data.GroupsScopes
-    :annotation:
 
-.. autodata:: globus_sdk.scopes.data.NexusScopes
-    :annotation:
+.. py:data:: globus_sdk.scopes.data.ComputeScopes
 
-.. autodata:: globus_sdk.scopes.data.SearchScopes
-    :annotation:
+    Compute scopes.
 
-.. note::
+    .. listknownscopes:: globus_sdk.scopes.ComputeScopes
 
-    ``TimersScopes`` is also available under the legacy name ``TimerScopes``.
 
-.. autodata:: globus_sdk.scopes.data.TimersScopes
-    :annotation:
+.. py:data:: globus_sdk.scopes.data.FlowsScopes
 
-.. autodata:: globus_sdk.scopes.data.TransferScopes
-    :annotation:
+    Globus Flows scopes.
+
+    .. listknownscopes:: globus_sdk.scopes.FlowsScopes
+
+
+.. py:data:: globus_sdk.scopes.data.GroupsScopes
+
+    Groups scopes.
+
+    .. listknownscopes:: globus_sdk.scopes.GroupsScopes
+
+
+.. py:data:: globus_sdk.scopes.data.NexusScopes
+
+    Nexus scopes.
+
+    .. listknownscopes:: globus_sdk.scopes.NexusScopes
+
+    .. warning::
+
+        Use of Nexus is deprecated. Users should use Groups instead.
+
+
+.. py:data:: globus_sdk.scopes.data.SearchScopes
+
+    Globus Search scopes.
+
+    .. listknownscopes:: globus_sdk.scopes.SearchScopes
+
+
+.. py:data:: globus_sdk.scopes.data.TimersScopes
+
+    Globus Timers scopes.
+
+    .. listknownscopes:: globus_sdk.scopes.TimersScopes
+
+    .. note::
+
+        ``TimersScopes`` is also available under the legacy name ``TimerScopes``.
+
+
+.. py:data:: globus_sdk.scopes.data.TransferScopes
+
+    Globus Transfer scopes.
+
+    .. listknownscopes:: globus_sdk.scopes.TransferScopes

--- a/src/globus_sdk/scopes/data/auth.py
+++ b/src/globus_sdk/scopes/data/auth.py
@@ -21,8 +21,3 @@ AuthScopes = _AuthScopesBuilder(
         "view_identity_set",
     ],
 )
-"""Globus Auth scopes.
-
-.. listknownscopes:: globus_sdk.scopes.AuthScopes
-    :example_scope: view_identity_set
-"""

--- a/src/globus_sdk/scopes/data/compute.py
+++ b/src/globus_sdk/scopes/data/compute.py
@@ -34,7 +34,3 @@ ComputeScopes = _ComputeScopeBuilder(
     "facd7ccc-c5f4-42aa-916b-a0e270e2c2a9",
     known_url_scopes=["all"],
 )
-"""Compute scopes.
-
-.. listknownscopes:: globus_sdk.scopes.ComputeScopes
-"""

--- a/src/globus_sdk/scopes/data/flows.py
+++ b/src/globus_sdk/scopes/data/flows.py
@@ -48,10 +48,6 @@ FlowsScopes = _FlowsScopeBuilder(
         "run_manage",
     ],
 )
-"""Globus Flows scopes.
-
-.. listknownscopes:: globus_sdk.scopes.FlowsScopes
-"""
 
 
 class _SpecificFlowScopesClassStub(ScopeBuilder):

--- a/src/globus_sdk/scopes/data/groups.py
+++ b/src/globus_sdk/scopes/data/groups.py
@@ -7,10 +7,6 @@ GroupsScopes = ScopeBuilder(
         "view_my_groups_and_memberships",
     ],
 )
-"""Groups scopes.
-
-.. listknownscopes:: globus_sdk.scopes.GroupsScopes
-"""
 
 
 NexusScopes = ScopeBuilder(
@@ -19,7 +15,3 @@ NexusScopes = ScopeBuilder(
         "groups",
     ],
 )
-"""Nexus scopes (internal use only).
-
-.. listknownscopes:: globus_sdk.scopes.NexusScopes
-"""

--- a/src/globus_sdk/scopes/data/search.py
+++ b/src/globus_sdk/scopes/data/search.py
@@ -9,7 +9,3 @@ SearchScopes = ScopeBuilder(
         "search",
     ],
 )
-"""Globus Search scopes.
-
-.. listknownscopes:: globus_sdk.scopes.SearchScopes
-"""

--- a/src/globus_sdk/scopes/data/timers.py
+++ b/src/globus_sdk/scopes/data/timers.py
@@ -6,7 +6,3 @@ TimersScopes = ScopeBuilder(
         "timer",
     ],
 )
-"""Globus Timers scopes.
-
-.. listknownscopes:: globus_sdk.scopes.TimersScopes
-"""

--- a/src/globus_sdk/scopes/data/transfer.py
+++ b/src/globus_sdk/scopes/data/transfer.py
@@ -7,7 +7,3 @@ TransferScopes = ScopeBuilder(
         "gcp_install",
     ],
 )
-"""Globus Transfer scopes.
-
-.. listknownscopes:: globus_sdk.scopes.TransferScopes
-"""


### PR DESCRIPTION
At some point, sphinx autodata directives for autodoc changed in
behavior. autodoc stopped picking up on the object docstrings we had
alongside each constant and started using the class docstring for each
element, which is often inappropriate to the relevant item.

Moving to explicit `py:data` directives evades any such issue and
gives us an opportunity to change the placement of admonitions (note
and warning usage) to be part of the data docstrings.


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1133.org.readthedocs.build/en/1133/

<!-- readthedocs-preview globus-sdk-python end -->