### PR TITLE
Remove the `globus_sdk.version` module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SDK_VERSION=$(shell grep '^__version__' src/globus_sdk/version.py | cut -d '"' -f2)
+SDK_VERSION=$(shell grep '^version' pyproject.toml | head -n 1 | cut -d '"' -f2)
 
 # these are just tox invocations wrapped nicely for convenience
 .PHONY: lint test docs all-checks

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -18,7 +18,7 @@
 - Decide on the new version number and create a branch;
    `git checkout -b release-$SDK_VERSION`
 
-- Update the version in `src/globus_sdk/version.py`
+- Update the version in `pyproject.toml`
 
 - Update metadata and changelog, then verify changes in `changelog.rst`
 
@@ -28,7 +28,7 @@ $EDITOR changelog.rst
 ```
 
 - Add changed files;
-    `git add changelog.d/ changelog.rst src/globus_sdk/version.py`
+    `git add changelog.d/ changelog.rst pyproject.toml`
 
 - Commit; `git commit -m 'Bump version and changelog for release'`
 

--- a/changelog.d/20250520_121116_kurtmckee_rm_executable_version_code.rst
+++ b/changelog.d/20250520_121116_kurtmckee_rm_executable_version_code.rst
@@ -1,0 +1,12 @@
+Breaking Changes
+~~~~~~~~~~~~~~~~
+
+- The SDK version is no longer available in ``globus_sdk.version.__version__``. (:pr:`NUMBER`)
+
+  Packages that want to query the SDK version must use ``importlib.metadata``:
+
+  ..  code-block:: python
+
+        import importlib.metadata
+
+        GLOBUS_SDK_VERSION = importlib.metadata.distribution("globus_sdk").version

--- a/changelog.d/check-version-is-new.py
+++ b/changelog.d/check-version-is-new.py
@@ -6,24 +6,22 @@ import os
 import re
 import sys
 
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    # Older Python versions
+    import tomli as tomllib
+
 PATTERN_FORMAT = "^v{version}\\s+\\({date}\\)$"
 CHANGELOG_D = os.path.dirname(__file__)
 REPO_ROOT = os.path.dirname(CHANGELOG_D)
 
 
 def parse_version():
-    # single source of truth for package version
-    version_string = ""
-    version_pattern = re.compile(r'__version__ = "([^"]*)"')
-    with open(os.path.join(REPO_ROOT, "src", "globus_sdk", "version.py")) as f:
-        for line in f:
-            match = version_pattern.match(line)
-            if match:
-                version_string = match.group(1)
-                break
-    if not version_string:
-        raise RuntimeError("Failed to parse version information")
-    return version_string
+    with open(os.path.join(REPO_ROOT, "pyproject.toml"), "rb") as f:
+        pyproject = tomllib.load(f)
+
+    return pyproject["project"]["version"]
 
 
 def get_header_re(version):

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -25,10 +25,10 @@ the globus-sdk at the same time, consider adding this snippet:
 
 .. code-block:: python
 
-    import globus_sdk
+    import importlib.metadata
 
-    GLOBUS_SDK_VERSION = tuple(globus_sdk.__version__.split("."))
-    GLOBUS_SDK_MAJOR_VERSION = int(GLOBUS_SDK_VERSION[0])
+    GLOBUS_SDK_VERSION = importlib.metadata.distribution("globus_sdk").version
+    GLOBUS_SDK_MAJOR_VERSION = int(GLOBUS_SDK_VERSION.split(".")[0])
 
 This will parse the Globus SDK version information into a tuple and grab the
 first element (the major version number) as an integer.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "globus-sdk"
+version = "4.0.0a1"
 authors = [
     { name = "Globus Team", email = "support@globus.org" },
 ]
@@ -36,7 +37,6 @@ dependencies = [
     # python versions older than 3.9 don't have importlib.resources
     'importlib_resources>=5.12.0; python_version<"3.9"',
 ]
-dynamic = ["version"]
 
 [project.readme]
 file = "README.rst"
@@ -100,9 +100,6 @@ globus_sdk = [
 ]
 "globus_sdk.login_flows.local_server_login_flow_manager.html_files" = ["*.html"]
 
-[tool.setuptools.dynamic.version]
-attr = "globus_sdk.__version__"
-
 # non-packaging tool configs follow
 
 [tool.pytest.ini_options]
@@ -149,7 +146,7 @@ exclude_lines =[
 ]
 
 [tool.scriv]
-version = "literal: src/globus_sdk/version.py: __version__"
+version = "literal: pyproject.toml: project.version"
 format = "rst"
 output_file = "changelog.rst"
 entry_title_template = 'v{{ version }} ({{ date.strftime("%Y-%m-%d") }})'

--- a/scripts/rtd-pre-sphinx-build.sh
+++ b/scripts/rtd-pre-sphinx-build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION=$(grep '^__version__' src/globus_sdk/version.py | cut -d '"' -f2)
+VERSION=$(grep '^version' pyproject.toml | head -n 1 | cut -d '"' -f2)
 
 case "$READTHEDOCS_VERSION_TYPE" in
     external)

--- a/src/globus_sdk/__init__.py
+++ b/src/globus_sdk/__init__.py
@@ -1,3 +1,4 @@
+import importlib.metadata
 import logging
 import sys
 
@@ -6,7 +7,8 @@ from ._lazy_import import (
     default_getattr_implementation,
     load_all_tuple,
 )
-from .version import __version__  # noqa: F401
+
+__version__ = importlib.metadata.distribution("globus_sdk").version
 
 
 def _force_eager_imports() -> None:

--- a/src/globus_sdk/__init__.pyi
+++ b/src/globus_sdk/__init__.pyi
@@ -127,7 +127,8 @@ from .services.transfer import (
     TransferData,
 )
 from .utils import MISSING, MissingType
-from .version import __version__
+
+__version__ = "x.y.z"
 
 def _force_eager_imports() -> None: ...
 

--- a/src/globus_sdk/tokenstorage/v1/file_adapters.py
+++ b/src/globus_sdk/tokenstorage/v1/file_adapters.py
@@ -5,7 +5,7 @@ import pathlib
 import typing as t
 
 import globus_sdk
-from globus_sdk.version import __version__
+from globus_sdk import __version__
 
 from .base import FileAdapter
 

--- a/src/globus_sdk/tokenstorage/v1/sqlite_adapter.py
+++ b/src/globus_sdk/tokenstorage/v1/sqlite_adapter.py
@@ -6,7 +6,7 @@ import sqlite3
 import typing as t
 
 import globus_sdk
-from globus_sdk.version import __version__
+from globus_sdk import __version__
 
 from .base import FileAdapter
 

--- a/src/globus_sdk/tokenstorage/v2/json.py
+++ b/src/globus_sdk/tokenstorage/v2/json.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import typing as t
 
-from globus_sdk.version import __version__
+from globus_sdk import __version__
 
 from .base import FileTokenStorage
 from .token_data import TokenStorageData

--- a/src/globus_sdk/tokenstorage/v2/sqlite.py
+++ b/src/globus_sdk/tokenstorage/v2/sqlite.py
@@ -6,8 +6,7 @@ import sqlite3
 import textwrap
 import typing as t
 
-from globus_sdk import exc
-from globus_sdk.version import __version__
+from globus_sdk import __version__, exc
 
 from .base import FileTokenStorage
 from .token_data import TokenStorageData

--- a/src/globus_sdk/transport/_clientinfo.py
+++ b/src/globus_sdk/transport/_clientinfo.py
@@ -10,8 +10,7 @@ from __future__ import annotations
 
 import typing as t
 
-from globus_sdk import exc
-from globus_sdk.version import __version__
+from globus_sdk import __version__, exc
 
 _RESERVED_CHARS = ";,="
 

--- a/src/globus_sdk/transport/requests.py
+++ b/src/globus_sdk/transport/requests.py
@@ -9,14 +9,13 @@ import typing as t
 
 import requests
 
-from globus_sdk import config, exc, utils
+from globus_sdk import __version__, config, exc, utils
 from globus_sdk.authorizers import GlobusAuthorizer
 from globus_sdk.transport.encoders import (
     FormRequestEncoder,
     JSONRequestEncoder,
     RequestEncoder,
 )
-from globus_sdk.version import __version__
 
 from ._clientinfo import GlobusClientInfo
 from .retry import (

--- a/src/globus_sdk/version.py
+++ b/src/globus_sdk/version.py
@@ -1,3 +1,0 @@
-# single source of truth for package version,
-# see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "4.0.0a1"

--- a/tests/functional/tokenstorage/v1/test_simplejson_file.py
+++ b/tests/functional/tokenstorage/v1/test_simplejson_file.py
@@ -3,8 +3,8 @@ import os
 
 import pytest
 
+from globus_sdk import __version__
 from globus_sdk.tokenstorage import SimpleJSONFileAdapter
-from globus_sdk.version import __version__
 
 IS_WINDOWS = os.name == "nt"
 

--- a/tests/functional/tokenstorage/v2/test_json_tokenstorage.py
+++ b/tests/functional/tokenstorage/v2/test_json_tokenstorage.py
@@ -3,8 +3,8 @@ import os
 
 import pytest
 
+from globus_sdk import __version__
 from globus_sdk.tokenstorage import JSONTokenStorage, SimpleJSONFileAdapter
-from globus_sdk.version import __version__
 
 IS_WINDOWS = os.name == "nt"
 

--- a/tests/non-pytest/lazy-imports/test_modules_do_not_require_requests.py
+++ b/tests/non-pytest/lazy-imports/test_modules_do_not_require_requests.py
@@ -39,7 +39,6 @@ PYTHON_BINARY = os.environ.get("GLOBUS_TEST_PY", sys.executable)
         "_serializable",
         "_types",
         "utils",
-        "version",
     ),
 )
 def test_module_does_not_require_requests(module_name):

--- a/tests/unit/tokenstorage/v1/test_simplejson_adapter.py
+++ b/tests/unit/tokenstorage/v1/test_simplejson_adapter.py
@@ -2,8 +2,8 @@ import json
 
 import pytest
 
+from globus_sdk import __version__ as sdkversion
 from globus_sdk.tokenstorage import SimpleJSONFileAdapter
-from globus_sdk.version import __version__ as sdkversion
 
 
 def test_simplejson_reading_bad_data(tmp_path):


### PR DESCRIPTION
Breaking Changes
----------------

- The SDK version is no longer available in ``globus_sdk.version.__version__``.

  Packages that want to query the SDK version must use ``importlib.metadata``:

  ```python
  import importlib.metadata

  GLOBUS_SDK_VERSION = importlib.metadata.distribution("globus_sdk").version
  ```

----

This PR aligns the SDK's versioning and documentation with current best practice, which is to use `importlib.metadata` to query for the installed package version. This technique works universally for all packages and, bonus, avoids executing package code and whatever side effects may be associated with that execution.