### PR TITLE
Revert "Fix license deprecation warning (#1223)"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,12 +7,12 @@ name = "globus-sdk"
 authors = [
     { name = "Globus Team", email = "support@globus.org" },
 ]
-license = "Apache-2.0"
 description = "Globus SDK for Python"
 keywords = ["globus"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
@@ -41,6 +41,9 @@ dynamic = ["version"]
 [project.readme]
 file = "README.rst"
 content-type = "text/x-rst"
+
+[project.license]
+text = "Apache-2.0"
 
 [project.urls]
 Homepage = "https://github.com/globus/globus-sdk-python"


### PR DESCRIPTION
This reverts commit 0f3b9bb5be9466468d1f41ed0568aaf75ff53e9c.

When this is re-introduced, the build-system config must be updated. Specifically, setuptools v77.0.0 or higher must be required (currently it's set to v61.2 or higher).

Note that this will mean the package cannot be built from a `.tar.gz` on Python 3.8 because setuptools dropped support for Python 3.8 in an earlier release.

<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1224.org.readthedocs.build/en/1224/

<!-- readthedocs-preview globus-sdk-python end -->