### PR TITLE
Convert the CHANGELOG to Markdown-compatible headers

### DIFF
--- a/changelog.d/20250618_152809_pjhinton_sc_38573_subscription_admin_verified_support.rst
+++ b/changelog.d/20250618_152809_pjhinton_sc_38573_subscription_admin_verified_support.rst
@@ -1,3 +1,3 @@
 Added
-~~~~~
+-----
 - Added the ``TransferClient.set_subscription_admin_verified()`` method. (:pr:`1227`)

--- a/changelog.d/20250623_074800_kurtmckee_fix_changelog_rendering.rst
+++ b/changelog.d/20250623_074800_kurtmckee_fix_changelog_rendering.rst
@@ -1,0 +1,7 @@
+Development
+-----------
+
+-   Convert the CHANGELOG to Markdown-compatible headers. (:pr:`NUMBER`)
+
+    This resolves rendering issues in Dependabot PRs in the CLI,
+    and simplifies compatibility between RST and Markdown.

--- a/changelog.rst
+++ b/changelog.rst
@@ -1,7 +1,7 @@
 .. _changelog:
 
 CHANGELOG
-=========
+#########
 
 .. _changelog_version3:
 
@@ -15,15 +15,15 @@ to a major new version of the SDK.
 .. _changelog-3.58.0:
 
 v3.58.0 (2025-06-16)
---------------------
+====================
 
 Added
-~~~~~
+-----
 
 - Add the ``SpecificFlow.validate_run()`` method. (:pr:`1221`)
 
 Fixed
-~~~~~
+-----
 
 - Fix an error which caused the ``restrict_transfers_to_high_assurance`` field
   to be malformed when set on a collection payload type. (:pr:`1211`)
@@ -31,33 +31,33 @@ Fixed
 .. _changelog-3.57.0:
 
 v3.57.0 (2025-06-04)
---------------------
+====================
 
 Added
-~~~~~
+-----
 
 - Globus Connect Server collection document classes now support attributes up
   to document version 1.15.0. (:pr:`1197`)
 
 Deprecated
-~~~~~~~~~~
+----------
 
 - Importing scope parsing tools from ``globus_sdk.experimental`` now emits a
   deprecation warning. These names were previously deprecated in documentation
   only. (:pr:`1201`)
 
 Documentation
-~~~~~~~~~~~~~
+-------------
 
 - Remove the badges at the top of the README. (:pr:`1194`)
 
 .. _changelog-3.56.1:
 
 v3.56.1 (2025-05-20)
---------------------
+====================
 
 Fixed
-~~~~~
+-----
 
 - Fix the type annotation on ``filter_roles`` for ``FlowsClient``
   to allow non-list iterables. (:pr:`1183`)
@@ -65,10 +65,10 @@ Fixed
 .. _changelog-3.56.0:
 
 v3.56.0 (2025-05-05)
---------------------
+====================
 
 Added
-~~~~~
+-----
 
 - Transport objects now provide a ``close()`` method for closing resources which
   belong to them, primarily the underlying session. (:pr:`1171`)
@@ -86,7 +86,7 @@ Added
   supplied ``GlobusAuthorizationParameters`` as part of the login flow. (:pr:`1179`)
 
 Changed
-~~~~~~~
+-------
 
 - When parsing GAREs using ``to_gare`` and ``to_gares``, the root document is
   now considered a possible location for a GARE when subdocument errors are
@@ -94,7 +94,7 @@ Changed
   only be considered in the absence of subdocument errors. (:pr:`1173`)
 
 Deprecated
-~~~~~~~~~~
+----------
 
 - ``filter_role`` parameter for ``FlowsClient.list_flows`` is deprecated. Use
   ``filter_roles`` instead. (:pr:`1174`)
@@ -102,10 +102,10 @@ Deprecated
 .. _changelog-3.55.0:
 
 v3.55.0 (2025-04-18)
---------------------
+====================
 
 Added
-~~~~~
+-----
 
 - ``FlowsClient.create_flow`` and ``FlowsClient.update_flow`` now support ``run_managers``
   and ``run_monitors``. (:pr:`1164`)
@@ -116,7 +116,7 @@ Added
   policies easier. (:pr:`1167`)
 
 Changed
-~~~~~~~
+-------
 
 - The initialization of a client with a ``GlobusApp`` has been improved and is
   now available under the public ``attach_globus_app`` method on client
@@ -130,10 +130,10 @@ Changed
 .. _changelog-3.54.0:
 
 v3.54.0 (2025-04-02)
---------------------
+====================
 
 Changed
-~~~~~~~
+-------
 
 - Added the optional ``required_mfa`` field to ``AuthClient.create_policy()`` and
   ``AuthClient.update_policy()`` request bodies. (:pr:`1159`)
@@ -141,22 +141,22 @@ Changed
 .. _changelog-3.53.0:
 
 v3.53.0 (2025-03-25)
---------------------
+====================
 
 Added
-~~~~~
+-----
 
 - Index listing in Globus Search is now available via
   ``SearchClient.index_list``. (:pr:`1155`)
 
 Changed
-~~~~~~~
+-------
 
 - The ``repr`` for ``globus_sdk.gare.GARE`` has been enhanced to be more
   informative. (:pr:`1156`)
 
 Documentation
-~~~~~~~~~~~~~
+-------------
 
 - New sections on ``Data Transfer`` and ``Session & Consents`` have been added
   to the User Guide in the docs.
@@ -166,10 +166,10 @@ Documentation
 .. _changelog-3.52.0:
 
 v3.52.0 (2025-03-19)
---------------------
+====================
 
 Added
-~~~~~
+-----
 
 - The ``transport`` attached to clients now exposes ``headers`` as a readable
   and writable dict of headers which will be included in every request.
@@ -177,7 +177,7 @@ Added
   before. (:pr:`1140`)
 
 Changed
-~~~~~~~
+-------
 
 - Updates to ``X-Globus-Client-Info`` in ``RequestsTransport.headers`` are now
   synchronized via a callback mechanism. Direct manipulations of the ``infos``
@@ -189,17 +189,17 @@ Changed
   messages have been downgraded to DEBUG. (:pr:`1146`)
 
 Documentation
-~~~~~~~~~~~~~
+-------------
 
 - The tutorial documentation has been rewritten. (:pr:`1145`)
 
 .. _changelog-3.51.0:
 
 v3.51.0 (2025-03-06)
---------------------
+====================
 
 Added
-~~~~~
+-----
 
 - Most client classes now have their ``__doc__`` attribute modified at runtime
   to provide better ``help()`` and sphinx documentation. (:pr:`1131`)
@@ -237,7 +237,7 @@ Added
 - Add ``ComputeClientV3.register_function()`` method. (:pr:`1142`)
 
 Changed
-~~~~~~~
+-------
 
 - The SDK now defaults JWT leeway to 300 seconds when decoding ``id_token``\s;
   the previous leeway was 0.5 seconds. Users should find that they are much
@@ -247,15 +247,15 @@ Changed
 .. _changelog-3.50.0:
 
 v3.50.0 (2025-01-14)
---------------------
+====================
 
 Added
-~~~~~
+-----
 
 - Subclasses of ``BaseClient`` may now specify ``base_url`` as class attribute. (:pr:`1125`)
 
 Fixed
-~~~~~
+-----
 
 - Fixed an incorrect URL path in ``ComputeClient.get_task_batch``. (:pr:`1117`)
 
@@ -264,17 +264,17 @@ Fixed
   ``"allowed_domains"``. (:pr:`1120`)
 
 Documentation
-~~~~~~~~~~~~~
+-------------
 
 - Updated GlobusAppConfig docs to explain how to disable auto-login. (:pr:`1127`)
 
 .. _changelog-3.49.0:
 
 v3.49.0 (2024-12-04)
---------------------
+====================
 
 Added
-~~~~~
+-----
 
 - Add ``filter_entity_type`` keyword argument on ``TransferClient.endpoint_search()``. (:pr:`1109`)
 
@@ -288,10 +288,10 @@ Added
 .. _changelog-3.48.0:
 
 v3.48.0 (2024-11-21)
---------------------
+====================
 
 Added
-~~~~~
+-----
 
 - Added the ``ComputeClientV2.register_endpoint()``, ``ComputeClientV2.get_endpoint()``
   ``ComputeClientV2.get_endpoint_status()``, ``ComputeClientV2.get_endpoints()``,
@@ -299,22 +299,22 @@ Added
   methods. (:pr:`1110`)
 
 Changed
