### PR TITLE
Merge version 3.57.0 into 4.x-dev

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,36 +1,3 @@
-.. image:: https://github.com/globus/globus-sdk-python/workflows/build/badge.svg?event=push
-    :alt: build status
-    :target: https://github.com/globus/globus-sdk-python/actions?query=workflow%3Abuild
-
-.. image:: https://img.shields.io/pypi/v/globus-sdk.svg
-    :alt: Latest Released Version
-    :target: https://pypi.org/project/globus-sdk/
-
-.. image:: https://img.shields.io/pypi/pyversions/globus-sdk.svg
-    :alt: Supported Python Versions
-    :target: https://pypi.org/project/globus-sdk/
-
-.. image:: https://img.shields.io/badge/License-Apache%202.0-blue.svg
-    :alt: License
-    :target: https://opensource.org/licenses/Apache-2.0
-
-.. image:: https://results.pre-commit.ci/badge/github/globus/globus-sdk-python/main.svg
-   :target: https://results.pre-commit.ci/latest/github/globus/globus-sdk-python/main
-   :alt: pre-commit.ci status
-
-..
-    This is the badge style used by the isort repo itself, so we'll use their
-    preferred colors
-
-.. image:: https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat&labelColor=ef8336
-    :alt: Import Style
-    :target: https://pycqa.github.io/isort/
-
-.. image:: https://img.shields.io/badge/code%20style-black-000000.svg
-    :alt: Code Style
-    :target: https://github.com/psf/black
-
-
 Globus SDK for Python
 =====================
 

--- a/changelog.rst
+++ b/changelog.rst
@@ -40,6 +40,29 @@ Breaking Changes
 
 - Updated MappedCollectionDoc and GuestCollectionDoc with MissingType. (:pr:`1189`)
 
+.. _changelog-3.57.0:
+
+v3.57.0 (2025-06-04)
+--------------------
+
+Added
+~~~~~
+
+- Globus Connect Server collection document classes now support attributes up
+  to document version 1.15.0. (:pr:`1197`)
+
+Deprecated
+~~~~~~~~~~
+
+- Importing scope parsing tools from ``globus_sdk.experimental`` now emits a
+  deprecation warning. These names were previously deprecated in documentation
+  only. (:pr:`1201`)
+
+Documentation
+~~~~~~~~~~~~~
+
+- Remove the badges at the top of the README. (:pr:`1194`)
+
 .. _changelog-3.56.1:
 
 v3.56.1 (2025-05-20)
@@ -49,7 +72,7 @@ Fixed
 ~~~~~
 
 - Fix the type annotation on ``filter_roles`` for ``FlowsClient``
-  to allow non-list iterables. (:pr:`1184`)
+  to allow non-list iterables. (:pr:`1183`)
 
 .. _changelog-3.56.0:
 

