### PR TITLE
Update search client classes to use MISSING defaults

### DIFF
--- a/src/globus_sdk/services/search/client.py
+++ b/src/globus_sdk/services/search/client.py
@@ -7,6 +7,7 @@ from globus_sdk import client, paging, response, utils
 from globus_sdk._types import UUIDLike
 from globus_sdk.exc.warnings import warn_deprecated
 from globus_sdk.scopes import Scope, SearchScopes
+from globus_sdk.utils import MISSING, MissingType, filter_missing
 
 from .data import SearchQuery, SearchScrollQuery
 from .errors import SearchAPIError
@@ -278,17 +279,13 @@ class SearchClient(client.BaseClient):
 
                 .. expandtestfixture:: search.search
         """  # noqa: E501
-        if query_params is None:
-            query_params = {}
-        query_params.update(
-            {
-                "q": q,
-                "offset": offset,
-                "limit": limit,
-                "advanced": advanced,
-            }
-        )
-
+        query_params = {
+            **(query_params or {}),
+            "q": q,
+            "offset": offset,
+            "limit": limit,
+            "advanced": advanced,
+        }
         log.debug(f"SearchClient.search({index_id}, ...)")
         return self.get(f"/v1/index/{index_id}/search", query_params=query_params)
 
@@ -304,8 +301,8 @@ class SearchClient(client.BaseClient):
         index_id: UUIDLike,
         data: dict[str, t.Any] | SearchQuery,
         *,
-        offset: int | None = None,
-        limit: int | None = None,
+        offset: int | MissingType = MISSING,
+        limit: int | MissingType = MISSING,
     ) -> response.GlobusHTTPResponse:
         """
         Execute a complex Search Query, using a query document to express filters,
@@ -359,13 +356,16 @@ class SearchClient(client.BaseClient):
                     :ref: search/reference/post_query/
         """
         log.debug(f"SearchClient.post_search({index_id}, ...)")
-        add_kwargs = {}
-        if offset is not None:
-            add_kwargs["offset"] = offset
-        if limit is not None:
-            add_kwargs["limit"] = limit
-        if add_kwargs:
-            data = {**data, **add_kwargs}
+        add_kwargs = filter_missing(
+            {
+                "offset": offset,
+                "limit": limit,
+            }
+        )
+        data = {
+            **data,
+            **add_kwargs,
+        }
         return self.post(f"v1/index/{index_id}/search", data=data)
 
     @paging.has_paginator(paging.MarkerPaginator, items_key="gmeta")
@@ -374,7 +374,7 @@ class SearchClient(client.BaseClient):
         index_id: UUIDLike,
         data: dict[str, t.Any] | SearchScrollQuery,
         *,
-        marker: str | None = None,
+        marker: str | MissingType = MISSING,
     ) -> response.GlobusHTTPResponse:
         """
         Scroll all data in a Search index. The paginated version of this API should
@@ -411,11 +411,15 @@ class SearchClient(client.BaseClient):
                     :ref: search/reference/scroll_query/
         """
         log.debug(f"SearchClient.scroll({index_id}, ...)")
-        add_kwargs = {}
-        if marker is not None:
-            add_kwargs["marker"] = marker
-        if add_kwargs:
-            data = {**data, **add_kwargs}
+        add_kwargs = filter_missing(
+            {
+                "marker": marker,
+            }
+        )
+        data = {
+            **data,
+            **add_kwargs,
+        }
         return self.post(f"v1/index/{index_id}/scroll", data=data)
 
     #
@@ -579,9 +583,10 @@ class SearchClient(client.BaseClient):
         # convert the provided subjects to a list and use the "safe iter" helper to
         # ensure that a single string is *not* treated as an iterable of strings,
         # which is usually not intentional
-        body = {"subjects": list(utils.safe_strseq_iter(subjects))}
-        if additional_params:
-            body.update(additional_params)
+        body = {
+            "subjects": list(utils.safe_strseq_iter(subjects)),
+            **(additional_params or {}),
+        }
         return self.post(f"/v1/index/{index_id}/batch_delete_by_subject", data=body)
 
     #
@@ -621,10 +626,11 @@ class SearchClient(client.BaseClient):
                 .. extdoclink:: Get By Subject
                     :ref: search/reference/get_subject/
         """
-        if query_params is None:
-            query_params = {}
-        query_params["subject"] = subject
         log.debug(f"SearchClient.get_subject({index_id}, {subject}, ...)")