-~~~~~~~
+-------
 
 -   Removed identity ID consistency validation from ``ClientApp``. (:pr:`1111`)
 
 Fixed
-~~~~~
+-----
 
 -   Fixed a bug that would cause ``ClientApp`` token refreshes to fail. (:pr:`1111`)
 
 .. _changelog-3.47.0:
 
 v3.47.0 (2024-11-08)
---------------------
+====================
 
 Added
-~~~~~
+-----
 
 - Add ``TimersClient.add_app_transfer_data_access_scope`` for ``TimersClient``
   instances which are integrated with ``GlobusApp``. This method registers the
@@ -334,20 +334,20 @@ Added
   and ``ComputeClientV2.get_task_group()`` methods. (:pr:`1094`)
 
 Changed
-~~~~~~~
+-------
 
 - Improved error messaging around EOF errors when prompting for code during a command
   line login flow (:pr:`1093`)
 
 Deprecated
-~~~~~~~~~~
+----------
 
 - Deprecated the ``ComputeFunctionDocument`` and ``ComputeFunctionMetadata`` classes.
   This change reflects an early design adjustment to better align with the existing
   Globus Compute SDK. (:pr:`1092`)
 
 Development
-~~~~~~~~~~~
+-----------
 
 - Introduce a ``toxfile.py`` to ensure clean builds during development. (:pr:`1098`)
 
@@ -357,15 +357,15 @@ Development
 .. _changelog-3.46.0:
 
 v3.46.0 (2024-10-15)
---------------------
+====================
 
 Python Support
-~~~~~~~~~~~~~~
+--------------
 
 - Support Python 3.13. (:pr:`1058`)
 
 Added
-~~~~~
+-----
 
 -   Added an initial Globus Compute client class, :class:`globus_sdk.ComputeClient`.
     (:pr:`1071`)
@@ -390,13 +390,13 @@ Added
     ``ValueError``\s caused by invalid content. (:pr:`1044`)
 
 Removed
-~~~~~~~
+-------
 
 -   Removed the ``skip_error_handling`` optional kwarg from the
     ``GlobusApp.get_authorizer(...)`` method interface. (:pr:`1060`)
 
 Changed
-~~~~~~~
+-------
 
 -   All previously experimental modules have been moved into main module namespaces
     and are no longer experimental. Aliases will remain in the experimental namespaces
@@ -465,7 +465,7 @@ Changed
     ``GlobusConnectionTimeoutError``, ``GlobusTimeoutError``, and ``NetworkError``.
 
 Fixed
-~~~~~
+-----
 
 -   Fixed the typing-time attributes of ``globus_sdk`` so that ``mypy`` and other
     type checkers won't erroneously suppress errors about missing attributes.
@@ -481,10 +481,10 @@ Fixed
 .. _changelog-3.45.0:
 
 v3.45.0 (2024-09-06)
---------------------
+====================
 
 Added
-~~~~~
+-----
 
 - The scope builder for ``SpecificFlowClient`` is now available for direct
   access and use via ``globus_sdk.scopes.SpecificFlowScopeBuilder``. Callers can
@@ -511,7 +511,7 @@ Added
         a login is required to satisfy local scope requirements.
 
 Removed
-~~~~~~~
+-------
 
 .. rubric:: Experimental
 
@@ -534,7 +534,7 @@ Removed
             app.login(force=True)
 
 Changed
-~~~~~~~
+-------
 
 - The client for Globus Timers has been renamed to ``TimersClient``. The prior
   name, ``TimerClient``, has been retained as an alias. (:pr:`1032`)
@@ -592,12 +592,12 @@ Changed
     requirements dictionary mapping resource server to a list of Scopes. (:pr:`1042`)
 
 Deprecated
-~~~~~~~~~~
+----------
 
 - ``TimerScopes`` is now a deprecated name. Use ``TimersScopes`` instead. (:pr:`1032`)
 
 Fixed
-~~~~~
+-----
 
 .. rubric:: Experimental
 
@@ -606,7 +606,7 @@ Fixed
   types like ``dict``. (:pr:`1035`)
 
 Documentation
-~~~~~~~~~~~~~
+-------------
 
 - The Globus Timers examples have been significantly enhanced and now leverage
   more modern usage patterns. (:pr:`1032`)
@@ -614,10 +614,10 @@ Documentation
 .. _changelog-3.44.0:
 
 v3.44.0 (2024-08-02)
---------------------
+====================
 
 Added
-~~~~~
+-----
 
 -   Added a reference to the new Flows all scope under
     ``globus_sdk.scopes.FlowsScopes.all``. (:pr:`1016`)
@@ -628,7 +628,7 @@ Added
     ``add_scope_requirements`` methods. (:pr:`1020`)
 
 Changed
-~~~~~~~
+-------
 
 -   Updated ``ScopeCollectionType`` to be defined recursively. (:pr:`1020`)
 
@@ -686,7 +686,7 @@ Changed
         ``for_globus_app(...) -> LoginFlowManager`` class method.
 
 Development
-~~~~~~~~~~~
+-----------
 
 -   Added a scope normalization function ``globus_sdk.scopes.scopes_to_scope_list`` to
     translate from ``ScopeCollectionType`` to a list of ``Scope`` objects.
@@ -695,16 +695,16 @@ Development
 .. _changelog-3.43.0:
 
 v3.43.0 (2024-07-25)
---------------------
+====================
 
 Added
-~~~~~
+-----
 
 - The ``TransferClient.task_list`` method now supports ``orderby`` as a
   parameter. (:pr:`1011`)
 
 Changed
-~~~~~~~
+-------
 
 -   The ``SQLiteTokenStorage`` component in ``globus_sdk.experimental`` has been
     changed in several ways to improve its interface. (:pr:`1004`)
@@ -722,7 +722,7 @@ Changed
     been removed.
 
 Documentation
-~~~~~~~~~~~~~
+-------------
 
 -   Added a new experimental "Updated Examples" section which rewrites and reorders
     many examples to aid in discovery. (:pr:`1008`)
@@ -737,15 +737,15 @@ Documentation
 .. _changelog-3.42.0:
 
 v3.42.0 (2024-07-15)
---------------------
+====================
 
 Python Support
-~~~~~~~~~~~~~~
+--------------
 
 - Remove support for Python 3.7. (:pr:`997`)
 
 Added
-~~~~~
+-----
 
 - Add ``globus_sdk.ConnectorTable`` which provides information on supported
   Globus Connect Server connectors. This object maps names to IDs and vice versa. (:pr:`955`)
@@ -819,7 +819,7 @@ Added
 - Added the configuration parameter ``GlobusAppConfig.environment``. (:pr:`1001`)
 
 Changed
-~~~~~~~
+-------
 
 - ``GCSClient`` instances now have a non-None ``resource_server`` property.
 
@@ -831,13 +831,13 @@ Changed
   ``globus_sdk.experimental.tokenstorage.JSONTokenStorage``. (:pr:`997`)
 
 Deprecated
-~~~~~~~~~~
+----------
 
 - ``GCSClient.connector_id_to_name`` has been deprecated.
   Use ``ConnectorTable.lookup`` instead. (:pr:`955`)
 
 Fixed
-~~~~~
+-----
 
 .. rubric:: Experimental
 
@@ -861,17 +861,17 @@ Fixed
   MacOS when versions earlier than Python 3.11. (:pr:`1003`)
 
 Documentation
-~~~~~~~~~~~~~
+-------------
 
 - Document how to manage Globus SDK warnings. (:pr:`988`)
 
 .. _changelog-3.41.0:
 
 v3.41.0 (2024-04-26)
---------------------
+====================
 
 Added
-~~~~~
+-----
 
 - Added a new AuthClient method ``get_consents`` and supporting local data objects.
   These allows a client to poll and interact with the current Globus Auth consent state
@@ -887,10 +887,10 @@ Added
 .. _changelog-3.40.0:
 
 v3.40.0 (2024-04-15)
---------------------
+====================
 
 Added
-~~~~~
+-----
 
 - Add ``globus_sdk.tokenstorage.MemoryAdapter`` for the simplest possible
   in-memory token storage mechanism. (:pr:`964`)
@@ -904,27 +904,27 @@ Added
 - Support updating subscriptions assigned to flows in the Flows service. (:pr:`974`)
 
 Development
-~~~~~~~~~~~
+-----------
 
 - Fix concurrency problems in the test suite caused by isort's ``.isorted`` temporary files. (:pr:`973`)
 
 .. _changelog-3.39.0:
 
 v3.39.0 (2024-03-06)
