### PR TITLE
Update flows client classes to use MISSING defaults

### DIFF
--- a/src/globus_sdk/client.py
+++ b/src/globus_sdk/client.py
@@ -11,6 +11,7 @@ from globus_sdk.paging import PaginatorTable
 from globus_sdk.response import GlobusHTTPResponse
 from globus_sdk.scopes import Scope, ScopeBuilder
 from globus_sdk.transport import RequestsTransport
+from globus_sdk.utils import MissingType
 
 if t.TYPE_CHECKING:
     from globus_sdk.globus_app import GlobusApp
@@ -313,7 +314,7 @@ class BaseClient:
         self,
         path: str,
         *,
-        query_params: dict[str, t.Any] | None = None,
+        query_params: dict[str, t.Any] | MissingType | None = None,
         headers: dict[str, str] | None = None,
         automatic_authorization: bool = True,
     ) -> GlobusHTTPResponse:
@@ -335,7 +336,7 @@ class BaseClient:
         self,
         path: str,
         *,
-        query_params: dict[str, t.Any] | None = None,
+        query_params: dict[str, t.Any] | MissingType | None = None,
         data: _DataParamType = None,
         headers: dict[str, str] | None = None,
         encoding: str | None = None,
@@ -361,7 +362,7 @@ class BaseClient:
         self,
         path: str,
         *,
-        query_params: dict[str, t.Any] | None = None,
+        query_params: dict[str, t.Any] | MissingType | None = None,
         headers: dict[str, str] | None = None,
         automatic_authorization: bool = True,
     ) -> GlobusHTTPResponse:
@@ -383,7 +384,7 @@ class BaseClient:
         self,
         path: str,
         *,
-        query_params: dict[str, t.Any] | None = None,
+        query_params: dict[str, t.Any] | MissingType | None = None,
         data: _DataParamType = None,
         headers: dict[str, str] | None = None,
         encoding: str | None = None,
@@ -409,7 +410,7 @@ class BaseClient:
         self,
         path: str,
         *,
-        query_params: dict[str, t.Any] | None = None,
+        query_params: dict[str, t.Any] | MissingType | None = None,
         data: _DataParamType = None,
         headers: dict[str, str] | None = None,
         encoding: str | None = None,
@@ -436,7 +437,7 @@ class BaseClient:
         method: str,
         path: str,
         *,
-        query_params: dict[str, t.Any] | None = None,
+        query_params: dict[str, t.Any] | MissingType | None = None,
         data: _DataParamType = None,
         headers: dict[str, str] | None = None,
         encoding: str | None = None,
@@ -470,6 +471,9 @@ class BaseClient:
         # prepare data...
         # copy headers if present
         rheaders = {**headers} if headers else {}
+
+        if isinstance(query_params, MissingType):
+            query_params = None
 
         # if a client is asked to make a request against a full URL, not just the path
         # component, then do not resolve the path, simply pass it through as the URL

--- a/src/globus_sdk/services/flows/client.py
+++ b/src/globus_sdk/services/flows/client.py
@@ -47,16 +47,16 @@ class FlowsClient(client.BaseClient):
         title: str,
         definition: dict[str, t.Any],
         input_schema: dict[str, t.Any],
-        subtitle: str | None = None,
-        description: str | None = None,
-        flow_viewers: list[str] | None = None,
-        flow_starters: list[str] | None = None,
-        flow_administrators: list[str] | None = None,
-        run_managers: list[str] | None = None,
-        run_monitors: list[str] | None = None,
-        keywords: list[str] | None = None,
-        subscription_id: UUIDLike | None = None,
-        additional_fields: dict[str, t.Any] | None = None,
+        subtitle: str | MissingType = MISSING,
+        description: str | MissingType = MISSING,
+        flow_viewers: list[str] | MissingType = MISSING,
+        flow_starters: list[str] | MissingType = MISSING,
+        flow_administrators: list[str] | MissingType = MISSING,
+        run_managers: list[str] | MissingType = MISSING,
+        run_monitors: list[str] | MissingType = MISSING,
+        keywords: list[str] | MissingType = MISSING,
+        subscription_id: UUIDLike | None | MissingType = MISSING,
+        additional_fields: dict[str, t.Any] | MissingType = MISSING,
     ) -> GlobusHTTPResponse:
         """
         Create a flow
@@ -201,9 +201,10 @@ class FlowsClient(client.BaseClient):
                 "keywords": keywords,
                 "subscription_id": subscription_id,
             }.items()
-            if v is not None
+            if not isinstance(v, MissingType)
         }
-        data.update(additional_fields or {})
+        if not isinstance(additional_fields, MissingType):
+            data.update(additional_fields)
 
         return self.post("/flows", data=data)
 
@@ -211,7 +212,7 @@ class FlowsClient(client.BaseClient):
         self,
         flow_id: UUIDLike,
         *,
-        query_params: dict[str, t.Any] | None = None,
+        query_params: dict[str, t.Any] | MissingType = MISSING,
     ) -> GlobusHTTPResponse:
         """Retrieve a flow by ID
 