+        query_params = {
+            **(query_params or {}),
+            "subject": subject,
+        }
         return self.get(f"/v1/index/{index_id}/subject", query_params=query_params)
 
     def delete_subject(
@@ -664,11 +670,11 @@ class SearchClient(client.BaseClient):
                 .. extdoclink:: Delete By Subject
                     :ref: search/reference/delete_subject/
         """
-        if query_params is None:
-            query_params = {}
-        query_params["subject"] = subject
-
         log.debug(f"SearchClient.delete_subject({index_id}, {subject}, ...)")
+        query_params = {
+            **(query_params or {}),
+            "subject": subject,
+        }
         return self.delete(f"/v1/index/{index_id}/subject", query_params=query_params)
 
     #
@@ -680,7 +686,7 @@ class SearchClient(client.BaseClient):
         index_id: UUIDLike,
         subject: str,
         *,
-        entry_id: str | None = None,
+        entry_id: str | MissingType = MISSING,
         query_params: dict[str, t.Any] | None = None,
     ) -> response.GlobusHTTPResponse:
         """
@@ -720,17 +726,21 @@ class SearchClient(client.BaseClient):
                 .. extdoclink:: Get Entry
                     :ref: search/reference/get_entry/
         """  # noqa: E501
-        if query_params is None:
-            query_params = {}
-        query_params["subject"] = subject
-        if entry_id is not None:
-            query_params["entry_id"] = entry_id
-
         log.debug(
             "SearchClient.get_entry({}, {}, {}, ...)".format(
                 index_id, subject, entry_id
             )
         )
+        add_kwargs = filter_missing(
+            {
+                "entry_id": entry_id,
+                "subject": subject,
+            }
+        )
+        query_params = {
+            **(query_params or {}),
+            **add_kwargs,
+        }
         return self.get(f"/v1/index/{index_id}/entry", query_params=query_params)
 
     def create_entry(
@@ -849,7 +859,7 @@ class SearchClient(client.BaseClient):
         index_id: UUIDLike,
         subject: str,
         *,
-        entry_id: str | None = None,
+        entry_id: str | MissingType = MISSING,
         query_params: dict[str, t.Any] | None = None,
     ) -> response.GlobusHTTPResponse:
         """
@@ -889,16 +899,21 @@ class SearchClient(client.BaseClient):
                 .. extdoclink:: Delete Entry
                     :ref: search/reference/delete_entry/
         """  # noqa: E501
-        if query_params is None:
-            query_params = {}
-        query_params["subject"] = subject
-        if entry_id is not None:
-            query_params["entry_id"] = entry_id
         log.debug(
             "SearchClient.delete_entry({}, {}, {}, ...)".format(
                 index_id, subject, entry_id
             )
         )
+        add_kwargs = filter_missing(
+            {
+                "entry_id": entry_id,
+                "subject": subject,
+            }
+        )
+        query_params = {
+            **(query_params or {}),
+            **add_kwargs,
+        }
         return self.delete(f"/v1/index/{index_id}/entry", query_params=query_params)
 
     #

--- a/src/globus_sdk/services/search/data.py
+++ b/src/globus_sdk/services/search/data.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import typing as t
 
 from globus_sdk import exc, utils
+from globus_sdk.utils import MISSING, MissingType
 
 # workaround for absence of Self type
 # for the workaround and some background, see:
@@ -107,25 +108,21 @@ class SearchQuery(SearchQueryBase):
 
     def __init__(
         self,
-        q: str | None = None,
+        q: str | MissingType = MISSING,
         *,
-        limit: int | None = None,
-        offset: int | None = None,
-        advanced: bool | None = None,
+        limit: int | MissingType = MISSING,
+        offset: int | MissingType = MISSING,
+        advanced: bool | MissingType = MISSING,
         additional_fields: dict[str, t.Any] | None = None,
     ) -> None:
         super().__init__()
         exc.warn_deprecated("'SearchQuery' is deprecated. Use 'SearchQueryV1' instead.")
-        if q is not None:
-            self["q"] = q
-        if limit is not None:
-            self["limit"] = limit
-        if offset is not None:
-            self["offset"] = offset
-        if advanced is not None:
-            self["advanced"] = advanced
-        if additional_fields is not None:
-            self.update(additional_fields)
+
+        self["q"] = q
+        self["limit"] = limit
+        self["offset"] = offset
+        self["advanced"] = advanced
+        self.update(additional_fields or {})
 
     def set_offset(self, offset: int) -> SearchQuery:
         """
@@ -143,9 +140,9 @@ class SearchQuery(SearchQueryBase):
         *,
         # pylint: disable=redefined-builtin
         type: str = "terms",
-        size: int | None = None,
-        date_interval: str | None = None,
-        histogram_range: tuple[t.Any, t.Any] | None = None,
+        size: int | MissingType = MISSING,
+        date_interval: str | MissingType = MISSING,
+        histogram_range: tuple[t.Any, t.Any] | MissingType = MISSING,
         additional_fields: dict[str, t.Any] | None = None,
     ) -> SearchQuery:
         """
@@ -164,15 +161,15 @@ class SearchQuery(SearchQueryBase):
             "name": name,
             "field_name": field_name,
             "type": type,
+            "size": size,
+            "date_interval": date_interval,
+            "histogram_range": (
+                dict(zip(["low", "high"], histogram_range))
+                if histogram_range
+                else histogram_range
+            ),
             **(additional_fields or {}),
         }
-        if size is not None:
-            facet["size"] = size
-        if date_interval is not None:
-            facet["date_interval"] = date_interval
-        if histogram_range is not None:
-            low, high = histogram_range
-            facet["histogram_range"] = {"low": low, "high": high}
         self["facets"].append(facet)
         return self
 
@@ -204,7 +201,7 @@ class SearchQuery(SearchQueryBase):
         self,
         field_name: str,
         *,
-        order: str | None = None,
+        order: str | MissingType = MISSING,
         additional_fields: dict[str, t.Any] | None = None,
     ) -> SearchQuery:
         """
