### PR TITLE
Improve the initialization ordering of GlobusApp

### DIFF
--- a/changelog.d/20250226_143341_sirosen_fix_app_init_order.rst
+++ b/changelog.d/20250226_143341_sirosen_fix_app_init_order.rst
@@ -5,3 +5,7 @@ Changed
   now available under the public ``attach_globus_app`` method on client
   classes. Attaching an app is only valid for clients which were initialized
   without an app or authorizer. (:pr:`NUMBER`)
+
+- When a ``GlobusApp`` is used with a client, that client's ``app_scopes``
+  attribute will now always be populated with the scopes that it passed back to
+  the app. (:pr:`NUMBER`)

--- a/changelog.d/20250226_143341_sirosen_fix_app_init_order.rst
+++ b/changelog.d/20250226_143341_sirosen_fix_app_init_order.rst
@@ -1,0 +1,7 @@
+Changed
+~~~~~~~
+
+- The initialization of a client with a ``GlobusApp`` has been improved and is
+  now available under the public ``attach_globus_app`` method on client
+  classes. Attaching an app is only valid for clients which were initialized
+  without an app or authorizer. (:pr:`NUMBER`)

--- a/src/globus_sdk/client.py
+++ b/src/globus_sdk/client.py
@@ -245,17 +245,12 @@ class BaseClient:
 
         # now, assign the app, app_name, and scopes
         self._app = app
-        self.app_scopes = app_scopes
+        self.app_scopes = app_scopes or self.default_scope_requirements
         if self.app_name is None:
             self.app_name = app.app_name
 
-        if self.app_scopes:
-            scope_requirements = self.app_scopes
-        else:
-            scope_requirements = self.default_scope_requirements
-
         # finally, register the scope requirements on the app side
