### PR TITLE
Update RELEASING.md to use PR process for 4.x-dev merge

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -62,12 +62,18 @@ or create the release via the GitHub CLI
   combine both announcements into a single email notice.)
 
 - Ensure the 4.x-dev branch is updated with the latest changes from main
+  by creating a PR:
     ```
     git checkout 4.x-dev
     git pull
+    git checkout -b merge-main-to-4x-dev-$(date +%Y%m%d)
     git merge origin/main
-    git push origin 4.x-dev
+    # Resolve any conflicts if they occur
+    git push -u origin merge-main-to-4x-dev-$(date +%Y%m%d)
+    gh pr create --base 4.x-dev --title "Merge main into 4.x-dev" \
+      --body "Merging latest changes from main branch into 4.x-dev"
     ```
+    After the PR is reviewed and merged, the 4.x-dev branch will be updated.
 
 ## Publish Pre-release 4.x packages to PyPi
 


### PR DESCRIPTION
## Summary
- Updated the release documentation to specify creating a PR when merging main into 4.x-dev

This ensures that any merge conflicts can be reviewed and the 4.x-dev branch remains protected.

<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1241.org.readthedocs.build/en/1241/

<!-- readthedocs-preview globus-sdk-python end -->