@@ -215,9 +212,11 @@ class SearchQuery(SearchQueryBase):
         :param additional_fields: additional data to include in the sort document
         """
         self["sort"] = self.get("sort", [])
-        sort = {"field_name": field_name, **(additional_fields or {})}
-        if order is not None:
-            sort["order"] = order
+        sort = {
+            "field_name": field_name,
+            "order": order,
+            **(additional_fields or {}),
+        }
         self["sort"].append(sort)
         return self
 
@@ -245,16 +244,16 @@ class SearchQueryV1(utils.PayloadWrapper):
     def __init__(
         self,
         *,
-        q: str | utils.MissingType = utils.MISSING,
-        limit: int | utils.MissingType = utils.MISSING,
-        offset: int | utils.MissingType = utils.MISSING,
-        advanced: bool | utils.MissingType = utils.MISSING,
-        filters: list[dict[str, t.Any]] | utils.MissingType = utils.MISSING,
-        facets: list[dict[str, t.Any]] | utils.MissingType = utils.MISSING,
-        post_facet_filters: list[dict[str, t.Any]] | utils.MissingType = utils.MISSING,
-        boosts: list[dict[str, t.Any]] | utils.MissingType = utils.MISSING,
-        sort: list[dict[str, t.Any]] | utils.MissingType = utils.MISSING,
-        additional_fields: dict[str, t.Any] | utils.MissingType = utils.MISSING,
+        q: str | MissingType = MISSING,
+        limit: int | MissingType = MISSING,
+        offset: int | MissingType = MISSING,
+        advanced: bool | MissingType = MISSING,
+        filters: list[dict[str, t.Any]] | MissingType = MISSING,
+        facets: list[dict[str, t.Any]] | MissingType = MISSING,
+        post_facet_filters: list[dict[str, t.Any]] | MissingType = MISSING,
+        boosts: list[dict[str, t.Any]] | MissingType = MISSING,
+        sort: list[dict[str, t.Any]] | MissingType = MISSING,
+        additional_fields: dict[str, t.Any] | None = None,
     ) -> None:
         super().__init__()
         self["@version"] = "query#1.0.0"
@@ -268,9 +267,7 @@ class SearchQueryV1(utils.PayloadWrapper):
         self["post_facet_filters"] = post_facet_filters
         self["boosts"] = boosts
         self["sort"] = sort
-
-        if not isinstance(additional_fields, utils.MissingType):
-            self.update(additional_fields)
+        self.update(additional_fields or {})
 
 
 class SearchScrollQuery(SearchQueryBase):
@@ -295,24 +292,19 @@ class SearchScrollQuery(SearchQueryBase):
 
     def __init__(
         self,
-        q: str | None = None,
+        q: str | MissingType = MISSING,
         *,
-        limit: int | None = None,
-        advanced: bool | None = None,
-        marker: str | None = None,
+        limit: int | MissingType = MISSING,
+        advanced: bool | MissingType = MISSING,
+        marker: str | MissingType = MISSING,
         additional_fields: dict[str, t.Any] | None = None,
     ) -> None:
         super().__init__()
-        if q is not None:
-            self["q"] = q
-        if limit is not None:
-            self["limit"] = limit
-        if advanced is not None:
-            self["advanced"] = advanced
-        if marker is not None:
-            self["marker"] = marker
-        if additional_fields is not None:
-            self.update(additional_fields)
+        self["q"] = q
+        self["limit"] = limit
+        self["advanced"] = advanced
+        self["marker"] = marker
+        self.update(additional_fields or {})
 
     def set_marker(self, marker: str) -> SearchScrollQuery:
         """

