### PR TITLE
Update the default JWT leeway to 300s

### DIFF
--- a/changelog.d/20250203_125146_sirosen_update_default_jwt_leeway.rst
+++ b/changelog.d/20250203_125146_sirosen_update_default_jwt_leeway.rst
@@ -1,0 +1,7 @@
+Changed
+~~~~~~~
+
+- The SDK now defaults JWT leeway to 300 seconds when decoding ``id_token``\s;
+  the previous leeway was 0.5 seconds. Users should find that they are much
+  less prone to validation errors when working in VMs or other scenarios which
+  can cause significant clock drift. (:pr:`NUMBER`)


### PR DESCRIPTION
Copy the rationale for this decision from the CLI, where we had a
deeper discussion and research phase. This is effectively backporting
a decision from the CLI to the SDK.


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1135.org.readthedocs.build/en/1135/

<!-- readthedocs-preview globus-sdk-python end -->