### PR TITLE
Tiny typo fix

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -21,7 +21,7 @@ Fixed
 ~~~~~
 
 - Fix the type annotation on ``filter_roles`` for ``FlowsClient``
-  to allow non-list iterables. (:pr:`1184`)
+  to allow non-list iterables. (:pr:`1183`)
 
 .. _changelog-3.56.0:
 


### PR DESCRIPTION
I also fixed it in the text of the release PR -- which is where I originally got confused.
Fix it before it disappears beneath the waves.


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1196.org.readthedocs.build/en/1196/

<!-- readthedocs-preview globus-sdk-python end -->