### PR TITLE
Remove the setter for GlobusAPIError.message

### DIFF
--- a/changelog.d/20250530_102408_sirosen_remove_deprecated_message_setter.rst
+++ b/changelog.d/20250530_102408_sirosen_remove_deprecated_message_setter.rst
@@ -1,0 +1,5 @@
+Removed
+~~~~~~~
+
+- ``GlobusAPIError`` no longer provides a setter for ``message``. The
+  ``message`` property is now read-only. (:pr:`NUMBER`)

--- a/src/globus_sdk/exc/api.py
+++ b/src/globus_sdk/exc/api.py
@@ -68,14 +68,6 @@ class GlobusAPIError(GlobusError):
             return "; ".join(self.messages)
         return None
 
-    @message.setter
-    def message(self, value: str) -> None:
-        warn_deprecated(
-            "Setting a message on GlobusAPIError objects is deprecated. "
-            "This overwrites any parsed messages. Append to 'messages' instead."
-        )
-        self.messages = [value]
-
     @property
     def http_reason(self) -> str:
         """

--- a/tests/unit/errors/test_common_functionality.py
+++ b/tests/unit/errors/test_common_functionality.py
@@ -65,24 +65,6 @@ def test_raw_text_property_warns():
         assert err.raw_text == body_text
 
 
-def test_imperative_message_setting_warns():
-    err = construct_error(
-        body={"code": "FooCode", "message": "FooMessage"}, http_status=400
-    )
-    assert err.message == "FooMessage"
-
-    with pytest.warns(
-        RemovedInV4Warning,
-        match=(
-            r"Setting a message on GlobusAPIError objects is deprecated\. "
-            r"This overwrites any parsed messages\. Append to 'messages' instead\."
-        ),
-    ):
-        err.message = "BarMessage"
-
-    assert err.message == "BarMessage"
-
-
 @pytest.mark.parametrize(
     "body, response_headers, http_status, expect_code, expect_message",
     (


### PR DESCRIPTION
This was deprecated under 3.x and is now being removed.

It is sufficiently minor that it probably doesn't warrant a call-out
in the upgrading guide doc.


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1204.org.readthedocs.build/en/1204/

<!-- readthedocs-preview globus-sdk-python end -->