### PR TITLE
Use the latest version of 'mddj'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,10 @@ typing-mindeps = [
     {include-group = "typing"},
     "typing-extensions==4.0",
 ]
+check-project-metadata = [
+    "ruamel.yaml<0.19",
+    "mddj==0.1.0",
+]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/tox.ini
+++ b/tox.ini
@@ -124,9 +124,7 @@ depends = freezedeps-print
 [testenv:check-min-python-is-tested]
 description = Check the Requires-Python metadata against CI config
 skip_install = true
-deps =
-    ruamel.yaml<0.18
-    mddj==0.0.8
+dependency_groups = check-project-metadata
 commands = python scripts/ensure_min_python_is_tested.py
 
 [testenv:prepare-release]


### PR DESCRIPTION
`mddj==0.1.0` supports reading data preferentially from
`pyproject.toml` and falls back to preparing metadata for a wheel
build if it cannot read from `pyproject.toml`. It makes it a full
second faster to run.

Also, move these dependencies into a `pyproject.toml` dependency group
for a mildly improved maintenance experience.


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1233.org.readthedocs.build/en/1233/

<!-- readthedocs-preview globus-sdk-python end -->