### PR TITLE
Remove an overly strict test parameter matcher

### DIFF
--- a/src/globus_sdk/_testing/data/flows/create_flow.py
+++ b/src/globus_sdk/_testing/data/flows/create_flow.py
@@ -1,5 +1,3 @@
-from responses import matchers
-
 from globus_sdk._testing.models import RegisteredResponse, ResponseSet
 
 from ._common import TWO_HOP_TRANSFER_FLOW_DOC
@@ -29,11 +27,6 @@ RESPONSES = ResponseSet(
         path="/flows",
         method="POST",
         json=TWO_HOP_TRANSFER_FLOW_DOC,
-        match=[
-            matchers.json_params_matcher(
-                params=_two_hop_transfer_create_request, strict_match=False
-            )
-        ],
     ),
     bad_admin_principal_error=RegisteredResponse(
         service="flows",


### PR DESCRIPTION
The presence of this matcher makes the fixture unusable in downstream
applications if they don't keep pace with all changes to the data
model made in `_testing`. As a result, this causes the current
globus-cli `sdkmain` builds to fail as they pick up on the new
`run_managers` and `run_monitors` fields, but cannot possibly send
those parameters because support has not been implemented yet.

Removing the matcher does not harm SDK testing and makes the default
fixture more usable by being more lenient. It is confirmed to make CLI
testing pass with a `localsdk` CLI test run.


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1168.org.readthedocs.build/en/1168/

<!-- readthedocs-preview globus-sdk-python end -->