### PR TITLE
Update GCS clients class to use MISSING defaults

### DIFF
--- a/changelog.d/20250605_095240_max.tuecke_sc_15807_gcs_missing_defaults.rst
+++ b/changelog.d/20250605_095240_max.tuecke_sc_15807_gcs_missing_defaults.rst
@@ -1,0 +1,4 @@
+Breaking Changes
+~~~~~~~~~~~~~~~~
+
+- All defaults of ``None`` converted to ``globus_sdk.MISSING`` for all payload types in the GCS client. (:pr:`1214`)

--- a/src/globus_sdk/services/gcs/client.py
+++ b/src/globus_sdk/services/gcs/client.py
@@ -8,6 +8,7 @@ from globus_sdk._types import UUIDLike
 from globus_sdk.authorizers import GlobusAuthorizer
 from globus_sdk.globus_app import GlobusApp
 from globus_sdk.scopes import Scope
+from globus_sdk.utils import MISSING, MissingType
 
 from .connector_table import ConnectorTable
 from .data import (
@@ -234,8 +235,8 @@ class GCSClient(client.BaseClient):
         endpoint_data: dict[str, t.Any] | EndpointDocument,
         *,
         include: (
-            t.Iterable[t.Literal["endpoint"]] | t.Literal["endpoint"] | None
-        ) = None,
+            t.Iterable[t.Literal["endpoint"]] | t.Literal["endpoint"] | MissingType
+        ) = MISSING,
         query_params: dict[str, t.Any] | None = None,
     ) -> UnpackingGCSResponse:
         """
@@ -256,10 +257,7 @@ class GCSClient(client.BaseClient):
                     :ref: openapi_Endpoint/#patchEndpoint
                     :service: gcs
         """