--- a/tests/functional/services/search/test_search.py
+++ b/tests/functional/services/search/test_search.py
@@ -7,6 +7,7 @@ import responses
 
 import globus_sdk
 from globus_sdk._testing import get_last_request, load_response
+from globus_sdk.utils import filter_missing
 from tests.common import register_api_route_fixture_file
 
 
@@ -73,7 +74,7 @@ def test_search_post_query_with_legacy_helper(search_client):
     req = get_last_request()
     assert req.body is not None
     req_body = json.loads(req.body)
-    assert req_body == dict(query_doc)
+    assert req_body == filter_missing(query_doc)
 
 
 def test_search_post_query_simple_with_v1_helper(search_client):
@@ -181,4 +182,4 @@ def test_search_paginated_scroll_query(search_client, query_doc):
     assert data[1]["entries"][0]["content"]["foo"] == "baz"
 
     # confirm that pagination was not side-effecting
-    assert "marker" not in query_doc
+    assert "marker" not in filter_missing(query_doc)

--- a/tests/unit/helpers/test_search.py
+++ b/tests/unit/helpers/test_search.py
@@ -5,6 +5,7 @@ Unit tests for globus_sdk.SearchQuery
 import pytest
 
 from globus_sdk import RemovedInV4Warning, SearchQuery, SearchQueryV1, utils
+from globus_sdk.utils import filter_missing
 
 
 def test_init_legacy():
@@ -19,7 +20,7 @@ def test_init_legacy_no_args():
     with pytest.warns(RemovedInV4Warning, match="'SearchQuery' is deprecated"):
         query = SearchQuery()
 
-    assert len(query) == 0
+    assert len(filter_missing(query)) == 0
 
 
 def test_init_legacy_additional_fields():
@@ -67,7 +68,7 @@ def test_set_method(attrname):
         query = SearchQuery()
     method = getattr(query, "set_{}".format("query" if attrname == "q" else attrname))
     # start absent
-    assert attrname not in query
+    assert attrname not in filter_missing(query)
     # returns self
     assert method("foo") is query
     # sets value
@@ -84,7 +85,7 @@ def test_add_facet():
     assert query.add_facet("facetname", "fieldname") is query
     assert query["facets"]
     assert len(query["facets"]) == 1
-    assert query["facets"][0] == {
+    assert filter_missing(query["facets"][0]) == {
         "type": "terms",
         "name": "facetname",
         "field_name": "fieldname",
@@ -93,7 +94,7 @@ def test_add_facet():
     # terms with size
     query.add_facet("n", "f", size=5)
     assert len(query["facets"]) == 2
-    assert query["facets"][1] == {
+    assert filter_missing(query["facets"][1]) == {
         "type": "terms",
         "name": "n",
         "field_name": "f",
@@ -109,7 +110,7 @@ def test_add_facet():
         histogram_range=(1870, 1880),
     )
     assert len(query["facets"]) == 3
-    assert query["facets"][2] == {
+    assert filter_missing(query["facets"][2]) == {
         "type": "date_histogram",
         "name": "n",
         "field_name": "f",
@@ -122,7 +123,7 @@ def test_add_facet():
         "facetname", "fieldname", additional_fields={"nonexistentparam": "value1"}
     )
     assert len(query["facets"]) == 4
-    assert query["facets"][3] == {
+    assert filter_missing(query["facets"][3]) == {
         "type": "terms",
         "name": "facetname",
         "field_name": "fieldname",
@@ -203,7 +204,7 @@ def test_add_sort():
 
     assert query["sort"]
     assert len(query["sort"]) == 1
-    assert query["sort"][0] == {"field_name": "f"}
+    assert filter_missing(query["sort"][0]) == {"field_name": "f"}
 
     # with order
     query.add_sort("f", order="asc")


### PR DESCRIPTION
[sc-15807](https://app.shortcut.com/globus/story/15807/sdkv4-convert-defaults-of-none-to-globus-sdk-missing-for-payload-types-allowing-explicit-null-by-setting-none)

This PR is for SDKv4 and is a followup to #1205.

### Changes
 - Converted defaults of `None` to `globus_sdk.MISSING` for payload types in the search client.
 - Updated search unit tests to test with `MISSING` defaults instead of `None`.

[Search OpenAPI spec](https://search.api.globus.org/autodoc/redoc) for reference.