@@ -227,22 +228,18 @@ class FlowsClient(client.BaseClient):
                     :service: flows
                     :ref: Flows/paths/~1flows~1{flow_id}/get
         """
-
-        if query_params is None:
-            query_params = {}
-
         return self.get(f"/flows/{flow_id}", query_params=query_params)
 
     @paging.has_paginator(paging.MarkerPaginator, items_key="flows")
     def list_flows(
         self,
         *,
-        filter_role: str | None = None,
-        filter_roles: str | t.Iterable[str] | None = None,
-        filter_fulltext: str | None = None,
-        orderby: str | t.Iterable[str] | None = None,
-        marker: str | None = None,
-        query_params: dict[str, t.Any] | None = None,
+        filter_role: str | MissingType = MISSING,
+        filter_roles: str | t.Iterable[str] | MissingType = MISSING,
+        filter_fulltext: str | MissingType = MISSING,
+        orderby: str | t.Iterable[str] | MissingType = MISSING,
+        marker: str | MissingType = MISSING,
+        query_params: dict[str, t.Any] | MissingType = MISSING,
     ) -> IterableFlowsResponse:
         """
         List deployed flows
@@ -345,23 +342,25 @@ class FlowsClient(client.BaseClient):
                     :ref: Flows/paths/~1flows/get
         """
 
-        if query_params is None:
+        if isinstance(query_params, MissingType):
             query_params = {}
-        if filter_role is not None:
+        if not isinstance(filter_role, MissingType):
             exc.warn_deprecated(
                 "The `filter_role` parameter is deprecated. Use `filter_roles` instead."
             )
             query_params["filter_role"] = filter_role
-        if filter_roles is not None:
+        if not isinstance(filter_roles, MissingType):
             query_params["filter_roles"] = utils.commajoin(filter_roles)
-        if filter_fulltext is not None:
+        if not isinstance(filter_fulltext, MissingType):
             query_params["filter_fulltext"] = filter_fulltext
 
-        if filter_role is not None and filter_roles is not None:
+        if not isinstance(filter_role, MissingType) and not isinstance(
+            filter_roles, MissingType
+        ):
             msg = "Mutually exclusive parameters: filter_role and filter_roles."
             raise GlobusSDKUsageError(msg)
 
-        if orderby is not None:
+        if not isinstance(orderby, MissingType):
             if isinstance(orderby, str):
                 query_params["orderby"] = orderby
             else:
@@ -370,7 +369,7 @@ class FlowsClient(client.BaseClient):
                 # this also ensures that we will consume non-sequence iterables
                 # (e.g. generator expressions) in a well-defined way
                 query_params["orderby"] = list(orderby)
-        if marker is not None:
+        if not isinstance(marker, MissingType):
             query_params["marker"] = marker
 
         return IterableFlowsResponse(self.get("/flows", query_params=query_params))
@@ -379,20 +378,20 @@ class FlowsClient(client.BaseClient):
         self,
         flow_id: UUIDLike,
         *,
-        title: str | None = None,
-        definition: dict[str, t.Any] | None = None,
-        input_schema: dict[str, t.Any] | None = None,
-        subtitle: str | None = None,
-        description: str | None = None,
-        flow_owner: str | None = None,
-        flow_viewers: list[str] | None = None,
-        flow_starters: list[str] | None = None,
-        flow_administrators: list[str] | None = None,
-        run_managers: list[str] | None = None,
-        run_monitors: list[str] | None = None,
-        keywords: list[str] | None = None,
+        title: str | MissingType = MISSING,
+        definition: dict[str, t.Any] | MissingType = MISSING,
+        input_schema: dict[str, t.Any] | MissingType = MISSING,
+        subtitle: str | MissingType = MISSING,
+        description: str | MissingType = MISSING,
+        flow_owner: str | MissingType = MISSING,
+        flow_viewers: list[str] | MissingType = MISSING,
+        flow_starters: list[str] | MissingType = MISSING,
+        flow_administrators: list[str] | MissingType = MISSING,
+        run_managers: list[str] | MissingType = MISSING,
+        run_monitors: list[str] | MissingType = MISSING,
+        keywords: list[str] | MissingType = MISSING,
         subscription_id: UUIDLike | t.Literal["DEFAULT"] | MissingType = MISSING,
-        additional_fields: dict[str, t.Any] | None = None,
+        additional_fields: dict[str, t.Any] | MissingType = MISSING,
     ) -> GlobusHTTPResponse:
         """
         Update a flow