-        query_params = query_params or {}
-        if include is not None:
-            query_params["include"] = utils.commajoin(include)
-
+        query_params = {"include": utils.commajoin(include), **(query_params or {})}
         return UnpackingGCSResponse(
             self.patch(
                 "/endpoint",
@@ -280,13 +278,13 @@ class GCSClient(client.BaseClient):
     def get_collection_list(
         self,
         *,
-        mapped_collection_id: UUIDLike | None = None,
+        mapped_collection_id: UUIDLike | MissingType = MISSING,
         filter: (  # pylint: disable=redefined-builtin
-            str | t.Iterable[str] | None
-        ) = None,
-        include: str | t.Iterable[str] | None = None,
-        page_size: int | None = None,
-        marker: str | None = None,
+            str | t.Iterable[str] | MissingType
+        ) = MISSING,
+        include: str | t.Iterable[str] | MissingType = MISSING,
+        page_size: int | MissingType = MISSING,
+        marker: str | MissingType = MISSING,
         query_params: dict[str, t.Any] | None = None,
     ) -> IterableGCSResponse:
         """
@@ -313,20 +311,14 @@ class GCSClient(client.BaseClient):
                     :ref: openapi_Collections/#ListCollections
                     :service: gcs
         """
-        if query_params is None:
-            query_params = {}
-        if include is not None:
-            query_params["include"] = ",".join(utils.safe_strseq_iter(include))
-        if page_size is not None:
-            query_params["page_size"] = page_size
-        if marker is not None:
-            query_params["marker"] = marker
-        if mapped_collection_id is not None:
-            query_params["mapped_collection_id"] = mapped_collection_id
-        if filter is not None:
-            if isinstance(filter, str):
-                filter = [filter]
-            query_params["filter"] = ",".join(filter)
+        query_params = {
+            "include": utils.commajoin(include),
+            "page_size": page_size,
+            "marker": marker,
+            "mapped_collection_id": mapped_collection_id,
+            "filter": utils.commajoin(filter),
+            **(query_params or {}),
+        }
         return IterableGCSResponse(self.get("collections", query_params=query_params))
 
     def get_collection(
@@ -455,9 +447,9 @@ class GCSClient(client.BaseClient):
     def get_storage_gateway_list(
         self,
         *,
-        include: None | str | t.Iterable[str] = None,
-        page_size: int | None = None,
-        marker: str | None = None,
+        include: str | t.Iterable[str] | MissingType = MISSING,
+        page_size: int | MissingType = MISSING,
+        marker: str | MissingType = MISSING,
         query_params: dict[str, t.Any] | None = None,
     ) -> IterableGCSResponse:
         """
@@ -486,14 +478,12 @@ class GCSClient(client.BaseClient):
                     :ref: openapi_Storage_Gateways/#getStorageGateways
                     :service: gcs
         """
-        if query_params is None:
-            query_params = {}
-        if include is not None:
-            query_params["include"] = ",".join(utils.safe_strseq_iter(include))
-        if page_size is not None:
-            query_params["page_size"] = page_size
-        if marker is not None:
-            query_params["marker"] = marker
+        query_params = {
+            "include": utils.commajoin(include),
+            "page_size": page_size,
+            "marker": marker,
+            **(query_params or {}),
+        }
         return IterableGCSResponse(
             self.get("/storage_gateways", query_params=query_params)
         )
@@ -530,7 +520,7 @@ class GCSClient(client.BaseClient):
         self,
         storage_gateway_id: UUIDLike,
         *,
-        include: None | str | t.Iterable[str] = None,
+        include: str | t.Iterable[str] | MissingType = MISSING,
         query_params: dict[str, t.Any] | None = None,
     ) -> UnpackingGCSResponse:
         """
@@ -553,11 +543,7 @@ class GCSClient(client.BaseClient):
                     :ref: openapi_Storage_Gateways/#getStorageGateway
                     :service: gcs
         """
-        if query_params is None:
-            query_params = {}
-        if include is not None:
-            query_params["include"] = ",".join(utils.safe_strseq_iter(include))
-
+        query_params = {"include": utils.commajoin(include), **(query_params or {})}
         return UnpackingGCSResponse(
             self.get(
                 f"/storage_gateways/{storage_gateway_id}",
@@ -633,10 +619,10 @@ class GCSClient(client.BaseClient):
     )
     def get_role_list(
         self,
-        collection_id: UUIDLike | None = None,
-        include: str | None = None,
-        page_size: int | None = None,
-        marker: str | None = None,
+        collection_id: UUIDLike | MissingType = MISSING,
+        include: str | MissingType = MISSING,
+        page_size: int | MissingType = MISSING,
+        marker: str | MissingType = MISSING,
         query_params: dict[str, t.Any] | None = None,
     ) -> IterableGCSResponse:
         """
@@ -663,17 +649,13 @@ class GCSClient(client.BaseClient):
                     :ref: openapi_Roles/#listRoles
                     :service: gcs
         """
-        if query_params is None:
-            query_params = {}
-        if include is not None:
-            query_params["include"] = include
-        if page_size is not None:
-            query_params["page_size"] = page_size
-        if marker is not None:
-            query_params["marker"] = marker
-        if collection_id is not None:
-            query_params["collection_id"] = collection_id
-
+        query_params = {
+            "include": include,
+            "page_size": page_size,
+            "marker": marker,
+            "collection_id": collection_id,
+            **(query_params or {}),
+        }
         path = "/roles"
         return IterableGCSResponse(self.get(path, query_params=query_params))
 
@@ -759,10 +741,10 @@ class GCSClient(client.BaseClient):
     )
     def get_user_credential_list(
         self,
-        storage_gateway: UUIDLike | None = None,
+        storage_gateway: UUIDLike | MissingType = MISSING,
+        page_size: int | MissingType = MISSING,
+        marker: str | MissingType = MISSING,
         query_params: dict[str, t.Any] | None = None,
-        page_size: int | None = None,
-        marker: str | None = None,
     ) -> IterableGCSResponse:
         """
         List User Credentials
@@ -783,15 +765,12 @@ class GCSClient(client.BaseClient):
                     :ref: openapi_User_Credentials/#getUserCredentials
                     :service: gcs
         """
-        if query_params is None:
-            query_params = {}
-        if storage_gateway is not None:
-            query_params["storage_gateway"] = storage_gateway
-        if page_size is not None:
-            query_params["page_size"] = page_size
-        if marker is not None:
-            query_params["marker"] = marker
-
+        query_params = {
+            "storage_gateway": storage_gateway,
+            "page_size": page_size,
+            "marker": marker,
+            **(query_params or {}),
+        }
         path = "/user_credentials"
         return IterableGCSResponse(self.get(path, query_params=query_params))
 

--- a/src/globus_sdk/services/gcs/data/role.py
+++ b/src/globus_sdk/services/gcs/data/role.py
@@ -4,6 +4,7 @@ import typing as t
 
 from globus_sdk import utils
 from globus_sdk._types import UUIDLike
+from globus_sdk.utils import MISSING, MissingType
 
 
 class GCSRoleDocument(utils.PayloadWrapper):
@@ -24,9 +25,9 @@ class GCSRoleDocument(utils.PayloadWrapper):
     def __init__(
         self,
         DATA_TYPE: str = "role#1.0.0",
-        collection: UUIDLike | None = None,
-        principal: str | None = None,
-        role: str | None = None,
+        collection: UUIDLike | MissingType = MISSING,
+        principal: str | MissingType = MISSING,
+        role: str | MissingType = MISSING,
         additional_fields: dict[str, t.Any] | None = None,
     ) -> None:
         super().__init__()
@@ -36,5 +37,4 @@ class GCSRoleDocument(utils.PayloadWrapper):
             principal=principal,
             role=role,
         )
