### PR TITLE
Add 'activity_notification_policy' to run_flow()

### DIFF
--- a/changelog.d/20250416_154422_sirosen_flows_activity_notification_policy.rst
+++ b/changelog.d/20250416_154422_sirosen_flows_activity_notification_policy.rst
@@ -1,0 +1,7 @@
+Added
+~~~~~
+
+- ``SpecificFlowClient.run_flow()`` now supports ``activity_notification_policy``
+  as an argument, allowing users to select when their run will notify them. A
+  new helper, ``RunActivityNotificationPolicy``, makes construction of valid
+  policies easier. (:pr:`NUMBER`)

--- a/docs/services/flows.rst
+++ b/docs/services/flows.rst
@@ -57,6 +57,18 @@ When an error occurs, a :class:`FlowsClient` will raise a ``FlowsAPIError``.
    :members:
    :show-inheritance:
 
+Helper Objects
+--------------
+
+``RunActivityNotificationPolicy`` objects encode the data for
+``activity_notification_policy`` when ``run_flow`` is called. Using the helper
+object allows you to have typing-time validation of your data when calling this
+API.
+
+.. autoclass:: RunActivityNotificationPolicy
+   :members:
+   :show-inheritance:
+
 Responses
 ---------
 

--- a/src/globus_sdk/__init__.pyi
+++ b/src/globus_sdk/__init__.pyi
@@ -55,6 +55,7 @@ from .services.flows import (
     FlowsAPIError,
     FlowsClient,
     IterableFlowsResponse,
+    RunActivityNotificationPolicy,
     SpecificFlowClient,
 )
 from .services.gcs import (
@@ -184,6 +185,7 @@ __all__ = (
     "FlowsAPIError",
     "FlowsClient",
     "IterableFlowsResponse",
+    "RunActivityNotificationPolicy",
     "SpecificFlowClient",
     "ActiveScaleStoragePolicies",
     "AzureBlobStoragePolicies",

--- a/src/globus_sdk/_testing/data/flows/run_flow.py
+++ b/src/globus_sdk/_testing/data/flows/run_flow.py
@@ -20,6 +20,15 @@ RESPONSES = ResponseSet(
         json=TWO_HOP_TRANSFER_RUN,
         match=[matchers.json_params_matcher(params=_request_params)],
     ),
+    # 'lenient' is the same as the 'default' above, but without requiring
+    # payload matching, which makes it more usable for a wide variety of tests
+    # TODO: revisit which of the fixtures should have which param matchers
+    lenient=RegisteredResponse(
+        service="flows",
+        method="POST",
+        path=f"/flows/{TWO_HOP_TRANSFER_FLOW_ID}/run",
+        json=TWO_HOP_TRANSFER_RUN,
+    ),
     missing_scope_error=RegisteredResponse(
         service="flows",
         method="POST",

--- a/src/globus_sdk/services/flows/__init__.py
+++ b/src/globus_sdk/services/flows/__init__.py
@@ -1,4 +1,5 @@
 from .client import FlowsClient, SpecificFlowClient
+from .data import RunActivityNotificationPolicy
 from .errors import FlowsAPIError
 from .response import IterableFlowsResponse
 
@@ -7,4 +8,5 @@ __all__ = (
     "FlowsClient",
     "IterableFlowsResponse",
     "SpecificFlowClient",
+    "RunActivityNotificationPolicy",
 )

--- a/src/globus_sdk/services/flows/client.py
+++ b/src/globus_sdk/services/flows/client.py
@@ -10,6 +10,7 @@ from globus_sdk.globus_app import GlobusApp
 from globus_sdk.scopes import FlowsScopes, Scope, ScopeBuilder, SpecificFlowScopeBuilder
 from globus_sdk.utils import MISSING, MissingType
 
+from .data import RunActivityNotificationPolicy
 from .errors import FlowsAPIError
 from .response import (
     IterableFlowsResponse,
@@ -934,6 +935,9 @@ class SpecificFlowClient(client.BaseClient):
         *,
         label: str | None = None,
         tags: list[str] | None = None,
+        activity_notification_policy: (
+            dict[str, t.Any] | RunActivityNotificationPolicy | None
+        ) = None,
         run_monitors: list[str] | None = None,
         run_managers: list[str] | None = None,
         additional_fields: dict[str, t.Any] | None = None,
@@ -945,6 +949,9 @@ class SpecificFlowClient(client.BaseClient):
         :param tags: A collection of searchable tags associated with the run. Tags are
             normalized by stripping leading and trailing whitespace, and replacing all
             whitespace with a single space.
+        :param activity_notification_policy: A policy document which declares when the
+            run will send notification emails. By default, notifications are only sent
+            when a run status changes to ``"INACTIVE"``.
         :param run_monitors: A list of authenticated entities (identified by URN)
             authorized to view this run in addition to the run owner
         :param run_managers: A list of authenticated entities (identified by URN)
@@ -966,6 +973,7 @@ class SpecificFlowClient(client.BaseClient):
                 "body": body,
                 "tags": tags,
                 "label": label,
+                "activity_notification_policy": activity_notification_policy,
                 "run_monitors": run_monitors,
                 "run_managers": run_managers,
             }.items()

--- a/src/globus_sdk/services/flows/data.py
+++ b/src/globus_sdk/services/flows/data.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import logging
+import typing as t
+
+from globus_sdk.utils import MISSING, MissingType, PayloadWrapper
+
+log = logging.getLogger(__name__)
+
+
+class RunActivityNotificationPolicy(PayloadWrapper):
+    """
+    A notification policy for a run, determining when emails will be sent.
+
+    :param status: A list of statuses which will trigger notifications. When
+        the run's status changes, it is evaluated against this list. If the new
+        status matches the policy, an email is sent.
+    """
+
+    def __init__(
+        self,
+        status: (
+            list[t.Literal["INACTIVE", "SUCCEEDED", "FAILED"]] | MissingType
+        ) = MISSING,
+    ) -> None:
+        super().__init__()
+        self["status"] = status

--- a/tests/functional/services/flows/test_run_flow.py
+++ b/tests/functional/services/flows/test_run_flow.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import json
+
 import pytest
 
+import globus_sdk
 from globus_sdk import FlowsAPIError, SpecificFlowClient
-from globus_sdk._testing import load_response
+from globus_sdk._testing import get_last_request, load_response
 
 
 def test_run_flow(specific_flow_client_class: type[SpecificFlowClient]):
@@ -31,3 +34,48 @@ def test_run_flow_missing_scope(specific_flow_client_class: type[SpecificFlowCli
     assert (
         err.message == "This action requires the following scope: frobulate[demuddle]"
     )
+
+
+def test_run_flow_without_activity_notification_policy(
+    specific_flow_client_class,
+):
+    metadata = load_response(SpecificFlowClient.run_flow, case="lenient").metadata
+    flow_client = specific_flow_client_class(flow_id=metadata["flow_id"])
+    resp = flow_client.run_flow({})
+    assert resp.http_status == 200
+
+    last_req = get_last_request()
+    sent_payload = json.loads(last_req.body)
+    assert "activity_notification_policy" not in sent_payload
+
+
+def test_run_flow_with_empty_activity_notification_policy(
+    specific_flow_client_class,
+):
+    metadata = load_response(SpecificFlowClient.run_flow, case="lenient").metadata
+    flow_client = specific_flow_client_class(flow_id=metadata["flow_id"])
+
+    policy = globus_sdk.RunActivityNotificationPolicy()
+    flow_client.run_flow({}, activity_notification_policy=policy)
+
+    last_req = get_last_request()
+    sent_payload = json.loads(last_req.body)
+    assert "activity_notification_policy" in sent_payload
+    assert sent_payload["activity_notification_policy"] == {}
+
+
+def test_run_flow_with_activity_notification_policy(
+    specific_flow_client_class,
+):
+    metadata = load_response(SpecificFlowClient.run_flow, case="lenient").metadata
+    flow_client = specific_flow_client_class(flow_id=metadata["flow_id"])
+
+    policy = globus_sdk.RunActivityNotificationPolicy(status=["FAILED", "INACTIVE"])
+    flow_client.run_flow({}, activity_notification_policy=policy)
+
+    last_req = get_last_request()
+    sent_payload = json.loads(last_req.body)
+    assert "activity_notification_policy" in sent_payload
+    assert sent_payload["activity_notification_policy"] == {
+        "status": ["FAILED", "INACTIVE"]
+    }

--- a/tests/non-pytest/mypy-ignore-tests/test_flow_activity_notification_policy.py
+++ b/tests/non-pytest/mypy-ignore-tests/test_flow_activity_notification_policy.py
@@ -1,0 +1,24 @@
+import typing as t
+
+import globus_sdk
+
+specific_flow_client = globus_sdk.SpecificFlowClient("foo")
+
+# running a flow without a notification policy is allowed by the types
+specific_flow_client.run_flow({})
+
+# passing a dict[str, t.Any] is allowed (even though the type cannot guarantee safety)
+policy_dict: dict[str, t.Any] = {"status": ["INACTIVE"]}
+specific_flow_client.run_flow({}, activity_notification_policy=policy_dict)
+
+# passing the object representation is allowed as well
+policy_object = globus_sdk.RunActivityNotificationPolicy(status=["FAILED"])
+specific_flow_client.run_flow({}, activity_notification_policy=policy_object)
+
+# the object representation does not allow bad values in the status field
+globus_sdk.RunActivityNotificationPolicy(status=["FAILURE"])  # type: ignore[list-item]
+
+# passing something of the wrong type (e.g. the status list) is also not allowed
+specific_flow_client.run_flow(
+    {}, activity_notification_policy=["SUCCEEDED"]  # type: ignore[arg-type]
+)


### PR DESCRIPTION
- Add a new data-constructor helper, `RunActivityNotificationPolicy`
- Add `activity_notification_policy` as an argument of type
  `RunActivityNotificationPolicy | dict | None`

One intentional oddity here is that for consistency with other
`run_flow` arguments, the default is `None`, which we omit, but in the
payload helper itself we use `MISSING`.


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1167.org.readthedocs.build/en/1167/

<!-- readthedocs-preview globus-sdk-python end -->