### PR TITLE
Adding Auth Policy support for required_mfa

### DIFF
--- a/changelog.d/20250325_182401_beth_add_required_mfa_to_auth_policies.rst
+++ b/changelog.d/20250325_182401_beth_add_required_mfa_to_auth_policies.rst
@@ -3,5 +3,3 @@ Changed
 
 - Added the optional ``required_mfa`` field to ``AuthClient.create_policy()`` and
   ``AuthClient.update_policy()`` request bodies. (:pr:`NUMBER`)
-- Updated the other _testing auth policy responses to include the additional
-  field, ``required_mfa``. (:pr:`NUMBER`)

--- a/changelog.d/20250325_182401_beth_add_required_mfa_to_auth_policies.rst
+++ b/changelog.d/20250325_182401_beth_add_required_mfa_to_auth_policies.rst
@@ -1,0 +1,7 @@
+Changed
+~~~~~~~
+
+- Added the optional ``required_mfa`` field to ``AuthClient.create_policy()`` and
+  ``AuthClient.update_policy()`` request bodies. (:pr:`NUMBER`)
+- Updated the other _testing auth policy responses to include the additional
+  field, ``required_mfa``. (:pr:`NUMBER`)

--- a/src/globus_sdk/_testing/data/auth/create_policy.py
+++ b/src/globus_sdk/_testing/data/auth/create_policy.py
@@ -71,9 +71,22 @@ RESPONSES = ResponseSet(
     project_id_str=register_response({"project_id": str(uuid.uuid1())}),
     project_id_uuid=register_response({"project_id": uuid.uuid1()}),
     high_assurance=register_response(
-        {"high_assurance": True, "authentication_assurance_timeout": 35}
+        {
+            "high_assurance": True,
+            "authentication_assurance_timeout": 35,
+            "required_mfa": False,
+        }
     ),
-    not_high_assurance=register_response({"high_assurance": False}),
+    not_high_assurance=register_response(
+        {"high_assurance": False, "required_mfa": False}
+    ),
+    required_mfa=register_response(
+        {
+            "high_assurance": True,
+            "authentication_assurance_timeout": 45,
+            "required_mfa": True,
+        }
+    ),
     authentication_assurance_timeout=register_response(
         {"authentication_assurance_timeout": 23}
     ),

--- a/src/globus_sdk/_testing/data/auth/delete_policy.py
+++ b/src/globus_sdk/_testing/data/auth/delete_policy.py
@@ -11,6 +11,7 @@ POLICY = {
     "domain_constraints_exclude": None,
     "project_id": "da84e531-1afb-43cb-8c87-135ab580516a",
     "authentication_assurance_timeout": 35,
+    "required_mfa": False,
 }
 
 RESPONSES = ResponseSet(

--- a/src/globus_sdk/_testing/data/auth/get_policies.py
+++ b/src/globus_sdk/_testing/data/auth/get_policies.py
@@ -11,6 +11,7 @@ GREEN_LIGHT_POLICY = {
     "domain_constraints_exclude": None,
     "project_id": "da84e531-1afb-43cb-8c87-135ab580516a",
     "authentication_assurance_timeout": 35,
+    "required_mfa": False,
 }
 
 RED_LIGHT_POLICY = {
@@ -22,6 +23,7 @@ RED_LIGHT_POLICY = {
     "domain_constraints_exclude": ["redlight.org"],
     "project_id": "da84e531-1afb-43cb-8c87-135ab580516a",
     "authentication_assurance_timeout": 35,
+    "required_mfa": False,
 }
 
 RESPONSES = ResponseSet(

--- a/src/globus_sdk/_testing/data/auth/get_policy.py
+++ b/src/globus_sdk/_testing/data/auth/get_policy.py
@@ -11,6 +11,7 @@ POLICY = {
     "domain_constraints_exclude": None,
     "project_id": "da84e531-1afb-43cb-8c87-135ab580516a",
     "authentication_assurance_timeout": 35,
+    "required_mfa": False,
 }
 
 RESPONSES = ResponseSet(

--- a/src/globus_sdk/_testing/data/auth/update_policy.py
+++ b/src/globus_sdk/_testing/data/auth/update_policy.py
@@ -15,6 +15,7 @@ def make_request_body(request_args: t.Mapping[str, t.Any]) -> t.Dict[str, t.Any]
 
     for field in [
         "authentication_assurance_timeout",
+        "required_mfa",
         "display_name",
         "description",
         "domain_constraints_include",
@@ -33,6 +34,7 @@ def make_response_body(request_args: t.Mapping[str, t.Any]) -> t.Dict[str, t.Any
     return {
         "project_id": str(request_args.get("project_id", uuid.uuid1())),
         "high_assurance": request_args.get("high_assurance", True),
+        "required_mfa": request_args.get("required_mfa", False),
         "authentication_assurance_timeout": request_args.get(
             "authentication_assurance_timeout", 25
         ),
@@ -76,6 +78,8 @@ RESPONSES = ResponseSet(
     authentication_assurance_timeout=register_response(
         {"authentication_assurance_timeout": 9100}
     ),
+    required_mfa=register_response({"required_mfa": True}),
+    not_required_mfa=register_response({"required_mfa": False}),
     display_name=register_response(
         {"display_name": str(uuid.uuid4()).replace("-", "")}
     ),

--- a/src/globus_sdk/services/auth/client/service_client.py
+++ b/src/globus_sdk/services/auth/client/service_client.py
@@ -54,6 +54,7 @@ def _create_policy_compat(f: F) -> F:
                     "project_id",
                     "high_assurance",
                     "authentication_assurance_timeout",
+                    "required_mfa",
                     "display_name",
                     "description",
                 ),
@@ -735,7 +736,8 @@ class AuthClient(client.BaseClient):
                         'id': 'f5eaae7e-807f-41be-891a-ec86ff88df8f',
                         'domain_constraints_exclude': None,
                         'project_id': 'da84e531-1afb-43cb-8c87-135ab580516a',
-                        'authentication_assurance_timeout': 35
+                        'authentication_assurance_timeout': 35,
+                        'required_mfa": False
                       }
                     }
 
@@ -777,6 +779,7 @@ class AuthClient(client.BaseClient):
                           'domain_constraints_exclude': None,
                           'project_id': 'da84e531-1afb-43cb-8c87-135ab580516a',
                           'authentication_assurance_timeout': 35,
+                          'required_mfa': False
                         },
                         {
                           'high_assurance': True,
@@ -787,6 +790,7 @@ class AuthClient(client.BaseClient):
                           'domain_constraints_exclude': ['redlight.org'],
                           'project_id': 'da84e531-1afb-43cb-8c87-135ab580516a',
                           'authentication_assurance_timeout': 35,
+                          'required_mfa': True
                         }
                       ]
                     }
@@ -813,6 +817,7 @@ class AuthClient(client.BaseClient):
         description: str,
         high_assurance: bool | utils.MissingType = utils.MISSING,
         authentication_assurance_timeout: int | utils.MissingType = utils.MISSING,
+        required_mfa: bool | utils.MissingType = utils.MISSING,
         domain_constraints_include: (
             t.Iterable[str] | None | utils.MissingType
         ) = utils.MISSING,
@@ -827,6 +832,9 @@ class AuthClient(client.BaseClient):
         :param high_assurance: Whether or not this policy is applied to sessions.
         :param authentication_assurance_timeout: Number of seconds within which someone
             must have authenticated to satisfy the policy
+        :param required_mfa: If True, then multi-factor authentication is required.
+            This can only be set to True for high-assurance policies. The default
+            is False.
         :param display_name: A user-friendly name for the policy
         :param description: A user-friendly description to explain the purpose of the
             policy
@@ -854,6 +862,7 @@ class AuthClient(client.BaseClient):
                     ...     project_id="da84e531-1afb-43cb-8c87-135ab580516a",
                     ...     high_assurance=True,
                     ...     authentication_assurance_timeout=35,
+                    ...     required_mfa=True,
                     ...     display_name="No RedLight domain Policy",
                     ...     description="Disallow access from @redlight.org",
                     ...     domain_constraints_exclude=["redlight.org"],
@@ -875,6 +884,7 @@ class AuthClient(client.BaseClient):
             "project_id": project_id,
             "high_assurance": high_assurance,
             "authentication_assurance_timeout": authentication_assurance_timeout,
+            "required_mfa": required_mfa,
             "display_name": display_name,
             "description": description,
             "domain_constraints_include": domain_constraints_include,
@@ -889,6 +899,7 @@ class AuthClient(client.BaseClient):
         *,
         project_id: UUIDLike | utils.MissingType = utils.MISSING,
         authentication_assurance_timeout: int | utils.MissingType = utils.MISSING,
+        required_mfa: bool | utils.MissingType = utils.MISSING,
         display_name: str | utils.MissingType = utils.MISSING,
         description: str | utils.MissingType = utils.MISSING,
         domain_constraints_include: (
@@ -905,6 +916,9 @@ class AuthClient(client.BaseClient):
         :param project_id: ID of the project for the new policy
         :param authentication_assurance_timeout: Number of seconds within which someone
             must have authenticated to satisfy the policy
+        :param required_mfa: If True, then multi-factor authentication is required.
+            This can only be set to True for high-assurance policies. The default
+            is False.
         :param display_name: A user-friendly name for the policy
         :param description: A user-friendly description to explain the purpose of the
             policy
@@ -935,6 +949,7 @@ class AuthClient(client.BaseClient):
         """
         body: dict[str, t.Any] = {
             "authentication_assurance_timeout": authentication_assurance_timeout,
+            "required_mfa": required_mfa,
             "display_name": display_name,
             "description": description,
             "domain_constraints_include": domain_constraints_include,

--- a/tests/functional/services/auth/service_client/test_create_policy.py
+++ b/tests/functional/services/auth/service_client/test_create_policy.py
@@ -15,6 +15,7 @@ from globus_sdk._testing import get_last_request, load_response
         "project_id_uuid",
         "high_assurance",
         "not_high_assurance",
+        "required_mfa",
         "authentication_assurance_timeout",
         "display_name",
         "description",

--- a/tests/functional/services/auth/service_client/test_update_policy.py
+++ b/tests/functional/services/auth/service_client/test_update_policy.py
@@ -11,6 +11,8 @@ from globus_sdk._testing import load_response
         "project_id_str",
         "project_id_uuid",
         "authentication_assurance_timeout",
+        "required_mfa",
+        "not_required_mfa",
         "display_name",
         "description",
         "no_domain_constrants_include",


### PR DESCRIPTION
NOTE: This will be added in the next couple of weeks to Globus Auth.  It is currently deployed in `integration` and `sandbox`.

This Globus Auth feature enables MFA to be required for High Assurance Auth Policies.  
- Shortcut Story: (https://app.shortcut.com/globus/story/35312/enable-auth-policies-to-support-requiring-mfa)
- Added `required_mfa` field to auth client policy documents. 
  - Added the `required_mfa` field to `AuthClient.create_policy()` and `AuthClient.update_policy()`.
  - Added the `required_mfa` field to the _testing Auth Policy responses.  This field is supported in GET, POST, and PUT routes.

<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1159.org.readthedocs.build/en/1159/

<!-- readthedocs-preview globus-sdk-python end -->