### PR TITLE
Release v3.54.0

### DIFF
--- a/changelog.d/20250325_182401_beth_add_required_mfa_to_auth_policies.rst
+++ b/changelog.d/20250325_182401_beth_add_required_mfa_to_auth_policies.rst
@@ -1,5 +1,0 @@
-Changed
-~~~~~~~
-
-- Added the optional ``required_mfa`` field to ``AuthClient.create_policy()`` and
-  ``AuthClient.update_policy()`` request bodies. (:pr:`1159`)

--- a/changelog.rst
+++ b/changelog.rst
@@ -12,6 +12,17 @@ to a major new version of the SDK.
 
 .. scriv-insert-here
 
+.. _changelog-3.54.0:
+
+v3.54.0 (2025-04-02)
+--------------------
+
+Changed
+~~~~~~~
+
+- Added the optional ``required_mfa`` field to ``AuthClient.create_policy()`` and
+  ``AuthClient.update_policy()`` request bodies. (:pr:`1159`)
+
 .. _changelog-3.53.0:
 
 v3.53.0 (2025-03-25)

--- a/src/globus_sdk/version.py
+++ b/src/globus_sdk/version.py
@@ -1,3 +1,3 @@
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "3.53.0"
+__version__ = "3.54.0"


### PR DESCRIPTION
v3.54.0 (2025-04-02)
================

Changed
---------

- Added the optional `required_mfa` field to `AuthClient.create_policy()` and
  `AuthClient.update_policy()` request bodies. (:pr:`1159`)

<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1161.org.readthedocs.build/en/1161/

<!-- readthedocs-preview globus-sdk-python end -->