### PR TITLE
[sc-38573] implement GCP subscription admin verification

### DIFF
--- a/changelog.d/20250618_152809_pjhinton_sc_38573_subscription_admin_verified_support.rst
+++ b/changelog.d/20250618_152809_pjhinton_sc_38573_subscription_admin_verified_support.rst
@@ -1,0 +1,3 @@
+Added
+~~~~~
+- Added the ``TransferClient.set_subscription_admin_verified()`` method. (:pr:`NUMBER`)

--- a/src/globus_sdk/_testing/data/transfer/set_subscription_admin_verified.py
+++ b/src/globus_sdk/_testing/data/transfer/set_subscription_admin_verified.py
@@ -1,0 +1,96 @@
+import uuid
+
+from globus_sdk._testing.models import RegisteredResponse, ResponseSet
+
+from ._common import ENDPOINT_ID, SUBSCRIPTION_ID
+
+NO_ADMIN_ROLE_ENDPOINT_ID = str(uuid.UUID(int=10))
+NON_SUBSCRIBED_ENDPOINT_ID = str(uuid.UUID(int=11))
+NO_IDENTITIES_IN_SESSION_ENDPOINT_ID = str(uuid.UUID(int=12))
+
+
+def _format_verify_route(epid: str) -> str:
+    return f"/endpoint/{epid}/subscription_admin_verified"
+
+
+RESPONSES = ResponseSet(
+    metadata={"endpoint_id": ENDPOINT_ID},
+    default=RegisteredResponse(
+        service="transfer",
+        method="PUT",
+        path=_format_verify_route(ENDPOINT_ID),
+        status=200,
+        json={
+            "DATA_TYPE": "result",
+            "code": "Updated",
+            "message": "Endpoint updated successfully",
+            "request_id": "SKWMqNWyv",
+            "resource": _format_verify_route(ENDPOINT_ID),
+        },
+    ),
+    no_admin_role=RegisteredResponse(
+        metadata={"endpoint_id": NO_ADMIN_ROLE_ENDPOINT_ID},
+        service="transfer",
+        method="PUT",
+        path=_format_verify_route(NO_ADMIN_ROLE_ENDPOINT_ID),
+        status=403,
+        json={
+            "code": "PermissionDenied",
+            "message": (
+                "User does not have an admin role on the collection's "
+                "subscription to set subscription_admin_verified"
+            ),
+            "request_id": "BHI2BHt8N",
+            "resource": _format_verify_route(NO_ADMIN_ROLE_ENDPOINT_ID),
+        },
+    ),
+    non_valid_verified_status=RegisteredResponse(
+        service="transfer",
+        method="PUT",
+        path=_format_verify_route(ENDPOINT_ID),
+        status=400,
+        json={
+            "code": "BadRequest",
+            "message": (
+                "Could not parse JSON: Expecting value: line 1 column 33 (char 32)"
+            ),
+            "request_id": "NPjnXpSD6",
+            "resource": _format_verify_route(ENDPOINT_ID),
+        },
+    ),
+    non_subscribed_endpoint=RegisteredResponse(
+        metadata={"endpoint_id": NON_SUBSCRIBED_ENDPOINT_ID},
+        service="transfer",
+        method="PUT",
+        path=_format_verify_route(NON_SUBSCRIBED_ENDPOINT_ID),
+        status=400,
+        json={
+            "code": "BadRequest",
+            "message": (
+                "The collection must be associated with a subscription to "
+                "set subscription_admin_verified"
+            ),
+            "request_id": "NPjnXpSD6",
+            "resource": _format_verify_route(NON_SUBSCRIBED_ENDPOINT_ID),
+        },
+    ),
+    no_identities_in_session=RegisteredResponse(
+        metadata={
+            "endpoint_id": NO_IDENTITIES_IN_SESSION_ENDPOINT_ID,
+            "subscription_id": SUBSCRIPTION_ID,
+        },
+        service="transfer",
+        method="PUT",
+        path=_format_verify_route(NO_IDENTITIES_IN_SESSION_ENDPOINT_ID),
+        status=400,
+        json={
+            "code": "BadRequest",
+            "message": (
+                "No manager or admin identities in session for high-assurance "
+                f"subscription {SUBSCRIPTION_ID}"
+            ),
+            "request_id": "NPjnXpSD6",
+            "resource": _format_verify_route(NO_IDENTITIES_IN_SESSION_ENDPOINT_ID),
+        },
+    ),
+)

--- a/src/globus_sdk/services/transfer/client.py
+++ b/src/globus_sdk/services/transfer/client.py
@@ -331,6 +331,60 @@ class TransferClient(client.BaseClient):
             data={"subscription_id": subscription_id},
         )
 