---------------------
+====================
 
 Added
-~~~~~
+-----
 
 - Added ``TransferClient.operation_stat`` helper method for getting the status of a path on a collection (:pr:`961`)
 
 .. _changelog-3.38.0:
 
 v3.38.0 (2024-03-01)
---------------------
+====================
 
 Added
-~~~~~
+-----
 
 - ``IterableGCSResponse`` and ``UnpackingGCSResponse`` are now available as
   top-level exported names. (:pr:`956`)
@@ -939,10 +939,10 @@ Added
 .. _changelog-3.37.0:
 
 v3.37.0 (2024-02-14)
---------------------
+====================
 
 Added
-~~~~~
+-----
 
 - All of the basic HTTP methods of ``BaseClient`` and its derived classes which
   accept a ``data`` parameter for a request body, e.g. ``TransferClient.post``
@@ -950,7 +950,7 @@ Added
   already encoded ``bytes``. (:pr:`951`)
 
 Fixed
-~~~~~
+-----
 
 - Update ``ensure_datatype`` to work with documents that set ``DATA_TYPE`` to
   ``MISSING`` instead of omitting it (:pr:`952`)
@@ -958,10 +958,10 @@ Fixed
 .. _changelog-3.36.0:
 
 v3.36.0 (2024-02-12)
---------------------
+====================
 
 Added
-~~~~~
+-----
 
 - Added support for GCS endpoint get & update operations (:pr:`933`)
 
@@ -977,29 +977,29 @@ Added
 .. _changelog-3.35.0:
 
 v3.35.0 (2024-01-29)
---------------------
+====================
 
 Added
-~~~~~
+-----
 
 - Added a ``session_required_mfa`` parameter to the ``AuthorizationParameterInfo`` error
   info object and ``oauth2_get_authorize_url`` method (:pr:`939`)
 
 Changed
-~~~~~~~
+-------
 
 - The argument specification for ``AuthClient.create_policy`` was incorrect.
   The corrected method will emit deprecation warnings if called with positional
   arguments, as the corrected version uses keyword-only arguments. (:pr:`936`)
 
 Deprecated
-~~~~~~~~~~
+----------
 
 - ``TransferClient.operation_symlink`` is now officially deprecated and will
   emit a ``RemovedInV4Warning`` if used. (:pr:`942`)
 
 Fixed
-~~~~~
+-----
 
 - Included documentation in ``AuthorizationParameterInfo`` for ``session_required_policies``
   (:pr:`939`)
@@ -1007,15 +1007,15 @@ Fixed
 .. _changelog-3.34.0:
 
 v3.34.0 (2024-01-02)
---------------------
+====================
 
 Added
-~~~~~
+-----
 
 - Add the ``delete_protected`` field to ``MappedCollectionDocument``. (:pr:`920`)
 
 Changed
-~~~~~~~
+-------
 
 - Minor improvements to handling of paths and URLs. (:pr:`922`)
 
@@ -1028,14 +1028,14 @@ Changed
     verbatim as the address for a ``GCSClient``.
 
 Deprecated
-~~~~~~~~~~
+----------
 
 - ``NativeAppAuthClient.oauth2_validate_token`` and
   ``ConfidentialAppAuthClient.oauth2_validate_token`` have been deprecated, as
   their usage is discouraged by the Auth service. (:pr:`921`)
 
 Development
-~~~~~~~~~~~
+-----------
 
 - Migrate from a CHANGELOG symlink to the RST ``.. include`` directive. (:pr:`918`)
 
@@ -1045,20 +1045,20 @@ Development
 .. _changelog-3.33.0.post0:
 
 v3.33.0.post0 (2023-12-05)
---------------------------
+==========================
 
 Documentation
-~~~~~~~~~~~~~
+-------------
 
 - Remove references to the Tutorial Endpoints from documentation. (:pr:`915`)
 
 .. _changelog-3.33.0:
 
 v3.33.0 (2023-12-04)
---------------------
+====================
 
 Added
-~~~~~
+-----
 
 - Support custom CA certificate bundles. (:pr:`903`)
 
@@ -1070,7 +1070,7 @@ Added
   This may be useful for interacting with Globus through certain proxy firewalls.
 
 Fixed
-~~~~~
+-----
 
 - Fix the type annotation for ``globus_sdk.IdentityMap`` init,
   which incorrectly rejected ``ConfidentialAppAuthClient``. (:pr:`912`)
@@ -1078,10 +1078,10 @@ Fixed
 .. _changelog-3.32.0:
 
 v3.32.0 (2023-11-09)
---------------------
+====================
 
 Added
-~~~~~
+-----
 
 .. note::
     These changes pertain to methods of the client objects in the SDK which
@@ -1145,7 +1145,7 @@ Added
   scopes APIs, ``globus_sdk.DependentScopeSpec`` (:pr:`884`)
 
 Fixed
-~~~~~
+-----
 
 - When serializing ``TransferTimer`` data, do not convert to UTC if the input
   was a valid datetime with an offset. (:pr:`900`)
@@ -1153,10 +1153,10 @@ Fixed
 .. _changelog-3.31.0:
 
 v3.31.0 (2023-11-01)
---------------------
+====================
 
 Added
-~~~~~
+-----
 
 - Add support for the new Transfer Timer creation method, in the form of a
   client method, ``TimerClient.create_timer``, and a payload builder type,
@@ -1174,7 +1174,7 @@ Added
   methods, but now it is universal. (:pr:`892`)
 
 Deprecated
-~~~~~~~~~~
+----------
 
 - Creation of timers to run transfers using ``TimerJob`` is now
   deprecated (:pr:`887`)
@@ -1182,10 +1182,10 @@ Deprecated
 .. _changelog-3.30.0:
 
 v3.30.0 (2023-10-27)
---------------------
+====================
 
 Added
-~~~~~
+-----
 
 - ``TransferClient.operation_ls`` now supports the ``limit`` and ``offset``
   parameters (:pr:`868`)
@@ -1198,7 +1198,7 @@ Added
     will be automatically removed from the payload before sending to the server
 
 Changed
-~~~~~~~
+-------
 
 - ``GroupPolicies`` objects now treat an explicit instantiation with
   ``high_assurance_timeout=None`` as setting the timeout to ``null`` (:pr:`885`)
@@ -1206,10 +1206,10 @@ Changed
 .. _changelog-3.29.0:
 
 v3.29.0 (2023-10-12)
---------------------
+====================
 
 Changed
-~~~~~~~
+-------
 
 - The inheritance structure used for Globus Auth client classes has changed.
   (:pr:`849`)
@@ -1226,7 +1226,7 @@ Changed
     would only be valid to call on ``AuthLoginClient`` subclasses.
 
 Deprecated
-~~~~~~~~~~
+----------
 
 - Several features of Auth client classes are now deprecated. (:pr:`849`)
 
@@ -1244,15 +1244,15 @@ Deprecated
 .. _changelog-3.28.0:
 
 v3.28.0 (2023-08-30)
---------------------
+====================
 
 Python Support
-~~~~~~~~~~~~~~
+--------------
 
 - Add support for Python 3.12. (:pr:`808`)
 
 Added
-~~~~~
+-----
 
 - Add a ``prompt`` keyword parameter to ``AuthClient.oauth2_get_authorize_url()``. (:pr:`813`)
 
@@ -1268,37 +1268,37 @@ Added
   resuming timers. (:pr:`827`)
 
 Documentation
-~~~~~~~~~~~~~
+-------------
 
 - Add an example script which handles creating and running a **flow**. (:pr:`826`)
 
 Development
-~~~~~~~~~~~
+-----------
 
 - Added responses to ``_testing`` reflecting an inactive Timers job (:pr:`828`)
 
 .. _changelog-3.27.0:
 
 v3.27.0 (2023-08-11)
---------------------
+====================
 
 Added
-~~~~~
+-----
 
 - Add a ``FlowsClient.get_run_definition()`` method. (:pr:`799`)
 
 Changed
-~~~~~~~
+-------
 
 - ``FlowsClient.get_run_logs()`` now uses an ``IterableRunLogsResponse``. (:pr:`797`)
 
 .. _changelog-3.26.0:
 
 v3.26.0 (2023-08-07)
---------------------
+====================
 
 Added
-~~~~~
+-----
 
 - New components are introduced to the experimental subpackage. See the SDK
   Experimental documentation for more details.
@@ -1312,7 +1312,7 @@ Added
     ``globus_sdk.experimental.scope_parser`` (:pr:`752`)
 
 Changed
