### PR TITLE
Add support for `filter_roles` option when listing flows and runs

### DIFF
--- a/changelog.d/20250429_153543_8730430+m1yag1_sc_40419_filter_roles_list_flows_and_runs.rst
+++ b/changelog.d/20250429_153543_8730430+m1yag1_sc_40419_filter_roles_list_flows_and_runs.rst
@@ -8,4 +8,4 @@ Deprecated
 ~~~~~~~~~~
 
 - ``filter_role`` parameter for ``FlowsClient.list_flows`` is deprecated. Use
-  ``filter_roles`` instead (:pr:`NUMBER`)
+  ``filter_roles`` instead (:pr:`NUMBER`).

--- a/changelog.d/20250429_153543_8730430+m1yag1_sc_40419_filter_roles_list_flows_and_runs.rst
+++ b/changelog.d/20250429_153543_8730430+m1yag1_sc_40419_filter_roles_list_flows_and_runs.rst
@@ -3,3 +3,9 @@ Added
 
 - ``FlowsClient.list_flows`` and ``FlowsClient.list_runs`` now support the
   ``filter_roles`` parameter to filter results by one or more roles (:pr:`NUMBER`).
+
+Deprecated
+~~~~~~~~~~
+
+- ``filter_role`` parameter for ``FlowsClient.list_flows`` is deprecated. Use
+  ``filter_roles`` instead (:pr:`NUMBER`)

--- a/changelog.d/20250429_153543_8730430+m1yag1_sc_40419_filter_roles_list_flows_and_runs.rst
+++ b/changelog.d/20250429_153543_8730430+m1yag1_sc_40419_filter_roles_list_flows_and_runs.rst
@@ -1,0 +1,5 @@
+Added
+~~~~~
+
+- ``FlowsClient.list_flows`` and ``FlowsClient.list_runs`` now support the
+  ``filter_roles`` parameter to filter results by one or more roles (:pr:`NUMBER`).

--- a/src/globus_sdk/services/flows/client.py
+++ b/src/globus_sdk/services/flows/client.py
@@ -3,7 +3,14 @@ from __future__ import annotations
 import logging
 import typing as t
 
-from globus_sdk import GlobusHTTPResponse, GlobusSDKUsageError, client, paging, utils
+from globus_sdk import (
+    GlobusHTTPResponse,
+    GlobusSDKUsageError,
+    client,
+    exc,
+    paging,
+    utils,
+)
 from globus_sdk._types import UUIDLike
 from globus_sdk.authorizers import GlobusAuthorizer
 from globus_sdk.globus_app import GlobusApp
@@ -341,6 +348,9 @@ class FlowsClient(client.BaseClient):
         if query_params is None:
             query_params = {}
         if filter_role is not None:
+            exc.warn_deprecated(
+                "The `filter_role` parameter is deprecated. Use `filter_roles` instead."
+            )
             query_params["filter_role"] = filter_role
         if filter_roles is not None:
             query_params["filter_roles"] = utils.commajoin(filter_roles)

--- a/src/globus_sdk/services/flows/client.py
+++ b/src/globus_sdk/services/flows/client.py
@@ -249,7 +249,7 @@ class FlowsClient(client.BaseClient):
 
         :param filter_role: A role name specifying the minimum permissions required for
             a flow to be included in the response. Mutually exclusive with
-            **filter_roles**.
+            **filter_roles**. (deprecated)
         :param filter_roles: A list of role names specifying the roles the user must
             have for a flow to be included in the response. Mutually exclusive with
             **filter_role**.

--- a/src/globus_sdk/services/flows/client.py
+++ b/src/globus_sdk/services/flows/client.py
@@ -252,28 +252,28 @@ class FlowsClient(client.BaseClient):
         :param query_params: Any additional parameters to be passed through
             as query params.
 
-        **Filter Role Values**
+        **Role Filters**
 
-        The valid values for ``role`` are, in order of precedence for ``filter_role``:
+        ``filter_roles`` accepts a list of roles which are used to filter the results to
+        flows where the caller has any of the specified roles.
 
-          - ``flow_viewer``
-          - ``flow_starter``
-          - ``flow_administrator``
-          - ``flow_owner``
+        The valid role values are:
 
-        For example, if ``flow_starter`` is specified then flows for which the user has
-        the ``flow_starter``, ``flow_administrator`` or ``flow_owner`` roles will be
-        returned.
+        - ``flow_viewer``
+        - ``flow_starter``
+        - ``flow_administrator``
+        - ``flow_owner``
+        - ``run_monitor``
+        - ``run_manager``
 
-        The role values ``run_manager`` and ``run_monitor`` are also supported but do
-        not follow an order of precedence.
+        .. note::
 