@@ -530,9 +529,10 @@ class FlowsClient(client.BaseClient):
                 "keywords": keywords,
                 "subscription_id": subscription_id,
             }.items()
-            if v is not None and v is not MISSING
+            if not isinstance(v, MissingType)
         }
-        data.update(additional_fields or {})
+        if not isinstance(additional_fields, MissingType):
+            data.update(additional_fields)
 
         return self.put(f"/flows/{flow_id}", data=data)
 
@@ -540,7 +540,7 @@ class FlowsClient(client.BaseClient):
         self,
         flow_id: UUIDLike,
         *,
-        query_params: dict[str, t.Any] | None = None,
+        query_params: dict[str, t.Any] | MissingType = MISSING,
     ) -> GlobusHTTPResponse:
         """Delete a flow
 
@@ -556,10 +556,6 @@ class FlowsClient(client.BaseClient):
                     :service: flows
                     :ref: Flows/paths/~1flows~1{flow_id}/delete
         """
-
-        if query_params is None:
-            query_params = {}
-
         return self.delete(f"/flows/{flow_id}", query_params=query_params)
 
     def validate_flow(
@@ -611,17 +607,19 @@ class FlowsClient(client.BaseClient):
                     :ref: Flows/paths/~1flows~1validate/post
         """  # noqa E501
 
-        data = {"definition": definition, "input_schema": input_schema}
+        data = {"definition": definition}
+        if not isinstance(input_schema, MissingType):
+            data["input_schema"] = input_schema
         return self.post("/flows/validate", data=data)
 
     @paging.has_paginator(paging.MarkerPaginator, items_key="runs")
     def list_runs(
         self,
         *,
-        filter_flow_id: t.Iterable[UUIDLike] | UUIDLike | None = None,
-        filter_roles: str | t.Iterable[str] | None = None,
-        marker: str | None = None,
-        query_params: dict[str, t.Any] | None = None,
+        filter_flow_id: t.Iterable[UUIDLike] | UUIDLike | MissingType = MISSING,
+        filter_roles: str | t.Iterable[str] | MissingType = MISSING,
+        marker: str | MissingType = MISSING,
+        query_params: dict[str, t.Any] | MissingType = MISSING,
     ) -> IterableRunsResponse:
         """
         List all runs.
@@ -661,15 +659,15 @@ class FlowsClient(client.BaseClient):
                     :service: flows
                     :ref: Runs/paths/~1runs/get
         """
-        if query_params is None:
+        if isinstance(query_params, MissingType):
             query_params = {}
-        if filter_flow_id is not None:
+        if not isinstance(filter_flow_id, MissingType):
             query_params["filter_flow_id"] = ",".join(
                 utils.safe_strseq_iter(filter_flow_id)
             )
-        if filter_roles:
+        if not isinstance(filter_roles, MissingType):
             query_params["filter_roles"] = utils.commajoin(filter_roles)
-        if marker is not None:
+        if not isinstance(marker, MissingType):
             query_params["marker"] = marker
         return IterableRunsResponse(self.get("/runs", query_params=query_params))
 
@@ -678,10 +676,10 @@ class FlowsClient(client.BaseClient):
         self,
         run_id: UUIDLike,
         *,
-        limit: int | None = None,
-        reverse_order: bool | None = None,
-        marker: str | None = None,
-        query_params: dict[str, t.Any] | None = None,
+        limit: int | MissingType = MISSING,
+        reverse_order: bool | MissingType = MISSING,
+        marker: str | MissingType = MISSING,
+        query_params: dict[str, t.Any] | MissingType = MISSING,
     ) -> IterableRunLogsResponse:
         """
         Retrieve the execution logs associated with a run
@@ -712,15 +710,18 @@ class FlowsClient(client.BaseClient):
                     :service: flows
                     :ref: Runs/paths/~1runs~1{action_id}~1log/get
         """
-
+        if isinstance(query_params, MissingType):
+            query_params = {}
         query_params = {
             "limit": limit,
             "reverse_order": reverse_order,
             "marker": marker,
-            **(query_params or {}),
+            **query_params,
         }
-        # Filter out request keys with None values to allow server defaults
-        query_params = {k: v for k, v in query_params.items() if v is not None}
+        # Filter out request keys with MISSING values to allow server defaults
+        query_params = {
+            k: v for k, v in query_params.items() if not isinstance(v, MissingType)
+        }
         return IterableRunLogsResponse(
             self.get(f"/runs/{run_id}/log", query_params=query_params)
         )
@@ -729,8 +730,8 @@ class FlowsClient(client.BaseClient):
         self,
         run_id: UUIDLike,
         *,
-        include_flow_description: bool | None = None,
-        query_params: dict[str, t.Any] | None = None,
+        include_flow_description: bool | MissingType = MISSING,
+        query_params: dict[str, t.Any] | MissingType = MISSING,
     ) -> GlobusHTTPResponse:
         """
         Retrieve information about a particular run of a flow
@@ -764,8 +765,9 @@ class FlowsClient(client.BaseClient):
                     :ref: Flows/paths/~1runs~1{run_id}/get
         """
 
-        query_params = query_params or {}
-        if include_flow_description is not None:
+        if isinstance(query_params, MissingType):
+            query_params = {}
+        if not isinstance(include_flow_description, MissingType):
             query_params["include_flow_description"] = include_flow_description
 
         return self.get(f"/runs/{run_id}", query_params=query_params)
@@ -838,11 +840,11 @@ class FlowsClient(client.BaseClient):
         self,
         run_id: UUIDLike,
         *,
-        label: str | None = None,
-        tags: list[str] | None = None,
-        run_monitors: list[str] | None = None,
-        run_managers: list[str] | None = None,
-        additional_fields: dict[str, t.Any] | None = None,
+        label: str | MissingType = MISSING,
+        tags: list[str] | MissingType = MISSING,
+        run_monitors: list[str] | MissingType = MISSING,
+        run_managers: list[str] | MissingType = MISSING,
+        additional_fields: dict[str, t.Any] | MissingType = MISSING,
     ) -> GlobusHTTPResponse:
         """
         Update the metadata of a specific run.
@@ -893,9 +895,10 @@ class FlowsClient(client.BaseClient):
                 "run_monitors": run_monitors,
                 "run_managers": run_managers,
             }.items()
