### PR TITLE
Convert all info-level logging to debug, and lint to enforce this

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -5,3 +5,8 @@ extend-ignore = W503,W504,E203
 
 # in pyi stubs, spacing rules are different (black handles this)
 per-file-ignores = *.pyi:E302,E305
+
+[flake8:local-plugins]
+extension =
+    SDK = _globus_sdk_flake8:Plugin
+paths = ./src/globus_sdk/

--- a/changelog.d/20250313_124025_sirosen_never_use_info_logging.rst
+++ b/changelog.d/20250313_124025_sirosen_never_use_info_logging.rst
@@ -1,0 +1,5 @@
+Changed
+~~~~~~~
+
+- ``globus_sdk`` logging no longer emits any INFO-level log messages. All INFO
+  messages have been downgraded to DEBUG. (:pr:`NUMBER`)

--- a/src/globus_sdk/_globus_sdk_flake8.py
+++ b/src/globus_sdk/_globus_sdk_flake8.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import ast
+import typing as t
+
+CODEMAP: dict[str, str] = {
+    # SDK001 is necessary for SDK002 enforcement to be easy
+    # otherwise, we would have to have a more sophisticated linter which knows about
+    # lexical scopes!
+    "SDK001": "SDK001 loggers should be named 'log'",
+    "SDK002": "SDK002 never use 'log.info'",
+}
+
+
+class Plugin:
+    name = "globus-sdk-flake8"
+    version = "1.0.0"
+
+    # args to init determine plugin behavior. see:
+    # https://flake8.pycqa.org/en/latest/plugin-development/plugin-parameters.html#indicating-desired-data
+    #
+    # by having "tree" as an init arg, we tell flake8 that we are an AST-handling
+    # plugin, run once per file
+    def __init__(self, tree: ast.AST) -> None:
+        self.tree = tree
+
+    # Plugin.run() is how checks will run. For detail, see implementation of:
+    # https://flake8.pycqa.org/en/latest/internal/checker.html#flake8.checker.FileChecker.run_ast_checks
+    def run(self) -> t.Iterator[tuple[int, int, str, type]]:
+        visitor = SDKVisitor()
+        visitor.visit(self.tree)
+        for lineno, col, code in visitor.collect:
+            yield lineno, col, CODEMAP[code], type(self)
+
+
+class SDKVisitor(ast.NodeVisitor):
+    def __init__(self) -> None:
+        super().__init__()
+        self.collect: list[tuple[int, int, str]] = []
+
+    def _record(self, node: ast.expr | ast.stmt, code: str) -> None:
+        self.collect.append((node.lineno, node.col_offset, code))
+
+    # see the structure of an assignment:
+    #
+    # >>> print(ast.dump(ast.parse("""\
+    # ... log = logging.getLogger(__name__)
+    # ... """), indent=4))
+    #
+    # Module(
+    #     body=[
+    #         Assign(
+    #             targets=[
+    #                 Name(id='log', ctx=Store())],
+    #             value=Call(
+    #                 func=Attribute(
+    #                     value=Name(id='logging', ctx=Load()),
+    #                     attr='getLogger',
+    #                     ctx=Load()),
+    #                 args=[
+    #                     Name(id='__name__', ctx=Load())],
+    #                 keywords=[]))],
+    #     type_ignores=[])
+    #
+    # we will try to find an optimal path to bail out quickly on most assignments
+    def visit_Assign(self, node: ast.Assign) -> None:
+        # the value must be a call and must be using attr access in the function call
+        # this eliminates bare funcs like `x = foo()` but allows `x = foo.bar()`
+        if not (
+            isinstance(node.value, ast.Call)
+            and isinstance(node.value.func, ast.Attribute)
+        ):
+            self.generic_visit(node)
+            return
+        call_node: ast.Call = node.value
+        func_node: ast.Attribute = node.value.func
+
+        # not getLogger? irrelevant!
+        # not a name access (e.g., `foo().bar`)? irrelevant!
+        # not `getLogger` of `logging` (e.g., `x.getLogger`)? irrelevant! (and weird!)
+        if not (
+            func_node.attr == "getLogger"
+            and isinstance(func_node.value, ast.Name)
+            and func_node.value.id == "logging"
+        ):
+            self.generic_visit(node)
+            return
+
+        # the assignee must be a single variable and it must be a name node
+        if not (len(node.targets) == 1 and isinstance(node.targets[0], ast.Name)):
+            self.generic_visit(node)
+            return
+        name_node: ast.Name = node.targets[0]
+
+        # confirm that the `logging.getLogger` args look right, if not... ignore
+        if len(call_node.args) != 1 or not isinstance(call_node.args[0], ast.Name):
+            self.generic_visit(node)
+            return
+        logger_arg: ast.Name = call_node.args[0]
+
+        # now, all data prepared, do the check:
+        # - if the argument to `getLogger` is `"__name__"`
+        # - and the assignee is not "log"
+        # that fails
+        #
+        # other usages are allowed, e.g. `liblog = logging.getLogger(otherlib_name)
+        if name_node.id != "log" and logger_arg.id == "__name__":
+            self._record(node, "SDK001")
+
+    # see the structure of a call:
+    #
+    # >>> print(ast.dump(ast.parse("log.info('foo')"), indent=4))
+    # Module(
+    #     body=[
+    #         Expr(
+    #             value=Call(
+    #                 func=Attribute(
+    #                     value=Name(id='log', ctx=Load()),
+    #                     attr='info',
+    #                     ctx=Load()),
+    #                 args=[
+    #                     Constant(value='foo')],
+    #                 keywords=[]))],
+    #     type_ignores=[])
+    #
+    def visit_Call(self, node: ast.Call) -> None:
+        # if it's not a call to 'x.info(...)', ignore
+        if not (isinstance(node.func, ast.Attribute) and node.func.attr == "info"):
+            self.generic_visit(node)
+            return
+        func_node: ast.Attribute = node.func
+
+        # if the function was not a method of something named "log", ignore
+        if not (isinstance(func_node.value, ast.Name) and func_node.value.id == "log"):
+            self.generic_visit(node)
+            return
+
+        # nothing left, it failed SDK002!
+        self._record(node, "SDK002")

--- a/src/globus_sdk/authorizers/access_token.py
+++ b/src/globus_sdk/authorizers/access_token.py
@@ -17,7 +17,7 @@ class AccessTokenAuthorizer(StaticGlobusAuthorizer):
     """
 
     def __init__(self, access_token: str) -> None:
-        log.info(
+        log.debug(
             "Setting up an AccessTokenAuthorizer. It will use an "
             "auth type of Bearer and cannot handle 401s."
         )

--- a/src/globus_sdk/authorizers/basic.py
+++ b/src/globus_sdk/authorizers/basic.py
@@ -18,11 +18,11 @@ class BasicAuthorizer(StaticGlobusAuthorizer):
     """
 
     def __init__(self, username: str, password: str) -> None:
