### PR TITLE
Fix typo in AuthClient.update_client docstring

### DIFF
--- a/src/globus_sdk/services/auth/client/service_client.py
+++ b/src/globus_sdk/services/auth/client/service_client.py
@@ -1322,16 +1322,11 @@ class AuthClient(client.BaseClient):
 
             .. tab-item:: Example Usage
 
-                When creating a project, your account is not necessarily included as an
-                admin. The following snippet uses the ``manage_projects`` scope as well
-                as the ``openid`` and ``email`` scopes to get the current user ID and
-                email address and use those data to setup the project.
-
                 .. code-block:: pycon
 
                     >>> ac = globus_sdk.AuthClient(...)
                     >>> client_id = ...
-                    >>> r = ac.create_update(client_id, name="Foo Utility")
+                    >>> r = ac.update_client(client_id, name="Foo Utility")
 
             .. tab-item:: Example Response Data
 


### PR DESCRIPTION

## Changes
Fixed some incorrect documentation in the `AuthClient.update_client` example usage tab:
1. The section's is copy-pasted from `create_project` and not applicable to `update_client`, so remove that.
2. The section uses an incorrect name (`create_update`) instead of `update_client`.

<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1220.org.readthedocs.build/en/1220/

<!-- readthedocs-preview globus-sdk-python end -->