--- a/src/globus_sdk/experimental/scope_parser.py
+++ b/src/globus_sdk/experimental/scope_parser.py
@@ -4,10 +4,34 @@ This module will be removed in a future release but is maintained in the interim
   backwards compatibility.
 """
 
-from globus_sdk.scopes import Scope, ScopeCycleError, ScopeParseError
+from __future__ import annotations
+
+import sys
+import typing as t
 
 __all__ = (
     "Scope",
     "ScopeParseError",
     "ScopeCycleError",
 )
+
+if t.TYPE_CHECKING:
+    from globus_sdk.scopes import Scope, ScopeCycleError, ScopeParseError
+else:
+
+    def __getattr__(name: str) -> t.Any:
+        import globus_sdk.scopes as scopes_module
+        from globus_sdk.exc import warn_deprecated
+
+        warn_deprecated(
+            "'globus_sdk.experimental.scope_parser' has been merged into "
+            "'globus_sdk.scopes'. "
+            f"Importing '{name}' from `globus_sdk.experimental` is deprecated. "
+            f"Use `globus_sdk.scopes.{name}` instead."
+        )
+
+        value = getattr(scopes_module, name, None)
+        if value is None:
+            raise AttributeError(f"module {__name__} has no attribute {name}")
+        setattr(sys.modules[__name__], name, value)
+        return value

--- a/src/globus_sdk/services/gcs/data/collection.py
+++ b/src/globus_sdk/services/gcs/data/collection.py
@@ -488,7 +488,6 @@ class GuestCollectionDocument(CollectionDocument):
             # additional fields
             additional_fields=additional_fields,
         )
-        self._set_value("activity_notification_policy", activity_notification_policy)
 
         self["mapped_collection_id"] = mapped_collection_id
         self["user_credential_id"] = user_credential_id

--- a/src/globus_sdk/services/gcs/data/collection.py
+++ b/src/globus_sdk/services/gcs/data/collection.py
@@ -36,6 +36,7 @@ from ._common import (
 # - strings, sorted alphabetically
 # - string lists, sorted alphabetically
 # - bools, sorted alphabetically
+# - ints, sorted alphabetically
 # - dicts and other types, sorted alphabetically
 #
 # This makes it possible to do side-by-side comparison of common arguments, to ensure
@@ -86,6 +87,9 @@ class CollectionDocument(utils.PayloadWrapper, abc.ABC):
         collection
     :param info_link: Link for more info about the collection
     :param organization: The organization which maintains the collection
+    :param restrict_transfers_to_high_assurance: Require that transfers of the
+        given type involve only collections that are high assurance.
+        Valid values: "inbound", "outbound", "all", None
     :param user_message: A message to display to users when interacting with this
         collection
     :param user_message_link: A link to additional messaging for users when interacting
@@ -102,11 +106,27 @@ class CollectionDocument(utils.PayloadWrapper, abc.ABC):
         collection
     :param public: If True, the collection will be visible to other Globus users
 
+    :param acl_expiration_mins: Length of time that guest collection permissions are
+        valid. Only settable on HA guest collections and HA mapped collections and
+        used by guest collections attached to it. When set on both the mapped and guest
+        collections, the lesser value is in effect.
+
+    :param associated_flow_policy: Policy describing Globus flows to run when the
+        collection is accessed. See
+        https://docs.globus.org/api/transfer/endpoints_and_collections/#associated_flow_policy
+        for expected shape.
+
     :param additional_fields: Additional data for inclusion in the collection document
     """
 
     DATATYPE_BASE: str = "collection"
     DATATYPE_VERSION_IMPLICATIONS: dict[str, tuple[int, int, int]] = {
+        "associated_flow_policy": (1, 15, 0),
+        "activity_notification_policy": (1, 14, 0),
+        "auto_delete_timeout": (1, 13, 0),
+        "skip_auto_delete": (1, 13, 0),
+        "restrict_transfers_to_high_assurance": (1, 12, 0),
+        "acl_expiration_mins": (1, 10, 0),
         "delete_protected": (1, 8, 0),
         "guest_auth_policy_id": (1, 6, 0),
         "disable_anonymous_writes": (1, 5, 0),
@@ -116,7 +136,6 @@ class CollectionDocument(utils.PayloadWrapper, abc.ABC):
         "enable_https": (1, 1, 0),
         "user_message": (1, 1, 0),
         "user_message_link": (1, 1, 0),
-        "activity_notification_policy": (1, 14, 0),
     }
     DATATYPE_VERSION_CALLBACKS: tuple[DatatypeCallback, ...] = (
         _user_message_length_callback,
@@ -138,6 +157,9 @@ class CollectionDocument(utils.PayloadWrapper, abc.ABC):
         identity_id: UUIDLike | MissingType = MISSING,
         info_link: str | None | MissingType = MISSING,
         organization: str | MissingType = MISSING,
+        restrict_transfers_to_high_assurance: (
+            t.Literal["inbound", "outbound", "all"] | MissingType
+        ) = MISSING,
         user_message: str | None | MissingType = MISSING,
         user_message_link: str | None | MissingType = MISSING,
         # str lists
@@ -148,6 +170,10 @@ class CollectionDocument(utils.PayloadWrapper, abc.ABC):
         force_encryption: bool | MissingType = MISSING,
         force_verify: bool | MissingType = MISSING,
         public: bool | MissingType = MISSING,
+        # ints
+        acl_expiration_mins: int | MissingType = MISSING,
+        # dicts
+        associated_flow_policy: dict[str, t.Any] | MissingType = MISSING,
         # additional fields
         additional_fields: dict[str, t.Any] | MissingType = MISSING,
     ) -> None:
