### PR TITLE
Update compute and groups clients classes to use MISSING defaults

### DIFF
--- a/src/globus_sdk/services/compute/client.py
+++ b/src/globus_sdk/services/compute/client.py
@@ -6,6 +6,7 @@ import typing as t
 from globus_sdk import GlobusHTTPResponse, client, utils
 from globus_sdk._types import UUIDLike
 from globus_sdk.scopes import ComputeScopes, Scope
+from globus_sdk.utils import MISSING, MissingType
 
 from .errors import ComputeAPIError
 
@@ -26,7 +27,7 @@ class ComputeClientV2(client.BaseClient):
     scopes = ComputeScopes
     default_scope_requirements = [Scope(ComputeScopes.all)]
 
-    def get_version(self, service: str | None = None) -> GlobusHTTPResponse:
+    def get_version(self, service: str | MissingType = MISSING) -> GlobusHTTPResponse:
         """Get the current version of the API and other services.
 
         :param service: Service for which to get version information.
@@ -39,7 +40,7 @@ class ComputeClientV2(client.BaseClient):
                     :service: compute
                     :ref: Root/operation/get_version_v2_version_get
         """
-        query_params = {"service": service} if service else None
+        query_params = {"service": service}
         return self.get("/v2/version", query_params=query_params)
 
     def get_result_amqp_url(self) -> GlobusHTTPResponse:

--- a/src/globus_sdk/services/groups/client.py
+++ b/src/globus_sdk/services/groups/client.py
@@ -5,6 +5,7 @@ import typing as t
 from globus_sdk import client, response, utils
 from globus_sdk._types import UUIDLike
 from globus_sdk.scopes import GroupsScopes, Scope
+from globus_sdk.utils import MISSING, MissingType
 
 from .data import BatchMembershipActions, GroupPolicies
 from .errors import GroupsAPIError
@@ -58,7 +59,7 @@ class GroupsClient(client.BaseClient):
         self,
         group_id: UUIDLike,
         *,
-        include: None | str | t.Iterable[str] = None,
+        include: str | t.Iterable[str] | MissingType = MISSING,
         query_params: dict[str, t.Any] | None = None,
     ) -> response.GlobusHTTPResponse:
         """
@@ -80,10 +81,7 @@ class GroupsClient(client.BaseClient):
                     :service: groups
                     :ref: get_group_v2_groups__group_id__get
         """
-        if query_params is None:
-            query_params = {}
-        if include is not None:
-            query_params["include"] = ",".join(utils.safe_strseq_iter(include))
+        query_params = {"include": utils.commajoin(include), **(query_params or {})}
         return self.get(f"/v2/groups/{group_id}", query_params=query_params)
 
     def get_group_by_subscription_id(


### PR DESCRIPTION
[sc-15807](https://app.shortcut.com/globus/story/15807/sdkv4-convert-defaults-of-none-to-globus-sdk-missing-for-payload-types-allowing-explicit-null-by-setting-none)

This PR is for SDKv4 and is a followup to #1205 and #1207.

### Changes
 - Converted defaults of `None` to `globus_sdk.MISSING` for payload types in the compute and groups clients.

[Groups openapi spec](https://groups.api.globus.org/redoc#tag/groups) and [Compute openapi spec](https://compute.api.globus.org/redoc) for reference.