-        if additional_fields is not None:
-            self.update(additional_fields)
+        self.update(additional_fields or {})

--- a/src/globus_sdk/services/gcs/data/storage_gateway.py
+++ b/src/globus_sdk/services/gcs/data/storage_gateway.py
@@ -5,6 +5,7 @@ import typing as t
 
 from globus_sdk import utils
 from globus_sdk._types import UUIDLike
+from globus_sdk.utils import MISSING, MissingType
 
 from ._common import DatatypeCallback, ensure_datatype
 
@@ -56,18 +57,18 @@ class StorageGatewayDocument(utils.PayloadWrapper):
 
     def __init__(
         self,
-        DATA_TYPE: str | None = None,
-        display_name: str | None = None,
-        connector_id: UUIDLike | None = None,
-        root: str | None = None,
-        identity_mappings: None | t.Iterable[dict[str, t.Any]] = None,
-        policies: StorageGatewayPolicies | dict[str, t.Any] | None = None,
-        allowed_domains: t.Iterable[str] | None = None,
-        high_assurance: bool | None = None,
-        require_mfa: bool | None = None,
-        authentication_timeout_mins: int | None = None,
-        users_allow: t.Iterable[str] | None = None,
-        users_deny: t.Iterable[str] | None = None,
+        DATA_TYPE: str | MissingType = MISSING,
+        display_name: str | MissingType = MISSING,
+        connector_id: UUIDLike | MissingType = MISSING,
+        root: str | MissingType = MISSING,
+        identity_mappings: t.Iterable[dict[str, t.Any]] | MissingType = MISSING,
+        policies: StorageGatewayPolicies | dict[str, t.Any] | MissingType = MISSING,
+        allowed_domains: t.Iterable[str] | MissingType = MISSING,
+        high_assurance: bool | MissingType = MISSING,
+        require_mfa: bool | MissingType = MISSING,
+        authentication_timeout_mins: int | MissingType = MISSING,
+        users_allow: t.Iterable[str] | MissingType = MISSING,
+        users_deny: t.Iterable[str] | MissingType = MISSING,
         additional_fields: dict[str, t.Any] | None = None,
     ) -> None:
         super().__init__()