-~~~~~~~
+-------
 
 - The ``scopes`` class attribute of ``SpecificFlowClient`` is now specialized
   to ensure that type checkers will allow access to ``SpecificFlowClient``
@@ -1323,23 +1323,23 @@ Changed
 .. _changelog-3.25.0:
 
 v3.25.0 (2023-07-20)
---------------------
+====================
 
 Added
-~~~~~
+-----
 
 - The ``jwt_params`` argument to ``decode_id_token()`` now allows ``"leeway"``
   to be included to pass a ``leeway`` parameter to pyjwt. (:pr:`790`)
 
 Fixed
-~~~~~
+-----
 
 - ``decode_id_token()`` defaulted to having no tolerance for clock drift. Slight
   clock drift could lead to JWT claim validation errors. The new default is
   0.5s which should be sufficient for most cases. (:pr:`790`)
 
 Documentation
-~~~~~~~~~~~~~
+-------------
 
 - New scripts in the example gallery demonstrate usage of the Globus Auth
   Developer APIs to List, Create, Delete, and Update Projects. (:pr:`777`)
@@ -1347,10 +1347,10 @@ Documentation
 .. _changelog-3.24.0:
 
 v3.24.0 (2023-07-18)
---------------------
+====================
 
 Added
-~~~~~
+-----
 
 - Add ``FlowsClient.list_runs`` as a method for listing all runs for the
   current user, with support for pagination. (:pr:`782`)
@@ -1359,7 +1359,7 @@ Added
   ``create_index``, ``delete_index``, and ``reopen_index`` (:pr:`785`)
 
 Changed
-~~~~~~~
+-------
 
 - The enforcement logic for URLs in ``BaseClient`` instantiation has been
   improved to only require that ``service_name`` be set if ``base_url`` is not
@@ -1375,10 +1375,10 @@ Changed
 .. _changelog-3.23.0:
 
 v3.23.0 (2023-07-06)
---------------------
+====================
 
 Added
-~~~~~
+-----
 
 - Add ``AuthClient`` methods to support the Projects APIs for listing,
   creating, updating, and deleting projects.
@@ -1400,7 +1400,7 @@ Added
   ``ErrorInfo.authorization_parameters``. (:pr:`773`)
 
 Changed
-~~~~~~~
+-------
 
 * ``AuthClient``, ``NativeAppAuthClient``, and ``ConfidentialAppAuthClient``
   have had their init signatures updated to explicitly list available
@@ -1418,7 +1418,7 @@ Changed
   supporting ``str`` (:pr:`769`)
 
 Fixed
-~~~~~
+-----
 
 - ``AuthorizationParameterInfo`` is now more type-safe, and will not return
   parsed data from a response without checking that the data has correct types
@@ -1428,7 +1428,7 @@ Fixed
   so it is submitted only when it has a value. (:pr:`778`)
 
 Documentation
-~~~~~~~~~~~~~
+-------------
 
 - The ``_testing`` documentation has been expanded with a dropdown view of the
   response contents for each method. In support of this, client method testing
@@ -1437,10 +1437,10 @@ Documentation
 .. _changelog-3.22.0:
 
 v3.22.0 (2023-06-22)
---------------------
+====================
 
 Added
-~~~~~
+-----
 
 * Add support for ``AuthClient.get_identity_providers`` for looking up Identity
   Providers by domain or ID in Globus Auth (:pr:`757`)
@@ -1451,17 +1451,17 @@ Added
   ``AuthClient.scopes.manage_projects`` (:pr:`761`)
 
 Documentation
-~~~~~~~~~~~~~
+-------------
 
 * Alpha features of globus-sdk are now documented in the "Unstable" doc section (:pr:`753`)
 
 .. _changelog-3.21.0:
 
 v3.21.0 (2023-06-16)
---------------------
+====================
 
 Added
-~~~~~
+-----
 
 * ``AuthAPIError`` will now parse a unique ``id`` found in the error
   subdocuments as the ``request_id`` attribute (:pr:`749`)
@@ -1477,10 +1477,10 @@ Added
 .. _changelog-3.20.1:
 
 v3.20.1 (2023-06-06)
---------------------
+====================
 
 Fixed
-~~~~~
+-----
 
 * Fix ``TransferClient.operation_mkdir`` and ``TransferClient.operation_rename`` to no
   longer send null ``local_user`` by default (:pr:`741`)
@@ -1488,10 +1488,10 @@ Fixed
 .. _changelog-3.20.0:
 
 v3.20.0 (2023-06-05)
---------------------
+====================
 
 Added
-~~~~~
+-----
 
 * Implemented ``FlowsClient.get_run(...)`` (:pr:`721`)
 
@@ -1514,7 +1514,7 @@ Added
   ``destination_local_user`` parameters  (:pr:`736`)
 
 Changed
-~~~~~~~
+-------
 
 * Behavior has changed slightly specifically for ``TimerAPIError``. When parsing
   fails, the ``code`` will be ``Error`` and the ``messages`` will be empty. The
@@ -1570,7 +1570,7 @@ Changed
     there is no ``code`` present in any responses.
 
 Fixed
-~~~~~
+-----
 
 * The TransferRequestsTransport will no longer automatically retry errors with a code of EndpointError
 
@@ -1588,10 +1588,10 @@ Fixed
 .. _changelog-3.19.0:
 
 v3.19.0 (2023-04-14)
---------------------
+====================
 
 Added
-~~~~~
+-----
 
 * Added ``FlowsClient.update_flow(...)`` (:pr:`710`)
 
@@ -1608,18 +1608,18 @@ Added
     bytes
 
 Deprecated
-~~~~~~~~~~
+----------
 
 * ``GlobusAPIError.raw_text`` is deprecated in favor of ``text``
 
 Fixed
-~~~~~
+-----
 
 * The return type of ``AuthClient.get_identities`` is now correctly annotated as
   an iterable type, ``globus_sdk.GetIdentitiesResponse`` (:pr:`716`)
 
 Documentation
-~~~~~~~~~~~~~
+-------------
 
 * Documentation for client methods has been improved to more consistently
   format and display examples and other information (:pr:`714`)
@@ -1627,16 +1627,16 @@ Documentation
 .. _changelog-3.18.0:
 
 v3.18.0 (2023-03-16)
---------------------
+====================
 
 Added
-~~~~~
+-----
 
 * ``ConfidentialAppAuthClient.oauth2_get_dependent_tokens`` now supports the
   ``refresh_tokens`` parameter to enable requests for dependent refresh tokens (:pr:`698`)
 
 Changed
-~~~~~~~
+-------
 
 * Behaviors which will change in version 4.0.0 of the ``globus-sdk`` now emit
   deprecation warnings.
@@ -1649,7 +1649,7 @@ Changed
   necessary for many use-cases (:pr:`696`)
 
 Deprecated
-~~~~~~~~~~
+----------
 
 * Omitting ``requested_scopes`` or specifying it as ``None`` is now deprecated
   and will emit a warning. In version 4, users will always be required to
@@ -1665,7 +1665,7 @@ Deprecated
   encouraged to switch to ``SearchClient.ingest`` instead (:pr:`695`)
 
 Fixed
-~~~~~
+-----
 
 * When users input empty ``requested_scopes`` values, these are now rejected
   with a usage error instead of being translated into the default set of
@@ -1677,22 +1677,22 @@ Fixed
 .. _changelog-3.17.0:
 
 v3.17.0 (2023-02-27)
---------------------
+====================
 
 Python Support
-~~~~~~~~~~~~~~
+--------------
 
 * Remove support for python3.6 (:pr:`681`)
 
 Added
-~~~~~
+-----
 
 * ``MutableScope`` objects can now be used in the ``oauth2_start_flow`` and
   ``oauth2_client_credentials_tokens`` methods of ``AuthClient`` classes as part
   of ``requested_scopes`` (:pr:`689`)
 
 Changed
-~~~~~~~
+-------
 
 * Make ``MutableScope.scope_string`` a public instance attribute (was
   ``_scope_string``) (:pr:`687`)
@@ -1703,7 +1703,7 @@ Changed
   correctly in these cases. (:pr:`691`)
 
 Fixed
-~~~~~
+-----
 
 * Fix a typo in ``TransferClient.endpoint_manager_task_successful_transfers``
   which prevented calls from being made correctly (:pr:`683`)
@@ -1711,16 +1711,16 @@ Fixed
 .. _changelog-3.16.0:
 
 v3.16.0 (2023-02-07)
