### PR TITLE
Remove transfer_client param to data constructors

### DIFF
--- a/changelog.d/20250620_104615_sirosen_remove_transfer_client_param.rst
+++ b/changelog.d/20250620_104615_sirosen_remove_transfer_client_param.rst
@@ -1,0 +1,6 @@
+Breaking Changes
+~~~~~~~~~~~~~~~~
+
+- Support for ``transfer_client`` as a parameter to ``TransferData`` and
+  ``DeleteData`` has been removed. See the upgrading doc for transition
+  details. (:pr:`NUMBER`)

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -45,6 +45,73 @@ Then, code can dispatch with
 From 3.x to 4.0
 ---------------
 
+``TransferData`` and ``DeleteData`` Do Not Take a ``TransferClient``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The signatures for these two data constructors has changed to remove support
+for ``transfer_client`` as their first parameter.
+
+Generally, update usage which passed a client to omit it:
+
+.. code-block:: python
+
+    from globus_sdk import TransferClient, TransferData, DeleteData
+
+    # globus-sdk v3
+
+    tc = TransferClient(...)
+    tdata = TransferData(tc, SRC_COLLECTION, DST_COLLECTION)
+    tc.submit_transfer(tdata)
+
+    tc = TransferClient(...)
+    ddata = DeleteData(tc, COLLECTION)
+    tc.submit_delete(tdata)
+
+    # globus-sdk v4
+
+    tdata = TransferData(SRC_COLLECTION, DST_COLLECTION)
+    tc = TransferClient(...)
+    tc.submit_transfer(tdata)
+
+    ddata = DeleteData(COLLECTION)
+    tc = TransferClient(...)
+    tc.submit_delete(tdata)
+
+Users who are using keyword arguments to pass collection IDs without a
+``transfer_client`` do not need to make any change. For example:
+
+.. code-block:: python
+
+    from globus_sdk import TransferData, DeleteData
+
+    # globus-sdk v3 or v4
+
+    tdata = TransferData(
+        source_endpoint=SRC_COLLECTION, destination_endpoint=DST_COLLECTION
+    )
+    ddata = DeleteData(endpoint=COLLECTION)
+
+The client object was used to fetch a ``submission_id`` on initialization.
+Users typically will rely on ``TransferClient.submit_transfer()`` and
+``TransferClient.submit_delete()`` filling in this value.
+To control when a submission ID is fetched, use
+``TransferClient.get_submsission_id()``, as in:
+
+.. code-block:: python
+
+    from globus_sdk import TransferClient, TransferData
+
+    # globus-sdk v3 or v4
+
+    tc = TransferClient(...)
+    submission_id = tc.get_submission_id()["value"]
+
+    tdata = TransferData(
+        source_endpoint=SRC_COLLECTION,
+        destination_endpoint=DST_COLLECTION,
+        submission_id=submission_id,
+    )
+
 Deprecated Timers Aliases Removed
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/user_guide/usage_patterns/data_transfer/detecting_data_access/submit_transfer_detect_data_access.py
+++ b/docs/user_guide/usage_patterns/data_transfer/detecting_data_access/submit_transfer_detect_data_access.py
@@ -42,10 +42,7 @@ if uses_data_access(transfer_client, SRC_COLLECTION):
 if uses_data_access(transfer_client, DST_COLLECTION):
     transfer_client.add_app_data_access_scope(DST_COLLECTION)
 
-transfer_request = globus_sdk.TransferData(
-    source_endpoint=SRC_COLLECTION,
-    destination_endpoint=DST_COLLECTION,
-)
+transfer_request = globus_sdk.TransferData(SRC_COLLECTION, DST_COLLECTION)
 transfer_request.add_item(SRC_PATH, DST_PATH)
 
 task = transfer_client.submit_transfer(transfer_request)

--- a/docs/user_guide/usage_patterns/data_transfer/scheduled_transfers/create_timer.py
+++ b/docs/user_guide/usage_patterns/data_transfer/scheduled_transfers/create_timer.py
@@ -19,10 +19,7 @@ DST_PATH = "/~/example-timer-destination.txt"
 
 # as with an immediate data transfer, we take our input data and wrap them in
 # a TransferData object, representing the transfer task
