### PR TITLE
Remove an empty 'automethodlist'

### DIFF
--- a/src/globus_sdk/services/compute/client.py
+++ b/src/globus_sdk/services/compute/client.py
@@ -371,6 +371,4 @@ class ComputeClient(ComputeClientV2):
     API version 2.
 
     .. sdk-sphinx-copy-params:: BaseClient
-
-    .. automethodlist:: globus_sdk.ComputeClient
     """


### PR DESCRIPTION
This produces empty header in the docs.


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1148.org.readthedocs.build/en/1148/

<!-- readthedocs-preview globus-sdk-python end -->