---------------------
+====================
 
 Added
-~~~~~
+-----
 
 * Allow UUID values for the ``client_id`` parameter to ``AuthClient`` and its
   subclasses (:pr:`676`)
 
 Changed
-~~~~~~~
+-------
 
 * Improved GCS Collection datatype detection to support ``collection#1.6.0``
   and ``collection#1.7.0`` documents (:pr:`675`)
@@ -1737,13 +1737,13 @@ Changed
   ``globus_sdk.response`` (:pr:`680`)
 
 Fixed
-~~~~~
+-----
 
 * ``ArrayResponse`` and ``IterableResponse`` have better error behaviors when
   the API data does not match their expected types (:pr:`680`)
 
 Documentation
-~~~~~~~~~~~~~
+-------------
 
 * Fix the Timer code example (:pr:`672`)
 
@@ -1753,15 +1753,15 @@ Documentation
 .. _changelog-3.15.1:
 
 v3.15.1 (2022-12-13)
---------------------
+====================
 
 Added
-~~~~~
+-----
 
 * AuthorizationParameterInfo now exposes session_required_policies (:pr:`658`)
 
 Fixed
-~~~~~
+-----
 
 * Fix a bug where ``TransferClient.endpoint_manager_task_list`` didn't handle
   the ``last_key`` argument when paginated (:pr:`662`)
@@ -1769,10 +1769,10 @@ Fixed
 .. _changelog-3.15.0:
 
 v3.15.0 (2022-11-22)
---------------------
+====================
 
 Added
-~~~~~
+-----
 
 * Scope Names can be set explicitly in a ``ScopeBuilder`` (:pr:`641`)
 
@@ -1800,7 +1800,7 @@ Added
     This allows, for example, ``TransferScopes.make_mutable("all", optional=True)``
 
 Changed
-~~~~~~~
+-------
 
 * Improve the ``__str__`` implementation for ``OAuthTokenResponse`` (:pr:`640`)
 
@@ -1809,14 +1809,14 @@ Changed
   (``None`` if unspecified) instead (:pr:`644`)
 
 Deprecated
-~~~~~~~~~~
+----------
 
 * The ``optional`` argument to ``add_dependency`` is deprecated.
   ``MutableScope(...).add_dependency(MutableScope("foo", optional=True))``
   can be used to add an optional dependency
 
 Fixed
-~~~~~
+-----
 
 * Fixed SpecificFlowClient scope string (:pr:`641`)
 
@@ -1826,15 +1826,15 @@ Fixed
 .. _changelog-3.14.0:
 
 v3.14.0 (2022-11-01)
---------------------
+====================
 
 Python Support
-~~~~~~~~~~~~~~
+--------------
 
 * Python 3.11 is now officially supported (:pr:`628`)
 
 Added
-~~~~~
+-----
 
 * Add support for ``FlowsClient.get_flow`` and ``FlowsClient.delete_flow``
   (:pr:`631`, :pr:`626`)
@@ -1845,10 +1845,10 @@ Added
 .. _changelog-3.13.0:
 
 v3.13.0 (2022-10-13)
---------------------
+====================
 
 Added
-~~~~~
+-----
 
 * Add ``connect_params`` to ``SQLiteAdapter``, enabling customization of the
   sqlite connection (:pr:`613`)
@@ -1862,17 +1862,17 @@ Added
   parameter (:pr:`621`, :pr:`622`)
 
 Documentation
-~~~~~~~~~~~~~
+-------------
 
 * Fix rst formatting for a few nested bullet points in existing changelog (:pr:`619`)
 
 .. _changelog-3.12.0:
 
 v3.12.0 (2022-09-21)
---------------------
+====================
 
 Added
-~~~~~
+-----
 
 * Add Mapped Collection policy helper types for constructing ``policies`` data. (:pr:`607`)
   The following new types are introduced:
@@ -1883,7 +1883,7 @@ Added
   * ``GoogleCloudStorageCollectionPolicies``
 
 Fixed
-~~~~~
+-----
 
 * Fix bug where ``UserCredential`` policies were being converted to a string (:pr:`608`)
 
@@ -1892,10 +1892,10 @@ Fixed
 .. _changelog-3.11.0:
 
 v3.11.0 (2022-08-30)
---------------------
+====================
 
 Added
-~~~~~
+-----
 
 * Implement ``__dir__`` for the lazy importer in ``globus_sdk``. This
   enables tab completion in the interpreter and other features with
@@ -1911,7 +1911,7 @@ Added
     ``globus_sdk.scopes.FlowsScopes`` or ``globus_sdk.FlowsClient.scopes``
 
 Changed
-~~~~~~~
+-------
 
 * Adjust behaviors of ``TransferData`` and ``TimerJob`` to make
   ``TimerJob.from_transfer_data`` work and to defer requesting the
@@ -1959,31 +1959,31 @@ the endpoints as named parameters:
 .. _changelog-3.10.1:
 
 v3.10.1 (2022-07-11)
---------------------
+====================
 
 Changed
-~~~~~~~
+-------
 
 * Use ``setattr`` in the lazy-importer. This makes attribute access after
   imports faster by several orders of magnitude. (:pr:`591`)
 
 Documentation
-~~~~~~~~~~~~~
+-------------
 
 * Add guest collection example script to docs (:pr:`590`)
 
 .. _changelog-3.10.0:
 
 v3.10.0 (2022-06-27)
---------------------
+====================
 
 Removed
-~~~~~~~
+-------
 
 * Remove nonexistent ``monitor_ongoing`` scope from ``TransferScopes`` (:pr:`583`)
 
 Added
-~~~~~
+-----
 
 * Add User Credential methods to ``GCSClient`` (:pr:`582`)
 
@@ -1999,10 +1999,10 @@ Added
 .. _changelog-3.9.0:
 
 v3.9.0 (2022-06-02)
--------------------
+===================
 
 Added
-~~~~~
+-----
 
 * Add helper objects and methods for interacting with Globus Connect Server
   Storage Gateways (:pr:`554`)
@@ -2049,7 +2049,7 @@ Added
     accurately to reject bad strings
 
 Changed
-~~~~~~~
+-------
 
 * Update the fields used to extract ``AuthAPIError`` messages (:pr:`566`)
 
@@ -2083,10 +2083,10 @@ Changed
 .. _changelog-3.8.0:
 
 v3.8.0 (2022-05-04)
--------------------
+===================
 
 Added
-~~~~~
+-----
 
 * Several changes expose more details of HTTP requests (:pr:`551`)
 
@@ -2113,10 +2113,10 @@ Added
 .. _changelog-3.7.0:
 
 v3.7.0 (2022-04-08)
--------------------
+===================
 
 Added
-~~~~~
+-----
 
 * Add a client for the Timer service (:pr:`548`)
 
@@ -2126,7 +2126,7 @@ Added
     Timer services
 
 Fixed
-~~~~~
+-----
 
 * Fix annotations to allow request data to be a string. This is
   supported at runtime but was missing from annotations. (:pr:`549`)
@@ -2134,10 +2134,10 @@ Fixed
 .. _changelog-3.6.0:
 
 v3.6.0 (2022-03-18)
--------------------
+===================
 
 Added
-~~~~~
+-----
 
 * ``ScopeBuilder`` objects now support ``known_url_scopes``, and known scope
   arguments to a ``ScopeBuilder`` may now be of type ``str`` in addition to
@@ -2149,10 +2149,10 @@ Added
 .. _changelog-3.5.0:
 
 v3.5.0 (2022-03-02)
--------------------
+===================
 
 Added
-~~~~~
+-----
 
 * ``globus_sdk.IdentityMap`` can now take a cache as an input. This allows
   multiple ``IdentityMap`` instances to share the same storage cache. Any
@@ -2166,7 +2166,7 @@ Added
   iterates over all namespaces visible in the token database (:pr:`529`)
 
 Changed
-~~~~~~~
+-------
 
 * Add ``TransferRequestsTransport`` class that does not retry ExternalErrors.
   This fixes cases in which the ``TransferClient`` incorrectly retried requests (:pr:`522`)
@@ -2174,17 +2174,17 @@ Changed
 * Use the "reason phrase" as a failover for stringified API errors with no body (:pr:`524`)
 
 Documentation
-~~~~~~~~~~~~~
+-------------
 
 * Enhance documentation for all of the parameters on methods of ``GroupsClient``
 
 .. _changelog-3.4.2:
 
 v3.4.2 (2022-02-18)
