### PR TITLE
Rename 'Full Reference' to 'Reference'

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,7 +28,7 @@ Table of Contents
     user_guide/getting_started/index
 
 .. toctree::
-    :caption: Full Reference
+    :caption: Reference
     :maxdepth: 2
 
     services/index


### PR DESCRIPTION
There is no difference between these terms.
Brevity is the soul of wit.


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1151.org.readthedocs.build/en/1151/

<!-- readthedocs-preview globus-sdk-python end -->