### PR TITLE
Update usage to leverage `MISSING`

### DIFF
--- a/src/globus_sdk/services/compute/client.py
+++ b/src/globus_sdk/services/compute/client.py
@@ -114,7 +114,7 @@ class ComputeClientV2(client.BaseClient):
                     :service: compute
                     :ref: Endpoints/operation/get_endpoints_v2_endpoints_get
         """  # noqa: E501
-        query_params = {"role": role} if role else None
+        query_params = {"role": role}
         return self.get("/v2/endpoints", query_params=query_params)
 
     def delete_endpoint(self, endpoint_id: UUIDLike) -> GlobusHTTPResponse:

--- a/tests/functional/services/compute/v2/test_get_endpoints.py
+++ b/tests/functional/services/compute/v2/test_get_endpoints.py
@@ -1,5 +1,7 @@
+import urllib.parse
+
 import globus_sdk
-from globus_sdk._testing import load_response
+from globus_sdk._testing import get_last_request, load_response
 
 
 def test_get_endpoints(compute_client_v2: globus_sdk.ComputeClientV2):
@@ -11,10 +13,19 @@ def test_get_endpoints(compute_client_v2: globus_sdk.ComputeClientV2):
     assert res.data[0]["uuid"] == meta["endpoint_id"]
     assert res.data[1]["uuid"] == meta["endpoint_id_2"]
 
+    # confirm that the 'role' param was not sent
+    last_req = get_last_request()
+    parsed_qs = urllib.parse.parse_qs(urllib.parse.urlparse(last_req.url).query)
+    assert "role" not in parsed_qs
+
 
 def test_get_endpoints_any(compute_client_v2: globus_sdk.ComputeClientV2):
     meta = load_response(compute_client_v2.get_endpoints, case="any").metadata
     res = compute_client_v2.get_endpoints(role="any")
+
+    last_req = get_last_request()
+    parsed_qs = urllib.parse.parse_qs(urllib.parse.urlparse(last_req.url).query)
+    assert parsed_qs["role"] == ["any"]
 
     assert res.http_status == 200
     assert res.data[0]["uuid"] == meta["endpoint_id"]


### PR DESCRIPTION
Because we auto-strip MISSING from payloads and params, this
conditional check was not necessary (and potentially confusing when
used in concert with MISSING).

Simplify the usage and add assertions to existing tests to confirm the
effect is as expected.


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1243.org.readthedocs.build/en/1243/

<!-- readthedocs-preview globus-sdk-python end -->