### PR TITLE
Remove an unnecessarily strict matcher

### DIFF
--- a/src/globus_sdk/_testing/data/flows/run_flow.py
+++ b/src/globus_sdk/_testing/data/flows/run_flow.py
@@ -1,5 +1,3 @@
-from responses import matchers
-
 from globus_sdk._testing.models import RegisteredResponse, ResponseSet
 
 from ._common import TWO_HOP_TRANSFER_FLOW_ID, TWO_HOP_TRANSFER_RUN
@@ -14,16 +12,6 @@ _request_params = {
 RESPONSES = ResponseSet(
     metadata={"flow_id": TWO_HOP_TRANSFER_FLOW_ID, "request_params": _request_params},
     default=RegisteredResponse(
-        service="flows",
-        method="POST",
-        path=f"/flows/{TWO_HOP_TRANSFER_FLOW_ID}/run",
-        json=TWO_HOP_TRANSFER_RUN,
-        match=[matchers.json_params_matcher(params=_request_params)],
-    ),
-    # 'lenient' is the same as the 'default' above, but without requiring
-    # payload matching, which makes it more usable for a wide variety of tests
-    # TODO: revisit which of the fixtures should have which param matchers
-    lenient=RegisteredResponse(
         service="flows",
         method="POST",
         path=f"/flows/{TWO_HOP_TRANSFER_FLOW_ID}/run",

--- a/tests/functional/services/flows/test_run_flow.py
+++ b/tests/functional/services/flows/test_run_flow.py
@@ -39,7 +39,7 @@ def test_run_flow_missing_scope(specific_flow_client_class: type[SpecificFlowCli
 def test_run_flow_without_activity_notification_policy(
     specific_flow_client_class,
 ):
-    metadata = load_response(SpecificFlowClient.run_flow, case="lenient").metadata
+    metadata = load_response(SpecificFlowClient.run_flow).metadata
     flow_client = specific_flow_client_class(flow_id=metadata["flow_id"])
     resp = flow_client.run_flow({})
     assert resp.http_status == 200
@@ -52,7 +52,7 @@ def test_run_flow_without_activity_notification_policy(
 def test_run_flow_with_empty_activity_notification_policy(
     specific_flow_client_class,
 ):
-    metadata = load_response(SpecificFlowClient.run_flow, case="lenient").metadata
+    metadata = load_response(SpecificFlowClient.run_flow).metadata
     flow_client = specific_flow_client_class(flow_id=metadata["flow_id"])
 
     policy = globus_sdk.RunActivityNotificationPolicy()
@@ -67,7 +67,7 @@ def test_run_flow_with_empty_activity_notification_policy(
 def test_run_flow_with_activity_notification_policy(
     specific_flow_client_class,
 ):
-    metadata = load_response(SpecificFlowClient.run_flow, case="lenient").metadata
+    metadata = load_response(SpecificFlowClient.run_flow).metadata
     flow_client = specific_flow_client_class(flow_id=metadata["flow_id"])
 
     policy = globus_sdk.RunActivityNotificationPolicy(status=["FAILED", "INACTIVE"])


### PR DESCRIPTION
Similar to #1168

Trying to use a mock response with payload param matching makes
development more difficult because a downstream testsuite *MUST*
provide all of the exact parameters declared or it gets no data. This
contradicts the goal of `_testing`, which is to provide easy,
low-friction mocking for downstream consumers.

If stricter matchers are a desirable feature, they can be opt-in by
making non-`default` case mocks which have these requirements.
(Essentially, the inverse of the `lenient` variant mock which is being
removed here.)


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1169.org.readthedocs.build/en/1169/

<!-- readthedocs-preview globus-sdk-python end -->