### PR TITLE
Create an SDKv4 branch and pre-release publishing workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "main"
+      - "4.x-dev"
   pull_request: null
   # build weekly at 4:00 AM UTC
   schedule:

--- a/.github/workflows/update_pr_references.yaml
+++ b/.github/workflows/update_pr_references.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - 4.x-dev
 
 jobs:
   update_pr_numbers_in_change_fragments:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -60,3 +60,19 @@ or create the release via the GitHub CLI
   changes and a link to the GitHub release page.
   (If the Globus CLI is releasing within a short interval,
   combine both announcements into a single email notice.)
+
+- Ensure the 4.x-dev branch is updated with the latest changes from main
+    ```
+    git checkout 4.x-dev
+    git pull
+    git merge origin/main
+    git push origin 4.x-dev
+    ```
+
+## Publish Pre-release 4.x packages to PyPi
+
+The steps above for deploying a package to PyPI can be used to push pre-release packages by:
+
+* Using the 4.x-dev branch instead of the main branch
+* Creating and pushing a tag on the 4.x-dev branch
+* Publishing the release through GitHub using the 4.x-dev branch


### PR DESCRIPTION
[sc-40988](https://app.shortcut.com/globus/story/40988/python-sdk-create-an-sdkv4-branch-and-pre-release-publishing-workflow)

The 4.x-dev branch has been created with version set to [4.0.0a](https://github.com/globus/globus-sdk-python/blob/4.x-dev/src/globus_sdk/version.py#L3)

* Added 4.x-dev branch to github workflows
* Added notes in RELEASING.md to keep 4.x-dev branch up to date
* Added section on publishing 4.x pre-release packages to PyPi in RELEASING.md


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1180.org.readthedocs.build/en/1180/

<!-- readthedocs-preview globus-sdk-python end -->