-transfer_request = globus_sdk.TransferData(
-    source_endpoint=SRC_COLLECTION,
-    destination_endpoint=DST_COLLECTION,
-)
+transfer_request = globus_sdk.TransferData(SRC_COLLECTION, DST_COLLECTION)
 transfer_request.add_item(SRC_PATH, DST_PATH)
 
 # we'll define the timer as one which runs every hour for 3 days

--- a/docs/user_guide/usage_patterns/data_transfer/scheduled_transfers/create_timer_detect_data_access.py
+++ b/docs/user_guide/usage_patterns/data_transfer/scheduled_transfers/create_timer_detect_data_access.py
@@ -41,10 +41,7 @@ def uses_data_access(collection_id: str) -> bool:
 
 # as with an immediate data transfer, we take our input data and wrap them in
 # a TransferData object, representing the transfer task
-transfer_request = globus_sdk.TransferData(
-    source_endpoint=SRC_COLLECTION,
-    destination_endpoint=DST_COLLECTION,
-)
+transfer_request = globus_sdk.TransferData(SRC_COLLECTION, DST_COLLECTION)
 transfer_request.add_item(SRC_PATH, DST_PATH)
 
 # we'll define the timer as one which runs every hour for 3 days

--- a/docs/user_guide/usage_patterns/data_transfer/submit_transfer/submit_transfer_collections_known.py
+++ b/docs/user_guide/usage_patterns/data_transfer/submit_transfer/submit_transfer_collections_known.py
@@ -24,10 +24,7 @@ def main():
     transfer_client.add_app_data_access_scope(SRC_COLLECTION)
     transfer_client.add_app_data_access_scope(DST_COLLECTION)
 
-    transfer_request = globus_sdk.TransferData(
-        source_endpoint=SRC_COLLECTION,
-        destination_endpoint=DST_COLLECTION,
-    )
+    transfer_request = globus_sdk.TransferData(SRC_COLLECTION, DST_COLLECTION)
     transfer_request.add_item(SRC_PATH, DST_PATH)
 
     task = transfer_client.submit_transfer(transfer_request)

--- a/docs/user_guide/usage_patterns/data_transfer/submit_transfer/submit_transfer_collections_unknown.py
+++ b/docs/user_guide/usage_patterns/data_transfer/submit_transfer/submit_transfer_collections_unknown.py
@@ -19,10 +19,7 @@ DST_PATH = "/~/example-transfer-script-destination.txt"
 def main():
     transfer_client = globus_sdk.TransferClient(app=USER_APP)
 
-    transfer_request = globus_sdk.TransferData(
-        source_endpoint=SRC_COLLECTION,
-        destination_endpoint=DST_COLLECTION,
-    )
+    transfer_request = globus_sdk.TransferData(SRC_COLLECTION, DST_COLLECTION)
     transfer_request.add_item(SRC_PATH, DST_PATH)
 
     try:

--- a/docs/user_guide/usage_patterns/data_transfer/transfer_relative_deadline/index.rst
+++ b/docs/user_guide/usage_patterns/data_transfer/transfer_relative_deadline/index.rst
@@ -79,8 +79,8 @@ a sample task document with a deadline set for "an hour from now":
 
     # create a Transfer Task request document, including a relative deadline
     transfer_request = globus_sdk.TransferData(
-        source_endpoint=SRC_COLLECTION,
-        destination_endpoint=DST_COLLECTION,
+        SRC_COLLECTION,
+        DST_COLLECTION,
         deadline=make_relative_deadline(datetime.timedelta(hours=1)),
     )
     transfer_request.add_item(SRC_PATH, DST_PATH)

