### PR TITLE
Release v3.56.1

### DIFF
--- a/changelog.d/20250505_160859_sirosen_bugfix_allow_iterable.rst
+++ b/changelog.d/20250505_160859_sirosen_bugfix_allow_iterable.rst
@@ -1,5 +1,0 @@
-Fixed
-~~~~~
-
-- Fix the type annotation on ``filter_roles`` for ``FlowsClient`` to allow
-  non-list iterables. (:pr:`1184`)

--- a/changelog.rst
+++ b/changelog.rst
@@ -12,6 +12,17 @@ to a major new version of the SDK.
 
 .. scriv-insert-here
 
+.. _changelog-3.56.1:
+
+v3.56.1 (2025-05-20)
+--------------------
+
+Fixed
+~~~~~
+
+- Fix the type annotation on ``filter_roles`` for ``FlowsClient``
+  to allow non-list iterables. (:pr:`1184`)
+
 .. _changelog-3.56.0:
 
 v3.56.0 (2025-05-05)

--- a/src/globus_sdk/version.py
+++ b/src/globus_sdk/version.py
@@ -1,3 +1,3 @@
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "3.56.0"
+__version__ = "3.56.1"


### PR DESCRIPTION
Fixed
-----

- Fix the type annotation on ``filter_roles`` for ``FlowsClient``
  to allow non-list iterables. #1184
