### PR TITLE
Support `session_message` in authorization URL

### DIFF
--- a/changelog.d/20250502_103545_ada_support_session_message_authorize_url.rst
+++ b/changelog.d/20250502_103545_ada_support_session_message_authorize_url.rst
@@ -1,0 +1,7 @@
+Added
+~~~~~
+
+- ``AuthLoginClient`` now supports a ``session_message`` when constructing an
+  OAuth2 authorization URL. (:pr:`NUMBER`)
+- ``LoginFlowManager`` will now use a ``session_message`` present in the
+  supplied ``GlobusAuthorizationParameters`` as part of the login flow. (:pr:`NUMBER`)

--- a/src/globus_sdk/login_flows/login_flow_manager.py
+++ b/src/globus_sdk/login_flows/login_flow_manager.py
@@ -57,6 +57,7 @@ class LoginFlowManager(metaclass=abc.ABCMeta):
             session_required_single_domain=session_required_single_domain,
             session_required_policies=auth_parameters.session_required_policies,
             session_required_mfa=auth_parameters.session_required_mfa,
+            session_message=auth_parameters.session_message,
             prompt=auth_parameters.prompt,  # type: ignore
         )
 

--- a/src/globus_sdk/services/auth/client/base_login_client.py
+++ b/src/globus_sdk/services/auth/client/base_login_client.py
@@ -145,6 +145,7 @@ class AuthLoginClient(client.BaseClient):
         session_required_single_domain: str | t.Iterable[str] | None = None,
         session_required_policies: UUIDLike | t.Iterable[UUIDLike] | None = None,
         session_required_mfa: bool | None = None,
+        session_message: str | None = None,
         prompt: t.Literal["login"] | None = None,
         query_params: dict[str, t.Any] | None = None,
     ) -> str:
@@ -160,6 +161,7 @@ class AuthLoginClient(client.BaseClient):
         :param session_required_policies: A list of IDs for policies which must
             be satisfied by the user.
         :param session_required_mfa: Whether MFA is required for the session.
+        :param session_message: A message to be displayed to the user by Globus Auth.
         :param prompt:
             Control whether a user is required to log in before the authorization step.
 
@@ -193,6 +195,8 @@ class AuthLoginClient(client.BaseClient):
             )
         if session_required_mfa is not None:
             query_params["session_required_mfa"] = session_required_mfa
+        if session_message is not None:
+            query_params["session_message"] = session_message
         if prompt is not None:
             query_params["prompt"] = prompt
         auth_url = self.current_oauth2_flow_manager.get_authorize_url(

--- a/tests/functional/services/auth/test_auth_client_flow.py
+++ b/tests/functional/services/auth/test_auth_client_flow.py
@@ -35,6 +35,7 @@ def confidential_client(no_retry_transport):
 #   identities: uuid | str | list[uuid] | list[str] | list[str | uuid]
 #   policies: uuid | str | list[uuid] | list[str] | list[str | uuid]
 #   mfa: True | False
+#   message: str | None
 #   prompt: Literal["prompt"] | None
 #
 # The order of these options is consequential.
@@ -56,16 +57,24 @@ policy_options = (
     ["baz-id", "quux-id"],
     ["baz-id", uuid.UUID(int=5)],
 )
+message_options = ("Test message",)
 mfa_options = (True, False)
 prompt_options = ("login",)
 # Seed an all-`None` option test, then use a loop to fill in the rest.
 # The number of parameters here must match the test parameters:
-_ALL_SESSION_PARAM_COMBINATIONS = [(None,) * 5]
+_ALL_SESSION_PARAM_COMBINATIONS = [(None,) * 6]
 for idx, options in enumerate(
-    (domain_options, identity_options, policy_options, mfa_options, prompt_options)
+    (
+        domain_options,
+        identity_options,
+        policy_options,
+        mfa_options,
+        message_options,
+        prompt_options,
+    )
 ):
     for option in options:
-        parameters = [None] * 5
+        parameters = [None] * 6
         parameters[idx] = option
         _ALL_SESSION_PARAM_COMBINATIONS.append(tuple(parameters))
 
@@ -73,7 +82,14 @@ for idx, options in enumerate(
 @pytest.mark.parametrize("flow_type", ("native_app", "confidential_app"))
 # parametrize over both what is and what *is not* passed as a parameter
 @pytest.mark.parametrize(
-    "domain_option, identity_option, policy_option, mfa_option, prompt_option",
+    [
+        "domain_option",
+        "identity_option",
+        "policy_option",
+        "mfa_option",
+        "message_option",
+        "prompt_option",
+    ],
     _ALL_SESSION_PARAM_COMBINATIONS,
 )
 def test_oauth2_get_authorize_url_supports_session_params(
@@ -84,6 +100,7 @@ def test_oauth2_get_authorize_url_supports_session_params(
     identity_option,
     policy_option,
     mfa_option,
+    message_option,
     prompt_option,
 ):
     if flow_type == "native_app":
@@ -100,6 +117,7 @@ def test_oauth2_get_authorize_url_supports_session_params(
         session_required_identities=identity_option,
         session_required_policies=policy_option,
         session_required_mfa=mfa_option,
+        session_message=message_option,
         prompt=prompt_option,
     )
 

--- a/tests/non-pytest/mypy-ignore-tests/get_authorize_url_supports_session_params.py
+++ b/tests/non-pytest/mypy-ignore-tests/get_authorize_url_supports_session_params.py
@@ -18,6 +18,7 @@ def generate_strs() -> t.Iterator[str]:
 url = ac.oauth2_get_authorize_url(session_required_identities="foo")
 url = ac.oauth2_get_authorize_url(session_required_single_domain="foo")
 url = ac.oauth2_get_authorize_url(session_required_policies="foo")
+url = ac.oauth2_get_authorize_url(session_message="foo")
 
 # or any iterable of strings
 url = ac.oauth2_get_authorize_url(session_required_identities=generate_strs())
@@ -32,6 +33,9 @@ url = ac.oauth2_get_authorize_url(session_required_policies=uuid.uuid4())
 url = ac.oauth2_get_authorize_url(
     session_required_single_domain=uuid.uuid4()  # type: ignore[arg-type]
 )
+url = ac.oauth2_get_authorize_url(
+    session_message=uuid.uuid4(),  # type: ignore[arg-type]
+)
 
 # integers and other non-str data are not acceptable
 url = ac.oauth2_get_authorize_url(
@@ -41,3 +45,4 @@ url = ac.oauth2_get_authorize_url(
     session_required_single_domain=1  # type: ignore[arg-type]
 )
 url = ac.oauth2_get_authorize_url(session_required_policies=1)  # type: ignore[arg-type]
+url = ac.oauth2_get_authorize_url(session_message=1)  # type: ignore[arg-type]


### PR DESCRIPTION
What it says on tin!

You can trivially test with:

```python
from globus_sdk import UserApp
from globus_sdk.gare import GlobusAuthorizationParameters

CLIENT_ID = "[YOUR CLIENT ID HERE]"

app = UserApp("sdk-session-message-test-app", client_id=CLIENT_ID)
auth_params = GlobusAuthorizationParameters(
    session_message="This is a test message",
    prompt="login",
)
app.login(auth_params=auth_params)
```

Then look for it in the generated URL. I clicked through to verify this is honored by Auth.

<img width="691" alt="Screenshot 2025-05-02 at 11 19 41" src="https://github.com/user-attachments/assets/7842b609-2fdf-4f6f-b9a3-d9ddf38cbe24" />



<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1179.org.readthedocs.build/en/1179/

<!-- readthedocs-preview globus-sdk-python end -->