-        self._app.add_scope_requirements({self.resource_server: scope_requirements})
+        self._app.add_scope_requirements({self.resource_server: self.app_scopes})
 
     def add_app_scope(self, scope_collection: ScopeCollectionType) -> BaseClient:
         """

--- a/src/globus_sdk/client.py
+++ b/src/globus_sdk/client.py
@@ -81,6 +81,16 @@ class BaseClient:
         app_name: str | None = None,
         transport_params: dict[str, t.Any] | None = None,
     ) -> None:
+        # check for input parameter conflicts
+        if app_scopes and not app:
+            raise exc.GlobusSDKUsageError(
+                f"A {type(self).__name__} must have an 'app' to use 'app_scopes'."
+            )
+        if app and authorizer:
+            raise exc.GlobusSDKUsageError(
+                f"A {type(self).__name__} cannot use both an 'app' and an 'authorizer'."
+            )
+
         # Determine the client's environment.
         if app is not None:
             # If we're using a GlobusApp, the client's environment must either match the
@@ -106,33 +116,22 @@ class BaseClient:
         self.transport = self.transport_class(**(transport_params or {}))
         log.debug(f"initialized transport of type {type(self.transport)}")
 
-        if app and authorizer:
-            raise exc.GlobusSDKUsageError(
-                f"A {type(self).__name__} cannot use both an 'app' and an 'authorizer'."
-            )
-
-        self._app = app
-        self.authorizer = authorizer
-
-        if app_scopes and not app:
-            raise exc.GlobusSDKUsageError(
-                f"A {type(self).__name__} must have an 'app' to use 'app_scopes'."
-            )
-
-        self.app_scopes = app_scopes
-
-        # set application name if available from app_name or app with app_name
-        # taking precedence if both are present
-        self._app_name: str | None = None
-        if app_name is not None:
-            self.app_name = app_name
-        elif app is not None:
-            self.app_name = app.app_name
-
         # setup paginated methods
         self.paginated = PaginatorTable(self)
 
-        self._finalize_app()
+        # set application name if available from app_name
+        # if this is not set, `app.app_name` may be applied below
+        self._app_name: str | None = None
+        if app_name is not None:
+            self.app_name = app_name
+
+        # attach the app or authorizer provided
+        # starting app attributes as `None` and calling the attachment method
+        self.authorizer = authorizer
+        self._app: GlobusApp | None = None
+        self.app_scopes: list[Scope] | None = None
+        if app:
+            self.attach_globus_app(app, app_scopes=app_scopes)
 
     @property
     def default_scope_requirements(self) -> list[Scope]:
@@ -176,20 +175,89 @@ class BaseClient:
             f"Clients must define either one or both of 'base_url' and 'service_name'."
         )
 
-    def _finalize_app(self) -> None:
+    def attach_globus_app(
+        self, app: GlobusApp, app_scopes: list[Scope] | None = None
+    ) -> None:
+        """
+        Attach a ``GlobusApp`` to this client and, conversely, register this client with
+        that app. The client's default scopes will be added to the app's scope
+        requirements unless ``app_scopes`` is used to override this.
+
+        If the ``app_name`` is not set on the client, it will be set to match that of
+        the app.
+
+        .. note::
+
+            This method is only safe to call once per client object. It is implicitly
+            called if the client is initialized with an app.
+
+        :param app: The ``GlobusApp`` to attach to this client.
+        :param app_scopes: Optional list of ``Scope`` objects to be added to ``app``'s
+            scope requirements instead of ``default_scope_requirements``. These will be
+            stored in the ``app_scopes`` attribute of the client.
+
+        :raises GlobusSDKUsageError: If the attachment appears to conflict with the
+            state of the client. e.g., an app or authorizer is already in place.
+        """
+        # If there are any incompatible or ambiguous data, usage error.
+        # "In the face of ambiguity, refuse the temptation to guess."
         if self._app:
-            if self.resource_server is None:
-                raise ValueError(
-                    "Unable to use an 'app' with a client with no "
-                    "'resource_server' defined."
-                )
+            raise exc.GlobusSDKUsageError(
+                f"Cannot attach GlobusApp to {type(self).__name__} when one is "
+                "already attached."
+            )
+        if self.app_scopes:
+            # technically, we *could* allow for this, but it's not clear what
+            # it would mean if a user wrote the following:
+            #
+            #   c = ClientClass()
+            #   c.app_scopes = [foo]
+            #   c.attach_globus_app(app, app_scopes=[bar])
+            #
+            # did the user expect a merge, overwrite, or other behavior?
+            raise exc.GlobusSDKUsageError(
+                f"Cannot attach GlobusApp to {type(self).__name__} when `app_scopes` "
+                "is already set. "
+                "The scopes for this client cannot be consistently resolved."
+            )
+        if self.authorizer:
+            raise exc.GlobusSDKUsageError(
+                f"Cannot attach GlobusApp to {type(self).__name__} when it "
+                "has an authorizer assigned."
+            )
+        if self.resource_server is None:
+            raise exc.GlobusSDKUsageError(
+                "Unable to use an 'app' with a client with no "
+                "'resource_server' defined."
+            )
+        # the client's environment must match the app's -- we can't tell which of these
+        # were set explicitly programmatically and which were implicit (e.g., from the
+        # env var), so erroring is the safest option
+        #
+        # although we can track the value used in init (e.g., add
+        # `self._init_environment = environment` to init), it's harder to keep track of
+        # usages like
+        # `client = FooClient(); client.environment = "test"; client.base_url = ...`
+        if self.environment != app.config.environment:
+            raise exc.GlobusSDKUsageError(
+                f"[Environment Mismatch] {type(self).__name__}'s environment "
+                f"({self.environment}) does not match the GlobusApp's configured "
+                f"environment ({app.config.environment})."
+            )
 
-            if self.app_scopes:
-                scope_requirements = self.app_scopes
-            else:
-                scope_requirements = self.default_scope_requirements
+        # now, assign the app, app_name, and scopes
+        self._app = app
+        self.app_scopes = app_scopes
+        if self.app_name is None:
+            self.app_name = app.app_name
 
-            self._app.add_scope_requirements({self.resource_server: scope_requirements})
+        if self.app_scopes:
+            scope_requirements = self.app_scopes
+        else:
+            scope_requirements = self.default_scope_requirements
+
+        # finally, register the scope requirements on the app side
+        self._app.add_scope_requirements({self.resource_server: scope_requirements})
 
     def add_app_scope(self, scope_collection: ScopeCollectionType) -> BaseClient:
         """