@@ -164,6 +190,9 @@ class CollectionDocument(utils.PayloadWrapper, abc.ABC):
         self["identity_id"] = identity_id
         self["info_link"] = info_link
         self["organization"] = organization
+        self["restrict_transfers_to_high_assurance"] = (
+            restrict_transfers_to_high_assurance
+        )
         self["user_message"] = user_message
         self["user_message_link"] = user_message_link
         self["keywords"] = (
@@ -176,6 +205,8 @@ class CollectionDocument(utils.PayloadWrapper, abc.ABC):
         self["force_encryption"] = force_encryption
         self["force_verify"] = force_verify
         self["public"] = public
+        self["acl_expiration_mins"] = acl_expiration_mins
+        self["associated_flow_policy"] = associated_flow_policy
 
         if not isinstance(additional_fields, MissingType):
             self.update(additional_fields)
@@ -222,6 +253,9 @@ class MappedCollectionDocument(CollectionDocument):
         attached to this Mapped Collection. This option is only usable on non
         high-assurance collections
 
+    :param auto_delete_timeout: Delete child guest collections that have not been
+        accessed within the specified timeout period in days.
+
     :param policies: Connector-specific collection policies
     :param sharing_restrict_paths: A PathRestrictions document
     """
@@ -247,6 +281,9 @@ class MappedCollectionDocument(CollectionDocument):
         identity_id: UUIDLike | MissingType = MISSING,
         info_link: str | None | MissingType = MISSING,
         organization: str | MissingType = MISSING,
+        restrict_transfers_to_high_assurance: (
+            t.Literal["inbound", "outbound", "all"] | MissingType
+        ) = MISSING,
         user_message: str | None | MissingType = MISSING,
         user_message_link: str | None | MissingType = MISSING,
         # str lists
@@ -257,6 +294,8 @@ class MappedCollectionDocument(CollectionDocument):
         force_encryption: bool | MissingType = MISSING,
         force_verify: bool | MissingType = MISSING,
         public: bool | MissingType = MISSING,
+        # ints
+        acl_expiration_mins: int | MissingType = MISSING,
         # > common args end <
         # > specific args start <
         # strs
@@ -271,7 +310,10 @@ class MappedCollectionDocument(CollectionDocument):
         delete_protected: bool | MissingType = MISSING,
         allow_guest_collections: bool | MissingType = MISSING,
         disable_anonymous_writes: bool | MissingType = MISSING,
+        # ints
+        auto_delete_timeout: int | MissingType = MISSING,
         # dicts
+        associated_flow_policy: dict[str, t.Any] | MissingType = MISSING,
         policies: CollectionPolicies | dict[str, t.Any] | MissingType = MISSING,
         # > specific args end <
         # additional fields
@@ -291,6 +333,7 @@ class MappedCollectionDocument(CollectionDocument):
             identity_id=identity_id,
             info_link=info_link,
             organization=organization,
+            restrict_transfers_to_high_assurance=restrict_transfers_to_high_assurance,
             user_message=user_message,
             user_message_link=user_message_link,
             # bools
@@ -299,13 +342,19 @@ class MappedCollectionDocument(CollectionDocument):
             force_encryption=force_encryption,
             force_verify=force_verify,
             public=public,
+            # ints
+            acl_expiration_mins=acl_expiration_mins,
             # str lists
             keywords=keywords,
+            # str dicts
+            associated_flow_policy=associated_flow_policy,
             # additional fields
             additional_fields=additional_fields,
         )
-
         self["domain_name"] = domain_name
+        self["restrict_transfers_to_high_assurance"] = (
+            restrict_transfers_to_high_assurance
+        )
         self["guest_auth_policy_id"] = guest_auth_policy_id
         self["storage_gateway_id"] = storage_gateway_id
 
@@ -323,6 +372,7 @@ class MappedCollectionDocument(CollectionDocument):
         self["delete_protected"] = delete_protected
         self["allow_guest_collections"] = allow_guest_collections
         self["disable_anonymous_writes"] = disable_anonymous_writes
+        self["auto_delete_timeout"] = auto_delete_timeout
         self["sharing_restrict_paths"] = sharing_restrict_paths
         self["policies"] = policies
         ensure_datatype(self)
@@ -349,6 +399,10 @@ class GuestCollectionDocument(CollectionDocument):
     :param user_credential_id: The ID of the User Credential which is used to access
         data on this collection. This credential must be owned by the collection’s
         ``identity_id``.
+
+    :param skip_auto_delete: Indicates whether the collection is exempt from its
+        parent mapped collection's automatic deletion policy.
+
     :param activity_notification_policy: Specification for when a notification email
         should be sent to a guest collection ``administrator``, ``activity_manager``,
         and ``activity_monitor`` roles when a transfer task reaches completion.
@@ -375,6 +429,9 @@ class GuestCollectionDocument(CollectionDocument):
         identity_id: UUIDLike | MissingType = MISSING,
         info_link: str | None | MissingType = MISSING,
         organization: str | MissingType = MISSING,
+        restrict_transfers_to_high_assurance: (
+            t.Literal["inbound", "outbound", "all"] | MissingType
+        ) = MISSING,
         user_message: str | None | MissingType = MISSING,
         user_message_link: str | None | MissingType = MISSING,
         # str lists
@@ -385,10 +442,15 @@ class GuestCollectionDocument(CollectionDocument):
         force_encryption: bool | MissingType = MISSING,
         force_verify: bool | MissingType = MISSING,
         public: bool | MissingType = MISSING,
+        # ints
+        acl_expiration_mins: int | MissingType = MISSING,
+        # dicts
+        associated_flow_policy: dict[str, t.Any] | MissingType = MISSING,
         # > common args end <
         # > specific args start <
         mapped_collection_id: UUIDLike | MissingType = MISSING,
         user_credential_id: UUIDLike | MissingType = MISSING,
+        skip_auto_delete: bool | MissingType = MISSING,
         activity_notification_policy: dict[str, list[str]] | MissingType = MISSING,
         # > specific args end <
         # additional fields
@@ -408,6 +470,7 @@ class GuestCollectionDocument(CollectionDocument):
             identity_id=identity_id,
             info_link=info_link,
             organization=organization,
+            restrict_transfers_to_high_assurance=restrict_transfers_to_high_assurance,
             user_message=user_message,
             user_message_link=user_message_link,
             # bools
@@ -416,14 +479,20 @@ class GuestCollectionDocument(CollectionDocument):
             force_encryption=force_encryption,
             force_verify=force_verify,
             public=public,
+            # ints
+            acl_expiration_mins=acl_expiration_mins,
             # str lists
             keywords=keywords,
+            # dicts
+            associated_flow_policy=associated_flow_policy,
             # additional fields
             additional_fields=additional_fields,
         )
+        self._set_value("activity_notification_policy", activity_notification_policy)
 
         self["mapped_collection_id"] = mapped_collection_id
         self["user_credential_id"] = user_credential_id
+        self["skip_auto_delete"] = skip_auto_delete
         self["activity_notification_policy"] = activity_notification_policy
         ensure_datatype(self)
 

--- a/tests/non-pytest/performance/parser_benchmark.py
+++ b/tests/non-pytest/performance/parser_benchmark.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import sys
+import timeit
+
+from globus_sdk.scopes._parser import parse_scope_graph
+
+
+def timeit_test() -> None:
+    for size, num_iterations, style in (
+        (10, 1000, "deep"),
+        (100, 1000, "deep"),
+        (1000, 1000, "deep"),
+        (2000, 100, "deep"),
+        (3000, 100, "deep"),
+        (4000, 100, "deep"),
+        (5000, 100, "deep"),
+        (5000, 1000, "wide"),
+        (10000, 1000, "wide"),
+    ):
+        if style == "deep":
+            setup = f"""\
+from globus_sdk.experimental.scope_parser import Scope
+big_scope = ""
+for i in range({size}):
+    big_scope += f"foo{{i}}["
+big_scope += "bar"
+for _ in range({size}):
+    big_scope += "]"
+"""
+        elif style == "wide":
+            setup = f"""\
+from globus_sdk.experimental.scope_parser import Scope
+big_scope = ""
+for i in range({size}):
+    big_scope += f"foo{{i}} "
+"""
+        else:
+            raise NotImplementedError
+
+        timer = timeit.Timer("Scope.parse(big_scope)", setup=setup)
+
+        raw_timings = timer.repeat(repeat=5, number=num_iterations)
+        best, worst, average, variance = _stats(raw_timings)
+        if style == "deep":
+            print(f"{num_iterations} runs on a deep scope, depth={size}")
+        elif style == "wide":
+            print(f"{num_iterations} runs on a wide scope, width={size}")
+        else:
+            raise NotImplementedError
+        print(f"  best={best} worst={worst} average={average} variance={variance}")
+        print(f"  normalized best={best / num_iterations}")
+        print()
+    print("The most informative stat over these timings is the min timing (best).")
+    print("Normed best is best/iterations.")
+    print(
+        "Max timing (worst) and dispersion (variance vis-a-vis average) indicate "
+        "how consistent the results are, but are not a report of speed."
+    )
+
+
+def _stats(timing_data: list[float]) -> tuple[float, float, float, float]:
+    best = min(timing_data)
+    worst = max(timing_data)
+    average = sum(timing_data) / len(timing_data)
+    variance = sum((x - average) ** 2 for x in timing_data) / len(timing_data)
+    return best, worst, average, variance
+
+
+def parse_test(scope_string: str) -> None:
+    parsed_graph = parse_scope_graph(scope_string)
+    print(
+        "top level scopes:",
+        ", ".join([name for name, _optional in parsed_graph.top_level_scopes]),
+    )
+    print(parsed_graph)
+
+
+def main() -> None:
+    if len(sys.argv) < 2 or sys.argv[1] in ("-h", "--help"):
+        print("This script supports two usage patterns:")
+        print("    python -m globus_sdk.experimental.scope_parser SCOPE_STRING")
+        print("    python -m globus_sdk.experimental.scope_parser --timeit")
+        sys.exit(0)
+
+    print()
+    if sys.argv[1] == "--timeit":
+        timeit_test()
+    else:
+        parse_test(sys.argv[1])
+
+
+main()

--- a/tests/unit/experimental/test_legacy_support.py
+++ b/tests/unit/experimental/test_legacy_support.py
@@ -15,11 +15,12 @@ from globus_sdk import RemovedInV4Warning
 
 
 def test_scope_importable_from_experimental():
-    from globus_sdk.experimental.scope_parser import (  # noqa: F401
-        Scope,
-        ScopeCycleError,
-        ScopeParseError,
-    )
+    with pytest.warns(RemovedInV4Warning):
+        from globus_sdk.experimental.scope_parser import (  # noqa: F401
+            Scope,
+            ScopeCycleError,
+            ScopeParseError,
+        )
 
 
 def test_login_flow_manager_importable_from_experimental():


### PR DESCRIPTION
The merge commit is nontrivial, as it converts new GCS Collection parameters into `MISSING`-style.

---

Commits from `3.57.0`:

- Remove the badges at the top of the README
- (actions) update PR references
- Tiny typo fix (#1196)
- Restore the scope parser performance benchmark
- Reduce Cognitive Complexity in the scope parser
- Improve speed and reusability of parser components
- Simplify scope parser: name pairwise token check
- Update src/globus_sdk/scopes/_parser.py
- Emit deprecation warnings on legacy scope imports
- (actions) update PR references
- update GCS collection document attributes to revision 1.15.0 (#1197)
- (actions) update PR references
- Bump version and changelog for release

Commits added in the merge:

- Merge tag '3.57.0' into merge-back-3.57.0
- Typo-fix from merge: double-set value

<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1210.org.readthedocs.build/en/1210/

<!-- readthedocs-preview globus-sdk-python end -->