### PR TITLE
Recognize `dependent_consent_required` errors from Auth as GAREs

### DIFF
--- a/changelog.d/20250708_150717_kurtmckee_recognize_unapproved_scopes_as_gare.rst
+++ b/changelog.d/20250708_150717_kurtmckee_recognize_unapproved_scopes_as_gare.rst
@@ -1,0 +1,6 @@
+Added
+-----
+
+- Recognize ``dependent_consent_required`` errors from the Auth API
+  as a Globus Auth Requirements Error (GARE)
+  and support converting them to GAREs. (:pr:`NUMBER`)

--- a/src/globus_sdk/gare/_functional_api.py
+++ b/src/globus_sdk/gare/_functional_api.py
@@ -12,6 +12,7 @@ from ._variants import (
     LegacyAuthRequirementsErrorVariant,
     LegacyConsentRequiredAPError,
     LegacyConsentRequiredTransferError,
+    LegacyDependentConsentRequiredAuthError,
 )
 
 if sys.version_info >= (3, 10):
@@ -128,6 +129,7 @@ def _lenient_dict2gare(error_dict: dict[str, t.Any] | None) -> GARE | None:
         LegacyAuthorizationParametersError,
         LegacyConsentRequiredTransferError,
         LegacyConsentRequiredAPError,
+        LegacyDependentConsentRequiredAuthError,
     ]
     for variant in supported_variants:
         try:


### PR DESCRIPTION
Added
-----

- Recognize ``dependent_consent_required`` errors from the Auth API  as a Globus Auth Requirements Error (GARE)  and support converting them to GAREs.
