### PR TITLE
Improve doc sidebar presentation of change docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -45,18 +45,22 @@ Table of Contents
     Experimental Components <experimental/index>
     experimental/examples/index
 
-
-.. toctree::
-    :caption: Additional Info
-    :maxdepth: 1
-
-    versioning
-    license
-    changelog
-    upgrading
-
 .. toctree::
     :caption: Examples
     :maxdepth: 1
 
     examples/index
+
+.. toctree::
+    :caption: Changes
+    :maxdepth: 1
+
+    versioning
+    changelog
+    upgrading
+
+.. toctree::
+    :caption: Additional Info
+    :maxdepth: 1
+
+    license


### PR DESCRIPTION
Our version policy, changelog, and upgrading guide are all associated.
Split "license" off and put it down at the bottom.

Also, put all of these after the examples.


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1152.org.readthedocs.build/en/1152/

<!-- readthedocs-preview globus-sdk-python end -->