--------------------
+===================
 
 Fixed
-~~~~~
+-----
 
 * Fix the pagination behavior for ``TransferClient`` on ``task_skipped_errors`` and
   ``task_successful_transfers``, and apply the same fix to the endpoint manager
@@ -2194,10 +2194,10 @@ Fixed
 .. _changelog-3.4.1:
 
 v3.4.1 (2022-02-11)
--------------------
+===================
 
 Fixed
-~~~~~
+-----
 
 * The ``typing_extensions`` requirement in package metadata now sets a lower
   bound of ``4.0``, to force upgrades of installations to get a new enough version
@@ -2206,10 +2206,10 @@ Fixed
 .. _changelog-3.4.0:
 
 v3.4.0 (2022-02-11)
--------------------
+===================
 
 Added
-~~~~~
+-----
 
 * Support pagination on ``SearchClient.post_search`` (:pr:`507`)
 
@@ -2236,10 +2236,10 @@ Added
 .. _changelog-3.3.1:
 
 v3.3.1 (2022-01-25)
--------------------
+===================
 
 Fixed
-~~~~~
+-----
 
 * Packaging bugfix. ``globus-sdk`` is now built with pypa's ``build`` tool, to
   resolve issues with wheel builds.
@@ -2247,10 +2247,10 @@ Fixed
 .. _changelog-3.3.0:
 
 v3.3.0 (2022-01-25)
--------------------
+===================
 
 Added
-~~~~~
+-----
 
 * Add ``update_group`` method to ``GroupsClient`` (:pr:`506`)
 
@@ -2265,14 +2265,14 @@ Added
   type checking. (:pr:`494`)
 
 Changed
-~~~~~~~
+-------
 
 * ``Paginator`` objects are now generics over a type var for their page type. The
   page type is bounded by ``GlobusHTTPResponse``, and most type-checker behaviors
   will remain unchanged (:pr:`495`)
 
 Fixed
-~~~~~
+-----
 
 * Several minor bugs have been found and fixed (:pr:`504`)
 
@@ -2291,7 +2291,7 @@ Fixed
     are now rectified.
 
 Documentation
-~~~~~~~~~~~~~
+-------------
 
 * Document ``globus_sdk.config.get_service_url`` and ``globus_sdk.config.get_webapp_url``
   (:pr:`496`)
@@ -2302,20 +2302,20 @@ Documentation
 .. _changelog-3.2.1:
 
 v3.2.1 (2021-12-13)
--------------------
+===================
 
 Python Support
-~~~~~~~~~~~~~~
+--------------
 
 * Update to avoid deprecation warnings on python 3.10 (:pr:`499`)
 
 .. _changelog-3.2.0:
 
 v3.2.0 (2021-12-02)
--------------------
+===================
 
 Added
-~~~~~
+-----
 
 * Add ``iter_items`` as a method on ``TransferData`` and ``DeleteData`` (:pr:`488`)
 
@@ -2334,23 +2334,23 @@ Added
     properties without setters
 
 Changed
-~~~~~~~
+-------
 
 * ClientCredentialsAuthorizer now accepts ``Union[str, Iterable[str]]``
   as the type for scopes (:pr:`498`)
 
 Fixed
-~~~~~
+-----
 
 * Fix type annotations on client methods with paginated variants (:pr:`491`)
 
 .. _changelog-3.1.0:
 
 v3.1.0 (2021-10-13)
--------------------
+===================
 
 Added
-~~~~~
+-----
 
 * Add ``filter`` as a supported parameter to ``TransferClient.task_list`` (:pr:`484`)
 
@@ -2360,7 +2360,7 @@ Added
   and is linked from the param docs for ``filter`` on each method (:pr:`484`)
 
 Changed
-~~~~~~~
+-------
 
 * Adjust package metadata for ``cryptography`` dependency, specifying
   ``cryptography>=3.3.1`` and no upper bound. This is meant to help mitigate
@@ -2370,10 +2370,10 @@ Changed
 .. _changelog-3.0.3:
 
 v3.0.3 (2021-10-11)
--------------------
+===================
 
 Fixed
-~~~~~
+-----
 
 * Fix several internal decorators which were destroying type information about
   decorated functions. Type signatures of many methods are therefore corrected (:pr:`485`)
@@ -2381,15 +2381,15 @@ Fixed
 .. _changelog-3.0.2:
 
 v3.0.2 (2021-09-29)
--------------------
+===================
 
 Changed
-~~~~~~~
+-------
 
 * Produce more debug logging when SDK logs are enabled (:pr:`480`)
 
 Fixed
-~~~~~
+-----
 
 * Update the minimum dependency versions to lower bounds which are verified to
   work with the testsuite (:pr:`482`)
@@ -2397,36 +2397,36 @@ Fixed
 .. _changelog-3.0.1:
 
 v3.0.1 (2021-09-15)
--------------------
+===================
 
 Added
-~~~~~
+-----
 
 * ``ScopeBuilder`` objects now define the type of ``__getattr__`` for ``mypy`` to
   know that dynamic attributes are strings (:pr:`472`)
 
 Fixed
-~~~~~
+-----
 
 * Fix malformed PEP508 ``python_version`` bound in dev dependencies (:pr:`474`)
 
 Development
-~~~~~~~~~~~
+-----------
 
 * Fix remaining ``type: ignore`` usages in globus-sdk (:pr:`473`)
 
 .. _changelog-3.0.0:
 
 v3.0.0 (2021-09-14)
--------------------
+===================
 
 Removed
-~~~~~~~
+-------
 
 * Remove support for ``bytes`` values for fields consuming UUIDs (:pr:`471`)
 
 Added
-~~~~~
+-----
 
 * Add ``filter_is_error`` parameter to advanced task list (:pr:`467`)
 
@@ -2441,15 +2441,15 @@ Added
 .. _changelog-3.0.0b4:
 
 v3.0.0b4 (2021-09-01)
----------------------
+=====================
 
 Removed
-~~~~~~~
+-------
 
 * Remove ``BaseClient.qjoin_path`` (:pr:`452`)
 
 Added
-~~~~~
+-----
 
 * Add a new ``GCSClient`` class for interacting with GCS Manager APIs
   (:pr:`447`)
@@ -2464,7 +2464,7 @@ Added
   keyword arguments, not only in ``query_params`` (:pr:`460`)
 
 Changed
-~~~~~~~
+-------
 
 * Rename ``GCSScopeBuilder`` to ``GCSCollectionScopeBuilder`` and add
   ``GCSEndpointScopeBuilder``. The ``GCSClient`` includes helpers for
@@ -2479,7 +2479,7 @@ Changed
   have been updated (:pr:`465`)
 
 Fixed
-~~~~~
+-----
 
 * Minor fix to wheel builds: do not declare wheels as universal (:pr:`444`)
 
@@ -2488,7 +2488,7 @@ Fixed
 * Fix ``visibility`` typo in ``GroupsClient`` (:pr:`463`)
 
 Documentation
-~~~~~~~~~~~~~
+-------------
 
 * Ensure all ``TransferClient`` method parameters are documented (:pr:`449`,
   :pr:`454`, :pr:`457`, :pr:`458`, :pr:`459`, :pr:`461`, :pr:`462`)
@@ -2496,10 +2496,10 @@ Documentation
 .. _changelog-3.0.0b3:
 
 v3.0.0b3 (2021-08-13)
----------------------
+=====================
 
 Added
-~~~~~
+-----
 
 * Flesh out the ``GroupsClient`` and add helpers for interacting with the
   Globus Groups service, including enumerated constants, payload builders, and
@@ -2513,10 +2513,10 @@ Added
 .. _changelog-3.0.0b2:
 
 v3.0.0b2 (2021-07-16)
----------------------
+=====================
 
 Added
-~~~~~
+-----
 
 * Add scope constants and scope construction helpers. See new documentation on
   :ref:`scopes and ScopeBuilders <scopes>` for details (:pr:`437`, :pr:`440`)
@@ -2526,7 +2526,7 @@ Added
   (:pr:`441`)
 
 Changed
-~~~~~~~
+-------
 
 * Improve the rendering of API exceptions in stack traces to include the
   method, URI, and authorization scheme (if recognized) (:pr:`439`)
@@ -2538,15 +2538,15 @@ Changed
 .. _changelog-3.0.0b1:
 
 v3.0.0b1 (2021-07-02)
----------------------
+=====================
 
 Added
-~~~~~
+-----
 
 * Add support for ``TransferClient.get_shared_endpoint_list`` (:pr:`434`)
 
 Changed
