### PR TITLE
Emit deprecation warnings on legacy scope imports

### DIFF
--- a/changelog.d/20250529_121708_sirosen_emit_warning_on_deprecated_scope_parser_import.rst
+++ b/changelog.d/20250529_121708_sirosen_emit_warning_on_deprecated_scope_parser_import.rst
@@ -1,0 +1,6 @@
+Deprecated
+~~~~~~~~~~
+
+- Importing scope parsing tools from ``globus_sdk.experimental`` now emits a
+  deprecation warning. These names were previously deprecated in documentation
+  only. (:pr:`NUMBER`)

--- a/src/globus_sdk/experimental/scope_parser.py
+++ b/src/globus_sdk/experimental/scope_parser.py
@@ -4,10 +4,34 @@ This module will be removed in a future release but is maintained in the interim
   backwards compatibility.
 """
 
-from globus_sdk.scopes import Scope, ScopeCycleError, ScopeParseError
+from __future__ import annotations
+
+import sys
+import typing as t
 
 __all__ = (
     "Scope",
     "ScopeParseError",
     "ScopeCycleError",
 )
+
+if t.TYPE_CHECKING:
+    from globus_sdk.scopes import Scope, ScopeCycleError, ScopeParseError
+else:
+
+    def __getattr__(name: str) -> t.Any:
+        import globus_sdk.scopes as scopes_module
+        from globus_sdk.exc import warn_deprecated
+
+        warn_deprecated(
+            "'globus_sdk.experimental.scope_parser' has been merged into "
+            "'globus_sdk.scopes'. "
+            f"Importing '{name}' from `globus_sdk.experimental` is deprecated. "
+            f"Use `globus_sdk.scopes.{name}` instead."
+        )
+
+        value = getattr(scopes_module, name, None)
+        if value is None:
+            raise AttributeError(f"module {__name__} has no attribute {name}")
+        setattr(sys.modules[__name__], name, value)
+        return value

--- a/tests/unit/experimental/test_legacy_support.py
+++ b/tests/unit/experimental/test_legacy_support.py
@@ -23,11 +23,12 @@ from globus_sdk.gare import (
 
 
 def test_scope_importable_from_experimental():
-    from globus_sdk.experimental.scope_parser import (  # noqa: F401
-        Scope,
-        ScopeCycleError,
-        ScopeParseError,
-    )
+    with pytest.warns(RemovedInV4Warning):
+        from globus_sdk.experimental.scope_parser import (  # noqa: F401
+            Scope,
+            ScopeCycleError,
+            ScopeParseError,
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
These imports were deprecated documentation-wise before we established
a policy of emitting warnings at import-time for our legacy imports.

Adding the deprecation warning helps to inform users and ensures that
these will be removed under SDK v4.
