### PR TITLE
Give GARE a nice repr

### DIFF
--- a/changelog.d/20250324_135926_sirosen_nice_gare_repr.rst
+++ b/changelog.d/20250324_135926_sirosen_nice_gare_repr.rst
@@ -1,0 +1,5 @@
+Changed
+~~~~~~~
+
+- The ``repr`` for ``globus_sdk.gare.GARE`` has been enhanced to be more
+  informative. (:pr:`NUMBER`)

--- a/src/globus_sdk/gare/_auth_requirements_error.py
+++ b/src/globus_sdk/gare/_auth_requirements_error.py
@@ -76,6 +76,24 @@ class GlobusAuthorizationParameters(Serializable):
         self.prompt = validators.opt_str("prompt", prompt)
         self.extra = extra or {}
 
+    def __repr__(self) -> str:
+        extra_repr = ""
+        if self.extra:
+            extra_repr = ", extra=..."
+        attrs = [
+            f"{name}={getattr(self, name)!r}"
+            for name in (
+                "session_message",
+                "session_required_identities",
+                "session_required_policies",
+                "session_required_single_domain",
+                "session_required_mfa",
+                "required_scopes",
+                "prompt",
+            )
+        ]
+        return "GlobusAuthorizationParameters(" + ", ".join(attrs) + extra_repr + ")"
+
 
 class GARE(Serializable):
     """
@@ -111,3 +129,13 @@ class GARE(Serializable):
             GlobusAuthorizationParameters,
         )
         self.extra = extra or {}
+
+    def __repr__(self) -> str:
+        extra_repr = ""
+        if self.extra:
+            extra_repr = ", extra=..."
+        return (
+            f"GARE(code={self.code!r}, "
+            f"authorization_parameters={self.authorization_parameters!r}"
+            f"{extra_repr})"
+        )

--- a/tests/unit/test_auth_requirements_error.py
+++ b/tests/unit/test_auth_requirements_error.py
@@ -459,13 +459,19 @@ def test_authorization_parameters_from_empty_dict(target_class):
     assert authorization_params.to_dict() == {}
 
 
-def test_gare_repr_shows_code():
+def test_gare_repr_shows_attrs():
     error_doc = GARE(
         code="NeedsReauth",
         authorization_parameters={"session_required_policies": ["foo"]},
     )
 
-    assert "code='NeedsReauth'" in repr(error_doc)
+    # the repr will include the parameters repr -- tested separately below
+    assert repr(error_doc) == (
+        "GARE("
+        "code='NeedsReauth', "
+        f"authorization_parameters={error_doc.authorization_parameters!r}"
+        ")"
+    )
 
 
 def test_gare_repr_indicates_presence_of_extra():
@@ -486,17 +492,17 @@ def test_gare_repr_indicates_presence_of_extra():
 
 def test_authorization_parameters_repr_shows_all_attrs():
     params = GlobusAuthorizationParameters()
-    params_repr = repr(params)
-    for name in (
-        "session_message",
-        "session_required_identities",
-        "session_required_policies",
-        "session_required_single_domain",
-        "session_required_mfa",
-        "required_scopes",
-        "prompt",
-    ):
-        assert f"{name}=None" in params_repr
+    assert repr(params) == (
+        "GlobusAuthorizationParameters("
+        "session_message=None, "
+        "session_required_identities=None, "
+        "session_required_policies=None, "
+        "session_required_single_domain=None, "
+        "session_required_mfa=None, "
+        "required_scopes=None, "
+        "prompt=None"
+        ")"
+    )
 
 
 def test_authorization_parameters_repr_indicates_presence_of_extra():

--- a/tests/unit/test_auth_requirements_error.py
+++ b/tests/unit/test_auth_requirements_error.py
@@ -457,3 +457,51 @@ def test_authorization_parameters_from_empty_dict(target_class):
     """ """
     authorization_params = target_class.from_dict({})
     assert authorization_params.to_dict() == {}
+
+
+def test_gare_repr_shows_code():
+    error_doc = GARE(
+        code="NeedsReauth",
+        authorization_parameters={"session_required_policies": ["foo"]},
+    )
+
+    assert "code='NeedsReauth'" in repr(error_doc)
+
+
+def test_gare_repr_indicates_presence_of_extra():
+    error_doc_no_extra = GARE(
+        code="NeedsReauth",
+        authorization_parameters={"session_required_policies": ["foo"]},
+    )
+
+    error_doc_with_extra = GARE(
+        code="NeedsReauth",
+        authorization_parameters={"session_required_policies": ["foo"]},
+        extra={"alpha": "beta"},
+    )
+
+    assert "extra=..." not in repr(error_doc_no_extra)
+    assert "extra=..." in repr(error_doc_with_extra)
+
+
+def test_authorization_parameters_repr_shows_all_attrs():
+    params = GlobusAuthorizationParameters()
+    params_repr = repr(params)
+    for name in (
+        "session_message",
+        "session_required_identities",
+        "session_required_policies",
+        "session_required_single_domain",
+        "session_required_mfa",
+        "required_scopes",
+        "prompt",
+    ):
+        assert f"{name}=None" in params_repr
+
+
+def test_authorization_parameters_repr_indicates_presence_of_extra():
+    params_no_extra = GlobusAuthorizationParameters()
+    params_with_extra = GlobusAuthorizationParameters(extra={"gamma": "delta"})
+
+    assert "extra=..." not in repr(params_no_extra)
+    assert "extra=..." in repr(params_with_extra)


### PR DESCRIPTION
While doing some debugging, I printed out a GARE, only to find the default `object` repr was used.
Although not a frequent need, a nice repr makes things better when we print or log a stringified object.


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1156.org.readthedocs.build/en/1156/

<!-- readthedocs-preview globus-sdk-python end -->