### PR TITLE
Remove the badges at the top of the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,36 +1,3 @@
-.. image:: https://github.com/globus/globus-sdk-python/workflows/build/badge.svg?event=push
-    :alt: build status
-    :target: https://github.com/globus/globus-sdk-python/actions?query=workflow%3Abuild
-
-.. image:: https://img.shields.io/pypi/v/globus-sdk.svg
-    :alt: Latest Released Version
-    :target: https://pypi.org/project/globus-sdk/
-
-.. image:: https://img.shields.io/pypi/pyversions/globus-sdk.svg
-    :alt: Supported Python Versions
-    :target: https://pypi.org/project/globus-sdk/
-
-.. image:: https://img.shields.io/badge/License-Apache%202.0-blue.svg
-    :alt: License
-    :target: https://opensource.org/licenses/Apache-2.0
-
-.. image:: https://results.pre-commit.ci/badge/github/globus/globus-sdk-python/main.svg
-   :target: https://results.pre-commit.ci/latest/github/globus/globus-sdk-python/main
-   :alt: pre-commit.ci status
-
-..
-    This is the badge style used by the isort repo itself, so we'll use their
-    preferred colors
-
-.. image:: https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat&labelColor=ef8336
-    :alt: Import Style
-    :target: https://pycqa.github.io/isort/
-
-.. image:: https://img.shields.io/badge/code%20style-black-000000.svg
-    :alt: Code Style
-    :target: https://github.com/psf/black
-
-
 Globus SDK for Python
 =====================
 

--- a/changelog.d/20250520_105851_kurtmckee_rm_readme_badges.rst
+++ b/changelog.d/20250520_105851_kurtmckee_rm_readme_badges.rst
@@ -1,0 +1,4 @@
+Documentation
+~~~~~~~~~~~~~
+
+- Remove the badges at the top of the README. (:pr:`NUMBER`)


### PR DESCRIPTION
Documentation
-------------

- Remove the badges at the top of the README.

-----

Because the README is frozen in time when published to PyPI, the badges represent a risk of aging poorly:

> ![image](https://github.com/user-attachments/assets/40217ffd-a3dc-4761-b4ca-3f4568012b95)

This PR removes the badges to reduce clutter ("sorted with isort") and to reduce the risk of breaking over time ("build status").

<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1194.org.readthedocs.build/en/1194/

<!-- readthedocs-preview globus-sdk-python end -->