### PR TITLE
Remove the "default requested scopes"

### DIFF
--- a/changelog.d/20250512_143605_sirosen_remove_default_scopes.rst
+++ b/changelog.d/20250512_143605_sirosen_remove_default_scopes.rst
@@ -1,0 +1,8 @@
+Removed
+~~~~~~~
+
+- The SDK no longer sets default scopes for direct use of client
+  credentials and auth client login flow methods. Users should either use
+  ``GlobusApp`` objects, which can specify scopes based on the clients in use,
+  or else pass a list of scopes explicitly to
+  ``oauth2_client_credentials_tokens`` or ``oauth2_start_flow``. (:pr:`1186`)

--- a/changelog.d/20250512_143605_sirosen_remove_default_scopes.rst
+++ b/changelog.d/20250512_143605_sirosen_remove_default_scopes.rst
@@ -1,5 +1,5 @@
-Removed
-~~~~~~~
+Breaking Changes
+~~~~~~~~~~~~~~~~
 
 - The SDK no longer sets default scopes for direct use of client
   credentials and auth client login flow methods. Users should either use

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -42,6 +42,42 @@ Then, code can dispatch with
     else:
         pass  # do another
 
+From 3.x to 4.0
+---------------
+
+``requested_scopes`` is Required
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Several methods have historically taken an optional parameter,
+``requested_scopes``.
+
+- ``ConfidentialAppAuthClient.oauth2_client_credentials_tokens``
+- ``ConfidentialAppAuthClient.oauth2_start_flow``
+- ``NativeAppAuthClient.oauth2_start_flow``
+
+In previous versions of the SDK, these methods provided a default value for
+``requested_scopes`` of
+``"openid profile email urn:globus:auth:scopes:transfer.api.globus.org:all"``.
+This default has now been removed and users should always specify the scopes
+they need when using these methods.
+
+Users of ``GlobusApp`` constructs (``UserApp`` and ``ClientApp``) do not need
+to update their usage.
+
+The default could only be used by applications which only use Globus Transfer
+and Globus Auth.
+Change:
+
+.. code-block:: python
+
+    # globus-sdk v3
+    auth_client.oauth2_start_flow()
+    authorize_url = auth_client.oauth2_get_authorize_url()
+
+    # globus-sdk v4
+    auth_client.oauth2_start_flow(requested_scopes=globus_sdk.TransferClient.scopes.all)
+    authorize_url = auth_client.oauth2_get_authorize_url()
+
 From 1.x or 2.x to 3.0
 -----------------------
 

--- a/src/globus_sdk/globus_app/client_app.py
+++ b/src/globus_sdk/globus_app/client_app.py
@@ -117,6 +117,10 @@ class ClientApp(GlobusApp):
             only the required_scopes parameter is used.
         """
         auth_params = self._auth_params_with_required_scopes(auth_params)
+        if not auth_params.required_scopes:
+            raise GlobusSDKUsageError(
+                "A ClientApp cannot get tokens without configured required scopes."
+            )
         token_response = self._login_client.oauth2_client_credentials_tokens(
             requested_scopes=auth_params.required_scopes
         )

--- a/src/globus_sdk/login_flows/login_flow_manager.py
+++ b/src/globus_sdk/login_flows/login_flow_manager.py
@@ -70,6 +70,12 @@ class LoginFlowManager(metaclass=abc.ABCMeta):
         """
         login_client = self.login_client
         requested_scopes = auth_parameters.required_scopes
+        if not requested_scopes:
+            raise globus_sdk.GlobusSDKUsageError(
+                f"{type(self).__name__} cannot start a login flow without scopes "
+                "in the authorization parameters."
+            )
+
         # Native and Confidential App clients have different signatures for this method,
         # so they must be type checked & called independently.
         if isinstance(login_client, globus_sdk.NativeAppAuthClient):

