### PR TITLE
Add a transport layer `close()` method

### DIFF
--- a/changelog.d/20250421_142908_sirosen_add_transport_close.rst
+++ b/changelog.d/20250421_142908_sirosen_add_transport_close.rst
@@ -1,0 +1,5 @@
+Added
+~~~~~
+
+- Transport objects now provide a ``close()`` method for closing resources which
+  belong to them, primarily the underlying session. (:pr:`NUMBER`)

--- a/src/globus_sdk/transport/requests.py
+++ b/src/globus_sdk/transport/requests.py
@@ -137,6 +137,13 @@ class RequestsTransport:
         # register internal checks
         self.register_default_retry_checks()
 
+    def close(self) -> None:
+        """
+        Closes all resources owned by the transport, primarily the underlying
+        network session.
+        """
+        self.session.close()
+
     @property
     def user_agent(self) -> str:
         return self._user_agent

--- a/tests/unit/transport/test_transport.py
+++ b/tests/unit/transport/test_transport.py
@@ -1,4 +1,5 @@
 import pathlib
+from unittest import mock
 
 import pytest
 
@@ -108,3 +109,12 @@ def test_double_clear_of_client_info_is_allowed():
     transport.globus_client_info.clear()
     transport.globus_client_info.clear()
     assert "X-Globus-Client-Info" not in transport.headers
+
+
+def test_transport_close_closes_session():
+    # there's no easy way to check if a real requests.Session object is closed,
+    # so just check that `close()` was called
+    transport = RequestsTransport()
+    with mock.patch.object(transport, "session") as mocked_session:
+        transport.close()
+        mocked_session.close.assert_called_once_with()


### PR DESCRIPTION
This makes it possible to close the requests session associated with a
client with one fewer layer. Instead of
`client.transport.session.close()`, `client.transport.close()`.


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1171.org.readthedocs.build/en/1171/

<!-- readthedocs-preview globus-sdk-python end -->