### PR TITLE
Fix type annotation on filter_roles

### DIFF
--- a/changelog.d/20250505_160859_sirosen_bugfix_allow_iterable.rst
+++ b/changelog.d/20250505_160859_sirosen_bugfix_allow_iterable.rst
@@ -1,0 +1,5 @@
+Fixed
+~~~~~
+
+- Fix the type annotation on ``filter_roles`` for ``FlowsClient`` to allow
+  non-list iterables. (:pr:`NUMBER`)

--- a/src/globus_sdk/services/flows/client.py
+++ b/src/globus_sdk/services/flows/client.py
@@ -238,7 +238,7 @@ class FlowsClient(client.BaseClient):
         self,
         *,
         filter_role: str | None = None,
-        filter_roles: str | list[str] | None = None,
+        filter_roles: str | t.Iterable[str] | None = None,
         filter_fulltext: str | None = None,
         orderby: str | t.Iterable[str] | None = None,
         marker: str | None = None,
@@ -619,7 +619,7 @@ class FlowsClient(client.BaseClient):
         self,
         *,
         filter_flow_id: t.Iterable[UUIDLike] | UUIDLike | None = None,
-        filter_roles: str | list[str] | None = None,
+        filter_roles: str | t.Iterable[str] | None = None,
         marker: str | None = None,
         query_params: dict[str, t.Any] | None = None,
     ) -> IterableRunsResponse:

--- a/tests/functional/services/flows/test_list_flows.py
+++ b/tests/functional/services/flows/test_list_flows.py
@@ -152,18 +152,22 @@ def test_list_flows_mutually_exclusive_roles(flows_client, filter_role, filter_r
 @pytest.mark.parametrize(
     "filter_roles, expected_filter_roles",
     [
-        # empty list, list with empty string, and None do not send the param
+        # empty list/tuple, list/tuple with empty string, and None do not send the param
+        ((), None),
         ([], None),
         ([""], None),
+        (("",), None),
         (None, None),
         # single role as string
         ("foo", ["foo"]),
-        # single role as list
+        # single role as list/tuple
         (["foo"], ["foo"]),
+        (("foo",), ["foo"]),
         # multiple roles as comma-separated string
         ("foo,bar", ["foo,bar"]),
-        # multiple roles as list
+        # multiple roles as list/tuple
         (["foo", "bar"], ["foo,bar"]),
+        (("foo", "bar"), ["foo,bar"]),
     ],
 )
 def test_list_flows_with_filter_roles_parameter(

--- a/tests/functional/services/flows/test_list_runs.py
+++ b/tests/functional/services/flows/test_list_runs.py
@@ -74,18 +74,22 @@ def test_list_runs_filter_flow_id(flows_client, pass_as_uuids):
 @pytest.mark.parametrize(
     "filter_roles, expected_filter_roles",
     [
-        # empty list, list with empty string, and None do not send the param
+        # empty list/tuple, list/tuple with empty string, and None do not send the param
         ([], None),
+        ((), None),
         ([""], None),
+        (("",), None),
         (None, None),
         # single role as string
         ("foo", ["foo"]),
-        # single role as list
+        # single role as list/tuple
         (["foo"], ["foo"]),
+        (("foo",), ["foo"]),
         # multiple roles as comma-separated string
         ("foo,bar", ["foo,bar"]),
-        # multiple roles as list
+        # multiple roles as list/tuple
         (["foo", "bar"], ["foo,bar"]),
+        (("foo", "bar"), ["foo,bar"]),
     ],
 )
 def test_list_runs_filter_roles(flows_client, filter_roles, expected_filter_roles):


### PR DESCRIPTION
I just noticed this, post-release. It's a trivial fix to align with our other
type annotations and with the supported runtime behavior.

---

This is unnecessarily strict and doesn't match the way that we
annotate other parameters which pass through commajoin or the safe str
sequence handler.

Partly because `list` is invariant, and partly to allow for tuples,
generators, etc. we prefer Iterable or Sequence as appropriate.


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1183.org.readthedocs.build/en/1183/

<!-- readthedocs-preview globus-sdk-python end -->