### PR TITLE
add `activity_notification_policy` to GCS `CollectionDocument` class.

### DIFF
--- a/changelog.d/20250421_180301_pjhinton_sc_40253_activity_notification_policy_for_collection_document.rst
+++ b/changelog.d/20250421_180301_pjhinton_sc_40253_activity_notification_policy_for_collection_document.rst
@@ -1,0 +1,7 @@
+
+Added
+~~~~~~~
+
+ - Add ``activity_notification_policy`` to GuestCollectionDocument,
+   associating it with GCS collection document version 1.14.0.
+   (:pr:`NUMBER`)

--- a/src/globus_sdk/services/gcs/data/collection.py
+++ b/src/globus_sdk/services/gcs/data/collection.py
@@ -115,6 +115,7 @@ class CollectionDocument(utils.PayloadWrapper, abc.ABC):
         "enable_https": (1, 1, 0),
         "user_message": (1, 1, 0),
         "user_message_link": (1, 1, 0),
+        "activity_notification_policy": (1, 14, 0),
     }
     DATATYPE_VERSION_CALLBACKS: tuple[DatatypeCallback, ...] = (
         _user_message_length_callback,
@@ -343,6 +344,9 @@ class GuestCollectionDocument(CollectionDocument):
     :param user_credential_id: The ID of the User Credential which is used to access
         data on this collection. This credential must be owned by the collection’s
         ``identity_id``.
+    :param activity_notification_policy: Specification for when a notification email
+        should be sent to a guest collection ``administrator``, ``activity_manager``,
+        and ``activity_monitor`` roles when a transfer task reaches completion.
     """
 
     @property
@@ -380,6 +384,7 @@ class GuestCollectionDocument(CollectionDocument):
         # > specific args start <
         mapped_collection_id: UUIDLike | None = None,
         user_credential_id: UUIDLike | None = None,
+        activity_notification_policy: dict[str, list[str]] | None = None,
         # > specific args end <
         # additional fields
         additional_fields: dict[str, t.Any] | None = None,
@@ -415,6 +420,8 @@ class GuestCollectionDocument(CollectionDocument):
             mapped_collection_id=mapped_collection_id,
             user_credential_id=user_credential_id,
         )
+        self._set_value("activity_notification_policy", activity_notification_policy)
+
         ensure_datatype(self)
 
 


### PR DESCRIPTION
This change is needed to add support for setting activity notification policies on GCS guest collections in the Globus CLI.

Add support for the `activity_notification_policy` field on the GCS `CollectionDocument` and associated it with schema version 1.14.0.



<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1172.org.readthedocs.build/en/1172/

<!-- readthedocs-preview globus-sdk-python end -->