### PR TITLE
Remove a doc stub for old scope parser docs

### DIFF
--- a/docs/experimental/index.rst
+++ b/docs/experimental/index.rst
@@ -10,12 +10,6 @@ Globus SDK Experimental Components
 
     **Use at your own risk.**
 
-.. toctree::
-    :caption: Contents
-    :maxdepth: 1
-
-    scope_parser
-
 
 Experimental Construct Lifecycle
 --------------------------------

--- a/docs/experimental/scope_parser.rst
+++ b/docs/experimental/scope_parser.rst
@@ -1,7 +1,0 @@
-.. _experimental_scope_parser:
-
-Scope Parser
-============
-
-The experimental scope parser has been promoted into
-:ref:`the main Scope implementation <scopes>`.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -42,7 +42,7 @@ Table of Contents
     :maxdepth: 1
 
     testing/index
-    experimental/index
+    Experimental Components <experimental/index>
     experimental/examples/index
 
 


### PR DESCRIPTION
The experimental docs have been moved for long enough that we can
remove the stub from "experimental" docs.


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1149.org.readthedocs.build/en/1149/

<!-- readthedocs-preview globus-sdk-python end -->