--- a/src/globus_sdk/client.py
+++ b/src/globus_sdk/client.py
@@ -90,22 +90,21 @@ class BaseClient:
             raise exc.GlobusSDKUsageError(
                 f"A {type(self).__name__} cannot use both an 'app' and an 'authorizer'."
             )
+        if app and environment and environment != app.config.environment:
+            raise exc.GlobusSDKUsageError(
+                f"[Environment Mismatch] {type(self).__name__}'s environment "
+                f"({environment}) does not match the GlobusApp's configured "
+                f"environment ({app.config.environment})."
+            )
 
-        # Determine the client's environment.
-        if app is not None:
-            # If we're using a GlobusApp, the client's environment must either match the
-            # app's or be omitted.
-            if environment is not None and environment != app.config.environment:
-                raise exc.GlobusSDKUsageError(
-                    f"[Environment Mismatch] {type(self).__name__}'s environment "
-                    f"({environment}) does not match the GlobusApp's configured "
-                    f"environment ({app.config.environment})."
-                )
-
+        # Determine the client's environment
+        # Either derived from the app used, or else from the provided kwarg
+        #
+        # If neither is specified, fallback to the GLOBUS_SDK_ENVIRONMENT environment
+        # variable.
+        if app:
             self.environment = app.config.environment
         else:
-            # Otherwise, figure out the environment from the provided kwarg or the
-            # GLOBUS_SDK_ENVIRONMENT environment variable.
             self.environment = config.get_environment_name(environment)
 
         # resolve the base_url for the client (see docstring for resolution precedence)


### PR DESCRIPTION
We have a cyclic dependency in GlobusApp init, in which we want a
self-registered client for `openid` scoped consent API usage, but we
need this as an input to various constructs before we are ready to
register any clients in the app. We have a "cycle breaker" bool flag
in app init which gets used to work around this behavior.

We cannot break the cycle fully in the current design: apps require
an auth client, and clients support use with apps.
But we can rephrase the cycle to make it easier to understand and
maintain.

1.  Externalize the app-attachment behavior of a client in a new
    `BaseClient.attach_globus_app()` method. This method is used to
    implement the client init behaviors (except for a slightly subtle
    one around environment setting), and replaces
    `BaseClient._finalize_app()`.

    This allows for a client to be instantiated and -- so long as no
    app, scopes, or authorizer are set on that client -- late-bound to a
    GlobusApp.

2.  Update `GlobusApp.__init__` to create the openid-scoped auth client
    without passing `app=self` or `app_scopes`; instead, late-bind
    these parameters to the client after the app is initialized to the
    point that it can handle the client's callbacks to the app.

    This is a more straightforward cycle-breaker to read and maintain
    than the prior internal bool tracking. Semantically, it does not
    change the behavior of the app (the now-unguarded cache-clearing
    call is a no-op on a new app).

3.  As an unanticipated benefit, `BaseClient.__init__` has
    significantly improved readability because app-attachment logic is
    all consolidated (moreso than it was under `_finalize_app()`).

Net-net, we have a new method to support,
`BaseClient.attach_globus_app()`, but it has a strict contract about
being called once per client and rejecting any internal data
conflicts. It also documents itself as being called during
initialization if an app is passed.


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1137.org.readthedocs.build/en/1137/

<!-- readthedocs-preview globus-sdk-python end -->