### PR TITLE
Accept authz params with dependent scopes in `app.login()`

### DIFF
--- a/changelog.d/20250709_084029_kurtmckee_app_login_with_dependent_scopes.rst
+++ b/changelog.d/20250709_084029_kurtmckee_app_login_with_dependent_scopes.rst
@@ -1,0 +1,6 @@
+Fixed
+-----
+
+-   Accept authorization parameters containing dependent scopes
+    when ``app.login()`` is called with a GARE's authorization parameters.
+    (:pr:`NUMBER`)

--- a/src/globus_sdk/globus_app/app.py
+++ b/src/globus_sdk/globus_app/app.py
@@ -379,13 +379,14 @@ class GlobusApp(metaclass=abc.ABCMeta):
 
         if not auth_params:
             auth_params = GlobusAuthorizationParameters()
+        parsed_required_scopes = []
+        for s in auth_params.required_scopes or []:
+            parsed_required_scopes.extend(Scope.parse(s))
 
         # merge scopes for deduplication to minimize url request length
         # this is useful even if there weren't any auth_param scope requirements
         # as the app's scope_requirements can have duplicates
-        combined_scopes = Scope.merge_scopes(
-            required_scopes, [Scope(s) for s in auth_params.required_scopes or []]
-        )
+        combined_scopes = Scope.merge_scopes(required_scopes, parsed_required_scopes)
         auth_params.required_scopes = [str(s) for s in combined_scopes]
 
         return auth_params


### PR DESCRIPTION
Fixed
-----

-   Accept authorization parameters containing dependent scopes
    when ``app.login()`` is called with a GARE's authorization parameters.
