### PR TITLE
Update `ComputeClientV2.get_endpoints` to list MEPs via a new `role` kwarg

### DIFF
--- a/changelog.d/20250630_144536_yadudoc1729_get_endpoints_with_role.rst
+++ b/changelog.d/20250630_144536_yadudoc1729_get_endpoints_with_role.rst
@@ -1,0 +1,4 @@
+Added
+-----
+
+- Updated ``ComputeClientV2.get_endpoints`` with a new ``role`` kwarg. (:pr:`1238`)

--- a/src/globus_sdk/_testing/data/compute/_common.py
+++ b/src/globus_sdk/_testing/data/compute/_common.py
@@ -1,11 +1,13 @@
 import uuid
 
 USER_ID = str(uuid.uuid1())
+NON_USER_ID = str(uuid.uuid1())
 
 SUBSCRIPTION_ID = str(uuid.uuid1())
 
 ENDPOINT_ID = str(uuid.uuid1())
 ENDPOINT_ID_2 = str(uuid.uuid1())
+ENDPOINT_ID_3 = str(uuid.uuid1())
 
 FUNCTION_ID = str(uuid.uuid1())
 FUNCTION_ID_2 = str(uuid.uuid1())

--- a/src/globus_sdk/_testing/data/compute/v2/get_endpoints.py
+++ b/src/globus_sdk/_testing/data/compute/v2/get_endpoints.py
@@ -1,6 +1,8 @@
+from responses.matchers import query_param_matcher
+
 from globus_sdk._testing.models import RegisteredResponse, ResponseSet
 
-from .._common import ENDPOINT_ID, ENDPOINT_ID_2, USER_ID
+from .._common import ENDPOINT_ID, ENDPOINT_ID_2, ENDPOINT_ID_3, NON_USER_ID, USER_ID
 
 DEFAULT_RESPONSE_DOC = [
     {
@@ -17,12 +19,44 @@ DEFAULT_RESPONSE_DOC = [
     },
 ]
 
+ANY_RESPONSE_DOC = [
+    {
+        "uuid": ENDPOINT_ID,
+        "name": "my-endpoint",
+        "display_name": "My Endpoint",
+        "owner": USER_ID,
+    },
+    {
+        "uuid": ENDPOINT_ID_2,
+        "name": "my-second-endpoint",
+        "display_name": "My Second Endpoint",
+        "owner": USER_ID,
+    },
+    {
+        "uuid": ENDPOINT_ID_3,
+        "name": "public_endpoint",
+        "display_name": "Public Endpoint",
+        "owner": NON_USER_ID,
+    },
+]
+
 RESPONSES = ResponseSet(
-    metadata={"endpoint_id": ENDPOINT_ID, "endpoint_id_2": ENDPOINT_ID_2},
+    metadata={
+        "endpoint_id": ENDPOINT_ID,
+        "endpoint_id_2": ENDPOINT_ID_2,
+        "endpoint_id_3": ENDPOINT_ID_3,
+    },
     default=RegisteredResponse(
         service="compute",
         path="/v2/endpoints",
         method="GET",
         json=DEFAULT_RESPONSE_DOC,
+    ),
+    any=RegisteredResponse(
+        service="compute",
+        path="/v2/endpoints",
+        method="GET",
+        json=ANY_RESPONSE_DOC,
+        match=[query_param_matcher(params={"role": "any"})],
     ),
 )

--- a/src/globus_sdk/services/compute/client.py
+++ b/src/globus_sdk/services/compute/client.py
@@ -3,10 +3,9 @@ from __future__ import annotations
 import logging
 import typing as t
 
-from globus_sdk import GlobusHTTPResponse, client, utils
+from globus_sdk import MISSING, GlobusHTTPResponse, MissingType, client, utils
 from globus_sdk._types import UUIDLike
 from globus_sdk.scopes import ComputeScopes, Scope
-from globus_sdk import MISSING, MissingType
 
 from .errors import ComputeAPIError
 

--- a/src/globus_sdk/services/compute/client.py
+++ b/src/globus_sdk/services/compute/client.py
@@ -6,6 +6,7 @@ import typing as t
 from globus_sdk import GlobusHTTPResponse, client, utils
 from globus_sdk._types import UUIDLike
 from globus_sdk.scopes import ComputeScopes, Scope
+from globus_sdk import MISSING, MissingType
 
 from .errors import ComputeAPIError
 
@@ -101,8 +102,10 @@ class ComputeClientV2(client.BaseClient):
         """  # noqa: E501
         return self.get(f"/v2/endpoints/{endpoint_id}/status")
 
-    def get_endpoints(self) -> GlobusHTTPResponse:
+    def get_endpoints(self, role: str | MissingType = MISSING) -> GlobusHTTPResponse:
         """Get a list of registered endpoints associated with the authenticated user.
+
+        :param role: Role of the user in relation to endpoints. (e.g.: owner, any)
 
         .. tab-set::
 
@@ -112,7 +115,8 @@ class ComputeClientV2(client.BaseClient):
                     :service: compute
                     :ref: Endpoints/operation/get_endpoints_v2_endpoints_get
         """  # noqa: E501
-        return self.get("/v2/endpoints")
+        query_params = {"role": role} if role else None
+        return self.get("/v2/endpoints", query_params=query_params)
 
     def delete_endpoint(self, endpoint_id: UUIDLike) -> GlobusHTTPResponse:
         """Delete a registered endpoint.

--- a/tests/functional/services/compute/v2/test_get_endpoints.py
+++ b/tests/functional/services/compute/v2/test_get_endpoints.py
@@ -10,3 +10,14 @@ def test_get_endpoints(compute_client_v2: globus_sdk.ComputeClientV2):
     assert res.http_status == 200
     assert res.data[0]["uuid"] == meta["endpoint_id"]
     assert res.data[1]["uuid"] == meta["endpoint_id_2"]
+
+
+def test_get_endpoints_any(compute_client_v2: globus_sdk.ComputeClientV2):
+    meta = load_response(compute_client_v2.get_endpoints, case="any").metadata
+    res = compute_client_v2.get_endpoints(role="any")
+
+    assert res.http_status == 200
+    assert res.data[0]["uuid"] == meta["endpoint_id"]
+    assert res.data[1]["uuid"] == meta["endpoint_id_2"]
+    assert res.data[2]["uuid"] == meta["endpoint_id_3"]
+    assert res.data[1]["owner"] != res.data[2]["owner"]


### PR DESCRIPTION
* Currently `get_endpoints` only queries for endpoints owned by the user.
  To list MEPs that are accessible but not owned by the user, the web-service supports a role query param that can be toggled from the
default of "owner" to "any". Refer: https://compute.api.globus.org/docs#/Endpoints/get_endpoints_v2_endpoints_get
* A new `role` kwarg is added to `ComputeClientV2.get_endpoints` that
  takes `roles="any"` to query for MEPs in addition to those owned by the user.


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1238.org.readthedocs.build/en/1238/

<!-- readthedocs-preview globus-sdk-python end -->