--- a/docs/user_guide/usage_patterns/data_transfer/transfer_relative_deadline/submit_transfer_relative_deadline.py
+++ b/docs/user_guide/usage_patterns/data_transfer/transfer_relative_deadline/submit_transfer_relative_deadline.py
@@ -32,8 +32,8 @@ transfer_client.add_app_data_access_scope(SRC_COLLECTION)
 transfer_client.add_app_data_access_scope(DST_COLLECTION)
 
 transfer_request = globus_sdk.TransferData(
-    source_endpoint=SRC_COLLECTION,
-    destination_endpoint=DST_COLLECTION,
+    SRC_COLLECTION,
+    DST_COLLECTION,
     deadline=make_relative_deadline(datetime.timedelta(hours=1)),
 )
 transfer_request.add_item(SRC_PATH, DST_PATH)

--- a/src/globus_sdk/services/timers/client.py
+++ b/src/globus_sdk/services/timers/client.py
@@ -67,9 +67,7 @@ class TimersClient(client.BaseClient):
                     app = UserApp("myapp", client_id=NATIVE_APP_CLIENT_ID)
                     client = TimersClient(app=app).add_app_transfer_data_access_scope(COLLECTION_ID)
 
-                    transfer_data = TransferData(
-                        source_endpoint=COLLECTION_ID, destination_endpoint=COLLECTION_ID
-                    )
+                    transfer_data = TransferData(COLLECTION_ID, COLLECTION_ID)
                     transfer_data.add_item("/staging/", "/active/")
 
                     daily_timer = TransferTimer(
@@ -155,15 +153,14 @@ class TimersClient(client.BaseClient):
 
                 .. code-block:: pycon
 
-                    >>> transfer_client = TransferClient(...)
-                    >>> transfer_data = TransferData(transfer_client, ...)
-                    >>> timer_client = globus_sdk.TimersClient(...)
+                    >>> transfer_data = TransferData(...)
+                    >>> timers_client = globus_sdk.TimersClient(...)
                     >>> create_doc = globus_sdk.TransferTimer(
                     ...     name="my-timer",
                     ...     schedule={"type": "recurring", "interval": 1800},
                     ...     body=transfer_data,
                     ... )
-                    >>> response = timer_client.create_timer(timer=create_doc)
+                    >>> response = timers_client.create_timer(timer=create_doc)
 
             .. tab-item:: Example Response Data
 
@@ -192,16 +189,15 @@ class TimersClient(client.BaseClient):
         **Examples**
 
         >>> from datetime import datetime, timedelta
-        >>> transfer_client = TransferClient(...)
-        >>> transfer_data = TransferData(transfer_client, ...)
-        >>> timer_client = globus_sdk.TimersClient(...)
+        >>> transfer_data = TransferData(...)
+        >>> timers_client = globus_sdk.TimersClient(...)
         >>> job = TimerJob.from_transfer_data(
         ...     transfer_data,
         ...     datetime.utcnow(),
         ...     timedelta(days=14),
         ...     name="my-timer-job"
         ... )
-        >>> timer_result = timer_client.create_job(job)
+        >>> timer_result = timers_client.create_job(job)
         """
         if isinstance(data, TransferTimer):
             raise exc.GlobusSDKUsageError(

--- a/src/globus_sdk/services/transfer/client.py
+++ b/src/globus_sdk/services/transfer/client.py
@@ -1558,16 +1558,16 @@ class TransferClient(client.BaseClient):
 
                 .. code-block:: python
 
-                    tc = globus_sdk.TransferClient(...)
                     tdata = globus_sdk.TransferData(
-                        tc,
                         source_endpoint_id,
                         destination_endpoint_id,
                         label="SDK example",
                         sync_level="checksum",
                     )
-                    tdata.add_item("/source/path/dir/", "/dest/path/dir/", recursive=True)
+                    tdata.add_item("/source/path/dir/", "/dest/path/dir/")
                     tdata.add_item("/source/path/file.txt", "/dest/path/file.txt")
+
+                    tc = globus_sdk.TransferClient(...)
                     transfer_result = tc.submit_transfer(tdata)
                     print("task_id =", transfer_result["task_id"])
 
@@ -1582,7 +1582,7 @@ class TransferClient(client.BaseClient):
                     :ref: transfer/task_submit/#submit_transfer_task
         """  # noqa: E501
         log.debug("TransferClient.submit_transfer(...)")
-        if "submission_id" not in data:
+        if "submission_id" not in data or data["submission_id"] is MISSING:
             log.debug("submit_transfer autofetching submission_id")
             data["submission_id"] = self.get_submission_id()["value"]
         return self.post("/v0.10/transfer", data=data)
@@ -1607,10 +1607,11 @@ class TransferClient(client.BaseClient):
 
                 .. code-block:: python
 
-                    tc = globus_sdk.TransferClient(...)
-                    ddata = globus_sdk.DeleteData(tc, endpoint_id, recursive=True)
+                    ddata = globus_sdk.DeleteData(endpoint_id, recursive=True)
                     ddata.add_item("/dir/to/delete/")
                     ddata.add_item("/file/to/delete/file.txt")
+
+                    tc = globus_sdk.TransferClient(...)
                     delete_result = tc.submit_delete(ddata)
                     print("task_id =", delete_result["task_id"])
 
@@ -1625,7 +1626,7 @@ class TransferClient(client.BaseClient):
                     :ref: transfer/task_submit/#submit_delete_task
         """
         log.debug("TransferClient.submit_delete(...)")
-        if "submission_id" not in data:
+        if "submission_id" not in data or data["submission_id"] is MISSING:
             log.debug("submit_delete autofetching submission_id")
             data["submission_id"] = self.get_submission_id()["value"]
         return self.post("/v0.10/delete", data=data)

--- a/tests/functional/services/timers/test_jobs.py
+++ b/tests/functional/services/timers/test_jobs.py
@@ -39,9 +39,7 @@ def test_get_job_errors(client):
 )
 def test_create_job(client, start, interval):
     meta = load_response(client.create_job).metadata
-    transfer_data = TransferData(
-        source_endpoint=GO_EP1_ID, destination_endpoint=GO_EP2_ID
-    )
+    transfer_data = TransferData(GO_EP1_ID, GO_EP2_ID)
     with pytest.warns(exc.RemovedInV4Warning, match="Prefer TransferTimer"):
         timer_job = TimerJob.from_transfer_data(transfer_data, start, interval)
     response = client.create_job(timer_job)
@@ -68,9 +66,7 @@ def test_create_job(client, start, interval):
 
 def test_create_job_validation_error(client):
     meta = load_response(client.create_job, case="validation_error").metadata
-    transfer_data = TransferData(
-        source_endpoint=GO_EP1_ID, destination_endpoint=GO_EP2_ID
-    )
+    transfer_data = TransferData(GO_EP1_ID, GO_EP2_ID)
     with pytest.warns(exc.RemovedInV4Warning, match="Prefer TransferTimer"):
         timer_job = TimerJob.from_transfer_data(
             transfer_data, "2022-04-05T06:00:00", 1800

--- a/tests/functional/services/transfer/test_task_submit.py
+++ b/tests/functional/services/transfer/test_task_submit.py
@@ -16,9 +16,7 @@ def test_transfer_submit_failure(client):
     meta = load_response(client.submit_transfer, case="failure").metadata
 
     with pytest.raises(TransferAPIError) as excinfo:
-        client.submit_transfer(
-            TransferData(source_endpoint=GO_EP1_ID, destination_endpoint=GO_EP2_ID)
-        )
+        client.submit_transfer(TransferData(GO_EP1_ID, GO_EP2_ID))
 
     assert excinfo.value.http_status == 400
     assert excinfo.value.request_id == meta["request_id"]
@@ -30,8 +28,8 @@ def test_transfer_submit_success(client):
     meta = load_response(client.submit_transfer).metadata
 
     tdata = TransferData(
-        source_endpoint=GO_EP1_ID,
-        destination_endpoint=GO_EP2_ID,
+        GO_EP1_ID,
+        GO_EP2_ID,
         label="mytask",
         sync_level="exists",
         deadline="2018-06-01",

--- a/tests/non-pytest/mypy-ignore-tests/transfer_data.py
+++ b/tests/non-pytest/mypy-ignore-tests/transfer_data.py
@@ -1,21 +1,20 @@
 import uuid
 
-from globus_sdk import TransferClient, TransferData
+from globus_sdk import TransferData
 
 # simple usage, ok
-tc = TransferClient()
-TransferData(tc, "srcep", "destep")
+TransferData("srcep", "destep")
 
 # can set sync level
-TransferData(tc, "srcep", "destep", sync_level=1)
-TransferData(tc, "srcep", "destep", sync_level="exists")
+TransferData("srcep", "destep", sync_level=1)
+TransferData("srcep", "destep", sync_level="exists")
 # unknown int values are allowed
-TransferData(tc, "srcep", "destep", sync_level=100)
+TransferData("srcep", "destep", sync_level=100)
 # unknown str values are rejected (Literal)
-TransferData(tc, "srcep", "destep", sync_level="sizes")  # type: ignore[arg-type]
+TransferData("srcep", "destep", sync_level="sizes")  # type: ignore[arg-type]
 
 # TransferData.add_filter_rule
-tdata = TransferData(tc, uuid.UUID(), uuid.UUID())
+tdata = TransferData(uuid.UUID(), uuid.UUID())
 tdata.add_filter_rule("*.tgz")
 tdata.add_filter_rule("*.tgz", method="exclude")
 tdata.add_filter_rule("*.tgz", type="file")

--- a/tests/unit/helpers/test_timer.py
+++ b/tests/unit/helpers/test_timer.py
@@ -15,7 +15,7 @@ from tests.common import GO_EP1_ID, GO_EP2_ID
 
 
 def test_timer_from_transfer_data_ok():
-    tdata = TransferData(None, GO_EP1_ID, GO_EP2_ID)
+    tdata = TransferData(GO_EP1_ID, GO_EP2_ID)
     with pytest.warns(exc.RemovedInV4Warning, match="Prefer TransferTimer"):
         job = TimerJob.from_transfer_data(tdata, "2022-01-01T00:00:00Z", 600)
     assert "callback_body" in job
@@ -30,14 +30,14 @@ def test_timer_from_transfer_data_ok():
     "badkey, value", (("submission_id", "foo"), ("skip_activation_check", True))
 )
 def test_timer_from_transfer_data_rejects_forbidden_keys(badkey, value):
-    tdata = TransferData(None, GO_EP1_ID, GO_EP2_ID, **{badkey: value})
+    tdata = TransferData(GO_EP1_ID, GO_EP2_ID, **{badkey: value})
     with pytest.raises(ValueError):
         with pytest.warns(exc.RemovedInV4Warning, match="Prefer TransferTimer"):
             TimerJob.from_transfer_data(tdata, "2022-01-01T00:00:00Z", 600)
 
 
 def test_transfer_timer_ok():
-    tdata = TransferData(source_endpoint=GO_EP1_ID, destination_endpoint=GO_EP2_ID)
+    tdata = TransferData(GO_EP1_ID, GO_EP2_ID)
     timer = TransferTimer(body=tdata, name="foo timer", schedule={"type": "once"})
     assert timer["name"] == "foo timer"
     assert timer["schedule"]["type"] == "once"


### PR DESCRIPTION
Since v0.x of the SDK (specifically, since 2e78893de4 ), we have
supported `transfer_client` as a parameter to `TransferData`, doing
the `get_submission_id()` call at initialization time.

In order to avoid a data constructor which accepts its relevant
client, and the burden this can impose (e.g., in a multi-user app,
keeping the two synced), we've been in transition to a model where the
client is responsible for making this call and writing the value back
into the payload at submission time.

The `submit_transfer` and `submit_delete` methods already support
fetching a submission ID on init, but they need a small tweak to allow
for `MISSING` values to trigger that fetch.

Docs and tests are updated, and a new section of the upgrading guide
covers how to handle the change.
