### PR TITLE
Fix py3.8-mindeps test failures on Windows

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -59,6 +59,7 @@ jobs:
           - name: "Windows"
             runner: "windows-latest"
             cpythons:
+              - "3.8"
               - "3.11"
             tox-post-environments:
               - "py3.8-mindeps"


### PR DESCRIPTION
### Context
GitHub removed Python 3.8.x from Windows 2019, Windows 2022, and Ubuntu 2022 runner images on 2025-06-06 ([ref](https://github.com/actions/runner-images/issues/12034)), causing our CI tests to fail for the `py3.8-mindeps` tox environment on Windows.

### Changes
Added python 3.8 to the `cpythons` array in the Windows test configuration to explicitly install Python 3.8 via `actions/setup-python`.

<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1218.org.readthedocs.build/en/1218/

<!-- readthedocs-preview globus-sdk-python end -->