### PR TITLE
Remove base_path from all client classes

### DIFF
--- a/changelog.d/20250512_144528_max.tuecke_sc_26346_remove_base_path_from_clients.rst
+++ b/changelog.d/20250512_144528_max.tuecke_sc_26346_remove_base_path_from_clients.rst
@@ -1,5 +1,5 @@
 Removed
 ~~~~~~~
 
-- SDK clients no longer define a ``base_path`` attribute which they prefix to paths.
+- SDK client classes no longer define nor prepend a ``base_path`` attribute which they prefix to paths.
   Make sure to use the full path now when using client methods. (:pr:`1185`)

--- a/changelog.d/20250512_144528_max.tuecke_sc_26346_remove_base_path_from_clients.rst
+++ b/changelog.d/20250512_144528_max.tuecke_sc_26346_remove_base_path_from_clients.rst
@@ -1,0 +1,5 @@
+Removed
+~~~~~~~
+
+- SDK clients no longer define a ``base_path`` attribute which they prefix to paths.
+  Make sure to use the full path now when using client methods. (:pr:`1185`)

--- a/src/globus_sdk/_testing/data/groups/create_group.py
+++ b/src/globus_sdk/_testing/data/groups/create_group.py
@@ -6,7 +6,7 @@ RESPONSES = ResponseSet(
     metadata={"group_id": GROUP_ID},
     default=RegisteredResponse(
         service="groups",
-        path="/groups",
+        path="/v2/groups",
         method="POST",
         json=BASE_GROUP_DOC,
     ),

--- a/src/globus_sdk/_testing/data/groups/delete_group.py
+++ b/src/globus_sdk/_testing/data/groups/delete_group.py
@@ -6,7 +6,7 @@ RESPONSES = ResponseSet(
     metadata={"group_id": GROUP_ID},
     default=RegisteredResponse(
         service="groups",
-        path=f"/groups/{GROUP_ID}",
+        path=f"/v2/groups/{GROUP_ID}",
         method="DELETE",
         json=BASE_GROUP_DOC,
     ),

--- a/src/globus_sdk/_testing/data/groups/get_group.py
+++ b/src/globus_sdk/_testing/data/groups/get_group.py
@@ -12,12 +12,12 @@ RESPONSES = ResponseSet(
     metadata={"group_id": GROUP_ID},
     default=RegisteredResponse(
         service="groups",
-        path=f"/groups/{GROUP_ID}",
+        path=f"/v2/groups/{GROUP_ID}",
         json=BASE_GROUP_DOC,
     ),
     subscription=RegisteredResponse(
         service="groups",
-        path=f"/groups/{SUBSCRIPTION_GROUP_ID}",
+        path=f"/v2/groups/{SUBSCRIPTION_GROUP_ID}",
         json=SUBSCRIPTION_GROUP_DOC,
         metadata={
             "group_id": SUBSCRIPTION_GROUP_ID,

--- a/src/globus_sdk/_testing/data/groups/get_group_by_subscription_id.py
+++ b/src/globus_sdk/_testing/data/groups/get_group_by_subscription_id.py
@@ -6,7 +6,7 @@ RESPONSES = ResponseSet(
     metadata={"group_id": SUBSCRIPTION_GROUP_ID, "subscription_id": SUBSCRIPTION_ID},
     default=RegisteredResponse(
         service="groups",
-        path=f"/subscription_info/{SUBSCRIPTION_ID}",
+        path=f"/v2/subscription_info/{SUBSCRIPTION_ID}",
         json={
             "group_id": SUBSCRIPTION_GROUP_ID,
             "subscription_id": SUBSCRIPTION_ID,

--- a/src/globus_sdk/_testing/data/groups/get_my_groups.py
+++ b/src/globus_sdk/_testing/data/groups/get_my_groups.py
@@ -175,7 +175,7 @@ RESPONSES = ResponseSet(
     },
     default=RegisteredResponse(
         service="groups",
-        path="/groups/my_groups",
+        path="/v2/groups/my_groups",
         json=raw_data,
     ),
 )

--- a/src/globus_sdk/_testing/data/groups/set_group_policies.py
+++ b/src/globus_sdk/_testing/data/groups/set_group_policies.py
@@ -6,7 +6,7 @@ RESPONSES = ResponseSet(
     metadata={"group_id": GROUP_ID},
     default=RegisteredResponse(
         service="groups",
-        path=f"/groups/{GROUP_ID}/policies",
+        path=f"/v2/groups/{GROUP_ID}/policies",
         method="PUT",
         json={
             "is_high_assurance": False,

--- a/src/globus_sdk/_testing/data/transfer/create_endpoint.py
+++ b/src/globus_sdk/_testing/data/transfer/create_endpoint.py
@@ -7,7 +7,7 @@ RESPONSES = ResponseSet(
     default=RegisteredResponse(
         service="transfer",
         method="POST",
-        path="/endpoint",
+        path="/v0.10/endpoint",
         json={
             "DATA_TYPE": "endpoint_create_result",
             "display_name": "my cool endpoint",
@@ -16,7 +16,7 @@ RESPONSES = ResponseSet(
             "id": ENDPOINT_ID,
             "message": "Endpoint created successfully",
             "request_id": "d4MqMwFJ9",
-            "resource": "/endpoint",
+            "resource": "/v0.10/endpoint",
         },
     ),
 )

--- a/src/globus_sdk/_testing/data/transfer/endpoint_manager_task_list.py
+++ b/src/globus_sdk/_testing/data/transfer/endpoint_manager_task_list.py
@@ -13,7 +13,7 @@ RESPONSES = ResponseSet(
     default=RegisteredResponse(
         service="transfer",
         method="GET",
-        path="/endpoint_manager/task_list",
+        path="/v0.10/endpoint_manager/task_list",
         metadata={
             "task_id": TASK_ID,
             "source": SRC_ENDPOINT_ID,

--- a/src/globus_sdk/_testing/data/transfer/endpoint_manager_task_successful_transfers.py
+++ b/src/globus_sdk/_testing/data/transfer/endpoint_manager_task_successful_transfers.py
@@ -7,7 +7,7 @@ RESPONSES = ResponseSet(
     default=RegisteredResponse(
         service="transfer",
         method="GET",
-        path=f"/endpoint_manager/task/{TASK_ID}/successful_transfers",
+        path=f"/v0.10/endpoint_manager/task/{TASK_ID}/successful_transfers",
         json={
             "DATA_TYPE": "successful_transfers",
             "marker": 0,

--- a/src/globus_sdk/_testing/data/transfer/get_endpoint.py
+++ b/src/globus_sdk/_testing/data/transfer/get_endpoint.py
@@ -57,7 +57,7 @@ RESPONSES = ResponseSet(
     metadata={"endpoint_id": ENDPOINT_ID},
     default=RegisteredResponse(
         service="transfer",
-        path=f"/endpoint/{ENDPOINT_ID}",
+        path=f"/v0.10/endpoint/{ENDPOINT_ID}",
         json=ENDPOINT_DOC,
     ),
 )

--- a/src/globus_sdk/_testing/data/transfer/get_submission_id.py
+++ b/src/globus_sdk/_testing/data/transfer/get_submission_id.py
@@ -6,7 +6,7 @@ RESPONSES = ResponseSet(
     metadata={"submission_id": SUBMISSION_ID},
     default=RegisteredResponse(
         service="transfer",
-        path="/submission_id",
+        path="/v0.10/submission_id",
         json={"value": SUBMISSION_ID},
     ),
 )

--- a/src/globus_sdk/_testing/data/transfer/operation_mkdir.py
+++ b/src/globus_sdk/_testing/data/transfer/operation_mkdir.py
@@ -7,13 +7,13 @@ RESPONSES = ResponseSet(
     default=RegisteredResponse(
         service="transfer",
         method="POST",
-        path=f"/operation/endpoint/{ENDPOINT_ID}/mkdir",
+        path=f"/v0.10/operation/endpoint/{ENDPOINT_ID}/mkdir",
         json={
             "DATA_TYPE": "mkdir_result",
             "code": "DirectoryCreated",
             "message": "The directory was created successfully",
             "request_id": "ShbIUzrWT",
-            "resource": f"/operation/endpoint/{ENDPOINT_ID}/mkdir",
+            "resource": f"/v0.10/operation/endpoint/{ENDPOINT_ID}/mkdir",
         },
     ),
 )

--- a/src/globus_sdk/_testing/data/transfer/operation_rename.py
+++ b/src/globus_sdk/_testing/data/transfer/operation_rename.py
@@ -7,13 +7,13 @@ RESPONSES = ResponseSet(
     default=RegisteredResponse(
         service="transfer",
         method="POST",
-        path=f"/operation/endpoint/{ENDPOINT_ID}/rename",
+        path=f"/v0.10/operation/endpoint/{ENDPOINT_ID}/rename",
         json={
             "DATA_TYPE": "result",
             "code": "FileRenamed",
             "message": "File or directory renamed successfully",
             "request_id": "ShbIUzrWT",
-            "resource": f"/operation/endpoint/{ENDPOINT_ID}/rename",
+            "resource": f"/v0.10/operation/endpoint/{ENDPOINT_ID}/rename",
         },
     ),
 )

--- a/src/globus_sdk/_testing/data/transfer/operation_stat.py
+++ b/src/globus_sdk/_testing/data/transfer/operation_stat.py
@@ -7,7 +7,7 @@ RESPONSES = ResponseSet(
     default=RegisteredResponse(
         service="transfer",
         method="GET",
-        path=f"/operation/endpoint/{ENDPOINT_ID}/stat",
+        path=f"/v0.10/operation/endpoint/{ENDPOINT_ID}/stat",
         json={
             "DATA_TYPE": "file",
             "group": "tutorial",
@@ -27,25 +27,25 @@ RESPONSES = ResponseSet(
     not_found=RegisteredResponse(
         service="transfer",
         method="GET",
-        path=f"/operation/endpoint/{ENDPOINT_ID}/stat",
+        path=f"/v0.10/operation/endpoint/{ENDPOINT_ID}/stat",
         status=404,
         json={
             "code": "NotFound",
             "message": f"Path not found, Error (list)\nEndpoint: Globus Tutorial Collection 1 ({ENDPOINT_ID})\nServer: 100.26.231.26:443\nMessage: No such file or directory\n---\nDetails: Error: '~/foo' not found\\r\\n550-GlobusError: v=1 c=PATH_NOT_FOUND\\r\\n550-GridFTP-Errno: 2\\r\\n550-GridFTP-Reason: System error in stat\\r\\n550-GridFTP-Error-String: No such file or directory\\r\\n550 End.\\r\\n\n",  # noqa 501
             "request_id": "aaabbbccc",
-            "resource": f"/operation/endpoint/{ENDPOINT_ID}/stat",
+            "resource": f"/v0.10/operation/endpoint/{ENDPOINT_ID}/stat",
         },
     ),
     permission_denied=RegisteredResponse(
         service="transfer",
         method="GET",
-        path=f"/operation/endpoint/{ENDPOINT_ID}/stat",
+        path=f"/v0.10/operation/endpoint/{ENDPOINT_ID}/stat",
         status=403,
         json={
             "code": "EndpointPermissionDenied",
             "message": f"Denied by endpoint, Error (list)\nEndpoint: Globus Tutorial Collection 1 ({ENDPOINT_ID})\nServer: 100.26.231.26:443\nCommand: MLST /foo\nMessage: Fatal FTP Response\n---\nDetails: 500 Command failed : Path not allowed.\\r\\n\n",  # noqa 501
             "request_id": "aaabbbccc",
-            "resource": f"/operation/endpoint/{ENDPOINT_ID}/stat",
+            "resource": f"/v0.10/operation/endpoint/{ENDPOINT_ID}/stat",
         },
     ),
 )

--- a/src/globus_sdk/_testing/data/transfer/set_subscription_id.py
+++ b/src/globus_sdk/_testing/data/transfer/set_subscription_id.py
@@ -11,31 +11,31 @@ RESPONSES = ResponseSet(
     default=RegisteredResponse(
         service="transfer",
         method="PUT",
-        path=f"/endpoint/{ENDPOINT_ID}/subscription",
+        path=f"/v0.10/endpoint/{ENDPOINT_ID}/subscription",
         json={
             "DATA_TYPE": "result",
             "code": "Updated",
             "message": "Endpoint updated successfully",
             "request_id": "dWTZZe17L",
-            "resource": f"/endpoint/{ENDPOINT_ID}/subscription",
+            "resource": f"/v0.10/endpoint/{ENDPOINT_ID}/subscription",
         },
     ),
     not_found=RegisteredResponse(
         service="transfer",
         method="PUT",
-        path=f"/endpoint/{ENDPOINT_ID}/subscription",
+        path=f"/v0.10/endpoint/{ENDPOINT_ID}/subscription",
         status=404,
         json={
             "code": "EndpointNotFound",
             "message": f"No such endpoint '{ENDPOINT_ID}'",
             "request_id": "BHI2BHt8N",
-            "resource": f"/endpoint/{ENDPOINT_ID}/subscription",
+            "resource": f"/v0.10/endpoint/{ENDPOINT_ID}/subscription",
         },
     ),
     multi_subscriber_cannot_use_default=RegisteredResponse(
         service="transfer",
         method="PUT",
-        path=f"/endpoint/{ENDPOINT_ID}/subscription",
+        path=f"/v0.10/endpoint/{ENDPOINT_ID}/subscription",
         status=400,
         json={
             "code": "BadRequest",
@@ -45,7 +45,7 @@ RESPONSES = ResponseSet(
                 f"{SUBSCRIPTION_ID}, {OTHER_SUBSCRIPTION_ID}"
             ),
             "request_id": "H1dFNg6QB",
-            "resource": f"/endpoint/{ENDPOINT_ID}/subscription",
+            "resource": f"/v0.10/endpoint/{ENDPOINT_ID}/subscription",
         },
         metadata={
             "endpoint_id": ENDPOINT_ID,

--- a/src/globus_sdk/_testing/data/transfer/submit_delete.py
+++ b/src/globus_sdk/_testing/data/transfer/submit_delete.py
@@ -7,7 +7,7 @@ RESPONSES = ResponseSet(
     default=RegisteredResponse(
         service="transfer",
         method="POST",
-        path="/delete",
+        path="/v0.10/delete",
         json={
             "DATA_TYPE": "delete_result",
             "code": "Accepted",
@@ -16,12 +16,12 @@ RESPONSES = ResponseSet(
                 "and queued for execution"
             ),
             "request_id": "NS2QXhLZ7",
-            "resource": "/delete",
+            "resource": "/v0.10/delete",
             "submission_id": SUBMISSION_ID,
             "task_id": TASK_ID,
             "task_link": {
                 "DATA_TYPE": "link",
-                "href": f"task/{TASK_ID}?format=json",
+                "href": f"/v0.10/task/{TASK_ID}?format=json",
                 "rel": "related",
                 "resource": "task",
                 "title": "related task",

--- a/src/globus_sdk/_testing/data/transfer/submit_transfer.py
+++ b/src/globus_sdk/_testing/data/transfer/submit_transfer.py
@@ -7,7 +7,7 @@ RESPONSES = ResponseSet(
     default=RegisteredResponse(
         service="transfer",
         method="POST",
-        path="/transfer",
+        path="/v0.10/transfer",
         json={
             "DATA_TYPE": "transfer_result",
             "code": "Accepted",
@@ -16,12 +16,12 @@ RESPONSES = ResponseSet(
                 "and queued for execution"
             ),
             "request_id": "7HgMVYazI",
-            "resource": "/transfer",
+            "resource": "/v0.10/transfer",
             "submission_id": SUBMISSION_ID,
             "task_id": TASK_ID,
             "task_link": {
                 "DATA_TYPE": "link",
-                "href": f"task/{TASK_ID}?format=json",
+                "href": f"/v0.10/task/{TASK_ID}?format=json",
                 "rel": "related",
                 "resource": "task",
                 "title": "related task",
@@ -31,12 +31,12 @@ RESPONSES = ResponseSet(
     failure=RegisteredResponse(
         service="transfer",
         method="POST",
-        path="/transfer",
+        path="/v0.10/transfer",
         json={
             "code": "ClientError.BadRequest.NoTransferItems",
             "message": "A transfer requires at least one item",
             "request_id": "oUAA6Sq2P",
-            "resource": "/transfer",
+            "resource": "/v0.10/transfer",
         },
         status=400,
         metadata={

--- a/src/globus_sdk/_testing/data/transfer/task_list.py
+++ b/src/globus_sdk/_testing/data/transfer/task_list.py
@@ -85,7 +85,7 @@ RESPONSES = ResponseSet(
     },
     default=RegisteredResponse(
         service="transfer",
-        path="/task_list",
+        path="/v0.10/task_list",
         json=TASK_LIST_DOC,
     ),
 )

--- a/src/globus_sdk/_testing/data/transfer/update_endpoint.py
+++ b/src/globus_sdk/_testing/data/transfer/update_endpoint.py
@@ -7,13 +7,13 @@ RESPONSES = ResponseSet(
     default=RegisteredResponse(
         service="transfer",
         method="PUT",
-        path=f"/endpoint/{ENDPOINT_ID}",
+        path=f"/v0.10/endpoint/{ENDPOINT_ID}",
         json={
             "DATA_TYPE": "result",
             "code": "Updated",
             "message": "Endpoint updated successfully",
             "request_id": "6aZjzldyM",
-            "resource": f"/endpoint/{ENDPOINT_ID}",
+            "resource": f"/v0.10/endpoint/{ENDPOINT_ID}",
         },
     ),
 )

--- a/src/globus_sdk/_testing/models.py
+++ b/src/globus_sdk/_testing/models.py
@@ -39,15 +39,11 @@ class RegisteredResponse:
         "nexus": "https://nexus.api.globusonline.org/",
         "transfer": "https://transfer.api.globus.org/",
         "search": "https://search.api.globus.org/",
-        "gcs": "https://abc.xyz.data.globus.org/api",
+        "gcs": "https://abc.xyz.data.globus.org/api/",
         "groups": "https://groups.api.globus.org/",
         "timer": "https://timer.automate.globus.org/",
         "flows": "https://flows.automate.globus.org/",
         "compute": "https://compute.api.globus.org/",
-    }
-    _path_prefix_map = {
-        "transfer": "/v0.10/",
-        "groups": "/v2/",
     }
 
     def __init__(
@@ -105,12 +101,6 @@ class RegisteredResponse:
         self.service = service
 
         if service:
-            # ensure a registered response path is prefixed by _path_prefix_map
-            # this allows a registered response to use a path like `/groups` with
-            # the GroupsClient, rather than *requiring* it use the full `/v2/groups`
-            path_prefix = self._path_prefix_map.get(service)
-            if path_prefix and not path.startswith(path_prefix):
-                path = slash_join(path_prefix, path)
             self.full_url = slash_join(self._url_map[service], path)
         else:
             self.full_url = path

--- a/src/globus_sdk/_testing/models.py
+++ b/src/globus_sdk/_testing/models.py
@@ -37,15 +37,15 @@ class RegisteredResponse:
     _url_map = {
         "auth": "https://auth.globus.org/",
         "nexus": "https://nexus.api.globusonline.org/",
-        "transfer": "https://transfer.api.globus.org/v0.10",
+        "transfer": "https://transfer.api.globus.org/",
         "search": "https://search.api.globus.org/",
         "gcs": "https://abc.xyz.data.globus.org/api",
-        "groups": "https://groups.api.globus.org/v2/",
+        "groups": "https://groups.api.globus.org/",
         "timer": "https://timer.automate.globus.org/",
         "flows": "https://flows.automate.globus.org/",
         "compute": "https://compute.api.globus.org/",
     }
-    _base_path_map = {
+    _path_prefix_map = {
         "transfer": "/v0.10/",
         "groups": "/v2/",
     }
@@ -105,13 +105,12 @@ class RegisteredResponse:
         self.service = service
 
         if service:
-            # strip base_paths to match the behavior of clients
-            # this allows a registered response to use a path like `/v2/groups` with
-            # the GroupsClient, rather than *requiring* that it use `/groups`
-            base_path = self._base_path_map.get(service)
-            if base_path and path.startswith(base_path):
-                path = path[len(base_path) :]
-
+            # ensure a registered response path is prefixed by _path_prefix_map
+            # this allows a registered response to use a path like `/groups` with
+            # the GroupsClient, rather than *requiring* it use the full `/v2/groups`
+            path_prefix = self._path_prefix_map.get(service)
+            if path_prefix and not path.startswith(path_prefix):
+                path = slash_join(path_prefix, path)
             self.full_url = slash_join(self._url_map[service], path)
         else:
             self.full_url = path

--- a/src/globus_sdk/client.py
+++ b/src/globus_sdk/client.py
@@ -100,9 +100,6 @@ class BaseClient:
         # resolve the base_url for the client (see docstring for resolution precedence)
         self.base_url = self._resolve_base_url(base_url, self.environment)
 
-        # ensure base_url always has a trailing slash
-        self.base_url = utils.slash_join(self.base_url, "/")
-
         self.transport = self.transport_class(**(transport_params or {}))
         log.debug(f"initialized transport of type {type(self.transport)}")
 

--- a/src/globus_sdk/client.py
+++ b/src/globus_sdk/client.py
@@ -54,12 +54,6 @@ class BaseClient:
     # `BaseClient._resolve_base_url` method for more details.
     base_url: str = "_base"
 
-    # path under the client base URL
-    # NOTE: using this attribute is now considered bad practice for client definitions,
-    # as it prevents calls to new routes at the root of an API's base_url
-    # Consider removing in a future release
-    base_path: str = "/"
-
     #: the class for errors raised by this client on HTTP 4xx and 5xx errors
     #: this can be set in subclasses, but must always be a subclass of GlobusError
     error_class: type[exc.GlobusAPIError] = exc.GlobusAPIError
@@ -105,8 +99,9 @@ class BaseClient:
 
         # resolve the base_url for the client (see docstring for resolution precedence)
         self.base_url = self._resolve_base_url(base_url, self.environment)
-        # append the base_path to the base_url if necessary
-        self.base_url = utils.slash_join(self.base_url, self.base_path)
+
+        # ensure base_url always has a trailing slash
+        self.base_url = utils.slash_join(self.base_url, "/")
 
         self.transport = self.transport_class(**(transport_params or {}))
         log.debug(f"initialized transport of type {type(self.transport)}")
@@ -484,11 +479,6 @@ class BaseClient:
         if path.startswith("https://") or path.startswith("http://"):
             url = path
         else:
-            # if passed a path which has a prefix matching the base_path, strip it
-            # this means that if a client has a base path of `/v1/`, a request for
-            # `/v1/foo` will hit `/v1/foo` rather than `/v1/v1/foo`
-            if path.startswith(self.base_path):
-                path = path[len(self.base_path) :]
             url = utils.slash_join(self.base_url, urllib.parse.quote(path))
 
         # either use given authorizer or get one from app

--- a/src/globus_sdk/services/groups/client.py
+++ b/src/globus_sdk/services/groups/client.py
@@ -24,9 +24,6 @@ class GroupsClient(client.BaseClient):
     .. automethodlist:: globus_sdk.GroupsClient
     """
 
-    # NOTE: setting base_path is no longer considered good practice
-    #       see the BaseClient source for details
-    base_path = "/v2/"
     error_class = GroupsAPIError
     service_name = "groups"
     scopes = GroupsScopes
@@ -54,7 +51,7 @@ class GroupsClient(client.BaseClient):
                     :ref: get_my_groups_and_memberships_v2_groups_my_groups_get
         """
         return response.ArrayResponse(
-            self.get("/groups/my_groups", query_params=query_params)
+            self.get("/v2/groups/my_groups", query_params=query_params)
         )
 
     def get_group(
@@ -87,7 +84,7 @@ class GroupsClient(client.BaseClient):
             query_params = {}
         if include is not None:
             query_params["include"] = ",".join(utils.safe_strseq_iter(include))
-        return self.get(f"/groups/{group_id}", query_params=query_params)
+        return self.get(f"/v2/groups/{group_id}", query_params=query_params)
 
     def get_group_by_subscription_id(
         self, subscription_id: UUIDLike
@@ -120,7 +117,7 @@ class GroupsClient(client.BaseClient):
                     :service: groups
                     :ref: get_group_by_subscription_id_v2_subscription_info__subscription_id__get
         """  # noqa: E501
-        return self.get(f"/subscription_info/{subscription_id}")
+        return self.get(f"/v2/subscription_info/{subscription_id}")
 
     def delete_group(
         self,
@@ -144,7 +141,7 @@ class GroupsClient(client.BaseClient):
                     :service: groups
                     :ref: delete_group_v2_groups__group_id__delete
         """
-        return self.delete(f"/groups/{group_id}", query_params=query_params)
+        return self.delete(f"/v2/groups/{group_id}", query_params=query_params)
 
     def create_group(
         self,
@@ -168,7 +165,7 @@ class GroupsClient(client.BaseClient):
                     :service: groups
                     :ref: create_group_v2_groups_post
         """
-        return self.post("/groups", data=data, query_params=query_params)
+        return self.post("/v2/groups", data=data, query_params=query_params)
 
     def update_group(
         self,
@@ -194,7 +191,7 @@ class GroupsClient(client.BaseClient):
                     :service: groups
                     :ref: update_group_v2_groups__group_id__put
         """
-        return self.put(f"/groups/{group_id}", data=data, query_params=query_params)
+        return self.put(f"/v2/groups/{group_id}", data=data, query_params=query_params)
 
     def get_group_policies(
         self,
@@ -218,7 +215,7 @@ class GroupsClient(client.BaseClient):
                     :service: groups
                     :ref: get_policies_v2_groups__group_id__policies_get
         """
-        return self.get(f"/groups/{group_id}/policies", query_params=query_params)
+        return self.get(f"/v2/groups/{group_id}/policies", query_params=query_params)
 
     def set_group_policies(
         self,
@@ -245,7 +242,7 @@ class GroupsClient(client.BaseClient):
                     :ref: update_policies_v2_groups__group_id__policies_put
         """
         return self.put(
-            f"/groups/{group_id}/policies", data=data, query_params=query_params
+            f"/v2/groups/{group_id}/policies", data=data, query_params=query_params
         )
 
     def get_identity_preferences(
@@ -267,7 +264,7 @@ class GroupsClient(client.BaseClient):
                     :service: groups
                     :ref: get_identity_set_preferences_v2_preferences_get
         """
-        return self.get("/preferences", query_params=query_params)
+        return self.get("/v2/preferences", query_params=query_params)
 
     def set_identity_preferences(
         self,
@@ -299,7 +296,7 @@ class GroupsClient(client.BaseClient):
                     :service: groups
                     :ref: put_identity_set_preferences_v2_preferences_put
         """
-        return self.put("/preferences", data=data, query_params=query_params)
+        return self.put("/v2/preferences", data=data, query_params=query_params)
 
     def get_membership_fields(
         self,
@@ -324,7 +321,7 @@ class GroupsClient(client.BaseClient):
                     :ref: get_membership_fields_v2_groups__group_id__membership_fields_get
         """  # noqa: E501
         return self.get(
-            f"/groups/{group_id}/membership_fields", query_params=query_params
+            f"/v2/groups/{group_id}/membership_fields", query_params=query_params
         )
 
     def set_membership_fields(
@@ -352,7 +349,7 @@ class GroupsClient(client.BaseClient):
                     :ref: put_membership_fields_v2_groups__group_id__membership_fields_put
         """  # noqa: E501
         return self.put(
-            f"/groups/{group_id}/membership_fields",
+            f"/v2/groups/{group_id}/membership_fields",
             data=data,
             query_params=query_params,
         )
@@ -393,4 +390,6 @@ class GroupsClient(client.BaseClient):
                     :service: groups
                     :ref: group_membership_post_actions_v2_groups__group_id__post
         """
-        return self.post(f"/groups/{group_id}", data=actions, query_params=query_params)
+        return self.post(
+            f"/v2/groups/{group_id}", data=actions, query_params=query_params
+        )

--- a/src/globus_sdk/services/transfer/client.py
+++ b/src/globus_sdk/services/transfer/client.py
@@ -103,9 +103,6 @@ class TransferClient(client.BaseClient):
     """
 
     service_name = "transfer"
-    # NOTE: setting base_path is no longer considered good practice
-    #       see the BaseClient source for details
-    base_path = "/v0.10/"
     transport_class: type[TransferRequestsTransport] = TransferRequestsTransport
     error_class = TransferAPIError
     scopes = TransferScopes
@@ -222,7 +219,7 @@ class TransferClient(client.BaseClient):
                     :ref: transfer/endpoints_and_collections/#get_endpoint_or_collection_by_id
         """  # noqa: E501
         log.debug(f"TransferClient.get_endpoint({endpoint_id})")
-        return self.get(f"endpoint/{endpoint_id}", query_params=query_params)
+        return self.get(f"/v0.10/endpoint/{endpoint_id}", query_params=query_params)
 
     def update_endpoint(
         self,
@@ -270,7 +267,9 @@ class TransferClient(client.BaseClient):
             data["myproxy_server"] = None
 
         log.debug(f"TransferClient.update_endpoint({endpoint_id}, ...)")
-        return self.put(f"endpoint/{endpoint_id}", data=data, query_params=query_params)
+        return self.put(
+            f"/v0.10/endpoint/{endpoint_id}", data=data, query_params=query_params
+        )
 
     def set_subscription_id(
         self,
@@ -327,7 +326,7 @@ class TransferClient(client.BaseClient):
                     :ref: transfer/gcp_management/#associate_collection_subscription
         """  # noqa: E501
         return self.put(
-            f"/endpoint/{collection_id}/subscription",
+            f"/v0.10/endpoint/{collection_id}/subscription",
             data={"subscription_id": subscription_id},
         )
 
@@ -348,7 +347,7 @@ class TransferClient(client.BaseClient):
             )
 
         log.debug("TransferClient.create_endpoint(...)")
-        return self.post("endpoint", data=data)
+        return self.post("/v0.10/endpoint", data=data)
 
     def delete_endpoint(self, endpoint_id: UUIDLike) -> response.GlobusHTTPResponse:
         """
@@ -371,7 +370,7 @@ class TransferClient(client.BaseClient):
                     :ref: transfer/gcp_management/#delete_collection_by_id
         """
         log.debug(f"TransferClient.delete_endpoint({endpoint_id})")
-        return self.delete(f"endpoint/{endpoint_id}")
+        return self.delete(f"/v0.10/endpoint/{endpoint_id}")
 
     @paging.has_paginator(
         paging.HasNextPaginator,
@@ -482,7 +481,7 @@ class TransferClient(client.BaseClient):
             query_params["offset"] = offset
         log.debug(f"TransferClient.endpoint_search({query_params})")
         return IterableTransferResponse(
-            self.get("endpoint_search", query_params=query_params)
+            self.get("/v0.10/endpoint_search", query_params=query_params)
         )
 
     def endpoint_autoactivate(
@@ -511,7 +510,7 @@ class TransferClient(client.BaseClient):
             query_params["if_expires_in"] = if_expires_in
         log.debug(f"TransferClient.endpoint_autoactivate({endpoint_id})")
         return self.post(
-            f"endpoint/{endpoint_id}/autoactivate", query_params=query_params
+            f"/v0.10/endpoint/{endpoint_id}/autoactivate", query_params=query_params
         )
 
     def endpoint_deactivate(
@@ -532,7 +531,7 @@ class TransferClient(client.BaseClient):
         """
         log.debug(f"TransferClient.endpoint_deactivate({endpoint_id})")
         return self.post(
-            f"endpoint/{endpoint_id}/deactivate", query_params=query_params
+            f"/v0.10/endpoint/{endpoint_id}/deactivate", query_params=query_params
         )
 
     def endpoint_activate(
@@ -558,7 +557,7 @@ class TransferClient(client.BaseClient):
         """
         log.debug(f"TransferClient.endpoint_activate({endpoint_id})")
         return self.post(
-            f"endpoint/{endpoint_id}/activate",
+            f"/v0.10/endpoint/{endpoint_id}/activate",
             data=requirements_data,
             query_params=query_params,
         )
@@ -582,7 +581,7 @@ class TransferClient(client.BaseClient):
         """
         return ActivationRequirementsResponse(
             self.get(
-                f"endpoint/{endpoint_id}/activation_requirements",
+                f"/v0.10/endpoint/{endpoint_id}/activation_requirements",
                 query_params=query_params,
             )
         )
@@ -610,7 +609,7 @@ class TransferClient(client.BaseClient):
         log.debug(f"TransferClient.my_effective_pause_rule_list({endpoint_id}, ...)")
         return IterableTransferResponse(
             self.get(
-                f"endpoint/{endpoint_id}/my_effective_pause_rule_list",
+                f"/v0.10/endpoint/{endpoint_id}/my_effective_pause_rule_list",
                 query_params=query_params,
             )
         )
@@ -642,7 +641,7 @@ class TransferClient(client.BaseClient):
         log.debug(f"TransferClient.my_shared_endpoint_list({endpoint_id}, ...)")
         return IterableTransferResponse(
             self.get(
-                f"endpoint/{endpoint_id}/my_shared_endpoint_list",
+                f"/v0.10/endpoint/{endpoint_id}/my_shared_endpoint_list",
                 query_params=query_params,
             )
         )
@@ -687,7 +686,7 @@ class TransferClient(client.BaseClient):
             query_params["next_token"] = next_token
         return IterableTransferResponse(
             self.get(
-                f"endpoint/{endpoint_id}/shared_endpoint_list",
+                f"/v0.10/endpoint/{endpoint_id}/shared_endpoint_list",
                 query_params=query_params,
             ),
             iter_key="shared_endpoints",
@@ -725,7 +724,7 @@ class TransferClient(client.BaseClient):
                     :ref: transfer/gcp_management/#create_guest_collection
         """
         log.debug("TransferClient.create_shared_endpoint(...)")
-        return self.post("shared_endpoint", data=data)
+        return self.post("/v0.10/shared_endpoint", data=data)
 
     # Endpoint servers
 
@@ -751,7 +750,9 @@ class TransferClient(client.BaseClient):
         """  # noqa: E501
         log.debug(f"TransferClient.endpoint_server_list({endpoint_id}, ...)")
         return IterableTransferResponse(
-            self.get(f"endpoint/{endpoint_id}/server_list", query_params=query_params)
+            self.get(
+                f"/v0.10/endpoint/{endpoint_id}/server_list", query_params=query_params
+            )
         )
 
     def get_endpoint_server(
@@ -779,7 +780,8 @@ class TransferClient(client.BaseClient):
             "TransferClient.get_endpoint_server(%s, %s, ...)", endpoint_id, server_id
         )
         return self.get(
-            f"endpoint/{endpoint_id}/server/{server_id}", query_params=query_params
+            f"/v0.10/endpoint/{endpoint_id}/server/{server_id}",
+            query_params=query_params,
         )
 
     def add_endpoint_server(
@@ -795,7 +797,7 @@ class TransferClient(client.BaseClient):
         :param server_data: Fields for the new server, as a server document
         """
         log.debug(f"TransferClient.add_endpoint_server({endpoint_id}, ...)")
-        return self.post(f"endpoint/{endpoint_id}/server", data=server_data)
+        return self.post(f"/v0.10/endpoint/{endpoint_id}/server", data=server_data)
 
     def update_endpoint_server(
         self,
@@ -818,7 +820,9 @@ class TransferClient(client.BaseClient):
             endpoint_id,
             server_id,
         )
-        return self.put(f"endpoint/{endpoint_id}/server/{server_id}", data=server_data)
+        return self.put(
+            f"/v0.10/endpoint/{endpoint_id}/server/{server_id}", data=server_data
+        )
 
     def delete_endpoint_server(
         self, endpoint_id: UUIDLike, server_id: IntLike
@@ -835,7 +839,7 @@ class TransferClient(client.BaseClient):
         log.debug(
             "TransferClient.delete_endpoint_server(%s, %s)", endpoint_id, server_id
         )
-        return self.delete(f"endpoint/{endpoint_id}/server/{server_id}")
+        return self.delete(f"/v0.10/endpoint/{endpoint_id}/server/{server_id}")
 
     #
     # Roles
@@ -863,7 +867,9 @@ class TransferClient(client.BaseClient):
         """
         log.debug(f"TransferClient.endpoint_role_list({endpoint_id}, ...)")
         return IterableTransferResponse(
-            self.get(f"endpoint/{endpoint_id}/role_list", query_params=query_params)
+            self.get(
+                f"/v0.10/endpoint/{endpoint_id}/role_list", query_params=query_params
+            )
         )
 
     def add_endpoint_role(
@@ -883,7 +889,7 @@ class TransferClient(client.BaseClient):
                     :ref: transfer/roles/#create_role
         """
         log.debug(f"TransferClient.add_endpoint_role({endpoint_id}, ...)")
-        return self.post(f"endpoint/{endpoint_id}/role", data=role_data)
+        return self.post(f"/v0.10/endpoint/{endpoint_id}/role", data=role_data)
 
     def get_endpoint_role(
         self,
@@ -908,7 +914,7 @@ class TransferClient(client.BaseClient):
         """
         log.debug(f"TransferClient.get_endpoint_role({endpoint_id}, {role_id}, ...)")
         return self.get(
-            f"endpoint/{endpoint_id}/role/{role_id}", query_params=query_params
+            f"/v0.10/endpoint/{endpoint_id}/role/{role_id}", query_params=query_params
         )
 
     def delete_endpoint_role(
@@ -928,7 +934,7 @@ class TransferClient(client.BaseClient):
                     :ref: transfer/roles/#delete_role_by_id
         """
         log.debug(f"TransferClient.delete_endpoint_role({endpoint_id}, {role_id})")
-        return self.delete(f"endpoint/{endpoint_id}/role/{role_id}")
+        return self.delete(f"/v0.10/endpoint/{endpoint_id}/role/{role_id}")
 
     #
     # ACLs
@@ -955,7 +961,9 @@ class TransferClient(client.BaseClient):
         """
         log.debug(f"TransferClient.endpoint_acl_list({endpoint_id}, ...)")
         return IterableTransferResponse(
-            self.get(f"endpoint/{endpoint_id}/access_list", query_params=query_params)
+            self.get(
+                f"/v0.10/endpoint/{endpoint_id}/access_list", query_params=query_params
+            )
         )
 
     def get_endpoint_acl_rule(
@@ -983,7 +991,7 @@ class TransferClient(client.BaseClient):
             "TransferClient.get_endpoint_acl_rule(%s, %s, ...)", endpoint_id, rule_id
         )
         return self.get(
-            f"endpoint/{endpoint_id}/access/{rule_id}", query_params=query_params
+            f"/v0.10/endpoint/{endpoint_id}/access/{rule_id}", query_params=query_params
         )
 
     def add_endpoint_acl_rule(
@@ -1021,7 +1029,7 @@ class TransferClient(client.BaseClient):
                     :ref: transfer/acl/#rest_access_create
         """
         log.debug(f"TransferClient.add_endpoint_acl_rule({endpoint_id}, ...)")
-        return self.post(f"endpoint/{endpoint_id}/access", data=rule_data)
+        return self.post(f"/v0.10/endpoint/{endpoint_id}/access", data=rule_data)
 
     def update_endpoint_acl_rule(
         self,
@@ -1048,7 +1056,9 @@ class TransferClient(client.BaseClient):
             endpoint_id,
             rule_id,
         )
-        return self.put(f"endpoint/{endpoint_id}/access/{rule_id}", data=rule_data)
+        return self.put(
+            f"/v0.10/endpoint/{endpoint_id}/access/{rule_id}", data=rule_data
+        )
 
     def delete_endpoint_acl_rule(
         self, endpoint_id: UUIDLike, rule_id: str
@@ -1069,7 +1079,7 @@ class TransferClient(client.BaseClient):
         log.debug(
             "TransferClient.delete_endpoint_acl_rule(%s, %s)", endpoint_id, rule_id
         )
-        return self.delete(f"endpoint/{endpoint_id}/access/{rule_id}")
+        return self.delete(f"/v0.10/endpoint/{endpoint_id}/access/{rule_id}")
 
     #
     # Bookmarks
@@ -1092,7 +1102,7 @@ class TransferClient(client.BaseClient):
         """
         log.debug(f"TransferClient.bookmark_list({query_params})")
         return IterableTransferResponse(
-            self.get("bookmark_list", query_params=query_params)
+            self.get("/v0.10/bookmark_list", query_params=query_params)
         )
 
     def create_bookmark(
@@ -1111,7 +1121,7 @@ class TransferClient(client.BaseClient):
                     :ref: transfer/collection_bookmarks/#create_bookmark
         """
         log.debug(f"TransferClient.create_bookmark({bookmark_data})")
-        return self.post("bookmark", data=bookmark_data)
+        return self.post("/v0.10/bookmark", data=bookmark_data)
 
     def get_bookmark(
         self,
@@ -1133,7 +1143,7 @@ class TransferClient(client.BaseClient):
                     :ref: transfer/collection_bookmarks/#get_bookmark_by_id
         """
         log.debug(f"TransferClient.get_bookmark({bookmark_id})")
-        return self.get(f"bookmark/{bookmark_id}", query_params=query_params)
+        return self.get(f"/v0.10/bookmark/{bookmark_id}", query_params=query_params)
 
     def update_bookmark(
         self, bookmark_id: UUIDLike, bookmark_data: dict[str, t.Any]
@@ -1152,7 +1162,7 @@ class TransferClient(client.BaseClient):
                     :ref: transfer/collection_bookmarks/#update_bookmark
         """
         log.debug(f"TransferClient.update_bookmark({bookmark_id})")
-        return self.put(f"bookmark/{bookmark_id}", data=bookmark_data)
+        return self.put(f"/v0.10/bookmark/{bookmark_id}", data=bookmark_data)
 
     def delete_bookmark(self, bookmark_id: UUIDLike) -> response.GlobusHTTPResponse:
         """
@@ -1168,7 +1178,7 @@ class TransferClient(client.BaseClient):
                     :ref: transfer/collection_bookmarks/#delete_bookmark_by_id
         """
         log.debug(f"TransferClient.delete_bookmark({bookmark_id})")
-        return self.delete(f"bookmark/{bookmark_id}")
+        return self.delete(f"/v0.10/bookmark/{bookmark_id}")
 
     #
     # Synchronous Filesys Operations
@@ -1283,7 +1293,9 @@ class TransferClient(client.BaseClient):
 
         log.debug(f"TransferClient.operation_ls({endpoint_id}, {query_params})")
         return IterableTransferResponse(
-            self.get(f"operation/endpoint/{endpoint_id}/ls", query_params=query_params)
+            self.get(
+                f"/v0.10/operation/endpoint/{endpoint_id}/ls", query_params=query_params
+            )
         )
 
     def operation_mkdir(
@@ -1327,7 +1339,7 @@ class TransferClient(client.BaseClient):
         if local_user is not None:
             json_body["local_user"] = local_user
         return self.post(
-            f"operation/endpoint/{endpoint_id}/mkdir",
+            f"/v0.10/operation/endpoint/{endpoint_id}/mkdir",
             data=json_body,
             query_params=query_params,
         )
@@ -1379,7 +1391,7 @@ class TransferClient(client.BaseClient):
         if local_user is not None:
             json_body["local_user"] = local_user
         return self.post(
-            f"operation/endpoint/{endpoint_id}/rename",
+            f"/v0.10/operation/endpoint/{endpoint_id}/rename",
             data=json_body,
             query_params=query_params,
         )
@@ -1429,7 +1441,7 @@ class TransferClient(client.BaseClient):
 
         log.debug(f"TransferClient.operation_stat({endpoint_id}, {query_params})")
         return self.get(
-            f"operation/endpoint/{endpoint_id}/stat", query_params=query_params
+            f"/v0.10/operation/endpoint/{endpoint_id}/stat", query_params=query_params
         )
 
     def operation_symlink(
@@ -1465,7 +1477,7 @@ class TransferClient(client.BaseClient):
             "path": path,
         }
         return self.post(
-            f"operation/endpoint/{endpoint_id}/symlink",
+            f"/v0.10/operation/endpoint/{endpoint_id}/symlink",
             data=data,
             query_params=query_params,
         )
@@ -1502,7 +1514,7 @@ class TransferClient(client.BaseClient):
                 .. expandtestfixture:: transfer.get_submission_id
         """
         log.debug(f"TransferClient.get_submission_id({query_params})")
-        return self.get("submission_id", query_params=query_params)
+        return self.get("/v0.10/submission_id", query_params=query_params)
 
     def submit_transfer(
         self, data: dict[str, t.Any] | TransferData
@@ -1551,7 +1563,7 @@ class TransferClient(client.BaseClient):
         if "submission_id" not in data:
             log.debug("submit_transfer autofetching submission_id")
             data["submission_id"] = self.get_submission_id()["value"]
-        return self.post("/transfer", data=data)
+        return self.post("/v0.10/transfer", data=data)
 
     def submit_delete(
         self, data: dict[str, t.Any] | DeleteData
@@ -1594,7 +1606,7 @@ class TransferClient(client.BaseClient):
         if "submission_id" not in data:
             log.debug("submit_delete autofetching submission_id")
             data["submission_id"] = self.get_submission_id()["value"]
-        return self.post("/delete", data=data)
+        return self.post("/v0.10/delete", data=data)
 
     #
     # Task inspection and management
@@ -1704,7 +1716,7 @@ class TransferClient(client.BaseClient):
         if filter is not None:
             query_params["filter"] = _format_filter_item(filter)
         return IterableTransferResponse(
-            self.get("task_list", query_params=query_params)
+            self.get("/v0.10/task_list", query_params=query_params)
         )
 
     @paging.has_paginator(
@@ -1762,7 +1774,7 @@ class TransferClient(client.BaseClient):
         if offset is not None:
             query_params["offset"] = offset
         return IterableTransferResponse(
-            self.get(f"task/{task_id}/event_list", query_params=query_params)
+            self.get(f"/v0.10/task/{task_id}/event_list", query_params=query_params)
         )
 
     def get_task(
@@ -1785,7 +1797,7 @@ class TransferClient(client.BaseClient):
                     :ref: transfer/task/#get_task_by_id
         """
         log.debug(f"TransferClient.get_task({task_id}, ...)")
-        return self.get(f"task/{task_id}", query_params=query_params)
+        return self.get(f"/v0.10/task/{task_id}", query_params=query_params)
 
     def update_task(
         self,
@@ -1812,7 +1824,7 @@ class TransferClient(client.BaseClient):
                     :ref: transfer/task/#update_task_by_id
         """
         log.debug(f"TransferClient.update_task({task_id}, ...)")
-        return self.put(f"task/{task_id}", data=data, query_params=query_params)
+        return self.put(f"/v0.10/task/{task_id}", data=data, query_params=query_params)
 
     def cancel_task(self, task_id: UUIDLike) -> response.GlobusHTTPResponse:
         """
@@ -1830,7 +1842,7 @@ class TransferClient(client.BaseClient):
                     :ref: transfer/task/#cancel_task_by_id
         """
         log.debug(f"TransferClient.cancel_task({task_id})")
-        return self.post(f"task/{task_id}/cancel")
+        return self.post(f"/v0.10/task/{task_id}/cancel")
 
     def task_wait(
         self, task_id: UUIDLike, *, timeout: int = 10, polling_interval: int = 10
@@ -1957,7 +1969,7 @@ class TransferClient(client.BaseClient):
                     :ref: transfer/task/#get_task_pause_info
         """
         log.debug(f"TransferClient.task_pause_info({task_id}, ...)")
-        return self.get(f"task/{task_id}/pause_info", query_params=query_params)
+        return self.get(f"/v0.10/task/{task_id}/pause_info", query_params=query_params)
 
     @paging.has_paginator(
         paging.NullableMarkerPaginator, items_key="DATA", marker_key="next_marker"
@@ -2013,7 +2025,9 @@ class TransferClient(client.BaseClient):
         if marker is not None:
             query_params["marker"] = marker
         return IterableTransferResponse(
-            self.get(f"task/{task_id}/successful_transfers", query_params=query_params)
+            self.get(
+                f"/v0.10/task/{task_id}/successful_transfers", query_params=query_params
+            )
         )
 
     @paging.has_paginator(
@@ -2064,7 +2078,7 @@ class TransferClient(client.BaseClient):
         if marker is not None:
             query_params["marker"] = marker
         return IterableTransferResponse(
-            self.get(f"task/{task_id}/skipped_errors", query_params=query_params)
+            self.get(f"/v0.10/task/{task_id}/skipped_errors", query_params=query_params)
         )
 
     #
@@ -2092,7 +2106,9 @@ class TransferClient(client.BaseClient):
             f"TransferClient.endpoint_manager_monitored_endpoints({query_params})"
         )
         return IterableTransferResponse(
-            self.get("endpoint_manager/monitored_endpoints", query_params=query_params)
+            self.get(
+                "/v0.10/endpoint_manager/monitored_endpoints", query_params=query_params
+            )
         )
 
     def endpoint_manager_hosted_endpoint_list(
@@ -2121,7 +2137,7 @@ class TransferClient(client.BaseClient):
         )
         return IterableTransferResponse(
             self.get(
-                f"endpoint_manager/endpoint/{endpoint_id}/hosted_endpoint_list",
+                f"/v0.10/endpoint_manager/endpoint/{endpoint_id}/hosted_endpoint_list",
                 query_params=query_params,
             )
         )
@@ -2149,7 +2165,7 @@ class TransferClient(client.BaseClient):
         """  # noqa: E501
         log.debug(f"TransferClient.endpoint_manager_get_endpoint({endpoint_id})")
         return self.get(
-            f"endpoint_manager/endpoint/{endpoint_id}", query_params=query_params
+            f"/v0.10/endpoint_manager/endpoint/{endpoint_id}", query_params=query_params
         )
 
     def endpoint_manager_acl_list(
@@ -2178,7 +2194,7 @@ class TransferClient(client.BaseClient):
         )
         return IterableTransferResponse(
             self.get(
-                f"endpoint_manager/endpoint/{endpoint_id}/access_list",
+                f"/v0.10/endpoint_manager/endpoint/{endpoint_id}/access_list",
                 query_params=query_params,
             )
         )
@@ -2342,7 +2358,7 @@ class TransferClient(client.BaseClient):
         if last_key is not None:
             query_params["last_key"] = last_key
         return IterableTransferResponse(
-            self.get("endpoint_manager/task_list", query_params=query_params)
+            self.get("/v0.10/endpoint_manager/task_list", query_params=query_params)
         )
 
     def endpoint_manager_get_task(
@@ -2368,7 +2384,9 @@ class TransferClient(client.BaseClient):
                     :ref: transfer/advanced_collection_management/#get_task
         """
         log.debug(f"TransferClient.endpoint_manager_get_task({task_id}, ...)")
-        return self.get(f"endpoint_manager/task/{task_id}", query_params=query_params)
+        return self.get(
+            f"/v0.10/endpoint_manager/task/{task_id}", query_params=query_params
+        )
 
     @paging.has_paginator(
         paging.LimitOffsetTotalPaginator,
@@ -2423,7 +2441,8 @@ class TransferClient(client.BaseClient):
             query_params["filter_is_error"] = 1 if filter_is_error else 0
         return IterableTransferResponse(
             self.get(
-                f"endpoint_manager/task/{task_id}/event_list", query_params=query_params
+                f"/v0.10/endpoint_manager/task/{task_id}/event_list",
+                query_params=query_params,
             )
         )
 
@@ -2451,7 +2470,8 @@ class TransferClient(client.BaseClient):
         """  # noqa: E501
         log.debug(f"TransferClient.endpoint_manager_task_pause_info({task_id}, ...)")
         return self.get(
-            f"endpoint_manager/task/{task_id}/pause_info", query_params=query_params
+            f"/v0.10/endpoint_manager/task/{task_id}/pause_info",
+            query_params=query_params,
         )
 
     @paging.has_paginator(
@@ -2495,7 +2515,7 @@ class TransferClient(client.BaseClient):
             query_params["marker"] = marker
         return IterableTransferResponse(
             self.get(
-                f"endpoint_manager/task/{task_id}/successful_transfers",
+                f"/v0.10/endpoint_manager/task/{task_id}/successful_transfers",
                 query_params=query_params,
             )
         )
@@ -2540,7 +2560,7 @@ class TransferClient(client.BaseClient):
             query_params["marker"] = marker
         return IterableTransferResponse(
             self.get(
-                f"endpoint_manager/task/{task_id}/skipped_errors",
+                f"/v0.10/endpoint_manager/task/{task_id}/skipped_errors",
                 query_params=query_params,
             )
         )
@@ -2575,7 +2595,7 @@ class TransferClient(client.BaseClient):
         )
         data = {"message": message, "task_id_list": str_task_ids}
         return self.post(
-            "endpoint_manager/admin_cancel", data=data, query_params=query_params
+            "/v0.10/endpoint_manager/admin_cancel", data=data, query_params=query_params
         )
 
     def endpoint_manager_cancel_status(
@@ -2602,7 +2622,7 @@ class TransferClient(client.BaseClient):
         """  # noqa: E501
         log.debug(f"TransferClient.endpoint_manager_cancel_status({admin_cancel_id})")
         return self.get(
-            f"endpoint_manager/admin_cancel/{admin_cancel_id}",
+            f"/v0.10/endpoint_manager/admin_cancel/{admin_cancel_id}",
             query_params=query_params,
         )
 
@@ -2636,7 +2656,7 @@ class TransferClient(client.BaseClient):
         )
         data = {"message": message, "task_id_list": str_task_ids}
         return self.post(
-            "endpoint_manager/admin_pause", data=data, query_params=query_params
+            "/v0.10/endpoint_manager/admin_pause", data=data, query_params=query_params
         )
 
     def endpoint_manager_resume_tasks(
@@ -2665,7 +2685,7 @@ class TransferClient(client.BaseClient):
         log.debug(f"TransferClient.endpoint_manager_resume_tasks({str_task_ids})")
         data = {"task_id_list": str_task_ids}
         return self.post(
-            "endpoint_manager/admin_resume", data=data, query_params=query_params
+            "/v0.10/endpoint_manager/admin_resume", data=data, query_params=query_params
         )
 
     #
@@ -2702,7 +2722,9 @@ class TransferClient(client.BaseClient):
         if filter_endpoint is not None:
             query_params["filter_endpoint"] = filter_endpoint
         return IterableTransferResponse(
-            self.get("endpoint_manager/pause_rule_list", query_params=query_params)
+            self.get(
+                "/v0.10/endpoint_manager/pause_rule_list", query_params=query_params
+            )
         )
 
     def endpoint_manager_create_pause_rule(
@@ -2739,7 +2761,7 @@ class TransferClient(client.BaseClient):
                     :ref: transfer/advanced_collection_management/#create_pause_rule
         """
         log.debug("TransferClient.endpoint_manager_create_pause_rule(...)")
-        return self.post("endpoint_manager/pause_rule", data=data)
+        return self.post("/v0.10/endpoint_manager/pause_rule", data=data)
 
     def endpoint_manager_get_pause_rule(
         self,
@@ -2765,7 +2787,8 @@ class TransferClient(client.BaseClient):
         """
         log.debug(f"TransferClient.endpoint_manager_get_pause_rule({pause_rule_id})")
         return self.get(
-            f"endpoint_manager/pause_rule/{pause_rule_id}", query_params=query_params
+            f"/v0.10/endpoint_manager/pause_rule/{pause_rule_id}",
+            query_params=query_params,
         )
 
     def endpoint_manager_update_pause_rule(
@@ -2803,7 +2826,9 @@ class TransferClient(client.BaseClient):
                     :ref: transfer/advanced_collection_management/#update_pause_rule
         """
         log.debug(f"TransferClient.endpoint_manager_update_pause_rule({pause_rule_id})")
-        return self.put(f"endpoint_manager/pause_rule/{pause_rule_id}", data=data)
+        return self.put(
+            f"/v0.10/endpoint_manager/pause_rule/{pause_rule_id}", data=data
+        )
 
     def endpoint_manager_delete_pause_rule(
         self,
@@ -2830,5 +2855,6 @@ class TransferClient(client.BaseClient):
         """
         log.debug(f"TransferClient.endpoint_manager_delete_pause_rule({pause_rule_id})")
         return self.delete(
-            f"endpoint_manager/pause_rule/{pause_rule_id}", query_params=query_params
+            f"/v0.10/endpoint_manager/pause_rule/{pause_rule_id}",
+            query_params=query_params,
         )

--- a/tests/functional/services/groups/test_group_memberships.py
+++ b/tests/functional/services/groups/test_group_memberships.py
@@ -63,7 +63,7 @@ def test_batch_action_payload(groups_client, role):
     group_id = str(uuid.uuid1())
     load_response(
         RegisteredResponse(
-            service="groups", method="POST", path=f"/groups/{group_id}", json={}
+            service="groups", method="POST", path=f"/v2/groups/{group_id}", json={}
         )
     )
     rolestr = role if isinstance(role, str) else role.value

--- a/tests/functional/services/transfer/test_operation_ls.py
+++ b/tests/functional/services/transfer/test_operation_ls.py
@@ -40,7 +40,7 @@ def _setup_ls_response():
     load_response(
         RegisteredResponse(
             service="transfer",
-            path=f"/operation/endpoint/{GO_EP1_ID}/ls",
+            path=f"/v0.10/operation/endpoint/{GO_EP1_ID}/ls",
             json=_mk_ls_data(),
         ),
     )

--- a/tests/functional/services/transfer/test_operation_symlink.py
+++ b/tests/functional/services/transfer/test_operation_symlink.py
@@ -16,7 +16,7 @@ def _setup_symlink_response(symlink_endpoint_id):
     RegisteredResponse(
         service="transfer",
         method="POST",
-        path=f"/operation/endpoint/{symlink_endpoint_id}/symlink",
+        path=f"/v0.10/operation/endpoint/{symlink_endpoint_id}/symlink",
         json={},
     ).add()
 

--- a/tests/unit/test_base_client.py
+++ b/tests/unit/test_base_client.py
@@ -47,12 +47,12 @@ def test_cannot_instantiate_plain_base_client():
 
 def test_can_instantiate_base_client_with_explicit_url():
     client = globus_sdk.BaseClient(base_url="https://example.org")
-    assert client.base_url == "https://example.org/"
+    assert client.base_url == "https://example.org"
 
 
 def test_can_instantiate_with_base_url_class_attribute():
     class MyCoolClient(globus_sdk.BaseClient):
-        base_url = "https://example.org"
+        base_url = "https://example.org/"
 
     client = MyCoolClient()
     assert client.base_url == "https://example.org/"
@@ -73,8 +73,8 @@ def test_base_url_resolution_precedence():
         service_name = "service-name"
 
     # All 3 are set
-    assert BothAttributesClient(base_url="init-base").base_url == "init-base/"
-    assert BothAttributesClient().base_url == "class-base/"
+    assert BothAttributesClient(base_url="init-base").base_url == "init-base"
+    assert BothAttributesClient().base_url == "class-base"
     assert OnlyServiceClient().base_url == "https://service-name.api.globus.org/"
 
 

--- a/tests/unit/test_base_client.py
+++ b/tests/unit/test_base_client.py
@@ -21,7 +21,6 @@ def auth_client():
 @pytest.fixture
 def base_client_class(no_retry_transport):
     class CustomClient(globus_sdk.BaseClient):
-        base_path = "/v0.10/"
         service_name = "transfer"
         transport_class = no_retry_transport
         scopes = TransferScopes
@@ -47,9 +46,6 @@ def test_cannot_instantiate_plain_base_client():
 
 
 def test_can_instantiate_base_client_with_explicit_url():
-    # note how a trailing slash is added due to the default
-    # base_path of '/'
-    # this may change in a future major version, to preserve the base_url exactly
     client = globus_sdk.BaseClient(base_url="https://example.org")
     assert client.base_url == "https://example.org/"
 
@@ -142,7 +138,7 @@ def test_http_methods(method, allows_body, base_client):
     """
     methodname = method.upper()
     resolved_method = getattr(base_client, method)
-    path = "/madeuppath/objectname"
+    path = "/v0.10/madeuppath/objectname"
     RegisteredResponse(
         service="transfer", path=path, method=methodname, json={"x": "y"}
     ).add()
@@ -196,7 +192,7 @@ def test_http_methods(method, allows_body, base_client):
 def test_handle_url_unsafe_chars(base_client):
     # make sure this path (escaped) and the request path (unescaped) match
     RegisteredResponse(service="transfer", path="/foo/foo%20bar", json={"x": "y"}).add()
-    res = base_client.get("foo/foo bar")
+    res = base_client.get("/v0.10/foo/foo bar")
     assert "x" in res
     assert res["x"] == "y"
 
@@ -209,33 +205,6 @@ def test_access_resource_server_property_via_instance(base_client):
 def test_access_resource_server_property_via_class(base_client_class):
     # get works (and returns accurate info)
     assert base_client_class.resource_server == TransferScopes.resource_server
-
-
-@pytest.mark.parametrize("leading_slash", (True, False))
-@pytest.mark.parametrize("test_fixture_uses_base_path", (True, False))
-def test_base_path_matching_prefix(
-    base_client, leading_slash, test_fixture_uses_base_path
-):
-    # self-check/sanity check
-    base_path = base_client.base_path
-    assert base_path == "/v0.10/"
-
-    # construct the path and confirm it (sanity check)
-    req_path = f"{base_client.base_path}foo"
-    if not leading_slash:
-        req_path.lstrip("/")
-
-    # register a response under the target path
-    # this is parametrized so that we are also testing the matching of our
-    # test fixtures against the same path construction
-    test_fixture_path = f"{base_path}foo" if test_fixture_uses_base_path else "foo"
-    RegisteredResponse(
-        service="transfer", path=test_fixture_path, json={"x": "y"}
-    ).add()
-
-    # confirm that a "GET" works
-    res = base_client.get(req_path)
-    assert res["x"] == "y"
 
 
 def test_app_integration(base_client_class):
@@ -356,7 +325,6 @@ def test_cannot_attach_app_when_authorizer_was_provided(base_client_class):
 
 def test_cannot_attach_app_when_resource_server_is_not_resolvable():
     class CustomClient(globus_sdk.BaseClient):
-        base_path = "/v0.10/"
         service_name = "transfer"
         default_scope_requirements = [Scope(TransferScopes.all)]
 

--- a/tests/unit/test_base_client.py
+++ b/tests/unit/test_base_client.py
@@ -191,7 +191,9 @@ def test_http_methods(method, allows_body, base_client):
 
 def test_handle_url_unsafe_chars(base_client):
     # make sure this path (escaped) and the request path (unescaped) match
-    RegisteredResponse(service="transfer", path="/foo/foo%20bar", json={"x": "y"}).add()
+    RegisteredResponse(
+        service="transfer", path="/v0.10/foo/foo%20bar", json={"x": "y"}
+    ).add()
     res = base_client.get("/v0.10/foo/foo bar")
     assert "x" in res
     assert res["x"] == "y"

--- a/tests/unit/test_gcs_client.py
+++ b/tests/unit/test_gcs_client.py
@@ -6,25 +6,23 @@ def test_client_address_handling():
     # variants of the same location
     c1 = GCSClient("foo.data.globus.org")
     c2 = GCSClient("https://foo.data.globus.org")
-    c3 = GCSClient("https://foo.data.globus.org/api")
-    c4 = GCSClient("https://foo.data.globus.org/api/")
+    c3 = GCSClient("https://foo.data.globus.org/api/")
     # explicit subpath of /api/
-    c5 = GCSClient("https://foo.data.globus.org/api/bar")
+    c4 = GCSClient("https://foo.data.globus.org/api/bar")
     # explicit construction can point at the root (rather than /api/)
-    c6 = GCSClient("foo.data.globus.org")
-    c6.base_url = "https://foo.data.globus.org/"
+    c5 = GCSClient("foo.data.globus.org")
+    c5.base_url = "https://foo.data.globus.org/"
 
-    # 1, 2, 3, and 4 are all the same
+    # 1, 2, and 3 are all the same
     assert c1.base_url == c2.base_url
     assert c1.base_url == c3.base_url
-    assert c1.base_url == c4.base_url
 
-    # 5 and 6 are different from the rest
+    # 4 and 5 are different from the rest
+    assert c4.base_url != c1.base_url
     assert c5.base_url != c1.base_url
-    assert c6.base_url != c1.base_url
 
-    # 6 is the root of 1
-    assert c1.base_url.startswith(c6.base_url)
+    # 5 is the root of 1
+    assert c1.base_url.startswith(c5.base_url)
 
 
 def test_gcs_client_resource_server_and_endpoint_client_id():


### PR DESCRIPTION
[sc-26346](https://app.shortcut.com/globus/story/26346/sdk-remove-base-path-from-client-classes)

### Changes
- All `base_path` declarations have been removed from all client classes.
- All methods on a client class that call an API for the corresponding service have been updated to include the base path explicitly in their path string.

**Reviewer notes:**
- Much of the test suite broke when removing `base_path` since many tests were not including the `base_path` for a service when creating a `RegisteredResponse`. Rather than update each individual test, I chose to [update](https://github.com/globus/globus-sdk-python/blob/c05f5bd8484d973dbf3bc6f8c44da4672359f1e0/src/globus_sdk/_testing/models.py#L108-L114) `RegisteredResponse` to always add a particular services `base_path` to the path if it was not included. 
- To preserve the previous behavior of `BaseClient`, `BaseClient.base_url` will always have a trailing slash added if needed.

<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1185.org.readthedocs.build/en/1185/

<!-- readthedocs-preview globus-sdk-python end -->