@@ -86,8 +87,7 @@ class StorageGatewayDocument(utils.PayloadWrapper):
         self._set_optints(authentication_timeout_mins=authentication_timeout_mins)
         self._set_value("identity_mappings", identity_mappings, callback=list)
         self._set_value("policies", policies)
-        if additional_fields is not None:
-            self.update(additional_fields)
+        self.update(additional_fields or {})
         ensure_datatype(self)
 
 
@@ -118,15 +118,14 @@ class POSIXStoragePolicies(StorageGatewayPolicies):
     def __init__(
         self,
         DATA_TYPE: str = "posix_storage_policies#1.0.0",
-        groups_allow: t.Iterable[str] | None = None,
-        groups_deny: t.Iterable[str] | None = None,
+        groups_allow: t.Iterable[str] | MissingType = MISSING,
+        groups_deny: t.Iterable[str] | MissingType = MISSING,
         additional_fields: dict[str, t.Any] | None = None,
     ) -> None:
         super().__init__()
         self._set_optstrs(DATA_TYPE=DATA_TYPE)
         self._set_optstrlists(groups_allow=groups_allow, groups_deny=groups_deny)
-        if additional_fields is not None:
-            self.update(additional_fields)
+        self.update(additional_fields or {})
 
 
 class POSIXStagingStoragePolicies(StorageGatewayPolicies):
@@ -149,10 +148,10 @@ class POSIXStagingStoragePolicies(StorageGatewayPolicies):
     def __init__(
         self,
         DATA_TYPE: str = "posix_staging_storage_policies#1.0.0",
-        groups_allow: t.Iterable[str] | None = None,
-        groups_deny: t.Iterable[str] | None = None,
-        stage_app: str | None = None,
-        environment: t.Iterable[dict[str, str]] | None = None,
+        groups_allow: t.Iterable[str] | MissingType = MISSING,
+        groups_deny: t.Iterable[str] | MissingType = MISSING,
+        stage_app: str | MissingType = MISSING,
+        environment: t.Iterable[dict[str, str]] | MissingType = MISSING,
         additional_fields: dict[str, t.Any] | None = None,
     ) -> None:
         super().__init__()
@@ -163,8 +162,7 @@ class POSIXStagingStoragePolicies(StorageGatewayPolicies):
             environment,
             callback=lambda env_iter: [{**e} for e in env_iter],
         )
-        if additional_fields is not None:
-            self.update(additional_fields)
+        self.update(additional_fields or {})
 
 
 class BlackPearlStoragePolicies(StorageGatewayPolicies):
@@ -185,8 +183,8 @@ class BlackPearlStoragePolicies(StorageGatewayPolicies):
     def __init__(
         self,
         DATA_TYPE: str = "blackpearl_storage_policies#1.0.0",
-        s3_endpoint: str | None = None,
-        bp_access_id_file: str | None = None,
+        s3_endpoint: str | MissingType = MISSING,
+        bp_access_id_file: str | MissingType = MISSING,
         additional_fields: dict[str, t.Any] | None = None,
     ) -> None:
         super().__init__()
@@ -195,8 +193,7 @@ class BlackPearlStoragePolicies(StorageGatewayPolicies):
             s3_endpoint=s3_endpoint,
             bp_access_id_file=bp_access_id_file,
         )
-        if additional_fields is not None:
-            self.update(additional_fields)
+        self.update(additional_fields or {})
 
 
 class BoxStoragePolicies(StorageGatewayPolicies):
@@ -216,15 +213,14 @@ class BoxStoragePolicies(StorageGatewayPolicies):
     def __init__(
         self,
         DATA_TYPE: str = "box_storage_policies#1.0.0",
-        enterpriseID: str | None = None,
-        boxAppSettings: dict[str, t.Any] | None = None,
+        enterpriseID: str | MissingType = MISSING,
+        boxAppSettings: dict[str, t.Any] | MissingType = MISSING,
         additional_fields: dict[str, t.Any] | None = None,
     ) -> None:
         super().__init__()
         self._set_optstrs(DATA_TYPE=DATA_TYPE, enterpriseID=enterpriseID)
         self._set_value("boxAppSettings", boxAppSettings)