-        log.info(
+        log.debug(
             "Setting up a BasicAuthorizer. It will use an "
             "auth type of Basic and cannot handle 401s."
         )
-        log.info(f"BasicAuthorizer.username = {username}")
+        log.debug(f"BasicAuthorizer.username = {username}")
         self.username = username
         self.password = password
 

--- a/src/globus_sdk/authorizers/client_credentials.py
+++ b/src/globus_sdk/authorizers/client_credentials.py
@@ -70,7 +70,7 @@ class ClientCredentialsAuthorizer(
         self.confidential_client = confidential_client
         self.scopes = scopes_to_str(scopes)
 
-        log.info(
+        log.debug(
             "Setting up ClientCredentialsAuthorizer with confidential_client="
             f"[instance:{id(confidential_client)}] and scopes={self.scopes}"
         )

--- a/src/globus_sdk/authorizers/refresh_token.py
+++ b/src/globus_sdk/authorizers/refresh_token.py
@@ -59,7 +59,7 @@ class RefreshTokenAuthorizer(
             None | t.Callable[[globus_sdk.OAuthRefreshTokenResponse], t.Any]
         ) = None,
     ) -> None:
-        log.info(
+        log.debug(
             "Setting up RefreshTokenAuthorizer with auth_client="
             f"[instance:{id(auth_client)}]"
         )

--- a/src/globus_sdk/authorizers/renewing.py
+++ b/src/globus_sdk/authorizers/renewing.py
@@ -59,7 +59,7 @@ class RenewingAuthorizer(GlobusAuthorizer, t.Generic[ResponseT], metaclass=abc.A
         self._access_token = None
         self._access_token_hash = None
 
-        log.info(
+        log.debug(
             "Setting up a RenewingAuthorizer. It will use an "
             "auth type of Bearer and can handle 401s."
         )
@@ -77,13 +77,13 @@ class RenewingAuthorizer(GlobusAuthorizer, t.Generic[ResponseT], metaclass=abc.A
         self.on_refresh = on_refresh
 
         if self.access_token is not None:
-            log.info(
+            log.debug(
                 "RenewingAuthorizer will start by using access_token "
                 f'with hash "{self._access_token_hash}"'
             )
         # if data were unspecified, fetch a new access token
         else:
-            log.info(
+            log.debug(
                 "Creating RenewingAuthorizer without Access "
                 "Token. Fetching initial token now."
             )
@@ -128,7 +128,7 @@ class RenewingAuthorizer(GlobusAuthorizer, t.Generic[ResponseT], metaclass=abc.A
         self.expires_at = token_data["expires_at_seconds"]
         self.access_token = token_data["access_token"]
 
-        log.info(
+        log.debug(
             "RenewingAuthorizer.access_token updated to "
             f'token with hash "{self._access_token_hash}"'
         )

--- a/src/globus_sdk/client.py
+++ b/src/globus_sdk/client.py
@@ -162,13 +162,13 @@ class BaseClient:
         :raises: GlobusSDKUsageError if base_url cannot be resolved.
         """
         if init_base_url is not None:
-            log.info(f"Creating client of type {cls}")
+            log.debug(f"Creating client of type {cls}")
             return init_base_url
         elif cls.base_url != "_base":
-            log.info(f"Creating client of type {cls}")
+            log.debug(f"Creating client of type {cls}")
             return cls.base_url
         elif cls.service_name != "_base":
-            log.info(f'Creating client of type {cls} for service "{cls.service_name}"')
+            log.debug(f'Creating client of type {cls} for service "{cls.service_name}"')
             return config.get_service_url(cls.service_name, environment)
 
         raise GlobusSDKUsageError(

--- a/src/globus_sdk/config/env_vars.py
+++ b/src/globus_sdk/config/env_vars.py
@@ -54,7 +54,7 @@ def _load_var(
     # meaning that if we define the default as 'foo' and someone explicitly sets 'foo',
     # no info log gets emitted
     if value != default:
-        log.info(f"on lookup, non-default setting: {varname}={value}")
+        log.debug(f"on lookup, non-default setting: {varname}={value}")
     else:
         log.debug(f"on lookup, default setting: {varname}={value}")
     return value

--- a/src/globus_sdk/services/auth/client/base_login_client.py
+++ b/src/globus_sdk/services/auth/client/base_login_client.py
@@ -65,7 +65,7 @@ class AuthLoginClient(client.BaseClient):
         # managers
         self.current_oauth2_flow_manager: GlobusOAuthFlowManager | None = None
 
-        log.info(
+        log.debug(
             "Finished initializing AuthLoginClient. "
             f"client_id='{client_id}', type(authorizer)={type(authorizer)}"
         )
@@ -89,7 +89,7 @@ class AuthLoginClient(client.BaseClient):
         Fetch the OpenID Connect configuration data from the well-known URI for Globus
         Auth.
         """
-        log.info("Fetching OIDC Config")
+        log.debug("Fetching OIDC Config")
         return self.get("/.well-known/openid-configuration")
 
     @t.overload
@@ -198,7 +198,7 @@ class AuthLoginClient(client.BaseClient):
         auth_url = self.current_oauth2_flow_manager.get_authorize_url(
             query_params=query_params
         )
-        log.info(f"Got authorization URL: {auth_url}")
+        log.debug(f"Got authorization URL: {auth_url}")
         return auth_url
 
     def oauth2_exchange_code_for_tokens(
@@ -212,7 +212,7 @@ class AuthLoginClient(client.BaseClient):
             is exchanging for tokens. Tokens are the credentials used to authenticate
             against Globus APIs.
         """
-        log.info(
+        log.debug(
             "Final Step of 3-legged OAuth2 Flows: "
             "Exchanging authorization code for token(s)"
         )
@@ -249,7 +249,7 @@ class AuthLoginClient(client.BaseClient):
         :param refresh_token: A Globus Refresh Token as a string
         :param body_params: A dict of extra params to encode in the refresh call.
         """
-        log.info("Executing token refresh; typically requires client credentials")
+        log.debug("Executing token refresh; typically requires client credentials")
         form_data = {"refresh_token": refresh_token, "grant_type": "refresh_token"}
         return self.oauth2_token(
             form_data, body_params=body_params, response_class=OAuthRefreshTokenResponse
@@ -278,7 +278,7 @@ class AuthLoginClient(client.BaseClient):
             "Tokens should be treated as valid until they are used and their "
             "validity can be assessed."
         )
-        log.info("Validating token")
+        log.debug("Validating token")
         body = {"token": token}
 
         # if this client has no way of authenticating itself but
@@ -321,7 +321,7 @@ class AuthLoginClient(client.BaseClient):
         >>> ac = ConfidentialAppAuthClient(CLIENT_ID, CLIENT_SECRET)
         >>> ac.oauth2_revoke_token('<token_string>')
         """
-        log.info("Revoking token")
+        log.debug("Revoking token")
         body = {"token": token}
 
         # if this client has no way of authenticating itself but
@@ -395,7 +395,7 @@ class AuthLoginClient(client.BaseClient):
         :rtype: ``response_class`` if set, defaults to
             :py:attr:`~globus_sdk.OAuthTokenResponse`
         """
-        log.info("Fetching new token from Globus Auth")
+        log.debug("Fetching new token from Globus Auth")
         # use the fact that requests implicitly encodes the `data` parameter as
         # a form POST
         data = dict(form_data)

--- a/src/globus_sdk/services/auth/client/confidential_client.py
+++ b/src/globus_sdk/services/auth/client/confidential_client.py
@@ -129,7 +129,7 @@ class ConfidentialAppAuthClient(AuthLoginClient):
         ...     tokens.by_resource_server["transfer.api.globus.org"])
         >>> transfer_token = transfer_token_info["access_token"]
         """
-        log.info("Fetching token(s) using client credentials")
+        log.debug("Fetching token(s) using client credentials")
         requested_scopes_string = stringify_requested_scopes(requested_scopes)
         return self.oauth2_token(
             {"grant_type": "client_credentials", "scope": requested_scopes_string},
@@ -175,7 +175,7 @@ class ConfidentialAppAuthClient(AuthLoginClient):
                 `in the Globus Auth Specification
                 <https://docs.globus.org/api/auth/developer-guide/#obtaining-authorization>`_.
         """
-        log.info("Starting OAuth2 Authorization Code Grant Flow")
+        log.debug("Starting OAuth2 Authorization Code Grant Flow")
         self.current_oauth2_flow_manager = GlobusAuthorizationCodeFlowManager(
             self,
             redirect_uri,
@@ -251,8 +251,10 @@ class ConfidentialAppAuthClient(AuthLoginClient):
                 .. extdoclink:: Dependent Token Grant
                     :ref: auth/reference/##dependent_token_grant_post_v2oauth2token
         """  # noqa: E501
-        log.info("Getting dependent tokens from access token")
-        log.debug(f"additional_params={additional_params}")
+        log.debug(
+            "Getting dependent tokens from access token"
+            f"additional_params={additional_params}"
+        )
         form_data = {
             "grant_type": "urn:globus:auth:grant_type:dependent_token",
             "token": token,
@@ -311,7 +313,7 @@ class ConfidentialAppAuthClient(AuthLoginClient):
                 .. extdoclink:: Token Introspection
                     :ref: auth/reference/#token_introspection_post_v2_oauth2_token_introspect
         """  # noqa: E501
-        log.info("Checking token validity (introspect)")
+        log.debug("Checking token validity (introspect)")
         body = {"token": token}
         if include is not None:
             body["include"] = include

--- a/src/globus_sdk/services/auth/client/native_client.py
+++ b/src/globus_sdk/services/auth/client/native_client.py
@@ -98,7 +98,7 @@ class NativeAppAuthClient(AuthLoginClient):
                 `The PKCE Security Protocol
                 <https://docs.globus.org/api/auth/developer-guide/#pkce>`_.
         """
-        log.info("Starting Native App Grant Flow")
+        log.debug("Starting Native App Grant Flow")
         self.current_oauth2_flow_manager = GlobusNativeAppFlowManager(
             self,
             requested_scopes=requested_scopes,
@@ -125,7 +125,7 @@ class NativeAppAuthClient(AuthLoginClient):
         :param refresh_token: The refresh token to use to get a new access token
         :param body_params: Extra parameters to include in the POST body
         """
-        log.info("Executing token refresh without client credentials")
+        log.debug("Executing token refresh without client credentials")
         form_data = {
             "refresh_token": refresh_token,
             "grant_type": "refresh_token",

--- a/src/globus_sdk/services/auth/client/service_client.py
+++ b/src/globus_sdk/services/auth/client/service_client.py
@@ -166,7 +166,7 @@ class AuthClient(client.BaseClient):
         Fetch the OpenID Connect configuration data from the well-known URI for Globus
         Auth.
         """
-        log.info("Fetching OIDC Config")
+        log.debug("Fetching OIDC Config")
         return self.get("/.well-known/openid-configuration")
 
     @t.overload
@@ -244,7 +244,7 @@ class AuthClient(client.BaseClient):
                 .. extdoclink:: Get Userinfo
                     :ref: auth/reference/#get_or_post_v2_oauth2_userinfo_resource
         """
-        log.info("Looking up OIDC-style Userinfo from Globus Auth")
+        log.debug("Looking up OIDC-style Userinfo from Globus Auth")
         return self.get("/v2/oauth2/userinfo")
 
     def oauth2_userinfo(self) -> GlobusHTTPResponse:
@@ -343,7 +343,7 @@ class AuthClient(client.BaseClient):
                     :ref: auth/reference/#v2_api_identities_resources
         """  # noqa: E501
 
-        log.info("Looking up Globus Auth Identities")
+        log.debug("Looking up Globus Auth Identities")
 
         if query_params is None:
             query_params = {}
@@ -436,7 +436,7 @@ class AuthClient(client.BaseClient):
                     :ref: auth/reference/#get_identity_providers
         """  # noqa: E501
 
-        log.info("Looking up Globus Auth Identity Providers")
+        log.debug("Looking up Globus Auth Identity Providers")
 
         if query_params is None:
             query_params = {}

--- a/src/globus_sdk/services/auth/flow_managers/authorization_code.py
+++ b/src/globus_sdk/services/auth/flow_managers/authorization_code.py
@@ -14,7 +14,7 @@ from .base import GlobusOAuthFlowManager
 if t.TYPE_CHECKING:
     import globus_sdk
 
-logger = logging.getLogger(__name__)
+log = logging.getLogger(__name__)
 
 
 class GlobusAuthorizationCodeFlowManager(GlobusOAuthFlowManager):
@@ -65,12 +65,14 @@ class GlobusAuthorizationCodeFlowManager(GlobusOAuthFlowManager):
         self.refresh_tokens = refresh_tokens
         self.state = state
 
-        logger.debug("Starting Authorization Code Flow with params:")
-        logger.debug(f"auth_client.client_id={auth_client.client_id}")
-        logger.debug(f"redirect_uri={redirect_uri}")
-        logger.debug(f"refresh_tokens={refresh_tokens}")
-        logger.debug(f"state={state}")
-        logger.debug(f"requested_scopes={self.requested_scopes}")
+        log.debug(
+            "Starting Authorization Code Flow with params: "
+            f"auth_client.client_id={auth_client.client_id} , "
+            f"redirect_uri={redirect_uri} , "
+            f"refresh_tokens={refresh_tokens} , "
+            f"state={state} , "
+            f"requested_scopes={self.requested_scopes}"
+        )
 
     def get_authorize_url(self, query_params: dict[str, t.Any] | None = None) -> str:
         """
@@ -88,8 +90,8 @@ class GlobusAuthorizationCodeFlowManager(GlobusOAuthFlowManager):
         authorize_base_url = utils.slash_join(
             self.auth_client.base_url, "/v2/oauth2/authorize"
         )
-        logger.debug(f"Building authorization URI. Base URL: {authorize_base_url}")
-        logger.debug(f"query_params={query_params}")
+        log.debug(f"Building authorization URI. Base URL: {authorize_base_url}")
+        log.debug(f"query_params={query_params}")
 
         params = {
             "client_id": self.client_id,
@@ -114,7 +116,7 @@ class GlobusAuthorizationCodeFlowManager(GlobusOAuthFlowManager):
 
         :param auth_code: The short-lived code to exchange for tokens
         """
-        logger.debug(
+        log.debug(
             "Performing Authorization Code auth_code exchange. "
             "Sending client_id and client_secret"
         )

--- a/src/globus_sdk/services/auth/flow_managers/native_app.py
+++ b/src/globus_sdk/services/auth/flow_managers/native_app.py
@@ -19,7 +19,7 @@ from .base import GlobusOAuthFlowManager
 if t.TYPE_CHECKING:
     import globus_sdk
 
-logger = logging.getLogger(__name__)
+log = logging.getLogger(__name__)
 
 
 def make_native_app_challenge(
@@ -49,7 +49,7 @@ def make_native_app_challenge(
         if bool(re.search(r"[^a-zA-Z0-9~_.-]", verifier)):
             raise GlobusSDKUsageError("verifier contained invalid characters")
     else:
-        logger.info(
+        log.debug(
             "Autogenerating verifier secret. On low-entropy systems "
             "this may be insecure"
         )
@@ -113,7 +113,7 @@ class GlobusNativeAppFlowManager(GlobusOAuthFlowManager):
         # set client_id, then check for validity
         self.client_id = auth_client.client_id
         if not self.client_id:
-            logger.error(
+            log.error(
                 "Invalid auth_client ID to start Native App Flow: {}".format(
                     self.client_id
                 )
@@ -142,16 +142,18 @@ class GlobusNativeAppFlowManager(GlobusOAuthFlowManager):
         self.state = state
         self.prefill_named_grant = prefill_named_grant
 
-        logger.debug("Starting Native App Flow with params:")
-        logger.debug(f"auth_client.client_id={auth_client.client_id}")
-        logger.debug(f"redirect_uri={self.redirect_uri}")
-        logger.debug(f"refresh_tokens={refresh_tokens}")
-        logger.debug(f"state={state}")
-        logger.debug(f"requested_scopes={self.requested_scopes}")
-        logger.debug(f"verifier=<REDACTED>,challenge={self.challenge}")
+        log.debug(
+            "Starting Native App Flow with params: "
+            f"auth_client.client_id={auth_client.client_id} , "
+            f"redirect_uri={self.redirect_uri} , "
+            f"refresh_tokens={refresh_tokens} , "
+            f"state={state} , "
+            f"requested_scopes={self.requested_scopes} , "
+            f"verifier=<REDACTED>,challenge={self.challenge}"
+        )
 
         if prefill_named_grant is not None:
-            logger.debug(f"prefill_named_grant={self.prefill_named_grant}")
+            log.debug(f"prefill_named_grant={self.prefill_named_grant}")
 
     def get_authorize_url(self, query_params: dict[str, t.Any] | None = None) -> str:
         """
@@ -169,8 +171,8 @@ class GlobusNativeAppFlowManager(GlobusOAuthFlowManager):
         authorize_base_url = utils.slash_join(
             self.auth_client.base_url, "/v2/oauth2/authorize"
         )
-        logger.debug(f"Building authorization URI. Base URL: {authorize_base_url}")
-        logger.debug(f"query_params={query_params}")
+        log.debug(f"Building authorization URI. Base URL: {authorize_base_url}")
+        log.debug(f"query_params={query_params}")
 
         params = {
             "client_id": self.client_id,
@@ -199,7 +201,7 @@ class GlobusNativeAppFlowManager(GlobusOAuthFlowManager):
 
         :param auth_code: The short-lived code to exchange for tokens
         """
-        logger.debug(
+        log.debug(
             "Performing Native App auth_code exchange. "
             "Sending verifier and client_id"
         )

--- a/src/globus_sdk/services/auth/response/oauth.py
+++ b/src/globus_sdk/services/auth/response/oauth.py
@@ -14,7 +14,7 @@ from globus_sdk.response import GlobusHTTPResponse
 from .._common import SupportsJWKMethods
 from ..id_token_decoder import IDTokenDecoder
 
-logger = logging.getLogger(__name__)
+log = logging.getLogger(__name__)
 
 
 def _convert_token_info_dict(
@@ -191,7 +191,7 @@ class OAuthTokenResponse(GlobusHTTPResponse):
             parameter, and all other values are passed as ``options``.
         """
         id_token = self["id_token"]
-        logger.debug('Decoding ID Token "%s"', id_token)
+        log.debug('Decoding ID Token "%s"', id_token)
         if not isinstance(self.client, SupportsJWKMethods):
             raise exc.GlobusSDKUsageError(
                 "decode_id_token() requires a client which supports JWK methods. "

--- a/src/globus_sdk/services/search/client.py
+++ b/src/globus_sdk/services/search/client.py
@@ -77,7 +77,7 @@ class SearchClient(client.BaseClient):
                 .. extdoclink:: Index Create
                     :ref: search/reference/index_create/
         """
-        log.info(f"SearchClient.create_index({display_name!r}, ...)")
+        log.debug(f"SearchClient.create_index({display_name!r}, ...)")
         return self.post(
             "/v1/index", data={"display_name": display_name, "description": description}
         )
@@ -118,7 +118,7 @@ class SearchClient(client.BaseClient):
                 .. extdoclink:: Index Delete
                     :ref: search/reference/index_delete/
         """
-        log.info(f"SearchClient.delete_index({index_id!r}, ...)")
+        log.debug(f"SearchClient.delete_index({index_id!r}, ...)")
         return self.delete(f"/v1/index/{index_id}")
 
     def reopen_index(self, index_id: UUIDLike) -> response.GlobusHTTPResponse:
@@ -147,7 +147,7 @@ class SearchClient(client.BaseClient):
                 .. extdoclink:: Index Reopen
                     :ref: search/reference/index_reopen/
         """
-        log.info(f"SearchClient.reopen_index({index_id!r}, ...)")
+        log.debug(f"SearchClient.reopen_index({index_id!r}, ...)")
         return self.post(f"/v1/index/{index_id}/reopen")
 
     def get_index(
@@ -181,7 +181,7 @@ class SearchClient(client.BaseClient):
                 .. extdoclink:: Index Show
                     :ref: search/reference/index_show/
         """  # noqa: E501
-        log.info(f"SearchClient.get_index({index_id})")
+        log.debug(f"SearchClient.get_index({index_id})")
         return self.get(f"/v1/index/{index_id}", query_params=query_params)
 
     #
@@ -255,7 +255,7 @@ class SearchClient(client.BaseClient):
             }
         )
 
-        log.info(f"SearchClient.search({index_id}, ...)")
+        log.debug(f"SearchClient.search({index_id}, ...)")
         return self.get(f"/v1/index/{index_id}/search", query_params=query_params)
 
     @paging.has_paginator(
@@ -324,7 +324,7 @@ class SearchClient(client.BaseClient):
                 .. extdoclink:: POST Search Query
                     :ref: search/reference/post_query/
         """
-        log.info(f"SearchClient.post_search({index_id}, ...)")
+        log.debug(f"SearchClient.post_search({index_id}, ...)")
         add_kwargs = {}
         if offset is not None:
             add_kwargs["offset"] = offset
@@ -376,7 +376,7 @@ class SearchClient(client.BaseClient):
                 .. extdoclink:: Scroll Query
                     :ref: search/reference/scroll_query/
         """
-        log.info(f"SearchClient.scroll({index_id}, ...)")
+        log.debug(f"SearchClient.scroll({index_id}, ...)")
         add_kwargs = {}
         if marker is not None:
             add_kwargs["marker"] = marker
@@ -448,7 +448,7 @@ class SearchClient(client.BaseClient):
                 .. extdoclink:: Ingest
                     :ref: search/reference/ingest/
         """
-        log.info(f"SearchClient.ingest({index_id}, ...)")
+        log.debug(f"SearchClient.ingest({index_id}, ...)")
         return self.post(f"/v1/index/{index_id}/ingest", data=data)
 
     #
@@ -495,7 +495,7 @@ class SearchClient(client.BaseClient):
                 .. extdoclink:: Delete By Query
                     :ref: search/reference/delete_by_query/
         """
-        log.info(f"SearchClient.delete_by_query({index_id}, ...)")
+        log.debug(f"SearchClient.delete_by_query({index_id}, ...)")
         return self.post(f"/v1/index/{index_id}/delete_by_query", data=data)
 
     def batch_delete_by_subject(
@@ -541,7 +541,7 @@ class SearchClient(client.BaseClient):
                 .. extdoclink:: Delete By Subject
                     :ref: search/reference/batch_delete_by_subject/
         """
-        log.info(f"SearchClient.batch_delete_by_subject({index_id}, ...)")
+        log.debug(f"SearchClient.batch_delete_by_subject({index_id}, ...)")
         # convert the provided subjects to a list and use the "safe iter" helper to
         # ensure that a single string is *not* treated as an iterable of strings,
         # which is usually not intentional
@@ -590,7 +590,7 @@ class SearchClient(client.BaseClient):
         if query_params is None:
             query_params = {}
         query_params["subject"] = subject
-        log.info(f"SearchClient.get_subject({index_id}, {subject}, ...)")
+        log.debug(f"SearchClient.get_subject({index_id}, {subject}, ...)")
         return self.get(f"/v1/index/{index_id}/subject", query_params=query_params)
 
     def delete_subject(
@@ -634,7 +634,7 @@ class SearchClient(client.BaseClient):
             query_params = {}
         query_params["subject"] = subject
 
-        log.info(f"SearchClient.delete_subject({index_id}, {subject}, ...)")
+        log.debug(f"SearchClient.delete_subject({index_id}, {subject}, ...)")
         return self.delete(f"/v1/index/{index_id}/subject", query_params=query_params)
 
     #
@@ -692,7 +692,7 @@ class SearchClient(client.BaseClient):
         if entry_id is not None:
             query_params["entry_id"] = entry_id
 
-        log.info(
+        log.debug(
             "SearchClient.get_entry({}, {}, {}, ...)".format(
                 index_id, subject, entry_id
             )
@@ -760,7 +760,7 @@ class SearchClient(client.BaseClient):
             "SearchClient.create_entry is deprecated. "
             "Users should prefer using `SearchClient.ingest`"
         )
-        log.info(f"SearchClient.create_entry({index_id}, ...)")
+        log.debug(f"SearchClient.create_entry({index_id}, ...)")
         return self.post(f"/v1/index/{index_id}/entry", data=data)
 
     def update_entry(
@@ -807,7 +807,7 @@ class SearchClient(client.BaseClient):
             "SearchClient.update_entry is deprecated. "
             "Users should prefer using `SearchClient.ingest`"
         )
-        log.info(f"SearchClient.update_entry({index_id}, ...)")
+        log.debug(f"SearchClient.update_entry({index_id}, ...)")
         return self.put(f"/v1/index/{index_id}/entry", data=data)
 
     def delete_entry(
@@ -860,7 +860,7 @@ class SearchClient(client.BaseClient):
         query_params["subject"] = subject
         if entry_id is not None:
             query_params["entry_id"] = entry_id
-        log.info(
+        log.debug(
             "SearchClient.delete_entry({}, {}, {}, ...)".format(
                 index_id, subject, entry_id
             )
@@ -901,7 +901,7 @@ class SearchClient(client.BaseClient):
                 .. extdoclink:: Get Task
                     :ref: search/reference/get_task/
         """
-        log.info(f"SearchClient.get_task({task_id})")
+        log.debug(f"SearchClient.get_task({task_id})")
         return self.get(f"/v1/task/{task_id}", query_params=query_params)
 
     def get_task_list(
@@ -935,7 +935,7 @@ class SearchClient(client.BaseClient):
                 .. extdoclink:: Task List
                     :ref: search/reference/task_list/
         """
-        log.info(f"SearchClient.get_task_list({index_id})")
+        log.debug(f"SearchClient.get_task_list({index_id})")
         return self.get(f"/v1/task_list/{index_id}", query_params=query_params)
 
     #
@@ -981,7 +981,7 @@ class SearchClient(client.BaseClient):
                 .. extdoclink:: Create Role
                     :ref: search/reference/role_create/
         """  # noqa: E501
-        log.info("SearchClient.create_role(%s, ...)", index_id)
+        log.debug("SearchClient.create_role(%s, ...)", index_id)
         return self.post(
             f"/v1/index/{index_id}/role", data=data, query_params=query_params
         )
@@ -1008,7 +1008,7 @@ class SearchClient(client.BaseClient):
                 .. extdoclink:: Get Role List
                     :ref: search/reference/role_list/
         """
-        log.info("SearchClient.get_role_list(%s)", index_id)
+        log.debug("SearchClient.get_role_list(%s)", index_id)
         return self.get(f"/v1/index/{index_id}/role_list", query_params=query_params)
 
     def delete_role(
@@ -1036,7 +1036,7 @@ class SearchClient(client.BaseClient):
                 .. extdoclink:: Role Delete
                     :ref: search/reference/role_delete/
         """
-        log.info("SearchClient.delete_role(%s, %s)", index_id, role_id)
+        log.debug("SearchClient.delete_role(%s, %s)", index_id, role_id)
         return self.delete(
             f"/v1/index/{index_id}/role/{role_id}", query_params=query_params
         )

--- a/src/globus_sdk/services/timers/client.py
+++ b/src/globus_sdk/services/timers/client.py
@@ -114,7 +114,7 @@ class TimersClient(client.BaseClient):
         >>> timer_client = globus_sdk.TimersClient(...)
         >>> jobs = timer_client.list_jobs()
         """
-        log.info(f"TimersClient.list_jobs({query_params})")
+        log.debug(f"TimersClient.list_jobs({query_params})")
         return self.get("/jobs/", query_params=query_params)
 
     def get_job(
@@ -135,7 +135,7 @@ class TimersClient(client.BaseClient):
         >>> job = timer_client.get_job(job_id)
         >>> assert job["job_id"] == job_id
         """
-        log.info(f"TimersClient.get_job({job_id})")
+        log.debug(f"TimersClient.get_job({job_id})")
         return self.get(f"/jobs/{job_id}", query_params=query_params)
 
     def create_timer(
@@ -178,7 +178,7 @@ class TimersClient(client.BaseClient):
                 "Cannot pass a TimerJob to create_timer(). "
                 "Create a TransferTimer instead."
             )
-        log.info("TimersClient.create_timer(...)")
+        log.debug("TimersClient.create_timer(...)")
         return self.post("/v2/timer", data={"timer": timer})
 
     def create_job(
@@ -208,7 +208,7 @@ class TimersClient(client.BaseClient):
                 "Cannot pass a TransferTimer to create_job(). Use create_timer() "
                 "instead."
             )
-        log.info(f"TimersClient.create_job({data})")
+        log.debug(f"TimersClient.create_job({data})")
         return self.post("/jobs/", data=data)
 
     def update_job(
@@ -225,7 +225,7 @@ class TimersClient(client.BaseClient):
         >>> timer_client = globus_sdk.TimersClient(...)
         >>> timer_client.update_job(job_id, {"name": "new name}"})
         """
-        log.info(f"TimersClient.update_job({job_id}, {data})")
+        log.debug(f"TimersClient.update_job({job_id}, {data})")
         return self.patch(f"/jobs/{job_id}", data=data)
 
     def delete_job(
@@ -242,7 +242,7 @@ class TimersClient(client.BaseClient):
         >>> timer_client = globus_sdk.TimersClient(...)
         >>> timer_client.delete_job(job_id)
         """
-        log.info(f"TimersClient.delete_job({job_id})")
+        log.debug(f"TimersClient.delete_job({job_id})")
         return self.delete(f"/jobs/{job_id}")
 
     def pause_job(
@@ -259,7 +259,7 @@ class TimersClient(client.BaseClient):
         >>> timer_client = globus_sdk.TimersClient(...)
         >>> timer_client.pause_job(job_id)
         """
-        log.info(f"TimersClient.pause_job({job_id})")
+        log.debug(f"TimersClient.pause_job({job_id})")
         return self.post(f"/jobs/{job_id}/pause")
 
     def resume_job(
@@ -287,7 +287,7 @@ class TimersClient(client.BaseClient):
         >>> timer_client = globus_sdk.TimersClient(...)
         >>> timer_client.resume_job(job_id)
         """
-        log.info(f"TimersClient.resume_job({job_id})")
+        log.debug(f"TimersClient.resume_job({job_id})")
         data = {}
         if update_credentials is not None:
             data["update_credentials"] = update_credentials

--- a/src/globus_sdk/services/timers/data.py
+++ b/src/globus_sdk/services/timers/data.py
@@ -306,7 +306,7 @@ class TimerJob(PayloadWrapper):
         transfer_action_url = slash_join(
             get_service_url("actions", environment=environment), "transfer/transfer/run"
         )
-        log.info(
+        log.debug(
             "Creating TimerJob from TransferData, action_url=%s", transfer_action_url
         )
         for key in ("submission_id", "skip_activation_check"):

--- a/src/globus_sdk/services/transfer/client.py
+++ b/src/globus_sdk/services/transfer/client.py
@@ -221,7 +221,7 @@ class TransferClient(client.BaseClient):
                 .. extdoclink:: Get Endpoint or Collection by ID
                     :ref: transfer/endpoints_and_collections/#get_endpoint_or_collection_by_id
         """  # noqa: E501
-        log.info(f"TransferClient.get_endpoint({endpoint_id})")
+        log.debug(f"TransferClient.get_endpoint({endpoint_id})")
         return self.get(f"endpoint/{endpoint_id}", query_params=query_params)
 
     def update_endpoint(
@@ -269,7 +269,7 @@ class TransferClient(client.BaseClient):
         elif data.get("oauth_server"):
             data["myproxy_server"] = None
 
-        log.info(f"TransferClient.update_endpoint({endpoint_id}, ...)")
+        log.debug(f"TransferClient.update_endpoint({endpoint_id}, ...)")
         return self.put(f"endpoint/{endpoint_id}", data=data, query_params=query_params)
 
     def set_subscription_id(
@@ -347,7 +347,7 @@ class TransferClient(client.BaseClient):
                 "not both"
             )
 
-        log.info("TransferClient.create_endpoint(...)")
+        log.debug("TransferClient.create_endpoint(...)")
         return self.post("endpoint", data=data)
 
     def delete_endpoint(self, endpoint_id: UUIDLike) -> response.GlobusHTTPResponse:
@@ -370,7 +370,7 @@ class TransferClient(client.BaseClient):
                 .. extdoclink:: Delete Globus Connect Personal collection by id
                     :ref: transfer/gcp_management/#delete_collection_by_id
         """
-        log.info(f"TransferClient.delete_endpoint({endpoint_id})")
+        log.debug(f"TransferClient.delete_endpoint({endpoint_id})")
         return self.delete(f"endpoint/{endpoint_id}")
 
     @paging.has_paginator(
@@ -480,7 +480,7 @@ class TransferClient(client.BaseClient):
             query_params["limit"] = limit
         if offset is not None:
             query_params["offset"] = offset
-        log.info(f"TransferClient.endpoint_search({query_params})")
+        log.debug(f"TransferClient.endpoint_search({query_params})")
         return IterableTransferResponse(
             self.get("endpoint_search", query_params=query_params)
         )
@@ -509,7 +509,7 @@ class TransferClient(client.BaseClient):
             query_params = {}
         if if_expires_in is not None:
             query_params["if_expires_in"] = if_expires_in
-        log.info(f"TransferClient.endpoint_autoactivate({endpoint_id})")
+        log.debug(f"TransferClient.endpoint_autoactivate({endpoint_id})")
         return self.post(
             f"endpoint/{endpoint_id}/autoactivate", query_params=query_params
         )
@@ -530,7 +530,7 @@ class TransferClient(client.BaseClient):
         :param query_params: Any additional parameters will be passed through
             as query params.
         """
-        log.info(f"TransferClient.endpoint_deactivate({endpoint_id})")
+        log.debug(f"TransferClient.endpoint_deactivate({endpoint_id})")
         return self.post(
             f"endpoint/{endpoint_id}/deactivate", query_params=query_params
         )
@@ -556,7 +556,7 @@ class TransferClient(client.BaseClient):
         :param query_params: Any additional parameters will be passed through
             as query params.
         """
-        log.info(f"TransferClient.endpoint_activate({endpoint_id})")
+        log.debug(f"TransferClient.endpoint_activate({endpoint_id})")
         return self.post(
             f"endpoint/{endpoint_id}/activate",
             data=requirements_data,
@@ -607,7 +607,7 @@ class TransferClient(client.BaseClient):
                 .. extdoclink:: Get my effective collection pause rules
                     :ref: transfer/endpoints_and_collections/#get_collection_pause_rules
         """
-        log.info(f"TransferClient.my_effective_pause_rule_list({endpoint_id}, ...)")
+        log.debug(f"TransferClient.my_effective_pause_rule_list({endpoint_id}, ...)")
         return IterableTransferResponse(
             self.get(
                 f"endpoint/{endpoint_id}/my_effective_pause_rule_list",
@@ -639,7 +639,7 @@ class TransferClient(client.BaseClient):
                 .. extdoclink:: Get my guest collection list
                     :ref: transfer/endpoints_and_collections/#get_my_guest_collection_list
         """  # noqa: E501
-        log.info(f"TransferClient.my_shared_endpoint_list({endpoint_id}, ...)")
+        log.debug(f"TransferClient.my_shared_endpoint_list({endpoint_id}, ...)")
         return IterableTransferResponse(
             self.get(
                 f"endpoint/{endpoint_id}/my_shared_endpoint_list",
@@ -678,7 +678,7 @@ class TransferClient(client.BaseClient):
                 .. extdoclink:: Get guest collection list
                     :ref: transfer/endpoints_and_collections/get_guest_collection_list
         """
-        log.info(f"TransferClient.get_shared_endpoint_list({endpoint_id}, ...)")
+        log.debug(f"TransferClient.get_shared_endpoint_list({endpoint_id}, ...)")
         if query_params is None:
             query_params = {}
         if max_results is not None:
@@ -724,7 +724,7 @@ class TransferClient(client.BaseClient):
                 .. extdoclink:: Create guest collection
                     :ref: transfer/gcp_management/#create_guest_collection
         """
-        log.info("TransferClient.create_shared_endpoint(...)")
+        log.debug("TransferClient.create_shared_endpoint(...)")
         return self.post("shared_endpoint", data=data)
 
     # Endpoint servers
@@ -749,7 +749,7 @@ class TransferClient(client.BaseClient):
                 .. extdoclink:: Get endpoint or collection server list
                     :ref: transfer/endpoints_and_collections/#get_endpoint_or_collection_server_list
         """  # noqa: E501
-        log.info(f"TransferClient.endpoint_server_list({endpoint_id}, ...)")
+        log.debug(f"TransferClient.endpoint_server_list({endpoint_id}, ...)")
         return IterableTransferResponse(
             self.get(f"endpoint/{endpoint_id}/server_list", query_params=query_params)
         )
@@ -775,7 +775,7 @@ class TransferClient(client.BaseClient):
                 .. extdoclink:: Get server by id
                     :ref: transfer/endpoints_and_collections/#get_server_by_id
         """
-        log.info(
+        log.debug(
             "TransferClient.get_endpoint_server(%s, %s, ...)", endpoint_id, server_id
         )
         return self.get(
@@ -794,7 +794,7 @@ class TransferClient(client.BaseClient):
         :param endpoint_id: The endpoint under which the server is being registered
         :param server_data: Fields for the new server, as a server document
         """
-        log.info(f"TransferClient.add_endpoint_server({endpoint_id}, ...)")
+        log.debug(f"TransferClient.add_endpoint_server({endpoint_id}, ...)")
         return self.post(f"endpoint/{endpoint_id}/server", data=server_data)
 
     def update_endpoint_server(
@@ -813,7 +813,7 @@ class TransferClient(client.BaseClient):
         :param server_id: The ID of the server to update
         :param server_data: Fields on the server to update, as a partial server document
         """
-        log.info(
+        log.debug(
             "TransferClient.update_endpoint_server(%s, %s, ...)",
             endpoint_id,
             server_id,
@@ -832,7 +832,7 @@ class TransferClient(client.BaseClient):
         :param endpoint_id: The endpoint under which the server is registered
         :param server_id: The ID of the server to delete
         """
-        log.info(
+        log.debug(
             "TransferClient.delete_endpoint_server(%s, %s)", endpoint_id, server_id
         )
         return self.delete(f"endpoint/{endpoint_id}/server/{server_id}")
@@ -861,7 +861,7 @@ class TransferClient(client.BaseClient):
                 .. extdoclink:: Get list of roles
                     :ref: transfer/roles/#role_list
         """
-        log.info(f"TransferClient.endpoint_role_list({endpoint_id}, ...)")
+        log.debug(f"TransferClient.endpoint_role_list({endpoint_id}, ...)")
         return IterableTransferResponse(
             self.get(f"endpoint/{endpoint_id}/role_list", query_params=query_params)
         )
@@ -882,7 +882,7 @@ class TransferClient(client.BaseClient):
                 .. extdoclink:: Create Globus Connect Personal collection role
                     :ref: transfer/roles/#create_role
         """
-        log.info(f"TransferClient.add_endpoint_role({endpoint_id}, ...)")
+        log.debug(f"TransferClient.add_endpoint_role({endpoint_id}, ...)")
         return self.post(f"endpoint/{endpoint_id}/role", data=role_data)
 
     def get_endpoint_role(
@@ -906,7 +906,7 @@ class TransferClient(client.BaseClient):
                 .. extdoclink:: Get role by id
                     :ref: transfer/roles/#get_role_by_id
         """
-        log.info(f"TransferClient.get_endpoint_role({endpoint_id}, {role_id}, ...)")
+        log.debug(f"TransferClient.get_endpoint_role({endpoint_id}, {role_id}, ...)")
         return self.get(
             f"endpoint/{endpoint_id}/role/{role_id}", query_params=query_params
         )
@@ -927,7 +927,7 @@ class TransferClient(client.BaseClient):
                 .. extdoclink:: Delete Globus Connect Personal collection role by id
                     :ref: transfer/roles/#delete_role_by_id
         """
-        log.info(f"TransferClient.delete_endpoint_role({endpoint_id}, {role_id})")
+        log.debug(f"TransferClient.delete_endpoint_role({endpoint_id}, {role_id})")
         return self.delete(f"endpoint/{endpoint_id}/role/{role_id}")
 
     #
@@ -953,7 +953,7 @@ class TransferClient(client.BaseClient):
                 .. extdoclink:: Get list of access rules
                     :ref: transfer/acl/#rest_access_get_list
         """
-        log.info(f"TransferClient.endpoint_acl_list({endpoint_id}, ...)")
+        log.debug(f"TransferClient.endpoint_acl_list({endpoint_id}, ...)")
         return IterableTransferResponse(
             self.get(f"endpoint/{endpoint_id}/access_list", query_params=query_params)
         )
@@ -979,7 +979,7 @@ class TransferClient(client.BaseClient):
                 .. extdoclink:: Get access rule by ID
                     :ref: transfer/acl/#get_access_rule_by_id
         """
-        log.info(
+        log.debug(
             "TransferClient.get_endpoint_acl_rule(%s, %s, ...)", endpoint_id, rule_id
         )
         return self.get(
@@ -1020,7 +1020,7 @@ class TransferClient(client.BaseClient):
                 .. extdoclink:: Create access rule
                     :ref: transfer/acl/#rest_access_create
         """
-        log.info(f"TransferClient.add_endpoint_acl_rule({endpoint_id}, ...)")
+        log.debug(f"TransferClient.add_endpoint_acl_rule({endpoint_id}, ...)")
         return self.post(f"endpoint/{endpoint_id}/access", data=rule_data)
 
     def update_endpoint_acl_rule(
@@ -1043,7 +1043,7 @@ class TransferClient(client.BaseClient):
                 .. extdoclink:: Update access rule
                     :ref: transfer/acl/#update_access_rule
         """
-        log.info(
+        log.debug(
             "TransferClient.update_endpoint_acl_rule(%s, %s, ...)",
             endpoint_id,
             rule_id,
@@ -1066,7 +1066,7 @@ class TransferClient(client.BaseClient):
                 .. extdoclink:: Delete access rule
                     :ref: transfer/acl/#delete_access_rule
         """
-        log.info(
+        log.debug(
             "TransferClient.delete_endpoint_acl_rule(%s, %s)", endpoint_id, rule_id
         )
         return self.delete(f"endpoint/{endpoint_id}/access/{rule_id}")
@@ -1090,7 +1090,7 @@ class TransferClient(client.BaseClient):
                 .. extdoclink:: Get list of bookmarks
                     :ref: transfer/collection_bookmarks/#get_list_of_bookmarks
         """
-        log.info(f"TransferClient.bookmark_list({query_params})")
+        log.debug(f"TransferClient.bookmark_list({query_params})")
         return IterableTransferResponse(
             self.get("bookmark_list", query_params=query_params)
         )
@@ -1110,7 +1110,7 @@ class TransferClient(client.BaseClient):
                 .. extdoclink:: Create bookmark
                     :ref: transfer/collection_bookmarks/#create_bookmark
         """
-        log.info(f"TransferClient.create_bookmark({bookmark_data})")
+        log.debug(f"TransferClient.create_bookmark({bookmark_data})")
         return self.post("bookmark", data=bookmark_data)
 
     def get_bookmark(
@@ -1132,7 +1132,7 @@ class TransferClient(client.BaseClient):
                 .. extdoclink:: Get bookmark by ID
                     :ref: transfer/collection_bookmarks/#get_bookmark_by_id
         """
-        log.info(f"TransferClient.get_bookmark({bookmark_id})")
+        log.debug(f"TransferClient.get_bookmark({bookmark_id})")
         return self.get(f"bookmark/{bookmark_id}", query_params=query_params)
 
     def update_bookmark(
@@ -1151,7 +1151,7 @@ class TransferClient(client.BaseClient):
                 .. extdoclink:: Update bookmark
                     :ref: transfer/collection_bookmarks/#update_bookmark
         """
-        log.info(f"TransferClient.update_bookmark({bookmark_id})")
+        log.debug(f"TransferClient.update_bookmark({bookmark_id})")
         return self.put(f"bookmark/{bookmark_id}", data=bookmark_data)
 
     def delete_bookmark(self, bookmark_id: UUIDLike) -> response.GlobusHTTPResponse:
@@ -1167,7 +1167,7 @@ class TransferClient(client.BaseClient):
                 .. extdoclink:: Delete bookmark by ID
                     :ref: transfer/collection_bookmarks/#delete_bookmark_by_id
         """
-        log.info(f"TransferClient.delete_bookmark({bookmark_id})")
+        log.debug(f"TransferClient.delete_bookmark({bookmark_id})")
         return self.delete(f"bookmark/{bookmark_id}")
 
     #
@@ -1281,7 +1281,7 @@ class TransferClient(client.BaseClient):
         if local_user is not None:
             query_params["local_user"] = local_user
 
-        log.info(f"TransferClient.operation_ls({endpoint_id}, {query_params})")
+        log.debug(f"TransferClient.operation_ls({endpoint_id}, {query_params})")
         return IterableTransferResponse(
             self.get(f"operation/endpoint/{endpoint_id}/ls", query_params=query_params)
         )
@@ -1318,7 +1318,7 @@ class TransferClient(client.BaseClient):
                 .. extdoclink:: Make Directory
                     :ref: transfer/file_operations/#make_directory
         """
-        log.info(
+        log.debug(
             "TransferClient.operation_mkdir({}, {}, {})".format(
                 endpoint_id, path, query_params
             )
@@ -1366,7 +1366,7 @@ class TransferClient(client.BaseClient):
                 .. extdoclink:: Rename
                     :ref: transfer/file_operations/#rename
         """  # noqa: E501
-        log.info(
+        log.debug(
             "TransferClient.operation_rename({}, {}, {}, {})".format(
                 endpoint_id, oldpath, newpath, query_params
             )
@@ -1427,7 +1427,7 @@ class TransferClient(client.BaseClient):
         if local_user is not None:
             query_params["local_user"] = local_user
 
-        log.info(f"TransferClient.operation_stat({endpoint_id}, {query_params})")
+        log.debug(f"TransferClient.operation_stat({endpoint_id}, {query_params})")
         return self.get(
             f"operation/endpoint/{endpoint_id}/stat", query_params=query_params
         )
@@ -1454,7 +1454,7 @@ class TransferClient(client.BaseClient):
             "operation_symlink is not currently supported by any collections. "
             "To reduce confusion, this method will be removed."
         )
-        log.info(
+        log.debug(
             "TransferClient.operation_symlink({}, {}, {}, {})".format(
                 endpoint_id, symlink_target, path, query_params
             )
@@ -1501,7 +1501,7 @@ class TransferClient(client.BaseClient):
 
                 .. expandtestfixture:: transfer.get_submission_id
         """
-        log.info(f"TransferClient.get_submission_id({query_params})")
+        log.debug(f"TransferClient.get_submission_id({query_params})")
         return self.get("submission_id", query_params=query_params)
 
     def submit_transfer(
@@ -1547,7 +1547,7 @@ class TransferClient(client.BaseClient):
                 .. extdoclink:: Submit a transfer task
                     :ref: transfer/task_submit/#submit_transfer_task
         """  # noqa: E501
-        log.info("TransferClient.submit_transfer(...)")
+        log.debug("TransferClient.submit_transfer(...)")
         if "submission_id" not in data:
             log.debug("submit_transfer autofetching submission_id")
             data["submission_id"] = self.get_submission_id()["value"]
@@ -1590,7 +1590,7 @@ class TransferClient(client.BaseClient):
                 .. extdoclink:: Submit a delete task
                     :ref: transfer/task_submit/#submit_delete_task
         """
-        log.info("TransferClient.submit_delete(...)")
+        log.debug("TransferClient.submit_delete(...)")
         if "submission_id" not in data:
             log.debug("submit_delete autofetching submission_id")
             data["submission_id"] = self.get_submission_id()["value"]
@@ -1689,7 +1689,7 @@ class TransferClient(client.BaseClient):
                 .. extdoclink:: Task List
                     :ref: transfer/task/#get_task_list
         """  # noqa: E501
-        log.info("TransferClient.task_list(...)")
+        log.debug("TransferClient.task_list(...)")
         if query_params is None:
             query_params = {}
         if limit is not None:
@@ -1754,7 +1754,7 @@ class TransferClient(client.BaseClient):
                 .. extdoclink:: Get Event List
                     :ref: transfer/task/#get_event_list
         """  # noqa: E501
-        log.info(f"TransferClient.task_event_list({task_id}, ...)")
+        log.debug(f"TransferClient.task_event_list({task_id}, ...)")
         if query_params is None:
             query_params = {}
         if limit is not None:
@@ -1784,7 +1784,7 @@ class TransferClient(client.BaseClient):
                 .. extdoclink:: Get task by ID
                     :ref: transfer/task/#get_task_by_id
         """
-        log.info(f"TransferClient.get_task({task_id}, ...)")
+        log.debug(f"TransferClient.get_task({task_id}, ...)")
         return self.get(f"task/{task_id}", query_params=query_params)
 
     def update_task(
@@ -1811,7 +1811,7 @@ class TransferClient(client.BaseClient):
                 .. extdoclink:: Update task by ID
                     :ref: transfer/task/#update_task_by_id
         """
-        log.info(f"TransferClient.update_task({task_id}, ...)")
+        log.debug(f"TransferClient.update_task({task_id}, ...)")
         return self.put(f"task/{task_id}", data=data, query_params=query_params)
 
     def cancel_task(self, task_id: UUIDLike) -> response.GlobusHTTPResponse:
@@ -1829,7 +1829,7 @@ class TransferClient(client.BaseClient):
                 .. extdoclink:: Cancel task by ID
                     :ref: transfer/task/#cancel_task_by_id
         """
-        log.info(f"TransferClient.cancel_task({task_id})")
+        log.debug(f"TransferClient.cancel_task({task_id})")
         return self.post(f"task/{task_id}/cancel")
 
     def task_wait(
@@ -1880,7 +1880,7 @@ class TransferClient(client.BaseClient):
                         print(".", end="")
                     print(f"\n{task_id} completed!")
         """  # noqa: E501
-        log.info(
+        log.debug(
             "TransferClient.task_wait(%s, %s, %s)", task_id, timeout, polling_interval
         )
 
@@ -1956,7 +1956,7 @@ class TransferClient(client.BaseClient):
                 .. extdoclink:: Get task pause info
                     :ref: transfer/task/#get_task_pause_info
         """
-        log.info(f"TransferClient.task_pause_info({task_id}, ...)")
+        log.debug(f"TransferClient.task_pause_info({task_id}, ...)")
         return self.get(f"task/{task_id}/pause_info", query_params=query_params)
 
     @paging.has_paginator(
@@ -2007,7 +2007,7 @@ class TransferClient(client.BaseClient):
                 .. extdoclink:: Get Task Successful Transfers
                     :ref: transfer/task/#get_task_successful_transfers
         """  # noqa: E501
-        log.info(f"TransferClient.task_successful_transfers({task_id}, ...)")
+        log.debug(f"TransferClient.task_successful_transfers({task_id}, ...)")
         if query_params is None:
             query_params = {}
         if marker is not None:
@@ -2058,7 +2058,7 @@ class TransferClient(client.BaseClient):
                 .. extdoclink:: Get Task Skipped Errors
                     :ref: transfer/task/#get_task_skipped_errors
         """  # noqa: E501
-        log.info("TransferClient.task_skipped_errors(%s, ...)", task_id)
+        log.debug("TransferClient.task_skipped_errors(%s, ...)", task_id)
         if query_params is None:
             query_params = {}
         if marker is not None:
@@ -2088,7 +2088,9 @@ class TransferClient(client.BaseClient):
                 .. extdoclink:: Get monitored endpoints and collections
                     :ref: transfer/advanced_collection_management/#get_monitored_endpoints_and_collections
         """  # noqa: E501
-        log.info(f"TransferClient.endpoint_manager_monitored_endpoints({query_params})")
+        log.debug(
+            f"TransferClient.endpoint_manager_monitored_endpoints({query_params})"
+        )
         return IterableTransferResponse(
             self.get("endpoint_manager/monitored_endpoints", query_params=query_params)
         )
@@ -2114,7 +2116,9 @@ class TransferClient(client.BaseClient):
                 .. extdoclink:: Get hosted endpoint list
                     :ref: transfer/advanced_collection_management/#get_hosted_collection_list
         """  # noqa: E501
-        log.info(f"TransferClient.endpoint_manager_hosted_endpoint_list({endpoint_id})")
+        log.debug(
+            f"TransferClient.endpoint_manager_hosted_endpoint_list({endpoint_id})"
+        )
         return IterableTransferResponse(
             self.get(
                 f"endpoint_manager/endpoint/{endpoint_id}/hosted_endpoint_list",
@@ -2143,7 +2147,7 @@ class TransferClient(client.BaseClient):
                 .. extdoclink:: Get endpoint as admin
                     :ref: transfer/advanced_collection_management/#mc_get_endpoint_or_collection
         """  # noqa: E501
-        log.info(f"TransferClient.endpoint_manager_get_endpoint({endpoint_id})")
+        log.debug(f"TransferClient.endpoint_manager_get_endpoint({endpoint_id})")
         return self.get(
             f"endpoint_manager/endpoint/{endpoint_id}", query_params=query_params
         )
@@ -2169,7 +2173,7 @@ class TransferClient(client.BaseClient):
                 .. extdoclink:: Get guest collection access list as admin
                     :ref: transfer/advanced_collection_management/#get_guest_collection_access_list_as_admin
         """  # noqa: E501
-        log.info(
+        log.debug(
             f"TransferClient.endpoint_manager_endpoint_acl_list({endpoint_id}, ...)"
         )
         return IterableTransferResponse(
@@ -2303,7 +2307,7 @@ class TransferClient(client.BaseClient):
                 .. extdoclink:: Advanced Collection Management: Get tasks
                     :ref: transfer/advanced_collection_management/#get_tasks
         """  # noqa: E501
-        log.info("TransferClient.endpoint_manager_task_list(...)")
+        log.debug("TransferClient.endpoint_manager_task_list(...)")
         if filter_endpoint is None and filter_endpoint_use is not None:
             raise exc.GlobusSDKUsageError(
                 "`filter_endpoint_use` is only valid when `filter_endpoint` is "
@@ -2363,7 +2367,7 @@ class TransferClient(client.BaseClient):
                 .. extdoclink:: Advanced Collection Management: Get task
                     :ref: transfer/advanced_collection_management/#get_task
         """
-        log.info(f"TransferClient.endpoint_manager_get_task({task_id}, ...)")
+        log.debug(f"TransferClient.endpoint_manager_get_task({task_id}, ...)")
         return self.get(f"endpoint_manager/task/{task_id}", query_params=query_params)
 
     @paging.has_paginator(
@@ -2408,7 +2412,7 @@ class TransferClient(client.BaseClient):
                 .. extdoclink:: Advanced Collection Management: Get task events
                     :ref: transfer/advanced_collection_management/#get_task_events
         """
-        log.info(f"TransferClient.endpoint_manager_task_event_list({task_id}, ...)")
+        log.debug(f"TransferClient.endpoint_manager_task_event_list({task_id}, ...)")
         if query_params is None:
             query_params = {}
         if limit is not None:
@@ -2445,7 +2449,7 @@ class TransferClient(client.BaseClient):
                 .. extdoclink:: Get task pause info as admin
                     :ref: transfer/advanced_collection_management/#get_task_pause_info_as_admin
         """  # noqa: E501
-        log.info(f"TransferClient.endpoint_manager_task_pause_info({task_id}, ...)")
+        log.debug(f"TransferClient.endpoint_manager_task_pause_info({task_id}, ...)")
         return self.get(
             f"endpoint_manager/task/{task_id}/pause_info", query_params=query_params
         )
@@ -2481,7 +2485,7 @@ class TransferClient(client.BaseClient):
                     :ref: transfer/advanced_collection_management/\
                             #get_task_successful_transfers_as_admin
         """
-        log.info(
+        log.debug(
             "TransferClient.endpoint_manager_task_successful_transfers(%s, ...)",
             task_id,
         )
@@ -2527,7 +2531,9 @@ class TransferClient(client.BaseClient):
                     :ref: transfer/advanced_collection_management/\
                             #get_task_skipped_errors_as_admin
         """
-        log.info(f"TransferClient.endpoint_manager_task_skipped_errors({task_id}, ...)")
+        log.debug(
+            f"TransferClient.endpoint_manager_task_skipped_errors({task_id}, ...)"
+        )
         if query_params is None:
             query_params = {}
         if marker is not None:
@@ -2564,7 +2570,7 @@ class TransferClient(client.BaseClient):
                     :ref: transfer/advanced_collection_management/#admin_cancel
         """
         str_task_ids = [str(i) for i in task_ids]
-        log.info(
+        log.debug(
             f"TransferClient.endpoint_manager_cancel_tasks({str_task_ids}, {message})"
         )
         data = {"message": message, "task_id_list": str_task_ids}
@@ -2594,7 +2600,7 @@ class TransferClient(client.BaseClient):
                 .. extdoclink:: Get cancel status by ID
                     :ref: transfer/advanced_collection_management/#get_cancel_status_by_id
         """  # noqa: E501
-        log.info(f"TransferClient.endpoint_manager_cancel_status({admin_cancel_id})")
+        log.debug(f"TransferClient.endpoint_manager_cancel_status({admin_cancel_id})")
         return self.get(
             f"endpoint_manager/admin_cancel/{admin_cancel_id}",
             query_params=query_params,
@@ -2625,7 +2631,7 @@ class TransferClient(client.BaseClient):
                     :ref: transfer/advanced_collection_management/#pause_tasks_as_admin
         """
         str_task_ids = [str(i) for i in task_ids]
-        log.info(
+        log.debug(
             f"TransferClient.endpoint_manager_pause_tasks({str_task_ids}, {message})"
         )
         data = {"message": message, "task_id_list": str_task_ids}
@@ -2656,7 +2662,7 @@ class TransferClient(client.BaseClient):
                     :ref: transfer/advanced_collection_management/#resume_tasks_as_admin
         """
         str_task_ids = [str(i) for i in task_ids]
-        log.info(f"TransferClient.endpoint_manager_resume_tasks({str_task_ids})")
+        log.debug(f"TransferClient.endpoint_manager_resume_tasks({str_task_ids})")
         data = {"task_id_list": str_task_ids}
         return self.post(
             "endpoint_manager/admin_resume", data=data, query_params=query_params
@@ -2690,7 +2696,7 @@ class TransferClient(client.BaseClient):
                 .. extdoclink:: Get pause rules
                     :ref: transfer/advanced_collection_management/#get_pause_rules
         """
-        log.info("TransferClient.endpoint_manager_pause_rule_list(...)")
+        log.debug("TransferClient.endpoint_manager_pause_rule_list(...)")
         if query_params is None:
             query_params = {}
         if filter_endpoint is not None:
@@ -2732,7 +2738,7 @@ class TransferClient(client.BaseClient):
                 .. extdoclink:: Create pause rule
                     :ref: transfer/advanced_collection_management/#create_pause_rule
         """
-        log.info("TransferClient.endpoint_manager_create_pause_rule(...)")
+        log.debug("TransferClient.endpoint_manager_create_pause_rule(...)")
         return self.post("endpoint_manager/pause_rule", data=data)
 
     def endpoint_manager_get_pause_rule(
@@ -2757,7 +2763,7 @@ class TransferClient(client.BaseClient):
                 .. extdoclink:: Get pause rule
                     :ref: transfer/advanced_collection_management/#get_pause_rule
         """
-        log.info(f"TransferClient.endpoint_manager_get_pause_rule({pause_rule_id})")
+        log.debug(f"TransferClient.endpoint_manager_get_pause_rule({pause_rule_id})")
         return self.get(
             f"endpoint_manager/pause_rule/{pause_rule_id}", query_params=query_params
         )
@@ -2796,7 +2802,7 @@ class TransferClient(client.BaseClient):
                 .. extdoclink:: Update pause rule
                     :ref: transfer/advanced_collection_management/#update_pause_rule
         """
-        log.info(f"TransferClient.endpoint_manager_update_pause_rule({pause_rule_id})")
+        log.debug(f"TransferClient.endpoint_manager_update_pause_rule({pause_rule_id})")
         return self.put(f"endpoint_manager/pause_rule/{pause_rule_id}", data=data)
 
     def endpoint_manager_delete_pause_rule(
@@ -2822,7 +2828,7 @@ class TransferClient(client.BaseClient):
                 .. extdoclink:: Delete pause rule
                     :ref: transfer/advanced_collection_management/#delete_pause_rule
         """
-        log.info(f"TransferClient.endpoint_manager_delete_pause_rule({pause_rule_id})")
+        log.debug(f"TransferClient.endpoint_manager_delete_pause_rule({pause_rule_id})")
         return self.delete(
             f"endpoint_manager/pause_rule/{pause_rule_id}", query_params=query_params
         )

--- a/src/globus_sdk/services/transfer/data/delete_data.py
+++ b/src/globus_sdk/services/transfer/data/delete_data.py
@@ -133,12 +133,12 @@ class DeleteData(utils.PayloadWrapper):
         )
 
         for k, v in self.items():
-            log.info("DeleteData.%s = %s", k, v)
+            log.debug("DeleteData.%s = %s", k, v)
 
         if additional_fields is not None:
             self.update(additional_fields)
             for option, value in additional_fields.items():
-                log.info(
+                log.debug(
                     f"DeleteData.{option} = {value} (option passed "
                     "in via additional_fields)"
                 )

--- a/src/globus_sdk/services/transfer/data/transfer_data.py
+++ b/src/globus_sdk/services/transfer/data/transfer_data.py
@@ -196,7 +196,7 @@ class TransferData(utils.PayloadWrapper):
         if destination_endpoint is None:
             raise exc.GlobusSDKUsageError("destination_endpoint is required")
 
-        log.info("Creating a new TransferData object")
+        log.debug("Creating a new TransferData object")
         self["DATA_TYPE"] = "transfer"
         self["DATA"] = []
         self._set_optstrs(
@@ -229,12 +229,12 @@ class TransferData(utils.PayloadWrapper):
         self._set_value("sync_level", sync_level, callback=_parse_sync_level)
 
         for k, v in self.items():
-            log.info("TransferData.%s = %s", k, v)
+            log.debug("TransferData.%s = %s", k, v)
 
         if additional_fields is not None:
             self.update(additional_fields)
             for option, value in additional_fields.items():
-                log.info(
+                log.debug(
                     f"TransferData.{option} = {value} (option passed "
                     "in via additional_fields)"
                 )

--- a/src/globus_sdk/transport/requests.py
+++ b/src/globus_sdk/transport/requests.py
@@ -291,7 +291,7 @@ class RequestsTransport:
             retries which may already have been attempted.
         """
         sleep_period = min(self.retry_backoff(ctx), self.max_sleep)
-        log.info("request retry_sleep(%s) [max=%s]", sleep_period, self.max_sleep)
+        log.debug("request retry_sleep(%s) [max=%s]", sleep_period, self.max_sleep)
         time.sleep(sleep_period)
 
     def request(
@@ -361,7 +361,7 @@ class RequestsTransport:
             else:
                 log.debug("request success, still check should-retry")
                 if not checker.should_retry(ctx):
-                    log.info("request done (success)")
+                    log.debug("request done (success)")
                     return resp
                 log.debug("request may retry, will check attempts")
 


### PR DESCRIPTION
Two commits:
- Add a custom flake8 plugin to lint for `log.info`
- Apply new no-info-logging rule

The changelog intentionally does not state this as a new policy, only as a new *fact* about the SDK.

Also, some log lines have been joined together (serial log invocations looked like they could use cleanup).


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1146.org.readthedocs.build/en/1146/

<!-- readthedocs-preview globus-sdk-python end -->