### PR TITLE
Better support parsing a GARE from the error root

### DIFF
--- a/changelog.d/20250423_134305_sirosen_handle_top_level_gares.rst
+++ b/changelog.d/20250423_134305_sirosen_handle_top_level_gares.rst
@@ -1,0 +1,7 @@
+Changed
+~~~~~~~
+
+- When parsing GAREs using ``to_gare`` and ``to_gares``, the root document is
+  now considered a possible location for a GARE when subdocument errors are
+  present on a ``GlobusAPIError`` object. Previously, the root document would
+  only be considered in the absence of subdocument errors. (:pr:`NUMBER`)

--- a/src/globus_sdk/gare/_functional_api.py
+++ b/src/globus_sdk/gare/_functional_api.py
@@ -13,12 +13,14 @@ from ._variants import (
     LegacyConsentRequiredTransferError,
 )
 
+AnyErrorDocumentType: t.TypeAlias = (
+    "exc.GlobusAPIError | exc.ErrorSubdocument | dict[str, t.Any]"
+)
+
 log = logging.getLogger(__name__)
 
 
-def to_gare(
-    error: exc.GlobusAPIError | exc.ErrorSubdocument | dict[str, t.Any],
-) -> GARE | None:
+def to_gare(error: AnyErrorDocumentType) -> GARE | None:
     """
     Converts a GlobusAPIError, ErrorSubdocument, or dict into a
     GARE by attempting to match to GARE (preferred) or legacy variants.
@@ -38,18 +40,78 @@ def to_gare(
     # GlobusAPIErrors may contain more than one error, so we consider all of them
     # even though we only return the first.
     if isinstance(error, GlobusAPIError):
+        # first, try to parse a GARE from the root document,
+        # and if we can do so, return it
+        authreq_error = _lenient_dict2gare(error.raw_json)
+        if authreq_error is not None:
+            return authreq_error
+
         # Iterate over ErrorSubdocuments
         for subdoc in error.errors:
-            authreq_error = to_gare(subdoc)
+            authreq_error = _lenient_dict2gare(subdoc.raw)
             if authreq_error is not None:
                 # Return only the first auth requirements error we encounter
                 return authreq_error
+
         # We failed to find a Globus Auth Requirements Error
         return None
     elif isinstance(error, ErrorSubdocument):
-        error_dict = error.raw
+        return _lenient_dict2gare(error.raw)
     else:
-        error_dict = error
+        return _lenient_dict2gare(error)
+
+
+def to_gares(errors: list[AnyErrorDocumentType]) -> list[GARE]:
+    """
+    Converts a list of GlobusAPIErrors, ErrorSubdocuments, or dicts into a list of
+    GAREs by attempting to match each error to GARE (preferred) or legacy variants.
+
+    .. note::
+
+        A GlobusAPIError may contain multiple errors, so the result
+        list could be longer than the provided list.
+
+    If no errors match any known formats, an empty list is returned.
+
+    :param errors: The errors to convert.
+    """
+    from globus_sdk.exc import GlobusAPIError
+
+    maybe_gares: list[GARE | None] = []
+    for error in errors:
+        # when handling an API error, avoid `to_gare(error)` because that will
+        # only unpack a single result
+        if isinstance(error, GlobusAPIError):
+            # Use the ErrorSubdocuments when handling API error types
+            maybe_gares.extend(to_gare(e) for e in error.errors)
+            # Also use the root document, but only if there is an `"errors"`
+            # key inside of the error document
+            # Why? Because the *default* for `.errors` when there is no inner
+            # `"errors"` array is an array containing the root document as a
+            # subdocument
+            if isinstance(error.raw_json, dict) and "errors" in error.raw_json:
+                # use dict parsing directly so that the native descent in 'to_gare'
+                # to subdocuments does not apply in this case
+                maybe_gares.append(_lenient_dict2gare(error.raw_json))
+        else:
+            maybe_gares.append(to_gare(error))
+
+    # Remove any errors that did not resolve to a Globus Auth Requirements Error
+    return [error for error in maybe_gares if error is not None]
+
+
+def _lenient_dict2gare(error_dict: dict[str, t.Any] | None) -> GARE | None:
+    """
+    Parse a GARE from a dict, accepting legacy variants.
+
+    If given ``None``, returns ``None``. This allows this to accept inputs
+    which are themselves dict|None.
+
+    :param error_dict: the error input
+    :eturns: ``None`` on a failed parse
+    """
+    if error_dict is None:
+        return None
 
     # Prefer a proper auth requirements error, if possible
     try:
@@ -71,42 +133,7 @@ def to_gare(
     return None
 
 
-def to_gares(
-    errors: list[exc.GlobusAPIError | exc.ErrorSubdocument | dict[str, t.Any]],
-) -> list[GARE]:
-    """
-    Converts a list of GlobusAPIErrors, ErrorSubdocuments, or dicts into a list of
-    GAREs by attempting to match each error to GARE (preferred) or legacy variants.
-
-    .. note::
-
-        A GlobusAPIError may contain multiple errors, so the result
-        list could be longer than the provided list.
-
-    If no errors match any known formats, an empty list is returned.
-
-    :param errors: The errors to convert.
-    """
-    from globus_sdk.exc import GlobusAPIError
-
-    candidate_errors: list[exc.ErrorSubdocument | dict[str, t.Any]] = []
-    for error in errors:
-        if isinstance(error, GlobusAPIError):
-            # Use the ErrorSubdocuments
-            candidate_errors.extend(error.errors)
-        else:
-            candidate_errors.append(error)
-
-    # Try to convert all candidate errors to auth requirements errors
-    all_errors = [to_gare(error) for error in candidate_errors]
-
-    # Remove any errors that did not resolve to a Globus Auth Requirements Error
-    return [error for error in all_errors if error is not None]
-
-
-def is_gare(
-    error: exc.GlobusAPIError | exc.ErrorSubdocument | dict[str, t.Any],
-) -> bool:
+def is_gare(error: AnyErrorDocumentType) -> bool:
     """
     Return True if the provided error matches a known
     Globus Auth Requirements Error format.
