### PR TITLE
Reduce cognitive complexity of the scope parser

### DIFF
--- a/src/globus_sdk/scopes/_parser.py
+++ b/src/globus_sdk/scopes/_parser.py
@@ -21,7 +21,7 @@ def _tokenize(scope_string: str) -> list[str]:
             tokens.append(scope_string[start:idx])
         start = idx + 1
 
-        if current_char in ("*", "[", "]"):
+        if current_char in SPECIAL_TOKENS:
             tokens.append(current_char)
         elif current_char == " ":
             pass

--- a/tests/non-pytest/performance/parser_benchmark.py
+++ b/tests/non-pytest/performance/parser_benchmark.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import sys
+import timeit
+
+from globus_sdk.scopes._parser import parse_scope_graph
+
+
+def timeit_test() -> None:
+    for size, num_iterations, style in (
+        (10, 1000, "deep"),
+        (100, 1000, "deep"),
+        (1000, 1000, "deep"),
+        (2000, 100, "deep"),
+        (3000, 100, "deep"),
+        (4000, 100, "deep"),
+        (5000, 100, "deep"),
+        (5000, 1000, "wide"),
+        (10000, 1000, "wide"),
+    ):
+        if style == "deep":
+            setup = f"""\
+from globus_sdk.experimental.scope_parser import Scope
+big_scope = ""
+for i in range({size}):
+    big_scope += f"foo{{i}}["
+big_scope += "bar"
+for _ in range({size}):
+    big_scope += "]"
+"""
+        elif style == "wide":
+            setup = f"""\
+from globus_sdk.experimental.scope_parser import Scope
+big_scope = ""
+for i in range({size}):
+    big_scope += f"foo{{i}} "
+"""
+        else:
+            raise NotImplementedError
+
+        timer = timeit.Timer("Scope.parse(big_scope)", setup=setup)
+
+        raw_timings = timer.repeat(repeat=5, number=num_iterations)
+        best, worst, average, variance = _stats(raw_timings)
+        if style == "deep":
+            print(f"{num_iterations} runs on a deep scope, depth={size}")
+        elif style == "wide":
+            print(f"{num_iterations} runs on a wide scope, width={size}")
+        else:
+            raise NotImplementedError
+        print(f"  best={best} worst={worst} average={average} variance={variance}")
+        print(f"  normalized best={best / num_iterations}")
+        print()
+    print("The most informative stat over these timings is the min timing (best).")
+    print("Normed best is best/iterations.")
+    print(
+        "Max timing (worst) and dispersion (variance vis-a-vis average) indicate "
+        "how consistent the results are, but are not a report of speed."
+    )
+
+
+def _stats(timing_data: list[float]) -> tuple[float, float, float, float]:
+    best = min(timing_data)
+    worst = max(timing_data)
+    average = sum(timing_data) / len(timing_data)
+    variance = sum((x - average) ** 2 for x in timing_data) / len(timing_data)
+    return best, worst, average, variance
+
+
+def parse_test(scope_string: str) -> None:
+    parsed_graph = parse_scope_graph(scope_string)
+    print(
+        "top level scopes:",
+        ", ".join([name for name, _optional in parsed_graph.top_level_scopes]),
+    )
+    print(parsed_graph)
+
+
+def main() -> None:
+    if len(sys.argv) < 2 or sys.argv[1] in ("-h", "--help"):
+        print("This script supports two usage patterns:")
+        print("    python -m globus_sdk.experimental.scope_parser SCOPE_STRING")
+        print("    python -m globus_sdk.experimental.scope_parser --timeit")
+        sys.exit(0)
+
+    print()
+    if sys.argv[1] == "--timeit":
+        timeit_test()
+    else:
+        parse_test(sys.argv[1])
+
+
+main()


### PR DESCRIPTION
This effort was based on analysis using `complexipy` to identify difficult-to-maintain codepaths.
The scope parser stands out as having dramatically higher complexity than the rest of the codebase, which makes it interesting to examine and update.

The updated version is at least arguably, if not definitively, more maintainable, at the cost of some micro-optimizations which dodge function-call overheads.

## Performance

Using the benchmark script, we see the following degradation in performance:

1. `depth=10`

- original: 2.9798308038152753e-05 seconds
- updated:  4.319636104628444e-05 seconds

Therefore, we're ~30% slower on small scopes, but still take fractions of a millisecond to parse.

2. `depth=100`

- original: 0.00031491286400705577 seconds
- updated:  0.00044869115098845213 seconds

This maintains the 30% perf degradation.

3. `depth=5000`

- original: 0.1826306022098288 seconds
- updated:  0.19780024648993277 seconds

Interestingly, as the scope becomes arbitrarily deeply nested, the perf loss shrinks.
Somehow, the overheads of calling more functions disappear the more times those functions are called.
Perhaps sets or strings are being interned more effectively as the program runs, or CPython is finding other ways to optimize this "hot path".

Therefore, at worst we've gotten a 30% perf loss in already *very fast* (for Python) code.

## Cognitive Complexity / Maintainability

`complexipy` is a cognitive complexity measurement tool.

It presents a nice chart of scores, but for comparison against `main` we just want the raw data.

Getting the 3 "worst" functions in the scope parser:
```
$ uvx complexipy src/globus_sdk/scopes/_parser.py -q -o > /dev/null; tail -n 3 complexipy.csv
_parser.py,_parser.py,ScopeGraph::_check_cycles,8
_parser.py,_parser.py,_tokenize,8
_parser.py,_parser.py,_parse_tokens,10
```

(scores are 8, 8, 10 above)

And getting the 3 "worst" functions in the src tree:
```
$ uvx complexipy src -q -o > /dev/null; tail -n 3 complexipy.csv
src/globus_sdk/transport/requests.py,requests.py,RequestsTransport::request,12
src/globus_sdk/_lazy_import.py,_lazy_import.py,_ParsedPYIData::_load_statement,13
src/globus_sdk/services/transfer/client.py,client.py,TransferClient::endpoint_manager_task_list,15
```

The above are taken after these changes.
Compare against scores before the change:
```
$ uvx complexipy src -q -o > /dev/null; tail -n 3 complexipy.csv
src/globus_sdk/services/transfer/client.py,client.py,TransferClient::endpoint_manager_task_list,15
src/globus_sdk/scopes/_parser.py,_parser.py,_tokenize,22
src/globus_sdk/scopes/_parser.py,_parser.py,_parse_tokens,23
```

We can see that `_tokenize()` was scored at 22, and `_parse_tokens()` at 23.

### Cognitive Complexity Scores are Only a Metric!

Obviously, a metric is only as good as what it actually tells us.

I tried cognitive complexity analysis on our codebase to see if it could find any maintenance risks by showing us outliers.

My *opinion* after examining what it showed is that the high cognitive complexity functions, `_tokenize` and `_parse_tokens` are good candidates for revision and are hard to maintain.

The metric is easy to confuse with an actual *assessment* of maintainability, but should be carefully distinguished from that.
I've made changes which lower the metric, and then reassessed -- "Is this code more readable?" -- and believe that the changes are net-good.


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1199.org.readthedocs.build/en/1199/

<!-- readthedocs-preview globus-sdk-python end -->