--- a/src/globus_sdk/services/auth/_common.py
+++ b/src/globus_sdk/services/auth/_common.py
@@ -9,30 +9,13 @@ from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 
 from globus_sdk._types import ScopeCollectionType
 from globus_sdk.exc import GlobusSDKUsageError
-from globus_sdk.exc.warnings import warn_deprecated
 from globus_sdk.response import GlobusHTTPResponse
-from globus_sdk.scopes import AuthScopes, TransferScopes, scopes_to_str
+from globus_sdk.scopes import scopes_to_str
 
 log = logging.getLogger(__name__)
 
-_DEFAULT_REQUESTED_SCOPES = (
-    AuthScopes.openid,
-    AuthScopes.profile,
-    AuthScopes.email,
-    TransferScopes.all,
-)
 
-
-def stringify_requested_scopes(requested_scopes: ScopeCollectionType | None) -> str:
-    if requested_scopes is None:
-        warn_deprecated(
-            "`requested_scopes` was not specified or was given as `None`. "
-            "A default set of scopes will be used, but this behavior is deprecated. "
-            "Specify an explicit set of scopes instead.",
-            stacklevel=3,
-        )
-        requested_scopes = _DEFAULT_REQUESTED_SCOPES
-
+def stringify_requested_scopes(requested_scopes: ScopeCollectionType) -> str:
     requested_scopes_string: str = scopes_to_str(requested_scopes)
     if requested_scopes_string == "":
         raise GlobusSDKUsageError(

--- a/src/globus_sdk/services/auth/client/confidential_client.py
+++ b/src/globus_sdk/services/auth/client/confidential_client.py
@@ -107,8 +107,7 @@ class ConfidentialAppAuthClient(AuthLoginClient):
         )
 
     def oauth2_client_credentials_tokens(
-        self,
-        requested_scopes: ScopeCollectionType | None = None,
+        self, requested_scopes: ScopeCollectionType
     ) -> OAuthClientCredentialsResponse:
         r"""
         Perform an OAuth2 Client Credentials Grant to get access tokens which
@@ -117,20 +116,25 @@ class ConfidentialAppAuthClient(AuthLoginClient):
         This method does not use a ``GlobusOAuthFlowManager`` because it is not
         at all necessary to do so.
 
-        :param requested_scopes: The scopes on the token(s) being requested. Defaults to
-            ``openid profile email urn:globus:auth:scope:transfer.api.globus.org:all``
+        :param requested_scopes: The scopes on the token(s) being requested.
 
         For example, with a Client ID of "CID1001" and a Client Secret of
         "RAND2002", you could use this grant type like so:
 
-        >>> client = ConfidentialAppAuthClient("CID1001", "RAND2002")
-        >>> tokens = client.oauth2_client_credentials_tokens()
-        >>> transfer_token_info = (
-        ...     tokens.by_resource_server["transfer.api.globus.org"])
-        >>> transfer_token = transfer_token_info["access_token"]
-        """
-        log.debug("Fetching token(s) using client credentials")
+        .. code-block:: pycon
+
+            >>> client = ConfidentialAppAuthClient("CID1001", "RAND2002")
+            >>> tokens = client.oauth2_client_credentials_tokens(
+            ...     "urn:globus:auth:scope:transfer.api.globus.org:all"
+            ... )
+            >>> transfer_token_info = tokens.by_resource_server["transfer.api.globus.org"]
+            >>> transfer_token = transfer_token_info["access_token"]
+        """  # noqa: E501
         requested_scopes_string = stringify_requested_scopes(requested_scopes)
+        log.debug(
+            "Fetching token(s) using client credentials, "
+            f"scope={requested_scopes_string}"
+        )
         return self.oauth2_token(
             {"grant_type": "client_credentials", "scope": requested_scopes_string},
             response_class=OAuthClientCredentialsResponse,

--- a/src/globus_sdk/services/auth/client/confidential_client.py
+++ b/src/globus_sdk/services/auth/client/confidential_client.py
@@ -143,7 +143,7 @@ class ConfidentialAppAuthClient(AuthLoginClient):
     def oauth2_start_flow(
         self,
         redirect_uri: str,
-        requested_scopes: ScopeCollectionType | None = None,
+        requested_scopes: ScopeCollectionType,
         *,
         state: str = "_default",
         refresh_tokens: bool = False,

--- a/src/globus_sdk/services/auth/client/native_client.py
+++ b/src/globus_sdk/services/auth/client/native_client.py
@@ -50,7 +50,7 @@ class NativeAppAuthClient(AuthLoginClient):
 
     def oauth2_start_flow(
         self,
-        requested_scopes: ScopeCollectionType | None = None,
+        requested_scopes: ScopeCollectionType,
         *,
         redirect_uri: str | None = None,
         state: str = "_default",

--- a/src/globus_sdk/services/auth/flow_managers/authorization_code.py
+++ b/src/globus_sdk/services/auth/flow_managers/authorization_code.py
@@ -36,8 +36,7 @@ class GlobusAuthorizationCodeFlowManager(GlobusOAuthFlowManager):
         and also to make calls to the Auth service.
     :param redirect_uri: The page that users should be directed to after authenticating
         at the authorize URL.
-    :param requested_scopes: The scopes on the token(s) being requested. Defaults to
-        ``openid profile email urn:globus:auth:scope:transfer.api.globus.org:all``
+    :param requested_scopes: The scopes on the token(s) being requested.
     :param state: This string allows an application to pass information back to itself
         in the course of the OAuth flow. Because the user will navigate away from the
         application to complete the flow, this parameter lets the app pass an arbitrary
@@ -50,7 +49,7 @@ class GlobusAuthorizationCodeFlowManager(GlobusOAuthFlowManager):
         self,
         auth_client: globus_sdk.ConfidentialAppAuthClient,
         redirect_uri: str,
-        requested_scopes: ScopeCollectionType | None = None,
+        requested_scopes: ScopeCollectionType,
         state: str = "_default",
         refresh_tokens: bool = False,
     ) -> None:

--- a/src/globus_sdk/services/auth/flow_managers/native_app.py
+++ b/src/globus_sdk/services/auth/flow_managers/native_app.py
@@ -80,8 +80,7 @@ class GlobusNativeAppFlowManager(GlobusOAuthFlowManager):
     :param auth_client: The client object on which this flow is based.
         It is used to extract default values for the flow, and also to make calls to the
         Auth service.
-    :param requested_scopes: The scopes on the token(s) being requested. Defaults to
-        ``openid profile email urn:globus:auth:scope:transfer.api.globus.org:all``
+    :param requested_scopes: The scopes on the token(s) being requested.
     :param redirect_uri: The page that users should be directed to after authenticating
         at the authorize URL. Defaults to 'https://auth.globus.org/v2/web/auth-code',
         which displays the resulting ``auth_code`` for users to copy-paste back into
@@ -101,7 +100,7 @@ class GlobusNativeAppFlowManager(GlobusOAuthFlowManager):
     def __init__(
         self,
         auth_client: globus_sdk.NativeAppAuthClient,
-        requested_scopes: ScopeCollectionType | None = None,
+        requested_scopes: ScopeCollectionType,
         redirect_uri: str | None = None,
         state: str = "_default",
         verifier: str | None = None,
@@ -123,7 +122,6 @@ class GlobusNativeAppFlowManager(GlobusOAuthFlowManager):
             )
 
         # convert scopes iterable to string immediately on load
-        # and default to the default requested scopes
         self.requested_scopes = stringify_requested_scopes(requested_scopes)
 
         # default to `/v2/web/auth-code` on whatever environment we're looking

--- a/tests/functional/services/auth/test_auth_client_flow.py
+++ b/tests/functional/services/auth/test_auth_client_flow.py
@@ -180,12 +180,10 @@ def test_oauth2_get_authorize_url_supports_session_params(
 
 
 def test_oauth2_get_authorize_url_native_defaults(native_client):
-    # default parameters for starting auth flow
-    # should warn because scopes were not specified
-    with pytest.warns(globus_sdk.RemovedInV4Warning):
-        flow_manager = globus_sdk.services.auth.GlobusNativeAppFlowManager(
-            native_client
-        )
+    flow_manager = globus_sdk.services.auth.GlobusNativeAppFlowManager(
+        native_client,
+        TransferScopes.all,
+    )
     native_client.current_oauth2_flow_manager = flow_manager
 
     # get url and validate results
@@ -197,7 +195,7 @@ def test_oauth2_get_authorize_url_native_defaults(native_client):
     assert parsed_params == {
         "client_id": [native_client.client_id],
         "redirect_uri": [native_client.base_url + "v2/web/auth-code"],
-        "scope": [f"openid profile email {TransferScopes.all}"],
+        "scope": [TransferScopes.all],
         "state": ["_default"],
         "response_type": ["code"],
         "code_challenge": [flow_manager.challenge],
@@ -238,12 +236,9 @@ def test_oauth2_get_authorize_url_native_custom_params(native_client):
 
 
 def test_oauth2_get_authorize_url_confidential_defaults(confidential_client):
-    # default parameters for starting auth flow
-    # warns because no requested_scopes was passed
-    with pytest.warns(globus_sdk.RemovedInV4Warning):
-        flow_manager = globus_sdk.services.auth.GlobusAuthorizationCodeFlowManager(
-            confidential_client, "uri"
-        )
+    flow_manager = globus_sdk.services.auth.GlobusAuthorizationCodeFlowManager(
+        confidential_client, "uri", TransferScopes.all
+    )
     confidential_client.current_oauth2_flow_manager = flow_manager
 
     # get url_and validate results
@@ -255,7 +250,7 @@ def test_oauth2_get_authorize_url_confidential_defaults(confidential_client):
     assert parsed_params == {
         "client_id": [confidential_client.client_id],
         "redirect_uri": ["uri"],
-        "scope": [f"openid profile email {TransferScopes.all}"],
+        "scope": [TransferScopes.all],
         "state": ["_default"],
         "response_type": ["code"],
         "access_type": ["online"],

--- a/tests/unit/helpers/test_auth_scope_stringify.py
+++ b/tests/unit/helpers/test_auth_scope_stringify.py
@@ -1,6 +1,6 @@
 import pytest
 
-from globus_sdk import GlobusSDKUsageError, RemovedInV4Warning
+from globus_sdk import GlobusSDKUsageError
 from globus_sdk.scopes import MutableScope
 from globus_sdk.services.auth._common import stringify_requested_scopes
 
@@ -32,12 +32,3 @@ def test_scope_stringify_rejects_empty_collection(collection_obj):
         match="requested_scopes cannot be the empty string or empty collection",
     ):
         stringify_requested_scopes(collection_obj)
-
-
-def test_scope_stringify_handles_none_with_default():
-    with pytest.warns(RemovedInV4Warning, match="Specify an explicit set of scopes"):
-        scope_string = stringify_requested_scopes(None)
-    assert (
-        scope_string
-        == "openid profile email urn:globus:auth:scope:transfer.api.globus.org:all"
-    )


### PR DESCRIPTION
[[sc-20185]](https://app.shortcut.com/globus/story/20185/remove-default-scopes-from-the-sdk)

These were the default for login flows and client credentials. When GlobusApp-driven logins are used, these defaults are not used. They were only applied for direct use of the login flow and token request mechanisms for login clients.

One log line has been changed to produce slightly more useful debug-level logs.

Also, introduce the first v3.x -> v4 upgrading section to the upgrading doc.

<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1186.org.readthedocs.build/en/1186/

<!-- readthedocs-preview globus-sdk-python end -->