-        if additional_fields is not None:
-            self.update(additional_fields)
+        self.update(additional_fields or {})
 
 
 class CephStoragePolicies(StorageGatewayPolicies):
@@ -247,10 +243,10 @@ class CephStoragePolicies(StorageGatewayPolicies):
     def __init__(
         self,
         DATA_TYPE: str = "ceph_storage_policies#1.0.0",
-        s3_endpoint: str | None = None,
-        s3_buckets: t.Iterable[str] | None = None,
-        ceph_admin_key_id: str | None = None,
-        ceph_admin_secret_key: str | None = None,
+        s3_endpoint: str | MissingType = MISSING,
+        s3_buckets: t.Iterable[str] | MissingType = MISSING,
+        ceph_admin_key_id: str | MissingType = MISSING,
+        ceph_admin_secret_key: str | MissingType = MISSING,
         additional_fields: dict[str, t.Any] | None = None,
     ) -> None:
         super().__init__()
@@ -261,8 +257,7 @@ class CephStoragePolicies(StorageGatewayPolicies):
             ceph_admin_secret_key=ceph_admin_secret_key,
         )
         self._set_optstrlists(s3_buckets=s3_buckets)
-        if additional_fields is not None:
-            self.update(additional_fields)
+        self.update(additional_fields or {})
 
 
 class GoogleDriveStoragePolicies(StorageGatewayPolicies):
@@ -283,16 +278,15 @@ class GoogleDriveStoragePolicies(StorageGatewayPolicies):
     def __init__(
         self,
         DATA_TYPE: str = "google_drive_storage_policies#1.0.0",
-        client_id: str | None = None,
-        secret: str | None = None,
-        user_api_rate_quota: int | None = None,
+        client_id: str | MissingType = MISSING,
+        secret: str | MissingType = MISSING,
+        user_api_rate_quota: int | MissingType = MISSING,
         additional_fields: dict[str, t.Any] | None = None,
     ) -> None:
         super().__init__()
         self._set_optstrs(DATA_TYPE=DATA_TYPE, client_id=client_id, secret=secret)
         self._set_optints(user_api_rate_quota=user_api_rate_quota)
-        if additional_fields is not None:
-            self.update(additional_fields)
+        self.update(additional_fields or {})
 
 
 class GoogleCloudStoragePolicies(StorageGatewayPolicies):
@@ -323,19 +317,18 @@ class GoogleCloudStoragePolicies(StorageGatewayPolicies):
     def __init__(
         self,
         DATA_TYPE: str = "google_cloud_storage_policies#1.0.0",
-        client_id: str | None = None,
-        secret: str | None = None,
-        service_account_key: dict[str, t.Any] | None = None,
-        buckets: t.Iterable[str] | None = None,
-        projects: t.Iterable[str] | None = None,
+        client_id: str | MissingType = MISSING,
+        secret: str | MissingType = MISSING,
+        service_account_key: dict[str, t.Any] | MissingType = MISSING,
+        buckets: t.Iterable[str] | MissingType = MISSING,
+        projects: t.Iterable[str] | MissingType = MISSING,
         additional_fields: dict[str, t.Any] | None = None,
     ) -> None:
         super().__init__()
         self._set_optstrs(DATA_TYPE=DATA_TYPE, client_id=client_id, secret=secret)
         self._set_optstrlists(buckets=buckets, projects=projects)
         self._set_value("service_account_key", service_account_key)
-        if additional_fields is not None:
-            self.update(additional_fields)
+        self.update(additional_fields or {})
 
 
 class OneDriveStoragePolicies(StorageGatewayPolicies):
