### PR TITLE
Expose `RequestsTransport.headers` dict

### DIFF
--- a/changelog.d/20250304_114414_sirosen_allow_setting_transport_headers.rst
+++ b/changelog.d/20250304_114414_sirosen_allow_setting_transport_headers.rst
@@ -1,0 +1,16 @@
+Added
+~~~~~
+
+- The ``transport`` attached to clients now exposes ``headers`` as a readable
+  and writable dict of headers which will be included in every request.
+  Headers provided to the transport's ``request()`` method overwrite these, as
+  before. (:pr:`NUMBER`)
+
+Changed
+~~~~~~~
+
+- Updates to ``X-Globus-Client-Info`` in ``RequestsTransport.headers`` are now
+  synchronized via a callback mechanism. Direct manipulations of the ``infos``
+  list will not result in headers being updated -- callers wishing to modify
+  these data should rely only on the ``add()`` and ``clear()`` methods of the
+  ``GlobusClientInfo`` object. (:pr:`NUMBER`)

--- a/src/globus_sdk/transport/requests.py
+++ b/src/globus_sdk/transport/requests.py
@@ -81,6 +81,9 @@ class RequestsTransport:
         computed sleep time or the backoff requested by a retry check exceeds this
         value, this amount of time will be used instead
     :param max_retries: The maximum number of retries allowed by this transport
+
+    :ivar dict[str, str] headers: The headers which are sent on every request. These
+        may be augmented by the transport when sending requests.
     """
 
     #: default maximum number of retries
@@ -115,7 +118,14 @@ class RequestsTransport:
         self.verify_ssl = config.get_ssl_verify(verify_ssl)
         self.http_timeout = config.get_http_timeout(http_timeout)
         self._user_agent = self.BASE_USER_AGENT
-        self.globus_client_info: GlobusClientInfo = GlobusClientInfo()
+        self.globus_client_info: GlobusClientInfo = GlobusClientInfo(
+            update_callback=self._handle_clientinfo_update
+        )
+        self.headers: dict[str, str] = {
+            "Accept": "application/json",
+            "User-Agent": self.user_agent,
+            "X-Globus-Client-Info": self.globus_client_info.format(),
+        }
 
         # retry parameters
         self.retry_backoff = retry_backoff
@@ -133,14 +143,26 @@ class RequestsTransport:
 
     @user_agent.setter
     def user_agent(self, value: str) -> None:
+        """
+        Setting the ``user_agent`` also updates the ``User-Agent`` header in
+        ``headers``.
+        """
         self._user_agent = f"{self.BASE_USER_AGENT}/{value}"
+        self.headers["User-Agent"] = self._user_agent
 
-    @property
-    def _headers(self) -> dict[str, str]:
-        headers = {"Accept": "application/json", "User-Agent": self.user_agent}
-        if self.globus_client_info:
-            headers["X-Globus-Client-Info"] = self.globus_client_info.format()
-        return headers
+    def _handle_clientinfo_update(self, info: GlobusClientInfo) -> None:
+        """
+        When the attached ``GlobusClientInfo`` is updated, write it back into
+        ``headers``.
+
+        If the client info is cleared, it will be removed from the headers.
+        """
+        formatted = self.globus_client_info.format()
+        if formatted:
+            self.headers["X-Globus-Client-Info"] = formatted
+        else:
+            # discard the element, so that this can be invoked multiple times
+            self.headers.pop("X-Globus-Client-Info", None)
 
     @contextlib.contextmanager
     def tune(
@@ -227,9 +249,10 @@ class RequestsTransport:
         headers: dict[str, str] | None = None,
         encoding: str | None = None,
     ) -> requests.Request:
-        if not headers:
-            headers = {}
-        headers = {**self._headers, **headers}
+        if headers:
+            headers = {**self.headers, **headers}
+        else:
+            headers = self.headers
 
         if encoding is None:
             if isinstance(data, (bytes, str)):

--- a/src/globus_sdk/transport/requests.py
+++ b/src/globus_sdk/transport/requests.py
@@ -144,13 +144,17 @@ class RequestsTransport:
     @user_agent.setter
     def user_agent(self, value: str) -> None:
         """
-        Setting the ``user_agent`` also updates the ``User-Agent`` header in
-        ``headers``.
+        Set the ``user_agent`` and update the ``User-Agent`` header in ``headers``.
+
+        :param value: The new user-agent string to set (after the base user-agent)
         """
         self._user_agent = f"{self.BASE_USER_AGENT}/{value}"
         self.headers["User-Agent"] = self._user_agent
 
-    def _handle_clientinfo_update(self, info: GlobusClientInfo) -> None:
+    def _handle_clientinfo_update(
+        self,
+        info: GlobusClientInfo,  # pylint: disable=unused-argument
+    ) -> None:
         """
         When the attached ``GlobusClientInfo`` is updated, write it back into
         ``headers``.

--- a/tests/functional/base_client/test_default_headers.py
+++ b/tests/functional/base_client/test_default_headers.py
@@ -25,7 +25,7 @@ def test_clientinfo_header_can_be_supressed(client):
     ).add()
 
     # clear the X-Globus-Client-Info header
-    client.transport.globus_client_info.infos = []
+    client.transport.globus_client_info.clear()
 
     res = client.request("GET", "/bar")
     assert res.http_status == 200

--- a/tests/unit/transport/test_clientinfo.py
+++ b/tests/unit/transport/test_clientinfo.py
@@ -7,7 +7,7 @@ from globus_sdk.transport import GlobusClientInfo
 def make_empty_clientinfo():
     # create a clientinfo with no contents, as a starting point for tests
     obj = GlobusClientInfo()
-    obj.infos = []
+    obj.clear()
     return obj
 
 
