### PR TITLE
Add `add_app_transfer_data_access_scope` for flows

### DIFF
--- a/changelog.d/20250415_155555_sirosen_add_specific_flow_data_access_scope_helper.rst
+++ b/changelog.d/20250415_155555_sirosen_add_specific_flow_data_access_scope_helper.rst
@@ -1,0 +1,7 @@
+Added
+~~~~~
+
+- ``SpecificFlowClient`` has a new method,
+  ``add_app_transfer_data_access_scope`` which facilitates declaration of scope
+  requirements when starting flows which interact with collections that need
+  ``data_access`` scopes. (:pr:`1166`)

--- a/tests/unit/globus_app/test_client_integration.py
+++ b/tests/unit/globus_app/test_client_integration.py
@@ -64,6 +64,17 @@ def test_timers_client_add_app_data_access_scope(app):
     assert expected in str_list
 
 
+def test_specific_flow_client_add_app_data_access_scope(app):
+    flow_id = str(uuid.UUID(int=1))
+    client = globus_sdk.SpecificFlowClient(flow_id, app=app)
+
+    collection_id = str(uuid.UUID(int=0))
+    client.add_app_transfer_data_access_scope(collection_id)
+    str_list = [str(s) for s in app.scope_requirements[client.resource_server]]
+    expected = f"{client.scopes.user}[*urn:globus:auth:scope:transfer.api.globus.org:all[*https://auth.globus.org/scopes/{collection_id}/data_access]]"  # noqa: E501
+    assert expected in str_list
+
+
 def test_transfer_client_add_app_data_access_scope_chaining(app):
     collection_id_1 = str(uuid.UUID(int=1))
     collection_id_2 = str(uuid.UUID(int=2))


### PR DESCRIPTION
This is a new SpecificFlowClient method for manipulating a GlobusApp's
scope registration data to add `data_access` requirements.


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1166.org.readthedocs.build/en/1166/

<!-- readthedocs-preview globus-sdk-python end -->