@@ -357,10 +350,10 @@ class OneDriveStoragePolicies(StorageGatewayPolicies):
     def __init__(
         self,
         DATA_TYPE: str = "onedrive_storage_policies#1.0.0",
-        client_id: str | None = None,
-        secret: str | None = None,
-        tenant: str | None = None,
-        user_api_rate_limit: int | None = None,
+        client_id: str | MissingType = MISSING,
+        secret: str | MissingType = MISSING,
+        tenant: str | MissingType = MISSING,
+        user_api_rate_limit: int | MissingType = MISSING,
         additional_fields: dict[str, t.Any] | None = None,
     ) -> None:
         super().__init__()
@@ -368,8 +361,7 @@ class OneDriveStoragePolicies(StorageGatewayPolicies):
             DATA_TYPE=DATA_TYPE, client_id=client_id, secret=secret, tenant=tenant
         )
         self._set_optints(user_api_rate_limit=user_api_rate_limit)
-        if additional_fields is not None:
-            self.update(additional_fields)
+        self.update(additional_fields or {})
 
 
 class AzureBlobStoragePolicies(StorageGatewayPolicies):
@@ -393,12 +385,12 @@ class AzureBlobStoragePolicies(StorageGatewayPolicies):
     def __init__(
         self,
         DATA_TYPE: str = "azure_blob_storage_policies#1.0.0",
-        client_id: str | None = None,
-        secret: str | None = None,
-        tenant: str | None = None,
-        account: str | None = None,
-        auth_type: str | None = None,
-        adls: bool | None = None,
+        client_id: str | MissingType = MISSING,
+        secret: str | MissingType = MISSING,
+        tenant: str | MissingType = MISSING,
+        account: str | MissingType = MISSING,
+        auth_type: str | MissingType = MISSING,
+        adls: bool | MissingType = MISSING,
         additional_fields: dict[str, t.Any] | None = None,
     ) -> None:
         super().__init__()
@@ -411,8 +403,7 @@ class AzureBlobStoragePolicies(StorageGatewayPolicies):
             auth_type=auth_type,
         )
         self._set_optbools(adls=adls)
-        if additional_fields is not None:
-            self.update(additional_fields)
+        self.update(additional_fields or {})
 
 
 class S3StoragePolicies(StorageGatewayPolicies):
@@ -435,17 +426,16 @@ class S3StoragePolicies(StorageGatewayPolicies):
     def __init__(
         self,
         DATA_TYPE: str = "s3_storage_policies#1.0.0",
-        s3_endpoint: str | None = None,
-        s3_buckets: t.Iterable[str] | None = None,
-        s3_user_credential_required: bool | None = None,
+        s3_endpoint: str | MissingType = MISSING,
+        s3_buckets: t.Iterable[str] | MissingType = MISSING,
+        s3_user_credential_required: bool | MissingType = MISSING,
         additional_fields: dict[str, t.Any] | None = None,
     ) -> None:
         super().__init__()
         self._set_optstrs(DATA_TYPE=DATA_TYPE, s3_endpoint=s3_endpoint)
         self._set_optbools(s3_user_credential_required=s3_user_credential_required)
         self._set_optstrlists(s3_buckets=s3_buckets)
-        if additional_fields is not None:
-            self.update(additional_fields)
+        self.update(additional_fields or {})
 
 
 class ActiveScaleStoragePolicies(S3StoragePolicies):
@@ -470,8 +460,8 @@ class IrodsStoragePolicies(StorageGatewayPolicies):
     def __init__(
         self,
         DATA_TYPE: str = "irods_storage_policies#1.0.0",
-        irods_environment_file: str | None = None,
-        irods_authentication_file: str | None = None,
+        irods_environment_file: str | MissingType = MISSING,
+        irods_authentication_file: str | MissingType = MISSING,
         additional_fields: dict[str, t.Any] | None = None,
     ) -> None:
         super().__init__()
