### PR TITLE
Add a test for an untested setter

### DIFF
--- a/tests/unit/errors/test_common_functionality.py
+++ b/tests/unit/errors/test_common_functionality.py
@@ -65,6 +65,24 @@ def test_raw_text_property_warns():
         assert err.raw_text == body_text
 
 
+def test_imperative_message_setting_warns():
+    err = construct_error(
+        body={"code": "FooCode", "message": "FooMessage"}, http_status=400
+    )
+    assert err.message == "FooMessage"
+
+    with pytest.warns(
+        RemovedInV4Warning,
+        match=(
+            r"Setting a message on GlobusAPIError objects is deprecated\. "
+            r"This overwrites any parsed messages\. Append to 'messages' instead\."
+        ),
+    ):
+        err.message = "BarMessage"
+
+    assert err.message == "BarMessage"
+
+
 @pytest.mark.parametrize(
     "body, response_headers, http_status, expect_code, expect_message",
     (


### PR DESCRIPTION
Setting `error.message` warns but works for API error types.


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1147.org.readthedocs.build/en/1147/

<!-- readthedocs-preview globus-sdk-python end -->