### PR TITLE
Test `mypy` at our boundary versions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -63,10 +63,12 @@ jobs:
           - name: "Quality"
             runner: "ubuntu-latest"
             cpythons:
+              - "3.8"
               - "3.13"
             tox-environments:
               - "check-min-python-is-tested"
-              - "mypy"
+              - "mypy-py3.13"
+              - "mypy-py3.8"
               - "mypy-test"
               - "poetry-check"
               - "pylint"

--- a/src/globus_sdk/services/auth/id_token_decoder.py
+++ b/src/globus_sdk/services/auth/id_token_decoder.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime
+import sys
 import typing as t
 
 import jwt
@@ -12,6 +13,11 @@ from ._common import SupportsJWKMethods
 
 if t.TYPE_CHECKING:
     from globus_sdk import AuthLoginClient, GlobusAppConfig
+
+    if sys.version_info >= (3, 11):
+        from typing import Self
+    else:
+        from typing_extensions import Self
 
 
 class IDTokenDecoder:
@@ -71,7 +77,7 @@ class IDTokenDecoder:
         app_name: str,  # pylint: disable=unused-argument
         config: GlobusAppConfig,  # pylint: disable=unused-argument
         login_client: AuthLoginClient,
-    ) -> t.Self:
+    ) -> Self:
         """
         Create an ``IDTokenDecoder`` for use in a GlobusApp.
 

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,7 @@ deps = pre-commit
 skip_install = true
 commands = pre-commit run --all-files
 
-[testenv:mypy]
+[testenv:mypy,mypy-{py3.8,py3.13}]
 deps = -r requirements/py{py_dot_ver}/typing.txt
 commands = mypy src/ {posargs}
 


### PR DESCRIPTION
During development, developers on lower Python versions (e.g. '3.10'
in this case) can see `mypy` errors which are not evident when `mypy`
runs on a higher supported Python version.

To ensure that type checking not only passes for all maintainers, but
also to guarantee that downstream consumption of SDK types works on
all suported Pythons, test `mypy` on our highest and lowest Python
versions explicitly. Doing so exposes the fact that `typing.Self` is
new in 3.11 and therefore not safe to use directly. Instead, we need a
`typing_extensions` dispatch.

The new testing is driven by `tox`, and by changes to CI:
- tox lists `mypy-py3.8` and `mypy-py3.13` environments, effectively
  as aliases for `mypy` (the default env_list is unchanged)
- the "Quality" job will now include a Python 3.8 interpreter
- the "Quality" job now runs `mypy-py3.8` and `mypy-py3.13`
  explicitly[^1]

[^1]: `mypy` and `mypy-py3.13` should be equivalent in this
environment, but choosing the explicit option gives less ambiguous
output in the run.


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1143.org.readthedocs.build/en/1143/

<!-- readthedocs-preview globus-sdk-python end -->