@@ -480,8 +470,7 @@ class IrodsStoragePolicies(StorageGatewayPolicies):
             irods_environment_file=irods_environment_file,
             irods_authentication_file=irods_authentication_file,
         )
-        if additional_fields is not None:
-            self.update(additional_fields)
+        self.update(additional_fields or {})
 
 
 class HPSSStoragePolicies(StorageGatewayPolicies):
@@ -501,9 +490,9 @@ class HPSSStoragePolicies(StorageGatewayPolicies):
     def __init__(
         self,
         DATA_TYPE: str = "hpss_storage_policies#1.0.0",
-        authentication_mech: str | None = None,
-        authenticator: str | None = None,
-        uda_checksum_support: bool | None = None,
+        authentication_mech: str | MissingType = MISSING,
+        authenticator: str | MissingType = MISSING,
+        uda_checksum_support: bool | MissingType = MISSING,
         additional_fields: dict[str, t.Any] | None = None,
     ) -> None:
         super().__init__()
@@ -513,5 +502,4 @@ class HPSSStoragePolicies(StorageGatewayPolicies):
             authenticator=authenticator,
         )
         self._set_optbools(uda_checksum_support=uda_checksum_support)
-        if additional_fields is not None:
-            self.update(additional_fields)
+        self.update(additional_fields or {})

--- a/src/globus_sdk/services/gcs/data/user_credential.py
+++ b/src/globus_sdk/services/gcs/data/user_credential.py
@@ -4,6 +4,7 @@ import typing as t
 
 from globus_sdk import utils
 from globus_sdk._types import UUIDLike
+from globus_sdk.utils import MISSING, MissingType
 
 
 class UserCredentialDocument(utils.PayloadWrapper):
@@ -27,12 +28,12 @@ class UserCredentialDocument(utils.PayloadWrapper):
     def __init__(
         self,
         DATA_TYPE: str = "user_credential#1.0.0",
-        identity_id: UUIDLike | None = None,
-        connector_id: UUIDLike | None = None,
-        username: str | None = None,
-        display_name: str | None = None,
-        storage_gateway_id: UUIDLike | None = None,
-        policies: dict[str, t.Any] | None = None,
+        identity_id: UUIDLike | MissingType = MISSING,
+        connector_id: UUIDLike | MissingType = MISSING,
+        username: str | MissingType = MISSING,
+        display_name: str | MissingType = MISSING,
+        storage_gateway_id: UUIDLike | MissingType = MISSING,
+        policies: dict[str, t.Any] | MissingType = MISSING,
         additional_fields: dict[str, t.Any] | None = None,
     ) -> None:
         super().__init__()
@@ -45,6 +46,4 @@ class UserCredentialDocument(utils.PayloadWrapper):
             storage_gateway_id=storage_gateway_id,
         )
         self._set_value("policies", policies)
-
-        if additional_fields is not None:
-            self.update(additional_fields)
+        self.update(additional_fields or {})

--- a/src/globus_sdk/utils.py
+++ b/src/globus_sdk/utils.py
@@ -183,7 +183,7 @@ class PayloadWrapper(PayloadWrapperBase):
         :param callback: An optional callback to apply to the value immediately
             before it is set.
         """
-        if val is not None:
+        if val is not None and val is not MISSING:
             self[key] = callback(val) if callback else val
 
     def _set_optstrs(self, **kwargs: t.Any) -> None:
@@ -195,7 +195,9 @@ class PayloadWrapper(PayloadWrapperBase):
         for k, v in kwargs.items():
             self._set_value(k, v, callback=str)
 
-    def _set_optstrlists(self, **kwargs: t.Iterable[t.Any] | None) -> None:
+    def _set_optstrlists(
+        self, **kwargs: t.Iterable[t.Any] | None | MissingType
+    ) -> None:
         """
         Convenience function for setting a collection of omittable string list values.
 
@@ -204,7 +206,7 @@ class PayloadWrapper(PayloadWrapperBase):
         for k, v in kwargs.items():
             self._set_value(k, v, callback=lambda x: list(safe_strseq_iter(x)))
 
