### PR TITLE
Release v3.58.0

### DIFF
--- a/changelog.d/20250604_172822_sirosen_bugfix_high_assuranc.rst
+++ b/changelog.d/20250604_172822_sirosen_bugfix_high_assuranc.rst
@@ -1,5 +1,0 @@
-Fixed
-~~~~~
-
-- Fix an error which caused the ``restrict_transfers_to_high_assurance`` field
-  to be malformed when set on a collection payload type. (:pr:`1211`)

--- a/changelog.d/20250609_165936_kurtmckee_add_validate_run.rst
+++ b/changelog.d/20250609_165936_kurtmckee_add_validate_run.rst
@@ -1,4 +1,0 @@
-Added
-~~~~~
-
-- Add the ``SpecificFlow.validate_run()`` method. (:pr:`1221`)

--- a/changelog.rst
+++ b/changelog.rst
@@ -12,6 +12,22 @@ to a major new version of the SDK.
 
 .. scriv-insert-here
 
+.. _changelog-3.58.0:
+
+v3.58.0 (2025-06-16)
+--------------------
+
+Added
+~~~~~
+
+- Add the ``SpecificFlow.validate_run()`` method. (:pr:`1221`)
+
+Fixed
+~~~~~
+
+- Fix an error which caused the ``restrict_transfers_to_high_assurance`` field
+  to be malformed when set on a collection payload type. (:pr:`1211`)
+
 .. _changelog-3.57.0:
 
 v3.57.0 (2025-06-04)

--- a/src/globus_sdk/version.py
+++ b/src/globus_sdk/version.py
@@ -1,3 +1,3 @@
 # single source of truth for package version,
 # see https://packaging.python.org/en/latest/single_source_version/
-__version__ = "3.57.0"
+__version__ = "3.58.0"


### PR DESCRIPTION
Added
-----

- Add the ``SpecificFlow.validate_run()`` method. ([#1221](https://github.com/globus/globus-sdk-python/pull/1221))

Fixed
-----

- Fix an error which caused the ``restrict_transfers_to_high_assurance`` field
  to be malformed when set on a collection payload type. ([#1211](https://github.com/globus/globus-sdk-python/pull/1211))

<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1226.org.readthedocs.build/en/1226/

<!-- readthedocs-preview globus-sdk-python end -->