-        **Filter Roles Values**
+            The deprecated ``filter_role`` parameter has similar behavior.
 
-        The valid values for ``filter_roles`` are the same as those for ``filter_role``.
-        However, unlike ``filter_role``, no order of precedence is evaluated. Only flows
-        where the user has one or more of the specified roles will be included in the
-        results.
+            ``filter_role`` accepts exactly one role name, and filters to flows
+            where the caller has the specified role or a strictly weaker role.
+            For example, ``filter_role="flow_administrator"`` will include flows
+            where the caller has the ``flow_starter`` role.
 
         **OrderBy Values**
 
@@ -343,11 +343,11 @@ class FlowsClient(client.BaseClient):
         if filter_role is not None:
             query_params["filter_role"] = filter_role
         if filter_roles is not None:
-            query_params["filter_roles"] = filter_roles
+            query_params["filter_roles"] = utils.commajoin(filter_roles)
         if filter_fulltext is not None:
             query_params["filter_fulltext"] = filter_fulltext
 
-        if filter_role and filter_roles:
+        if filter_role is not None and filter_roles is not None:
             msg = "Mutually exclusive parameters: filter_role and filter_roles."
             raise GlobusSDKUsageError(msg)
 
@@ -658,7 +658,7 @@ class FlowsClient(client.BaseClient):
                 utils.safe_strseq_iter(filter_flow_id)
             )
         if filter_roles:
-            query_params["filter_roles"] = filter_roles
+            query_params["filter_roles"] = utils.commajoin(filter_roles)
         if marker is not None:
             query_params["marker"] = marker
         return IterableRunsResponse(self.get("/runs", query_params=query_params))