-    def _set_optbools(self, **kwargs: bool | None) -> None:
+    def _set_optbools(self, **kwargs: bool | None | MissingType) -> None:
         """
         Convenience function for setting a collection of omittable bool values.
 

--- a/tests/functional/services/gcs/test_get_collection_list.py
+++ b/tests/functional/services/gcs/test_get_collection_list.py
@@ -2,6 +2,7 @@ import pytest
 
 from globus_sdk import GCSAPIError
 from globus_sdk._testing import get_last_request, load_response
+from globus_sdk.utils import MISSING
 
 
 def test_get_collection_list(client):
@@ -22,7 +23,7 @@ def test_get_collection_list(client):
 @pytest.mark.parametrize(
     "include_param, expected",
     (
-        (None, None),
+        (MISSING, None),
         ("foo", "foo"),
         ("foo,bar", "foo,bar"),
         (("foo", "bar"), "foo,bar"),
@@ -32,7 +33,7 @@ def test_get_collection_list_include_param(client, include_param, expected):
     load_response(client.get_collection_list)
     client.get_collection_list(include=include_param)
     req = get_last_request()
-    if include_param is not None:
+    if include_param is not MISSING:
         assert "include" in req.params
         assert req.params["include"] == expected
     else:

--- a/tests/functional/services/gcs/test_storage_gateways.py
+++ b/tests/functional/services/gcs/test_storage_gateways.py
@@ -4,11 +4,12 @@ import pytest
 
 import globus_sdk
 from globus_sdk._testing import get_last_request, load_response
+from globus_sdk.utils import MISSING
 
 
 @pytest.mark.parametrize(
     "include_param",
-    [None, "private_policies", "private_policies,foo", ("private_policies", "foo")],
+    [MISSING, "private_policies", "private_policies,foo", ("private_policies", "foo")],
 )
 def test_get_storage_gateway_list(client, include_param):
     meta = load_response(client.get_storage_gateway_list).metadata
@@ -28,7 +29,7 @@ def test_get_storage_gateway_list(client, include_param):
     req = get_last_request()
     assert req.body is None
     parsed_qs = urllib.parse.parse_qs(urllib.parse.urlparse(req.url).query)
-    if include_param is None:
+    if include_param is MISSING:
         assert parsed_qs == {}
     elif isinstance(include_param, str):
         assert parsed_qs == {"include": [include_param]}
@@ -65,7 +66,7 @@ def test_create_storage_gateway_validation_error(client):
 
 @pytest.mark.parametrize(
     "include_param",
-    [None, "private_policies", "private_policies,foo", ("private_policies", "foo")],
+    [MISSING, "private_policies", "private_policies,foo", ("private_policies", "foo")],
 )
 def test_get_storage_gateway(client, include_param):
     meta = load_response(client.get_storage_gateway).metadata
@@ -80,7 +81,7 @@ def test_get_storage_gateway(client, include_param):
     req = get_last_request()
     assert req.body is None
     parsed_qs = urllib.parse.parse_qs(urllib.parse.urlparse(req.url).query)
-    if include_param is None:
+    if include_param is MISSING:
         assert parsed_qs == {}
     elif isinstance(include_param, str):
         assert parsed_qs == {"include": [include_param]}


### PR DESCRIPTION
[sc-15807](https://app.shortcut.com/globus/story/15807/sdkv4-convert-defaults-of-none-to-globus-sdk-missing-for-payload-types-allowing-explicit-null-by-setting-none)

This PR is for SDKv4 and is a followup to #1205 and #1207.

### Changes
 - Converted defaults of `None` to `globus_sdk.MISSING` for payload types in the GCS client.
 - Updated GCS unit tests to test with `MISSING` defaults instead of `None`.

<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1214.org.readthedocs.build/en/1214/

<!-- readthedocs-preview globus-sdk-python end -->