-            if v is not None
+            if not isinstance(v, MissingType)
         }
-        data.update(additional_fields or {})
+        if not isinstance(additional_fields, MissingType):
+            data.update(additional_fields)
 
         return self.put(f"/runs/{run_id}", data=data)
 
@@ -979,14 +982,14 @@ class SpecificFlowClient(client.BaseClient):
         self,
         body: dict[str, t.Any],
         *,
-        label: str | None = None,
-        tags: list[str] | None = None,
+        label: str | MissingType = MISSING,
+        tags: list[str] | MissingType = MISSING,
         activity_notification_policy: (
-            dict[str, t.Any] | RunActivityNotificationPolicy | None
-        ) = None,
-        run_monitors: list[str] | None = None,
-        run_managers: list[str] | None = None,
-        additional_fields: dict[str, t.Any] | None = None,
+            dict[str, t.Any] | RunActivityNotificationPolicy | MissingType
+        ) = MISSING,
+        run_monitors: list[str] | MissingType = MISSING,
+        run_managers: list[str] | MissingType = MISSING,
+        additional_fields: dict[str, t.Any] | MissingType = MISSING,
     ) -> GlobusHTTPResponse:
         """
         :param body: The input json object handed to the first flow state. The flows
@@ -1023,9 +1026,10 @@ class SpecificFlowClient(client.BaseClient):
                 "run_monitors": run_monitors,
                 "run_managers": run_managers,
             }.items()
-            if v is not None
+            if not isinstance(v, MissingType)
         }
-        data.update(additional_fields or {})
+        if not isinstance(additional_fields, MissingType):
+            data.update(additional_fields)
 
         return self.post(f"/flows/{self._flow_id}/run", data=data)
 

--- a/tests/functional/services/flows/test_flow_crud.py
+++ b/tests/functional/services/flows/test_flow_crud.py
@@ -6,9 +6,10 @@ from responses import matchers
 from globus_sdk import FlowsAPIError
 from globus_sdk._testing import get_last_request, load_response
 from globus_sdk._testing.models import RegisteredResponse
+from globus_sdk.utils import MISSING
 
 
-@pytest.mark.parametrize("subscription_id", [None, "dummy_subscription_id"])
+@pytest.mark.parametrize("subscription_id", [MISSING, None, "dummy_subscription_id"])
 def test_create_flow(flows_client, subscription_id):
     metadata = load_response(flows_client.create_flow).metadata
 
@@ -19,13 +20,13 @@ def test_create_flow(flows_client, subscription_id):
 
     last_req = get_last_request()
     req_body = json.loads(last_req.body)
-    if subscription_id:
+    if subscription_id is not MISSING:
         assert req_body["subscription_id"] == subscription_id
     else:
         assert "subscription_id" not in req_body
 
 
-@pytest.mark.parametrize("value", [None, [], ["dummy_value"]])
+@pytest.mark.parametrize("value", [MISSING, [], ["dummy_value"]])
 @pytest.mark.parametrize("key", ["run_managers", "run_monitors"])
 def test_create_flow_run_role_serialization(flows_client, key, value):
 
@@ -40,7 +41,8 @@ def test_create_flow_run_role_serialization(flows_client, key, value):
         "input_schema": {},
     }
 
-    request_body[key] = value
+    if value is not MISSING:
+        request_body[key] = value
 
     load_response(
         RegisteredResponse(
@@ -66,7 +68,7 @@ def test_create_flow_run_role_serialization(flows_client, key, value):
     last_req = get_last_request()
     req_body = json.loads(last_req.body)
 
-    if value is None:
+    if value is MISSING:
         assert key not in req_body
     else:
         assert req_body[key] == value
@@ -108,7 +110,7 @@ def test_update_flow(flows_client):
         assert resp[k] == v
 
 
-@pytest.mark.parametrize("value", [None, [], ["dummy_value"]])
+@pytest.mark.parametrize("value", [MISSING, [], ["dummy_value"]])
 @pytest.mark.parametrize("key", ["run_managers", "run_monitors"])
 def test_update_flow_run_role_serialization(flows_client, key, value):
     metadata = load_response(flows_client.update_flow).metadata
@@ -119,7 +121,7 @@ def test_update_flow_run_role_serialization(flows_client, key, value):
     last_req = get_last_request()
     req_body = json.loads(last_req.body)
 
-    if value is None:
+    if value is MISSING:
         assert key not in req_body
     else:
         assert req_body[key] == value

--- a/tests/functional/services/flows/test_flow_validate.py
+++ b/tests/functional/services/flows/test_flow_validate.py
@@ -4,15 +4,16 @@ import pytest
 
 from globus_sdk import FlowsAPIError
 from globus_sdk._testing import get_last_request, load_response
+from globus_sdk.utils import MISSING
 
 
-@pytest.mark.parametrize("input_schema", [None, {}])
+@pytest.mark.parametrize("input_schema", [MISSING, {}])
 def test_validate_flow(flows_client, input_schema):
     metadata = load_response(flows_client.validate_flow).metadata
 
     # Prepare the payload
     payload = {"definition": metadata["success"]}
-    if input_schema is not None:
+    if input_schema is not MISSING:
         payload["input_schema"] = input_schema
 
     resp = flows_client.validate_flow(**payload)

--- a/tests/functional/services/flows/test_get_run.py
+++ b/tests/functional/services/flows/test_get_run.py
@@ -1,9 +1,10 @@
 import pytest
 
 from globus_sdk._testing import get_last_request, load_response
+from globus_sdk.utils import MISSING
 
 
-@pytest.mark.parametrize("include_flow_description", (None, False, True))
+@pytest.mark.parametrize("include_flow_description", (MISSING, False, True))
 def test_get_run(flows_client, include_flow_description):
     metadata = load_response(flows_client.get_run).metadata
 
@@ -14,7 +15,7 @@ def test_get_run(flows_client, include_flow_description):
     assert response.http_status == 200
 
     request = get_last_request()
-    if include_flow_description is None:
+    if include_flow_description is MISSING:
         assert "flow_description" not in response
         assert "include_flow_description" not in request.url
     elif include_flow_description is False:

--- a/tests/functional/services/flows/test_list_flows.py
+++ b/tests/functional/services/flows/test_list_flows.py
@@ -4,11 +4,12 @@ import pytest
 
 from globus_sdk import GlobusSDKUsageError, RemovedInV4Warning
 from globus_sdk._testing import get_last_request, load_response
+from globus_sdk.utils import MISSING
 
 
-@pytest.mark.parametrize("filter_fulltext", [None, "foo"])
-@pytest.mark.parametrize("filter_role", [None, "bar"])
-@pytest.mark.parametrize("orderby", [None, "created_at ASC"])
+@pytest.mark.parametrize("filter_fulltext", [MISSING, "foo"])
+@pytest.mark.parametrize("filter_role", [MISSING, "bar"])
+@pytest.mark.parametrize("orderby", [MISSING, "created_at ASC"])
 def test_list_flows_simple(flows_client, filter_fulltext, filter_role, orderby):
     meta = load_response(flows_client.list_flows).metadata
 
@@ -45,7 +46,7 @@ def test_list_flows_simple(flows_client, filter_fulltext, filter_role, orderby):
             ("filter_role", filter_role),
             ("orderby", orderby),
         )
-        if v is not None
+        if v is not MISSING
     }
     assert parsed_qs == expect_query_params
 
@@ -157,7 +158,7 @@ def test_list_flows_mutually_exclusive_roles(flows_client, filter_role, filter_r
         ([], None),
         ([""], None),
         (("",), None),
-        (None, None),
+        (MISSING, None),
         # single role as string
         ("foo", ["foo"]),
         # single role as list/tuple

--- a/tests/functional/services/flows/test_list_runs.py
+++ b/tests/functional/services/flows/test_list_runs.py
@@ -4,6 +4,7 @@ import uuid
 import pytest
 
 from globus_sdk._testing import get_last_request, load_response
+from globus_sdk.utils import MISSING
 
 
 def test_list_runs_simple(flows_client):
@@ -79,7 +80,7 @@ def test_list_runs_filter_flow_id(flows_client, pass_as_uuids):
         ((), None),
         ([""], None),
         (("",), None),
-        (None, None),
+        (MISSING, None),
         # single role as string
         ("foo", ["foo"]),
         # single role as list/tuple


### PR DESCRIPTION
[sc-15807](https://app.shortcut.com/globus/story/15807/sdkv4-convert-defaults-of-none-to-globus-sdk-missing-for-payload-types-allowing-explicit-null-by-setting-none)

### Changes
 - Converted all defaults of `None` to `globus_sdk.MISSING` for all payload types in the flows client.
 - [Updated](https://github.com/globus/globus-sdk-python/blob/ac05d917e1234b76da234a6d1027be1e267b70b9/src/globus_sdk/client.py#L440) the base client’s request functions to allow the `MissingType` for `query_params`.
 - Updated flows unit tests to test with `MISSING` defaults instead of `None`.

[Flows OpenAPI spec](https://globusonline.github.io/globus-flows) for reference.

### Thought process
When determining if a property's new type should keep or loose its none type, I tried generally to follow this rule:

If the property is both nullable AND a user provided explicit None value has a different behavior than not including the property in the payload, it should transform like so:
`field: field_type | None = None` -> `field: field_type | None | MissingType = MISSING`

Otherwise, it should loose its none type and transform like so:
`field: field_type | None = None` -> `field: field_type | MissingType = MISSING`

I'm not completely convinced that this is the correct way of thinking about this, so I would very much appreciate any feedback on this. Specifically, any potential cases where this logic breaks down would be useful to try and get a more concrete ruleset to apply to the other client classes.