@@ -110,3 +110,22 @@ def test_clientinfo_parses_as_expected():
             "alpha": "b01",
         },
     }
+
+
+def test_client_info_can_write_back_via_callback():
+    myvalue = ""
+
+    def onupdate(info):
+        nonlocal myvalue
+        myvalue = info.format()
+
+    info = GlobusClientInfo(update_callback=onupdate)
+
+    # initializing with the callback does not make it fire
+    # the value is unchanged
+    assert myvalue == ""
+
+    # now, add something and make sure it rendered back into the value
+    # (along with python-sdk info)
+    info.add("version=1.0.1,product=my-cool-tool")
+    assert "version=1.0.1,product=my-cool-tool" in myvalue

--- a/tests/unit/transport/test_clientinfo.py
+++ b/tests/unit/transport/test_clientinfo.py
@@ -125,7 +125,12 @@ def test_client_info_can_write_back_via_callback():
     # the value is unchanged
     assert myvalue == ""
 
+    segment = "version=1.0.1,product=my-cool-tool"
     # now, add something and make sure it rendered back into the value
     # (along with python-sdk info)
-    info.add("version=1.0.1,product=my-cool-tool")
-    assert "version=1.0.1,product=my-cool-tool" in myvalue
+    info.add(segment)
+
+    # our new segment is visible
+    assert segment in myvalue
+    # but other values (the default, python-sdk version!) are also there
+    assert myvalue != segment

--- a/tests/unit/transport/test_transport.py
+++ b/tests/unit/transport/test_transport.py
@@ -50,3 +50,61 @@ def test_transport_tuning(param_name, init_value, tune_value):
         assert getattr(transport, param_name) == expected_value
 
     assert getattr(transport, param_name) == init_value
+
+
+def test_transport_can_manipulate_user_agent():
+    transport = RequestsTransport()
+
+    # starting state -- the user agent is visible and equivalent in two places
+    assert "User-Agent" in transport.headers
+    assert transport.headers["User-Agent"] == transport.user_agent
+
+    # setting it slash-appends it to the base agent (in both places)
+    transport.user_agent = "frobulator-1.0"
+    assert (
+        transport.headers["User-Agent"] == f"{transport.BASE_USER_AGENT}/frobulator-1.0"
+    )
+    assert transport.user_agent == f"{transport.BASE_USER_AGENT}/frobulator-1.0"
+
+    # deleting it doesn't clear the property
+    # but accessing the property doesn't add it back into the dict
+    del transport.headers["User-Agent"]
+    assert transport.user_agent == f"{transport.BASE_USER_AGENT}/frobulator-1.0"
+    assert "User-Agent" not in transport.headers
+
+    # but updating it will add it back
+    transport.user_agent = "demuddler-2.2"
+    assert (
+        transport.headers["User-Agent"] == f"{transport.BASE_USER_AGENT}/demuddler-2.2"
+    )
+    assert transport.user_agent == f"{transport.BASE_USER_AGENT}/demuddler-2.2"
+
+
+def test_transport_can_manipulate_client_info():
+    transport = RequestsTransport()
+
+    # starting state -- the clientinfo is visible in headers
+    # and a fake product is not
+    assert "X-Globus-Client-Info" in transport.headers
+    assert "frobulator" not in transport.headers["X-Globus-Client-Info"]
+
+    # we can add said product to the header
+    transport.globus_client_info.add({"product": "frobulator", "version": "1.0"})
+    assert "product=frobulator,version=1.0" in transport.headers["X-Globus-Client-Info"]
+
+    # clearing the client info removes the header
+    transport.globus_client_info.clear()
+    assert "X-Globus-Client-Info" not in transport.headers
+
+    # adding a product re-adds the header
+    transport.globus_client_info.add({"product": "demuddler", "version": "8.8"})
+    assert "product=demuddler,version=8.8" in transport.headers["X-Globus-Client-Info"]
+
+
+def test_double_clear_of_client_info_is_allowed():
+    # clear the client info twice -- catching any potential bugs with `del ...` or
+    # similar assumptions that the value is present
+    transport = RequestsTransport()
+    transport.globus_client_info.clear()
+    transport.globus_client_info.clear()
+    assert "X-Globus-Client-Info" not in transport.headers


### PR DESCRIPTION
The dict itself needs very little explanation -- it's an
instance-level setting which lets a user add a header to a transport
imperatively, simply by doing

    >>> client.transport.headers["My-Header"] = "foo"

or similar.

Its interactions with `User-Agent` and `X-Globus-Client-Info`,
however, are more subtle. These two values act as "dynamic headers",
meaning we either would need to split the headers into two locations
-- the static and the dynamic ones -- or else find a mechanism to keep
these data synchronized. After examining a split static/dynamic state,
it is notably harder to explain to users, harder to use, and does not
allow as much freedom to rewrite or manipulate these data. Therefore,
a new update-contract is put in place around
`RequestsTransport.headers`:

- Whenever `RequestsTransport.user_agent` is written (it is a
  property), it will write back into `headers`. This is unconditional
  and does not worry about overwriting data -- if a user is setting
  the `User-Agent` string manually, they should refrain from
  manipulating this property.

- Whenever `RequestsTransport.globus_client_info` is updated via
  `add()`, it triggers a callback to update `headers`. This mirrors
  the contract around `user_agent` being written as a property.

For almost all usages, this works fine, but there are a few cases in
the testsuite where this new callback-based mechanism results in
surprising behavior. Because tests are setting
`transport.globus_client_info.infos = []` in order to strictly control
the header, they are "desynced". In support of these test scenarios, a
new `clear()` method is added.
A review of usages reveals that no callers outside of the SDK
testsuite are relying on this behavior today.


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1140.org.readthedocs.build/en/1140/

<!-- readthedocs-preview globus-sdk-python end -->