--- a/src/globus_sdk/services/flows/client.py
+++ b/src/globus_sdk/services/flows/client.py
@@ -247,9 +247,9 @@ class FlowsClient(client.BaseClient):
         """
         List deployed flows
 
-        :param filter_role: A role name specifying the minimum permissions required for
-            a flow to be included in the response. Mutually exclusive with
-            **filter_roles**. (deprecated)
+        :param filter_role: (deprecated) A role name specifying the minimum permissions
+            required for a flow to be included in the response. Mutually exclusive with
+            **filter_roles**.
         :param filter_roles: A list of role names specifying the roles the user must
             have for a flow to be included in the response. Mutually exclusive with
             **filter_role**.

--- a/tests/functional/services/flows/test_list_flows.py
+++ b/tests/functional/services/flows/test_list_flows.py
@@ -2,7 +2,7 @@ import urllib.parse
 
 import pytest
 
-from globus_sdk import GlobusSDKUsageError
+from globus_sdk import GlobusSDKUsageError, RemovedInV4Warning
 from globus_sdk._testing import get_last_request, load_response
 
 
@@ -20,7 +20,15 @@ def test_list_flows_simple(flows_client, filter_fulltext, filter_role, orderby):
     if orderby:
         add_kwargs["orderby"] = orderby
 
-    res = flows_client.list_flows(**add_kwargs)
+    if filter_role:
+        with pytest.warns(
+            RemovedInV4Warning,
+            match=r"The `filter_role` parameter is deprecated.*",
+        ):
+            res = flows_client.list_flows(**add_kwargs)
+    else:
+        res = flows_client.list_flows(**add_kwargs)
+
     assert res.http_status == 200
     # dict-like indexing
     assert meta["first_flow_id"] == res["flows"][0]["id"]

--- a/tests/functional/services/flows/test_list_flows.py
+++ b/tests/functional/services/flows/test_list_flows.py
@@ -145,18 +145,16 @@ def test_list_flows_orderby_multi(flows_client, orderby_style, orderby_value):
     ],
 )
 def test_list_flows_mutually_exclusive_roles(flows_client, filter_role, filter_roles):
-    with pytest.raises(GlobusSDKUsageError):
+    with pytest.raises(GlobusSDKUsageError), pytest.warns(RemovedInV4Warning):
         flows_client.list_flows(filter_role=filter_role, filter_roles=filter_roles)
 
 
 @pytest.mark.parametrize(
     "filter_roles, expected_filter_roles",
     [
-        # empty list
-        ([], []),
-        # list with empty string
-        ([""], [""]),
-        # None
+        # empty list, list with empty string, and None do not send the param
+        ([], None),
+        ([""], None),
         (None, None),
         # single role as string
         ("foo", ["foo"]),
@@ -181,7 +179,7 @@ def test_list_flows_with_filter_roles_parameter(
     parsed_qs = urllib.parse.parse_qs(urllib.parse.urlparse(req.url).query)
 
     # Only check filter_roles in parsed_qs if we expect a non-empty value
-    if expected_filter_roles and any(role for role in expected_filter_roles):
+    if expected_filter_roles:
         assert parsed_qs["filter_roles"] == expected_filter_roles
     else:
         assert "filter_roles" not in parsed_qs

--- a/tests/functional/services/flows/test_list_runs.py
+++ b/tests/functional/services/flows/test_list_runs.py
@@ -74,11 +74,9 @@ def test_list_runs_filter_flow_id(flows_client, pass_as_uuids):
 @pytest.mark.parametrize(
     "filter_roles, expected_filter_roles",
     [
-        # empty list
-        ([], []),
-        # list with empty string
-        ([""], [""]),
-        # None
+        # empty list, list with empty string, and None do not send the param
+        ([], None),
+        ([""], None),
         (None, None),
         # single role as string
         ("foo", ["foo"]),
@@ -99,7 +97,7 @@ def test_list_runs_filter_roles(flows_client, filter_roles, expected_filter_role
     assert req.body is None
     parsed_qs = urllib.parse.parse_qs(urllib.parse.urlparse(req.url).query)
 
-    if expected_filter_roles and any(role for role in expected_filter_roles):
+    if expected_filter_roles:
         assert parsed_qs["filter_roles"] == expected_filter_roles
     else:
         assert "filter_roles" not in parsed_qs

--- a/tests/functional/services/flows/test_list_runs.py
+++ b/tests/functional/services/flows/test_list_runs.py
@@ -71,8 +71,26 @@ def test_list_runs_filter_flow_id(flows_client, pass_as_uuids):
         assert run["flow_id"] in {str(flow_id_one), str(flow_id_two)}
 
 
-@pytest.mark.parametrize("filter_roles", [None, ["run_manager", "run_monitor"]])
-def test_list_runs_filter_roles(flows_client, filter_roles):
+@pytest.mark.parametrize(
+    "filter_roles, expected_filter_roles",
+    [
+        # empty list
+        ([], []),
+        # list with empty string
+        ([""], [""]),
+        # None
+        (None, None),
+        # single role as string
+        ("foo", ["foo"]),
+        # single role as list
+        (["foo"], ["foo"]),
+        # multiple roles as comma-separated string
+        ("foo,bar", ["foo,bar"]),
+        # multiple roles as list
+        (["foo", "bar"], ["foo,bar"]),
+    ],
+)
+def test_list_runs_filter_roles(flows_client, filter_roles, expected_filter_roles):
     load_response(flows_client.list_runs).metadata
     res = flows_client.list_runs(filter_roles=filter_roles)
     assert res.http_status == 200
@@ -81,7 +99,7 @@ def test_list_runs_filter_roles(flows_client, filter_roles):
     assert req.body is None
     parsed_qs = urllib.parse.parse_qs(urllib.parse.urlparse(req.url).query)
 
-    if filter_roles:
-        assert parsed_qs["filter_roles"] == filter_roles
+    if expected_filter_roles and any(role for role in expected_filter_roles):
+        assert parsed_qs["filter_roles"] == expected_filter_roles
     else:
         assert "filter_roles" not in parsed_qs

--- a/tests/functional/services/flows/test_list_runs.py
+++ b/tests/functional/services/flows/test_list_runs.py
@@ -1,8 +1,9 @@
+import urllib.parse
 import uuid
 
 import pytest
 
-from globus_sdk._testing import load_response
+from globus_sdk._testing import get_last_request, load_response
 
 
 def test_list_runs_simple(flows_client):
@@ -68,3 +69,19 @@ def test_list_runs_filter_flow_id(flows_client, pass_as_uuids):
     )
     for run in res_combined:
         assert run["flow_id"] in {str(flow_id_one), str(flow_id_two)}
+
+
+@pytest.mark.parametrize("filter_roles", [None, ["run_manager", "run_monitor"]])
+def test_list_runs_filter_roles(flows_client, filter_roles):
+    load_response(flows_client.list_runs).metadata
+    res = flows_client.list_runs(filter_roles=filter_roles)
+    assert res.http_status == 200
+
+    req = get_last_request()
+    assert req.body is None
+    parsed_qs = urllib.parse.parse_qs(urllib.parse.urlparse(req.url).query)
+
+    if filter_roles:
+        assert parsed_qs["filter_roles"] == filter_roles
+    else:
+        assert "filter_roles" not in parsed_qs


### PR DESCRIPTION
https://app.shortcut.com/globus/story/40419
## Changelog
### Added
 - `FlowsClient.list_flows` and `FlowsClient.list_runs` now support the
   `filter_roles` parameter to filter results by one or more roles.

<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1174.org.readthedocs.build/en/1174/

<!-- readthedocs-preview globus-sdk-python end -->