-~~~~~~~
+-------
 
 * Passthrough parameters to SDK methods for query params and body params are no
   longer accepted as extra keyword arguments. Instead, they must be passed
@@ -2561,31 +2561,31 @@ Changed
 .. _changelog-3.0.0a4:
 
 v3.0.0a4 (2021-06-28)
----------------------
+=====================
 
 Added
-~~~~~
+-----
 
 * Add ``BaseClient`` to the top-level exports of ``globus_sdk``, so it can now
   be accessed under the name ``globus_sdk.BaseClient``
 
 Fixed
-~~~~~
+-----
 
 * Fix several paginators which were broken in ``3.0.0a3`` (:pr:`431`)
 
 Documentation
-~~~~~~~~~~~~~
+-------------
 
 * Autodocumentation of paginated methods (:pr:`432`)
 
 .. _changelog-3.0.0a3:
 
 v3.0.0a3 (2021-06-25)
----------------------
+=====================
 
 Changed
-~~~~~~~
+-------
 
 * Pagination has changed significantly. (:pr:`418`)
 
@@ -2607,10 +2607,10 @@ Changed
 .. _changelog-3.0.0a2:
 
 v3.0.0a2 (2021-06-10)
----------------------
+=====================
 
 Added
-~~~~~
+-----
 
 * A new subpackage is available for public use,
   ``globus_sdk.tokenstorage`` (:pr:`405`)
@@ -2619,17 +2619,17 @@ Added
   dedicated error class, ``globus_sdk.GroupsAPIError``
 
 Changed
-~~~~~~~
+-------
 
 * Refactor response classes (:pr:`425`)
 
 .. _changelog-3.0.0a1:
 
 v3.0.0a1 (2021-06-04)
----------------------
+=====================
 
 Removed
-~~~~~~~
+-------
 
 * Remove ``allowed_authorizer_types`` restriction from ``BaseClient`` (:pr:`407`)
 
@@ -2637,7 +2637,7 @@ Removed
   ``OAuthTokenResponse.decode_id_token`` (:pr:`400`)
 
 Added
-~~~~~
+-----
 
 * ``globus-sdk`` now provides PEP561 typing data (:pr:`420`)
 
@@ -2647,7 +2647,7 @@ Added
   There is no automatic caching of these data. (:pr:`403`)
 
 Changed
-~~~~~~~
+-------
 
 * The interface for ``GlobusAuthorizer`` now defines
   ``get_authorization_header`` instead of ``set_authorization_header``, and
@@ -2678,7 +2678,7 @@ Changed
   ``set_app_name`` (:pr:`415`)
 
 Documentation
-~~~~~~~~~~~~~
+-------------
 
 * Update documentation site style and layout (:pr:`423`)
 
@@ -2687,10 +2687,10 @@ Documentation
 .. _changelog-2.0.1:
 
 v2.0.1 (2021-02-02)
--------------------
+===================
 
 Python Support
-~~~~~~~~~~~~~~
+--------------
 
 * Remove support for python2 (:pr:`396`, :pr:`397`, :pr:`398`)
 
@@ -2700,74 +2700,74 @@ Python Support
 .. _changelog-1.11.0:
 
 v1.11.0 (2021-01-29)
---------------------
+====================
 
 Added
-~~~~~
+-----
 
 * Add support for task skipped errors via
   ``TransferClient.task_skipped_errors`` and
   ``TransferClient.endpoint_manager_task_skipped_errors`` (:pr:`393`)
 
 Development
-~~~~~~~~~~~
+-----------
 
 * Internal maintenance (:pr:`389`, :pr:`390`, :pr:`391`, :pr:`392`)
 
 .. _changelog-1.10.0:
 
 v1.10.0 (2020-12-18)
---------------------
+====================
 
 Fixed
-~~~~~
+-----
 
 * Add support for pyinstaller installation of globus-sdk (:pr:`387`)
 
 .. _changelog-1.9.1:
 
 v1.9.1 (2020-08-27)
--------------------
+===================
 
 Fixed
-~~~~~
+-----
 
 * Fix ``GlobusHTTPResponse`` to handle responses with no ``Content-Type`` header (:pr:`375`)
 
 .. _changelog-1.9.0:
 
 v1.9.0 (2020-03-05)
--------------------
+===================
 
 Added
-~~~~~
+-----
 
 * Add ``globus_sdk.IdentityMap``, a mapping-like object for Auth ID lookups (:pr:`367`)
 
 * Add ``external_checksum`` and ``checksum_algorithm`` to ``TransferData.add_item()`` named arguments (:pr:`365`)
 
 Changed
-~~~~~~~
+-------
 
 * Don't append trailing slashes when no path is given to a low-level client method like ``get()`` (:pr:`364`)
 
 Development
-~~~~~~~~~~~
+-----------
 
 * Minor documentation and build improvements (:pr:`369`, :pr:`362`)
 
 .. _changelog-1.8.0:
 
 v1.8.0 (2019-07-11)
--------------------
+===================
 
 Added
-~~~~~
+-----
 
 * Add a property to paginated results which shows if more results are available (:pr:`346`)
 
 Fixed
-~~~~~
+-----
 
 * Fix ``RefreshTokenAuthorizer`` to handle a new ``refresh_token`` being sent back by Auth (:pr:`359`)
 
@@ -2776,69 +2776,69 @@ Fixed
 * Fix Globus Web App activation links in docs (:pr:`356`)
 
 Documentation
-~~~~~~~~~~~~~
+-------------
 
 * Update docs to state that Globus SDK uses semver (:pr:`357`)
 
 .. _changelog-1.7.1:
 
 v1.7.1 (2019-02-21)
--------------------
+===================
 
 Added
-~~~~~
+-----
 
 * Allow arbitrary keyword args to ``TransferData.add_item()`` and ``DeleteData.add_item()``, which passthrough to the item bodies (:pr:`339`)
 
 Development
-~~~~~~~~~~~
+-----------
 
 * Minor internal improvements (:pr:`342`, :pr:`343`)
 
 .. _changelog-1.7.0:
 
 v1.7.0 (2018-12-18)
--------------------
+===================
 
 Added
-~~~~~
+-----
 
 * Add ``get_task`` and ``get_task_list`` to ``SearchClient`` (:pr:`335`, :pr:`336`)
 
 Development
-~~~~~~~~~~~
+-----------
 
 * Internal maintenance and testing improvements (:pr:`331`, :pr:`334`, :pr:`333`)
 
 .. _changelog-1.6.1:
 
 v1.6.1 (2018-10-30)
--------------------
+===================
 
 Changed
-~~~~~~~
+-------
 
 * Replace egg distribution format with wheels (:pr:`314`)
 
 Development
-~~~~~~~~~~~
+-----------
 
 * Internal maintenance
 
 .. _changelog-1.6.0:
 
 v1.6.0 (2018-08-29)
--------------------
+===================
 
 Python Support
-~~~~~~~~~~~~~~
+--------------
 
 * Officially add support for python 3.7 (:pr:`300`)
 
 Removed
-~~~~~~~
+-------
 Added
-~~~~~
+-----
 
 * RenewingAuthorizer and its subclasses now expose the check_expiration_time method (:pr:`309`)
 
@@ -2847,7 +2847,7 @@ Added
 * Add the patch() method to BaseClient and its subclasses, sending an HTTP PATCH request (:pr:`302`)
 
 Changed
-~~~~~~~
+-------
 
 * Use sha256 hashes of tokens (instead of last 5 chars) in debug logging (:pr:`305`)
 
@@ -2856,59 +2856,59 @@ Changed
 * Malformed SDK usage may now raise GlobusSDKUsageError instead of ValueError. GlobusSDKUsageError inherits from ValueError (:pr:`281`)
 
 Fixed
-~~~~~
+-----
 
 * Correct handling of environment="production" as an argument to client construction (:pr:`307`)
 
 Documentation
-~~~~~~~~~~~~~
+-------------
 
 * Numerous documentation improvements (:pr:`279`, :pr:`294`, :pr:`296`, :pr:`297`)
 
 .. _changelog-1.5.0:
 
 v1.5.0 (2018-02-09)
--------------------
+===================
 
 Added
-~~~~~
+-----
 
 * Add support for retrieving a local Globus Connect Personal endpoint's UUID (:pr:`276`)
 
 Fixed
-~~~~~
+-----
 
 * Fix bug in search client parameter handling (:pr:`274`)
 
 .. _changelog-1.4.1:
 
 v1.4.1 (2017-12-20)
