### PR TITLE
Add an entry to the upgrading doc for MutableScope

### DIFF
--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -45,6 +45,31 @@ Then, code can dispatch with
 From 3.x to 4.0
 ---------------
 
+``MutableScope`` is Removed, use ``Scope`` Instead
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``MutableScope`` type was removed in version 4 in favor of the ``Scope``
+type.
+When manipulating scopes as objects, use the ``Scope`` object anywhere that
+``MutableScope`` was used, for example:
+
+.. code-block:: python
+
+    # globus-sdk v3
+    from globus_sdk.scopes import MutableScope
+
+    my_scope = MutableScope("urn:globus:auth:scopes:transfer.api.globus.org:all")
+
+    # globus-sdk v4
+    from globus_sdk.scopes import Scope
+
+    my_scope = Scope("urn:globus:auth:scopes:transfer.api.globus.org:all")
+
+.. note::
+
+    The ``Scope`` type was added in Globus SDK v3, so this transition can be
+    made prior to upgrading to version 4.
+
 ``requested_scopes`` is Required
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
I intentionally omitted any doc update when removing `MutableScope`, but have reconsidered.
I think a minimal stub is still worth adding, and we can enhance it later.

---

This is a small/minimal entry so that we're guaranteed to have something to build upon.

It intentionally does not go into detail on how to use `Scope` because these interfaces are being redesigned.
