### PR TITLE
Fix changelog2md.py, now that RST headers have changed

### DIFF
--- a/scripts/changelog2md.py
+++ b/scripts/changelog2md.py
@@ -23,8 +23,8 @@ CHANGELOG_ANCHOR_PATTERN = re.compile(
 )
 CHANGELOG_HEADER_PATTERN = re.compile(r"^v(\d+\.\d+\.\d+).*$", re.MULTILINE)
 
-H2_RST_PATTERN = re.compile(r"-+")
-H3_RST_PATTERN = re.compile(r"~+")
+H2_RST_PATTERN = re.compile(r"=+")
+H3_RST_PATTERN = re.compile(r"-+")
 
 SPHINX_ISSUES_PR_PATTERN = re.compile(r":pr:`(\d+)`")
 SPHINX_ISSUES_ISSUE_PATTERN = re.compile(r":issue:`(\d+)`")


### PR DESCRIPTION
Exactly what it says on the tin.

----

## Before:

```
$ ./scripts/changelog2md.py 
- Recognize `dependent_consent_required` errors from the Auth API
  as a Globus Auth Requirements Error (GARE)
  and support converting them to GAREs. (#1246)

Fixed
-----

-   Accept authorization parameters containing dependent scopes
    when `app.login()` is called with a GARE's authorization parameters.
    (#1247)
```

## After:

```
$ ./scripts/changelog2md.py 
## Added

- Recognize `dependent_consent_required` errors from the Auth API
  as a Globus Auth Requirements Error (GARE)
  and support converting them to GAREs. (#1246)

## Fixed

-   Accept authorization parameters containing dependent scopes
    when `app.login()` is called with a GARE's authorization parameters.
    (#1247)
```

<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1249.org.readthedocs.build/en/1249/

<!-- readthedocs-preview globus-sdk-python end -->