--------------------
+===================
 
 Added
-~~~~~
+-----
 
 * Support connection timeouts. Default timeout of 60 seconds (:pr:`264`)
 
 Fixed
-~~~~~
+-----
 
 * Send ``Content-Type: application/json`` on requests with JSON request bodies (:pr:`266`)
 
 .. _changelog-1.4.0:
 
 v1.4.0 (2017-12-13)
--------------------
+===================
 
 Added
-~~~~~
+-----
 
 * Access token response data by way of scope name (:pr:`261`)
 
 * Add (beta) SearchClient class (:pr:`259`)
 
 Changed
-~~~~~~~
+-------
 
 * Make ``cryptography`` a strict requirement, globus-sdk[jwt] is no longer necessary (:pr:`257`, :pr:`260`)
 
@@ -2917,153 +2917,153 @@ Changed
 .. _changelog-1.3.0:
 
 v1.3.0 (2017-11-20)
--------------------
+===================
 
 Python Support
-~~~~~~~~~~~~~~
+--------------
 
 * Improve error message when installation onto python2.6 is attempted (:pr:`245`)
 
 Changed
-~~~~~~~
+-------
 
 * Raise errors on client instantiation when ``GLOBUS_SDK_ENVIRONMENT`` appears to be invalid, support ``GLOBUS_SDK_ENVIRONMENT=preview`` (:pr:`247`)
 
 .. _changelog-1.2.2:
 
 v1.2.2 (2017-11-01)
--------------------
+===================
 
 Added
-~~~~~
+-----
 
 * Allow client classes to accept ``base_url`` as an argument to ``_init__()`` (:pr:`241`)
 
 Changed
-~~~~~~~
+-------
 
 * Improve docs on ``TransferClient`` helper classes (:pr:`231`, :pr:`233`)
 
 Fixed
-~~~~~
+-----
 
 * Fix packaging to not include testsuite (:pr:`232`)
 
 .. _changelog-1.2.1:
 
 v1.2.1 (2017-09-29)
--------------------
+===================
 
 Changed
-~~~~~~~
+-------
 
 * Use PyJWT instead of python-jose for JWT support (:pr:`227`)
 
 .. _changelog-1.2.0:
 
 v1.2.0 (2017-08-18)
--------------------
+===================
 
 Added
-~~~~~
+-----
 
 * Add Transfer symlink support (:pr:`218`)
 
 Fixed
-~~~~~
+-----
 
 * Better handle UTF-8 inputs (:pr:`208`)
 
 * Fix endpoint manager resume (:pr:`224`)
 
 Documentation
-~~~~~~~~~~~~~
+-------------
 
 * Doc Updates & Minor Improvements
 
 .. _changelog-1.1.1:
 
 v1.1.1 (2017-05-19)
--------------------
+===================
 
 Fixed
-~~~~~
+-----
 
 * Use correct paging style when making ``endpoint_manager_task_list`` calls (:pr:`210`)
 
 .. _changelog-1.1.0:
 
 v1.1.0 (2017-05-01)
--------------------
+===================
 
 Python Support
-~~~~~~~~~~~~~~
+--------------
 
 * Add python 3.6 to supported platforms (:pr:`180`)
 
 Added
-~~~~~
+-----
 
 * Add endpoint_manager methods to TransferClient (:pr:`191`, :pr:`199`, :pr:`200`, :pr:`201`, :pr:`203`)
 
 * Support iterable requested_scopes everywhere (:pr:`185`)
 
 Changed
-~~~~~~~
+-------
 
 * Change "identities_set" to "identity_set" for token introspection (:pr:`163`)
 
 * Update dev status classifier to 5, prod (:pr:`178`)
 
 Documentation
-~~~~~~~~~~~~~
+-------------
 
 * Fix docs references to ``oauth2_start_flow_*`` (:pr:`190`)
 
 * Remove "Beta" from docs (:pr:`179`)
 
 Development
-~~~~~~~~~~~
+-----------
 
 * Numerous improvements to testsuite
 
 .. _changelog-1.0.0:
 
 v1.0.0 (2017-04-10)
--------------------
+===================
 
 Added
-~~~~~
+-----
 
 * Adds ``AuthAPIError`` with more flexible error payload handling (:pr:`175`)
 
 .. _changelog-0.7.2:
 
 v0.7.2 (2017-04-05)
--------------------
+===================
 
 Added
-~~~~~
+-----
 
 * Add ``AuthClient.validate_token`` (:pr:`172`)
 
 Fixed
-~~~~~
+-----
 
 * Bugfix for ``on_refresh`` users of ``RefreshTokenAuthorizer`` and ``ClientCredentialsAuthorizer`` (:pr:`173`)
 
 .. _changelog-0.7.1:
 
 v0.7.1 (2017-04-03)
--------------------
+===================
 
 Removed
-~~~~~~~
+-------
 
 * Remove deprecated ``oauth2_start_flow_*`` methods (:pr:`170`)
 
 Added
-~~~~~
+-----
 
 * Add the ``ClientCredentialsAuthorizer`` (:pr:`164`)
 
@@ -3072,52 +3072,52 @@ Added
 .. _changelog-0.7.0:
 
 v0.7.0 (2017-03-30)
--------------------
+===================
 
 Removed
-~~~~~~~
+-------
 
 * Remove all properties of ``OAuthTokenResponse`` other than ``by_resource_server`` (:pr:`162`)
 
 Fixed
-~~~~~
+-----
 
 * Make ``OAuthTokenResponse.decode_id_token()`` respect ``ssl_verify=no`` configuration (:pr:`161`)
 
 .. _changelog-0.6.0:
 
 v0.6.0 (2017-03-21)
--------------------
+===================
 
 Added
-~~~~~
+-----
 
 * Add ``deadline`` support to ``TransferData`` and ``DeleteData`` (:pr:`159`)
 
 Changed
-~~~~~~~
+-------
 
 * Opt out of the Globus Auth behavior where a ``GET`` of an identity username will provision that identity (:pr:`145`)
 
 * Wrap some ``requests`` network-related errors in custom exceptions (:pr:`155`)
 
 Fixed
-~~~~~
+-----
 
 * Fixup OAuth2 PKCE to be spec-compliant (:pr:`154`)
 
 .. _changelog-0.5.1:
 
 v0.5.1 (2017-02-25)
--------------------
+===================
 
 Added
-~~~~~
+-----
 
 * Add support for the ``prefill_named_grant`` option to the Native App authorization flow (:pr:`143`)
 
 Changed
-~~~~~~~
+-------
 
 * Unicode string improvements (:pr:`129`)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,7 +153,7 @@ version = "literal: src/globus_sdk/version.py: __version__"
 format = "rst"
 output_file = "changelog.rst"
 entry_title_template = 'v{{ version }} ({{ date.strftime("%Y-%m-%d") }})'
-rst_header_chars = "-~"
+rst_header_chars = "=-"
 categories = [
     "Python Support",
     "Added",


### PR DESCRIPTION
> [!NOTE]
>
> This is a mostly mechanical change. See below for the code that rewrote the header lines, which may be easier to review than the sprawling CHANGELOG diff.

Development
-----------

-   Convert the CHANGELOG to Markdown-compatible headers.

    This resolves rendering issues in Dependabot PRs in the CLI,
    and simplifies compatibility between RST and Markdown.

----

[Recent example of Dependabot PR CHANGELOG rendering in the CLI](https://github.com/globus/globus-cli/pull/1129):

<blockquote>
<h2>v3.58.0 (2025-06-16)</h2>
<p>Added</p>
<pre><code>
- Add the ``SpecificFlow.validate_run()`` method. (:pr:`1221`)
<p>Fixed<br />
</code></pre></p>
<ul>
<li>Fix an error which caused the <code>restrict_transfers_to_high_assurance</code> field
to be malformed when set on a collection payload type. (:pr:<code>1211</code>)</li>
</ul>
<p>.. _changelog-3.57.0:</p>
</blockquote>

----

Code that rewrote the header lines:

```python
contents = open("changelog.rst").read()
replacement_lines = []
for line in contents.splitlines():
    if set(line) == {"="}:
        replacement_lines.append("#" * len(line))
    elif set(line) == {"-"}:
        replacement_lines.append("=" * len(line))
    elif set(line) == {"~"}:
        replacement_lines.append("-" * len(line))
    else:
        replacement_lines.append(line)
open("changelog.rst", "w").write("\n".join(replacement_lines) + "\n")
```