### PR TITLE
Simplify custom parsing for TimersAPIError

### DIFF
--- a/changelog.d/20250514_011903_sirosen_simplify_timersapierror.rst
+++ b/changelog.d/20250514_011903_sirosen_simplify_timersapierror.rst
@@ -1,0 +1,6 @@
+Breaking Changes
+~~~~~~~~~~~~~~~~
+
+- ``TimersAPIError`` no longer sets ``code="ValidationError"`` when an error
+  with no code which appears to be validation related is parsed. Like other
+  error classes, the default when no ``code`` is set is ``None``. (:pr:`NUMBER`)

--- a/src/globus_sdk/services/timers/errors.py
+++ b/src/globus_sdk/services/timers/errors.py
@@ -10,9 +10,8 @@ class TimersAPIError(GlobusAPIError):
     """
     Error class to represent error responses from Timers.
 
-    Has no particular additions to the base ``GlobusAPIError``, but implements a
-    different method for parsing error responses from Timers due to the differences
-    between various error formats used.
+    Implements a dedicated method for parsing error responses from Timers due
+    to the differences between various error formats used.
     """
 
     def _parse_undefined_error_format(self) -> bool:
@@ -48,42 +47,38 @@ class TimersAPIError(GlobusAPIError):
         # but before that fallback, try the two relevant branches
 
         # if 'error' is present, use it to populate the errors array
-        # extract 'code' from it
-        # and extract 'messages' from it
+        # extract 'code' and 'messages' from it
         if isinstance(self._dict_data.get("error"), dict):
             self.errors = [ErrorSubdocument(self._dict_data["error"])]
             self.code = self._extract_code_from_error_array(self.errors)
             self.messages = self._extract_messages_from_error_array(self.errors)
             return True
         elif _guards.is_list_of(self._dict_data.get("detail"), dict):
-            # FIXME:
-            # the 'code' is currently being set explicitly by the
-            # SDK in this case even though none was provided by
-            # the service
-            # in a future version of the SDK, the code should be `None`
-            self.code = "Validation Error"
-
             # collect the errors array from details
-            self.errors = [ErrorSubdocument(d) for d in self._dict_data["detail"]]
+            self.errors = [
+                ErrorSubdocument(d, message_fields=("msg",))
+                for d in self._dict_data["detail"]
+            ]
+            # extract a 'code' if there is one
+            self.code = self._extract_code_from_error_array(self.errors)
 
-            # drop error objects which don't have the relevant fields
-            # and then build custom 'messages' for Globus Timers errors
-            details = list(_details_from_errors(self.errors))
+            # build custom 'messages' for this case
             self.messages = [
-                f"{e['msg']}: {'.'.join(k for k in e['loc'])}" for e in details
+                f"{message}: {loc}"
+                for (message, loc) in _parse_detail_docs(self.errors)
             ]
             return True
         else:
             return super()._parse_undefined_error_format()
 
 
-def _details_from_errors(
+def _parse_detail_docs(
     errors: list[ErrorSubdocument],
-) -> t.Iterator[dict[str, t.Any]]:
+) -> t.Iterator[tuple[str, str]]:
     for d in errors:
-        if not isinstance(d.get("msg"), str):
+        if d.message is None:
             continue
         loc_list = d.get("loc")
         if not _guards.is_list_of(loc_list, str):
             continue
-        yield d.raw
+        yield (d.message, ".".join(loc_list))

--- a/tests/functional/services/timers/test_jobs.py
+++ b/tests/functional/services/timers/test_jobs.py
@@ -80,7 +80,7 @@ def test_create_job_validation_error(client):
 
     err = excinfo.value
     assert err.http_status == 422
-    assert err.code == "Validation Error"
+    assert err.code is None
     assert err.messages == meta["expect_messages"]
 
 

--- a/tests/unit/errors/test_timers_errors.py
+++ b/tests/unit/errors/test_timers_errors.py
@@ -33,7 +33,7 @@ def test_timer_error_load_nested():
         http_status=422,
     )
 
-    assert err.code == "Validation Error"
+    assert err.code is None
     assert err.message == "field required: body.start; field required: body.end"
 
 


### PR DESCRIPTION
[[sc-24215]](https://app.shortcut.com/globus/story/24215)

In particular, remove the special-case `code` default. Also, make use of subdocument message parsing to capture the `msg` field of sub-errors.

---

In the original specification for this work, I wrote that we should remove a lot of the custom `message` building as well.
On closer inspection, it's not so bad, although not ideal, so I've retained the core of it. Open to altering this in response to feedback on that approach, but I felt that removing the injected `code` value was the most important, since that keeps this subclass consistent with the change in #1190.


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1191.org.readthedocs.build/en/1191/

<!-- readthedocs-preview globus-sdk-python end -->