+    def set_subscription_admin_verified(
+        self,
+        collection_id: UUIDLike,
+        subscription_admin_verified: bool,
+    ) -> response.GlobusHTTPResponse:
+        """
+        Sets the value of ``subscription_admin_verified`` on a Globus Connect Personal
+        mapped collection. A value of ``True`` grants verified status, and a
+        value of ``False`` revokes verified status.
+
+        This operation requires membership in a Globus subscription group and
+        has authorization requirements which depend upon the caller's roles on
+        the subscription group and the collection.
+
+        Subscription administrators can grant or revoke verification on a collection
+        that is associated with their subscription without needing an administrator
+        role on the collection itself.
+
+        Users with the administrator effective role on the collection can revoke
+        verification on a collection, but must still be a subscription administrator
+        to grant verification.
+
+        :param collection_id: The collection ID which is having its subscription set.
+        :param subscription_admin_verified: The verification status of the collection
+            expressed as a Boolean type.
+
+        .. tab-set::
+
+            .. tab-item:: Example Usage
+
+                .. code-block:: python
+
+                    import globus_sdk
+
+                    LOCAL_GCP = globus_sdk.LocalGlobusConnectPersonal()
+
+                    tc = globus_sdk.TransferClient(...)
+                    tc.endpoint_set_subscription_id(
+                        LOCAL_GCP.endpoint_id,
+                        True,
+                    )
+
+            .. tab-item:: API Info
+
+                ``PUT /endpoint/<collection_id>/subscription_admin_verified``
+
+                .. extdoclink:: Set Subscription Admin Verified
+                    :ref: transfer/gcp_management/#set_subscription_admin_verified
+        """  # noqa: E501
+        return self.put(
+            f"/endpoint/{collection_id}/subscription_admin_verified",
+            data={"subscription_admin_verified": subscription_admin_verified},
+        )
+
     def create_endpoint(self, data: dict[str, t.Any]) -> response.GlobusHTTPResponse:
         """
         .. warning::

--- a/tests/functional/services/transfer/test_set_subscription_admin_verified.py
+++ b/tests/functional/services/transfer/test_set_subscription_admin_verified.py
@@ -1,0 +1,83 @@
+import pytest
+
+import globus_sdk
+from globus_sdk._testing import load_response
+
+
+def test_set_subscription_admin_verified(client):
+    meta = load_response(client.set_subscription_admin_verified).metadata
+    epid = meta["endpoint_id"]
+
+    res = client.set_subscription_admin_verified(epid, True)
+    assert res["code"] == "Updated"
+    assert res["message"] == "Endpoint updated successfully"
+
+
+def test_set_subscription_admin_verified_fails_no_admin_role(client):
+    meta = load_response(
+        client.set_subscription_admin_verified, case="no_admin_role"
+    ).metadata
+    epid = meta["endpoint_id"]
+
+    with pytest.raises(globus_sdk.TransferAPIError) as excinfo:
+        client.set_subscription_admin_verified(epid, True)
+
+    assert excinfo.value.code == "PermissionDenied"
+    assert len(excinfo.value.messages) == 1
+    message = excinfo.value.messages[0]
+    assert message == (
+        "User does not have an admin role on the collection's subscription to set "
+        "subscription_admin_verified"
+    )
+
+
+def test_set_subscription_admin_verified_fails_non_valid_verified_status(client):
+    meta = load_response(
+        client.set_subscription_admin_verified, case="non_valid_verified_status"
+    ).metadata
+    epid = meta["endpoint_id"]
+
+    with pytest.raises(globus_sdk.TransferAPIError) as excinfo:
+        client.set_subscription_admin_verified(epid, None)
+
+    assert excinfo.value.code == "BadRequest"
+    assert len(excinfo.value.messages) == 1
+    message = excinfo.value.messages[0]
+    assert message.startswith("Could not parse JSON: ")
+
+
+def test_set_subscription_admin_verified_fails_non_subscribed_endpoint(client):
+    meta = load_response(
+        client.set_subscription_admin_verified, case="non_subscribed_endpoint"
+    ).metadata
+    epid = meta["endpoint_id"]
+
+    with pytest.raises(globus_sdk.TransferAPIError) as excinfo:
+        client.set_subscription_admin_verified(epid, True)
+
+    assert excinfo.value.code == "BadRequest"
+    assert len(excinfo.value.messages) == 1
+    message = excinfo.value.messages[0]
+    assert message == (
+        "The collection must be associated with a subscription to "
+        "set subscription_admin_verified"
+    )
+
+
+def test_set_subscription_admin_verified_fails_no_identities_in_session(client):
+    meta = load_response(
+        client.set_subscription_admin_verified, case="no_identities_in_session"
+    ).metadata
+    epid = meta["endpoint_id"]
+    subid = meta["subscription_id"]
+
+    with pytest.raises(globus_sdk.TransferAPIError) as excinfo:
+        client.set_subscription_admin_verified(epid, True)
+
+    assert excinfo.value.code == "BadRequest"
+    assert len(excinfo.value.messages) == 1
+    message = excinfo.value.messages[0]
+    assert message == (
+        "No manager or admin identities in session for high-assurance subscription "
+        f"{subid}"
+    )


### PR DESCRIPTION
**Shortcut Story**: [sc-38573 / SDK/CLI support for verified data collections](https://app.shortcut.com/globus/story/38573/sdk-cli-support-for-verified-data-collections)

This pull request implements support for setting the subscription administrator verification status on a Globus Connect Personal collection.

* Add method `set_subscription_admin_verified()` to `TransferClient` class.
* Include reference guide in method docstring.
* Add mock responses for success and  failure paths on API.
* Add functional tests to exercise happy path and all failure modes.
* Add changelog fragment.

<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1227.org.readthedocs.build/en/1227/

<!-- readthedocs-preview globus-sdk-python end -->