@@ -116,9 +143,7 @@ def is_gare(
     return to_gare(error) is not None
 
 
-def has_gares(
-    errors: list[exc.GlobusAPIError | exc.ErrorSubdocument | dict[str, t.Any]],
-) -> bool:
+def has_gares(errors: list[AnyErrorDocumentType]) -> bool:
     """
     Return True if any of the provided errors match a known
     Globus Auth Requirements Error format.

--- a/src/globus_sdk/gare/_functional_api.py
+++ b/src/globus_sdk/gare/_functional_api.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import sys
 import typing as t
 
 from globus_sdk import exc
@@ -13,7 +14,13 @@ from ._variants import (
     LegacyConsentRequiredTransferError,
 )
 
-AnyErrorDocumentType: t.TypeAlias = (
+if sys.version_info >= (3, 10):
+    from typing import TypeAlias
+else:
+    from typing_extensions import TypeAlias
+
+
+AnyErrorDocumentType: TypeAlias = (
     "exc.GlobusAPIError | exc.ErrorSubdocument | dict[str, t.Any]"
 )
 


### PR DESCRIPTION
When parsing a GARE from an API error object, we previously would
consider the sub-errors in `err.errors` (where `err` is a
`GlobusAPIError`) but would not inspect the root of the error object.
We now parse a GARE from the root error in these situations.

Because the default parse for non-JSON:API errors populates
`err.errors` with `data["errors"]` if present, *and falls back* to
`[data]` otherwise, there's some ambiguity we need to resolve. It's
important that `to_gares`, the plural/list variant, does not create
two GAREs when there is only one, found at the root.

To make the revised code simple, the conversion of
`dict | None -> GARE | None` is separated from the main `to_gare`
interface in a minor refactor.


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1173.org.readthedocs.build/en/1173/

<!-- readthedocs-preview globus-sdk-python end -->