### PR TITLE
Add support for Search `index_list`

### DIFF
--- a/changelog.d/20250321_171304_sirosen_search_list_indices.rst
+++ b/changelog.d/20250321_171304_sirosen_search_list_indices.rst
@@ -1,0 +1,5 @@
+Added
+~~~~~
+
+- Index listing in Globus Search is now available via
+  ``SearchClient.index_list``. (:pr:`NUMBER`)

--- a/src/globus_sdk/_testing/data/search/index_list.py
+++ b/src/globus_sdk/_testing/data/search/index_list.py
@@ -1,50 +1,58 @@
+from __future__ import annotations
+
+import typing as t
 import uuid
 
 from globus_sdk._testing.models import RegisteredResponse, ResponseSet
 
 INDEX_IDS = [str(uuid.uuid1()), str(uuid.uuid1())]
-SUBSCRIPTIONS = [None, str(uuid.uuid1())]
+INDEX_ATTRIBUTES: dict[str, dict[str, t.Any]] = {
+    INDEX_IDS[0]: {
+        "subscription_id": None,
+        "creation_date": "2038-07-17 16:48:24",
+        "display_name": "Index of Indexed Awesomeness",
+        "description": "Turbo Awesome",
+        "max_size_in_mb": 1,
+        "size_in_mb": 0,
+        "num_subjects": 0,
+        "num_entries": 0,
+        "permissions": ["owner"],
+    },
+    INDEX_IDS[1]: {
+        "subscription_id": str(uuid.uuid1()),
+        "creation_date": "2470-10-11 20:09:40",
+        "display_name": "Catalog of encyclopediae",
+        "description": "Encyclopediae from Britannica to Wikipedia",
+        "max_size_in_mb": 100,
+        "size_in_mb": 23,
+        "num_subjects": 1822,
+        "num_entries": 3644,
+        "permissions": ["writer"],
+    },
+}
+
+
+def _make_doc(index_id: str) -> dict[str, t.Any]:
+    attrs = INDEX_ATTRIBUTES[index_id]
+    return {
+        "@datatype": "GSearchIndex",
+        "@version": "2017-09-01",
+        "id": index_id,
+        "is_trial": False if attrs["subscription_id"] else True,
+        "status": "open",
+        **attrs,
+    }
 
 
 RESPONSES = ResponseSet(
-    metadata={"index_ids": INDEX_IDS, "subscription_ids": SUBSCRIPTIONS},
+    metadata={"index_ids": INDEX_IDS, "index_attributes": INDEX_ATTRIBUTES},
     default=RegisteredResponse(
         service="search",
         path="/v1/index_list",
         json={
             "index_list": [
-                {
-                    "@datatype": "GSearchIndex",
-                    "@version": "2017-09-01",
-                    "display_name": "Index of Indexed Awesomeness",
-                    "description": "Turbo Awesome",
-                    "id": INDEX_IDS[0],
-                    "max_size_in_mb": 1,
-                    "size_in_mb": 0,
-                    "num_subjects": 0,
-                    "num_entries": 0,
-                    "creation_date": "2038-07-17 16:48:24",
-                    "subscription_id": SUBSCRIPTIONS[0],
-                    "is_trial": True,
-                    "status": "open",
-                    "permissions": ["owner"],
-                },
-                {
-                    "@datatype": "GSearchIndex",
-                    "@version": "2017-09-01",
-                    "display_name": "Catalog of encyclopediae",
-                    "description": "Encyclopediae from Britannica to Wikipedia",
-                    "id": INDEX_IDS[1],
-                    "max_size_in_mb": 100,
-                    "size_in_mb": 23,
-                    "num_subjects": 1822,
-                    "num_entries": 3644,
-                    "creation_date": "2470-10-11 20:09:40",
-                    "subscription_id": SUBSCRIPTIONS[1],
-                    "is_trial": False,
-                    "status": "open",
-                    "permissions": ["writer"],
-                },
+                _make_doc(INDEX_IDS[0]),
+                _make_doc(INDEX_IDS[1]),
             ]
         },
     ),

--- a/src/globus_sdk/_testing/data/search/index_list.py
+++ b/src/globus_sdk/_testing/data/search/index_list.py
@@ -1,0 +1,51 @@
+import uuid
+
+from globus_sdk._testing.models import RegisteredResponse, ResponseSet
+
+INDEX_IDS = [str(uuid.uuid1()), str(uuid.uuid1())]
+SUBSCRIPTIONS = [None, str(uuid.uuid1())]
+
+
+RESPONSES = ResponseSet(
+    metadata={"index_ids": INDEX_IDS, "subscription_ids": SUBSCRIPTIONS},
+    default=RegisteredResponse(
+        service="search",
+        path="/v1/index_list",
+        json={
+            "index_list": [
+                {
+                    "@datatype": "GSearchIndex",
+                    "@version": "2017-09-01",
+                    "display_name": "Index of Indexed Awesomeness",
+                    "description": "Turbo Awesome",
+                    "id": INDEX_IDS[0],
+                    "max_size_in_mb": 1,
+                    "size_in_mb": 0,
+                    "num_subjects": 0,
+                    "num_entries": 0,
+                    "creation_date": "2038-07-17 16:48:24",
+                    "subscription_id": SUBSCRIPTIONS[0],
+                    "is_trial": True,
+                    "status": "open",
+                    "permissions": ["owner"],
+                },
+                {
+                    "@datatype": "GSearchIndex",
+                    "@version": "2017-09-01",
+                    "display_name": "Catalog of encyclopediae",
+                    "description": "Encyclopediae from Britannica to Wikipedia",
+                    "id": INDEX_IDS[1],
+                    "max_size_in_mb": 100,
+                    "size_in_mb": 23,
+                    "num_subjects": 1822,
+                    "num_entries": 3644,
+                    "creation_date": "2470-10-11 20:09:40",
+                    "subscription_id": SUBSCRIPTIONS[1],
+                    "is_trial": False,
+                    "status": "open",
+                    "permissions": ["writer"],
+                },
+            ]
+        },
+    ),
+)

--- a/src/globus_sdk/services/search/client.py
+++ b/src/globus_sdk/services/search/client.py
@@ -10,6 +10,7 @@ from globus_sdk.scopes import Scope, SearchScopes
 
 from .data import SearchQuery, SearchScrollQuery
 from .errors import SearchAPIError
+from .response import IndexListResponse
 
 log = logging.getLogger(__name__)
 
@@ -181,6 +182,41 @@ class SearchClient(client.BaseClient):
         """  # noqa: E501
         log.debug(f"SearchClient.get_index({index_id})")
         return self.get(f"/v1/index/{index_id}", query_params=query_params)
+
+    def index_list(
+        self,
+        *,
+        query_params: dict[str, t.Any] | None = None,
+    ) -> response.IterableResponse:
+        """
+        Get a list of indices on which the caller has permissions.
+
+        :param query_params: additional parameters to pass as query params
+
+        .. tab-set::
+
+            .. tab-item:: Example Usage
+
+                .. code-block:: python
+
+                    sc = globus_sdk.SearchClient(...)
+                    for index_doc in sc.index_list():
+                        print(index_doc["display_name"], f"({index_doc['id']}):")
+                        print("  permissions:", ", ".join(index_doc["permissions"]))
+
+            .. tab-item:: Example Response Data
+
+                .. expandtestfixture:: search.index_list
+
+            .. tab-item:: API Info
+
+                ``GET /v1/index_list``
+
+                .. extdoclink:: Index List
+                    :ref: search/reference/index_list/
+        """  # noqa: E501
+        log.debug("SearchClient.index_list()")
+        return IndexListResponse(self.get("/v1/index_list", query_params=query_params))
 
     #
     # Search queries

--- a/src/globus_sdk/services/search/response.py
+++ b/src/globus_sdk/services/search/response.py
@@ -1,0 +1,9 @@
+from globus_sdk.response import IterableResponse
+
+
+class IndexListResponse(IterableResponse):
+    """
+    Iterable response class for /v1/index_list
+    """
+
+    default_iter_key = "index_list"

--- a/tests/functional/services/search/test_index_list.py
+++ b/tests/functional/services/search/test_index_list.py
@@ -1,0 +1,26 @@
+from globus_sdk._testing import load_response
+
+
+def test_search_index_list(client):
+    meta = load_response(client.index_list).metadata
+    index_ids = meta["index_ids"]
+
+    res = client.index_list()
+    assert res.http_status == 200
+
+    index_list = res["index_list"]
+    assert isinstance(index_list, list)
+    assert len(index_list) == len(index_ids)
+    assert [i["id"] for i in index_list] == index_ids
+
+
+def test_search_index_list_is_iterable(client):
+    meta = load_response(client.index_list).metadata
+    index_ids = meta["index_ids"]
+
+    res = client.index_list()
+    assert res.http_status == 200
+
+    index_list = list(res)
+    assert len(index_list) == len(index_ids)
+    assert [i["id"] for i in index_list] == index_ids


### PR DESCRIPTION
Recently noticed this was missing. The addition covers:

- a response type for iterability
- a client method
- a test fixture
- basic usage tests


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1155.org.readthedocs.build/en/1155/

<!-- readthedocs-preview globus-sdk-python end -->