### PR TITLE
Remove the 'UUIDLike' type alias

### DIFF
--- a/src/globus_sdk/_guards.py
+++ b/src/globus_sdk/_guards.py
@@ -4,8 +4,6 @@ import sys
 import typing as t
 import uuid
 
-from globus_sdk._types import UUIDLike
-
 # some error types use guards, so import from the specific module to avoid circularity
 from globus_sdk.exc.base import ValidationError
 
@@ -94,7 +92,7 @@ class validators:
         )
 
     @staticmethod
-    def uuidlike(name: str, s: t.Any) -> UUIDLike:
+    def uuidlike(name: str, s: t.Any) -> uuid.UUID | str:
         """
         Raise an error if the input is not a UUID
 
@@ -108,7 +106,7 @@ class validators:
 
         .. code-block:: python
 
-            def frob_it(collection_id: UUIDLike) -> Frob:
+            def frob_it(collection_id: uuid.UUID | str) -> Frob:
                 validators.uuidlike(collection_id, name="collection_id")
                 return Frob(collection_id)
 

--- a/src/globus_sdk/_types.py
+++ b/src/globus_sdk/_types.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import datetime
 import typing as t
-import uuid
 
 if t.TYPE_CHECKING:
     from globus_sdk.scopes import MutableScope, Scope
@@ -10,7 +9,6 @@ if t.TYPE_CHECKING:
 
 # these types are aliases meant for internal use
 IntLike = t.Union[int, str]
-UUIDLike = t.Union[uuid.UUID, str]
 DateLike = t.Union[str, datetime.datetime]
 
 ScopeCollectionType = t.Union[

--- a/src/globus_sdk/globus_app/app.py
+++ b/src/globus_sdk/globus_app/app.py
@@ -4,6 +4,7 @@ import abc
 import contextlib
 import copy
 import typing as t
+import uuid
 
 from globus_sdk import (
     AuthClient,
@@ -12,7 +13,7 @@ from globus_sdk import (
     IDTokenDecoder,
     Scope,
 )
-from globus_sdk._types import ScopeCollectionType, UUIDLike
+from globus_sdk._types import ScopeCollectionType
 from globus_sdk.authorizers import GlobusAuthorizer
 from globus_sdk.gare import GlobusAuthorizationParameters
 from globus_sdk.scopes import AuthScopes, scopes_to_scope_list
@@ -65,7 +66,7 @@ class GlobusApp(metaclass=abc.ABCMeta):
         app_name: str = "Unnamed Globus App",
         *,
         login_client: AuthLoginClient | None = None,
-        client_id: UUIDLike | None = None,
+        client_id: uuid.UUID | str | None = None,
         client_secret: str | None = None,
         scope_requirements: t.Mapping[str, ScopeCollectionType] | None = None,
         config: GlobusAppConfig = DEFAULT_CONFIG,
@@ -135,9 +136,9 @@ class GlobusApp(metaclass=abc.ABCMeta):
         app_name: str,
         config: GlobusAppConfig,
         login_client: AuthLoginClient | None,
-        client_id: UUIDLike | None,
+        client_id: uuid.UUID | str | None,
         client_secret: str | None,
-    ) -> tuple[UUIDLike, AuthLoginClient]:
+    ) -> tuple[uuid.UUID | str, AuthLoginClient]:
         """
         Extracts a client_id and login_client from GlobusApp initialization parameters,
         validating that the parameters were provided correctly.
@@ -188,7 +189,7 @@ class GlobusApp(metaclass=abc.ABCMeta):
         self,
         app_name: str,
         config: GlobusAppConfig,
-        client_id: UUIDLike,
+        client_id: uuid.UUID | str,
         client_secret: str | None,
     ) -> AuthLoginClient:
         """
@@ -216,7 +217,7 @@ class GlobusApp(metaclass=abc.ABCMeta):
         return validating_token_storage
 
     def _resolve_token_storage(
-        self, app_name: str, client_id: UUIDLike, config: GlobusAppConfig
+        self, app_name: str, client_id: uuid.UUID | str, config: GlobusAppConfig
     ) -> TokenStorage:
         """
         Resolve the raw token storage to be used by the app.

--- a/src/globus_sdk/globus_app/client_app.py
+++ b/src/globus_sdk/globus_app/client_app.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import uuid
+
 from globus_sdk import AuthLoginClient, ConfidentialAppAuthClient, GlobusSDKUsageError
-from globus_sdk._types import ScopeCollectionType, UUIDLike
+from globus_sdk._types import ScopeCollectionType
 from globus_sdk.gare import GlobusAuthorizationParameters
 
 from .app import GlobusApp
@@ -55,7 +57,7 @@ class ClientApp(GlobusApp):
         app_name: str = "Unnamed Globus App",
         *,
         login_client: ConfidentialAppAuthClient | None = None,
-        client_id: UUIDLike | None = None,
+        client_id: uuid.UUID | str | None = None,
         client_secret: str | None = None,
         scope_requirements: dict[str, ScopeCollectionType] | None = None,
         config: GlobusAppConfig = DEFAULT_CONFIG,
@@ -81,7 +83,7 @@ class ClientApp(GlobusApp):
         self,
         app_name: str,
         config: GlobusAppConfig,
-        client_id: UUIDLike,
+        client_id: uuid.UUID | str,
         client_secret: str | None,
     ) -> AuthLoginClient:
         if not client_secret:

--- a/src/globus_sdk/globus_app/protocols.py
+++ b/src/globus_sdk/globus_app/protocols.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import typing as t
+import uuid
 
 if t.TYPE_CHECKING:
     from globus_sdk import AuthLoginClient, IDTokenDecoder
-    from globus_sdk._types import UUIDLike
     from globus_sdk.login_flows import LoginFlowManager
     from globus_sdk.tokenstorage import TokenStorage, TokenValidationError
 
@@ -26,7 +26,7 @@ class TokenStorageProvider(t.Protocol):
         *,
         app_name: str,
         config: GlobusAppConfig,
-        client_id: UUIDLike,
+        client_id: uuid.UUID | str,
         namespace: str,
     ) -> TokenStorage:
         """

--- a/src/globus_sdk/globus_app/user_app.py
+++ b/src/globus_sdk/globus_app/user_app.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import typing as t
+import uuid
 
 from globus_sdk import (
     AuthClient,
@@ -10,7 +11,7 @@ from globus_sdk import (
     NativeAppAuthClient,
     Scope,
 )
-from globus_sdk._types import ScopeCollectionType, UUIDLike
+from globus_sdk._types import ScopeCollectionType
 from globus_sdk.gare import GlobusAuthorizationParameters
 from globus_sdk.login_flows import CommandLineLoginFlowManager, LoginFlowManager
 from globus_sdk.tokenstorage import (
@@ -78,7 +79,7 @@ class UserApp(GlobusApp):
         app_name: str = "Unnamed Globus App",
         *,
         login_client: AuthLoginClient | None = None,
-        client_id: UUIDLike | None = None,
+        client_id: uuid.UUID | str | None = None,
         client_secret: str | None = None,
         scope_requirements: t.Mapping[str, ScopeCollectionType] | None = None,
         config: GlobusAppConfig = DEFAULT_CONFIG,
@@ -127,7 +128,7 @@ class UserApp(GlobusApp):
         self,
         app_name: str,
         config: GlobusAppConfig,
-        client_id: UUIDLike,
+        client_id: uuid.UUID | str,
         client_secret: str | None,
     ) -> AuthLoginClient:
         if client_secret:

--- a/src/globus_sdk/scopes/consents/_model.py
+++ b/src/globus_sdk/scopes/consents/_model.py
@@ -27,10 +27,9 @@ from __future__ import annotations
 
 import textwrap
 import typing as t
+import uuid
 from dataclasses import dataclass
 from datetime import datetime
-
-from globus_sdk._types import UUIDLike
 
 from ..representation import Scope
 from ._errors import ConsentParseError, ConsentTreeConstructionError
@@ -49,11 +48,11 @@ class Consent:
             operations (consents) defined in the "dependency_path".
     """
 
-    client: UUIDLike
-    scope: UUIDLike
+    client: uuid.UUID | str
+    scope: uuid.UUID | str
     scope_name: str
     id: int
-    effective_identity: UUIDLike
+    effective_identity: uuid.UUID | str
     # A list representing the path of consent dependencies leading from a "root consent"
     #   to this. The last element of this list will always be this consent's ID.
     # Downstream dependency relationships may exist but will not be defined here.

--- a/src/globus_sdk/scopes/data/flows.py
+++ b/src/globus_sdk/scopes/data/flows.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 import typing as t
-
-from globus_sdk._types import UUIDLike
+import uuid
 
 from ..builder import ScopeBuilder, ScopeBuilderScopes
 
@@ -105,7 +104,7 @@ class SpecificFlowScopeBuilder(ScopeBuilder):
 
     _CLASS_STUB = _SpecificFlowScopesClassStub()
 
-    def __init__(self, flow_id: UUIDLike) -> None:
+    def __init__(self, flow_id: uuid.UUID | str) -> None:
         self._flow_id = flow_id
         str_flow_id = str(flow_id)
         super().__init__(

--- a/src/globus_sdk/services/auth/client/base_login_client.py
+++ b/src/globus_sdk/services/auth/client/base_login_client.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 import logging
 import typing as t
+import uuid
 
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 
 from globus_sdk import _guards, client, exc, utils
-from globus_sdk._types import UUIDLike
 from globus_sdk.authorizers import GlobusAuthorizer, NullAuthorizer
 from globus_sdk.response import GlobusHTTPResponse
 from globus_sdk.scopes import AuthScopes, Scope
@@ -45,7 +45,7 @@ class AuthLoginClient(client.BaseClient):
 
     def __init__(
         self,
-        client_id: UUIDLike | None = None,
+        client_id: uuid.UUID | str | None = None,
         environment: str | None = None,
         base_url: str | None = None,
         authorizer: GlobusAuthorizer | None = None,
@@ -141,9 +141,13 @@ class AuthLoginClient(client.BaseClient):
     def oauth2_get_authorize_url(
         self,
         *,
-        session_required_identities: UUIDLike | t.Iterable[UUIDLike] | None = None,
+        session_required_identities: (
+            uuid.UUID | str | t.Iterable[uuid.UUID | str] | None
+        ) = None,
         session_required_single_domain: str | t.Iterable[str] | None = None,
-        session_required_policies: UUIDLike | t.Iterable[UUIDLike] | None = None,
+        session_required_policies: (
+            uuid.UUID | str | t.Iterable[uuid.UUID | str] | None
+        ) = None,
         session_required_mfa: bool | None = None,
         session_message: str | None = None,
         prompt: t.Literal["login"] | None = None,

--- a/src/globus_sdk/services/auth/client/confidential_client.py
+++ b/src/globus_sdk/services/auth/client/confidential_client.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import logging
 import typing as t
+import uuid
 
 from globus_sdk import exc, utils
-from globus_sdk._types import ScopeCollectionType, UUIDLike
+from globus_sdk._types import ScopeCollectionType
 from globus_sdk.authorizers import BasicAuthorizer
 from globus_sdk.response import GlobusHTTPResponse
 
@@ -44,7 +45,7 @@ class ConfidentialAppAuthClient(AuthLoginClient):
 
     def __init__(
         self,
-        client_id: UUIDLike,
+        client_id: uuid.UUID | str,
         client_secret: str,
         environment: str | None = None,
         base_url: str | None = None,
@@ -64,7 +65,7 @@ class ConfidentialAppAuthClient(AuthLoginClient):
         self,
         *,
         usernames: t.Iterable[str] | str | None = None,
-        ids: t.Iterable[UUIDLike] | UUIDLike | None = None,
+        ids: t.Iterable[uuid.UUID | str] | uuid.UUID | str | None = None,
         provision: bool = False,
         query_params: dict[str, t.Any] | None = None,
     ) -> GetIdentitiesResponse:
@@ -344,8 +345,8 @@ class ConfidentialAppAuthClient(AuthLoginClient):
         redirect_uris: t.Iterable[str] | utils.MissingType = utils.MISSING,
         terms_and_conditions: str | utils.MissingType = utils.MISSING,
         privacy_policy: str | utils.MissingType = utils.MISSING,
-        required_idp: UUIDLike | utils.MissingType = utils.MISSING,
-        preselect_idp: UUIDLike | utils.MissingType = utils.MISSING,
+        required_idp: uuid.UUID | str | utils.MissingType = utils.MISSING,
+        preselect_idp: uuid.UUID | str | utils.MissingType = utils.MISSING,
         additional_fields: dict[str, t.Any] | utils.MissingType = utils.MISSING,
     ) -> GlobusHTTPResponse:
         """

--- a/src/globus_sdk/services/auth/client/native_client.py
+++ b/src/globus_sdk/services/auth/client/native_client.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import logging
 import typing as t
+import uuid
 
-from globus_sdk._types import ScopeCollectionType, UUIDLike
+from globus_sdk._types import ScopeCollectionType
 from globus_sdk.authorizers import NullAuthorizer
 from globus_sdk.response import GlobusHTTPResponse
 
@@ -33,7 +34,7 @@ class NativeAppAuthClient(AuthLoginClient):
 
     def __init__(
         self,
-        client_id: UUIDLike,
+        client_id: uuid.UUID | str,
         environment: str | None = None,
         base_url: str | None = None,
         app_name: str | None = None,
@@ -137,7 +138,7 @@ class NativeAppAuthClient(AuthLoginClient):
 
     def create_native_app_instance(
         self,
-        template_id: UUIDLike,
+        template_id: uuid.UUID | str,
         name: str,
     ) -> GlobusHTTPResponse:
         """

--- a/src/globus_sdk/services/auth/client/service_client.py
+++ b/src/globus_sdk/services/auth/client/service_client.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 import functools
 import logging
 import typing as t
+import uuid
 
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 
 from globus_sdk import client, exc, utils
-from globus_sdk._types import UUIDLike
 from globus_sdk.authorizers import GlobusAuthorizer
 from globus_sdk.response import GlobusHTTPResponse, IterableResponse
 from globus_sdk.scopes import AuthScopes, Scope
@@ -109,7 +109,7 @@ class AuthClient(client.BaseClient):
 
     def __init__(
         self,
-        client_id: UUIDLike | None = None,
+        client_id: uuid.UUID | str | None = None,
         environment: str | None = None,
         base_url: str | None = None,
         app: GlobusApp | None = None,
@@ -150,7 +150,7 @@ class AuthClient(client.BaseClient):
         return self._client_id
 
     @client_id.setter
-    def client_id(self, value: UUIDLike) -> None:
+    def client_id(self, value: uuid.UUID | str) -> None:
         exc.warn_deprecated(
             "The client_id attribute on `AuthClient` / "
             "`AuthClient` is deprecated. "
@@ -261,7 +261,7 @@ class AuthClient(client.BaseClient):
         self,
         *,
         usernames: t.Iterable[str] | str | None = None,
-        ids: t.Iterable[UUIDLike] | UUIDLike | None = None,
+        ids: t.Iterable[uuid.UUID | str] | uuid.UUID | str | None = None,
         provision: bool = False,
         query_params: dict[str, t.Any] | None = None,
     ) -> GetIdentitiesResponse:
@@ -374,7 +374,7 @@ class AuthClient(client.BaseClient):
         self,
         *,
         domains: t.Iterable[str] | str | None = None,
-        ids: t.Iterable[UUIDLike] | UUIDLike | None = None,
+        ids: t.Iterable[uuid.UUID | str] | uuid.UUID | str | None = None,
         query_params: dict[str, t.Any] | None = None,
     ) -> GetIdentityProvidersResponse:
         r"""
@@ -470,7 +470,7 @@ class AuthClient(client.BaseClient):
     # Developer APIs
     #
 
-    def get_project(self, project_id: UUIDLike) -> GlobusHTTPResponse:
+    def get_project(self, project_id: uuid.UUID | str) -> GlobusHTTPResponse:
         """
         Look up a project. Requires the ``manage_projects`` scope.
 
@@ -571,8 +571,8 @@ class AuthClient(client.BaseClient):
         display_name: str,
         contact_email: str,
         *,
-        admin_ids: UUIDLike | t.Iterable[UUIDLike] | None = None,
-        admin_group_ids: UUIDLike | t.Iterable[UUIDLike] | None = None,
+        admin_ids: uuid.UUID | str | t.Iterable[uuid.UUID | str] | None = None,
+        admin_group_ids: uuid.UUID | str | t.Iterable[uuid.UUID | str] | None = None,
     ) -> GlobusHTTPResponse:
         """
         Create a new project. Requires the ``manage_projects`` scope.
@@ -629,12 +629,12 @@ class AuthClient(client.BaseClient):
 
     def update_project(
         self,
-        project_id: UUIDLike,
+        project_id: uuid.UUID | str,
         *,
         display_name: str | None = None,
         contact_email: str | None = None,
-        admin_ids: UUIDLike | t.Iterable[UUIDLike] | None = None,
-        admin_group_ids: UUIDLike | t.Iterable[UUIDLike] | None = None,
+        admin_ids: uuid.UUID | str | t.Iterable[uuid.UUID | str] | None = None,
+        admin_group_ids: uuid.UUID | str | t.Iterable[uuid.UUID | str] | None = None,
     ) -> GlobusHTTPResponse:
         """
         Update a project. Requires the ``manage_projects`` scope.
@@ -683,7 +683,7 @@ class AuthClient(client.BaseClient):
             body["admin_group_ids"] = list(utils.safe_strseq_iter(admin_group_ids))
         return self.put(f"/v2/api/projects/{project_id}", data={"project": body})
 
-    def delete_project(self, project_id: UUIDLike) -> GlobusHTTPResponse:
+    def delete_project(self, project_id: uuid.UUID | str) -> GlobusHTTPResponse:
         """
         Delete a project. Requires the ``manage_projects`` scope.
 
@@ -712,7 +712,7 @@ class AuthClient(client.BaseClient):
         """
         return self.delete(f"/v2/api/projects/{project_id}")
 
-    def get_policy(self, policy_id: UUIDLike) -> GlobusHTTPResponse:
+    def get_policy(self, policy_id: uuid.UUID | str) -> GlobusHTTPResponse:
         """
         Look up a policy. Requires the ``manage_projects`` scope.
 
@@ -812,7 +812,7 @@ class AuthClient(client.BaseClient):
     def create_policy(  # pylint: disable=missing-param-doc
         self,
         *,
-        project_id: UUIDLike,
+        project_id: uuid.UUID | str,
         display_name: str,
         description: str,
         high_assurance: bool | utils.MissingType = utils.MISSING,
@@ -895,9 +895,9 @@ class AuthClient(client.BaseClient):
 
     def update_policy(
         self,
-        policy_id: UUIDLike,
+        policy_id: uuid.UUID | str,
         *,
-        project_id: UUIDLike | utils.MissingType = utils.MISSING,
+        project_id: uuid.UUID | str | utils.MissingType = utils.MISSING,
         authentication_assurance_timeout: int | utils.MissingType = utils.MISSING,
         required_mfa: bool | utils.MissingType = utils.MISSING,
         display_name: str | utils.MissingType = utils.MISSING,
@@ -958,7 +958,7 @@ class AuthClient(client.BaseClient):
         }
         return self.put(f"/v2/api/policies/{policy_id}", data={"policy": body})
 
-    def delete_policy(self, policy_id: UUIDLike) -> GlobusHTTPResponse:
+    def delete_policy(self, policy_id: uuid.UUID | str) -> GlobusHTTPResponse:
         """
         Delete a policy. Requires the ``manage_projects`` scope.
 
@@ -990,7 +990,7 @@ class AuthClient(client.BaseClient):
     def get_client(
         self,
         *,
-        client_id: UUIDLike | utils.MissingType = utils.MISSING,
+        client_id: uuid.UUID | str | utils.MissingType = utils.MISSING,
         fqdn: str | utils.MissingType = utils.MISSING,
     ) -> GlobusHTTPResponse:
         """
@@ -1139,7 +1139,7 @@ class AuthClient(client.BaseClient):
     def create_client(
         self,
         name: str,
-        project: UUIDLike,
+        project: uuid.UUID | str,
         *,
         public_client: bool | utils.MissingType = utils.MISSING,
         client_type: (
@@ -1157,8 +1157,8 @@ class AuthClient(client.BaseClient):
         redirect_uris: t.Iterable[str] | utils.MissingType = utils.MISSING,
         terms_and_conditions: str | utils.MissingType = utils.MISSING,
         privacy_policy: str | utils.MissingType = utils.MISSING,
-        required_idp: UUIDLike | utils.MissingType = utils.MISSING,
-        preselect_idp: UUIDLike | utils.MissingType = utils.MISSING,
+        required_idp: uuid.UUID | str | utils.MissingType = utils.MISSING,
+        preselect_idp: uuid.UUID | str | utils.MissingType = utils.MISSING,
         additional_fields: dict[str, t.Any] | utils.MissingType = utils.MISSING,
     ) -> GlobusHTTPResponse:
         """
@@ -1287,15 +1287,15 @@ class AuthClient(client.BaseClient):
 
     def update_client(
         self,
-        client_id: UUIDLike,
+        client_id: uuid.UUID | str,
         *,
         name: str | utils.MissingType = utils.MISSING,
         visibility: utils.MissingType | t.Literal["public", "private"] = utils.MISSING,
         redirect_uris: t.Iterable[str] | utils.MissingType = utils.MISSING,
         terms_and_conditions: str | None | utils.MissingType = utils.MISSING,
         privacy_policy: str | None | utils.MissingType = utils.MISSING,
-        required_idp: UUIDLike | None | utils.MissingType = utils.MISSING,
-        preselect_idp: UUIDLike | None | utils.MissingType = utils.MISSING,
+        required_idp: uuid.UUID | str | None | utils.MissingType = utils.MISSING,
+        preselect_idp: uuid.UUID | str | None | utils.MissingType = utils.MISSING,
         additional_fields: dict[str, t.Any] | utils.MissingType = utils.MISSING,
     ) -> GlobusHTTPResponse:
         """
@@ -1371,7 +1371,7 @@ class AuthClient(client.BaseClient):
 
         return self.put(f"/v2/api/clients/{client_id}", data={"client": body})
 
-    def delete_client(self, client_id: UUIDLike) -> GlobusHTTPResponse:
+    def delete_client(self, client_id: uuid.UUID | str) -> GlobusHTTPResponse:
         """
         Delete a client. Requires the ``manage_projects`` scope.
 
@@ -1400,7 +1400,7 @@ class AuthClient(client.BaseClient):
         """
         return self.delete(f"/v2/api/clients/{client_id}")
 
-    def get_client_credentials(self, client_id: UUIDLike) -> IterableResponse:
+    def get_client_credentials(self, client_id: uuid.UUID | str) -> IterableResponse:
         """
         Look up client credentials by ``client_id``.  Requires the
         ``manage_projects`` scope.
@@ -1443,7 +1443,7 @@ class AuthClient(client.BaseClient):
 
     def create_client_credential(
         self,
-        client_id: UUIDLike,
+        client_id: uuid.UUID | str,
         name: str,
     ) -> GlobusHTTPResponse:
         """
@@ -1492,8 +1492,8 @@ class AuthClient(client.BaseClient):
 
     def delete_client_credential(
         self,
-        client_id: UUIDLike,
-        credential_id: UUIDLike,
+        client_id: uuid.UUID | str,
+        credential_id: uuid.UUID | str,
     ) -> GlobusHTTPResponse:
         """
         Delete a credential. Requires the ``manage_projects`` scope.
@@ -1525,7 +1525,7 @@ class AuthClient(client.BaseClient):
         """
         return self.delete(f"/v2/api/clients/{client_id}/credentials/{credential_id}")
 
-    def get_scope(self, scope_id: UUIDLike) -> GlobusHTTPResponse:
+    def get_scope(self, scope_id: uuid.UUID | str) -> GlobusHTTPResponse:
         """
         Look up a scope by ``scope_id``.  Requires the ``manage_projects`` scope.
 
@@ -1571,7 +1571,9 @@ class AuthClient(client.BaseClient):
         self,
         *,
         scope_strings: t.Iterable[str] | str | utils.MissingType = utils.MISSING,
-        ids: t.Iterable[UUIDLike] | UUIDLike | utils.MissingType = utils.MISSING,
+        ids: (
+            t.Iterable[uuid.UUID | str] | uuid.UUID | str | utils.MissingType
+        ) = utils.MISSING,
         query_params: dict[str, t.Any] | utils.MissingType = utils.MISSING,
     ) -> IterableResponse:
         """
@@ -1660,7 +1662,7 @@ class AuthClient(client.BaseClient):
 
     def create_scope(
         self,
-        client_id: UUIDLike,
+        client_id: uuid.UUID | str,
         name: str,
         description: str,
         scope_suffix: str,
@@ -1731,7 +1733,7 @@ class AuthClient(client.BaseClient):
 
     def update_scope(
         self,
-        scope_id: UUIDLike,
+        scope_id: uuid.UUID | str,
         *,
         name: str | utils.MissingType = utils.MISSING,
         description: str | utils.MissingType = utils.MISSING,
@@ -1794,7 +1796,7 @@ class AuthClient(client.BaseClient):
 
         return self.put(f"/v2/api/scopes/{scope_id}", data={"scope": body})
 
-    def delete_scope(self, scope_id: UUIDLike) -> GlobusHTTPResponse:
+    def delete_scope(self, scope_id: uuid.UUID | str) -> GlobusHTTPResponse:
         """
         Delete a scope. Requires the ``manage_projects`` scope.
 
@@ -1825,7 +1827,7 @@ class AuthClient(client.BaseClient):
 
     def get_consents(
         self,
-        identity_id: UUIDLike,
+        identity_id: uuid.UUID | str,
         *,
         # pylint: disable=redefined-builtin
         all: bool = False,

--- a/src/globus_sdk/services/auth/data.py
+++ b/src/globus_sdk/services/auth/data.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
+import uuid
+
 from globus_sdk import utils
-from globus_sdk._types import UUIDLike
 
 
 class DependentScopeSpec(utils.PayloadWrapper):
@@ -18,7 +21,7 @@ class DependentScopeSpec(utils.PayloadWrapper):
 
     def __init__(
         self,
-        scope: UUIDLike,
+        scope: uuid.UUID | str,
         optional: bool,
         requires_refresh_token: bool,
     ) -> None:

--- a/src/globus_sdk/services/compute/client.py
+++ b/src/globus_sdk/services/compute/client.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import logging
 import typing as t
+import uuid
 
 from globus_sdk import MISSING, GlobusHTTPResponse, MissingType, client, utils
-from globus_sdk._types import UUIDLike
 from globus_sdk.scopes import ComputeScopes, Scope
 
 from .errors import ComputeAPIError
@@ -71,7 +71,7 @@ class ComputeClientV2(client.BaseClient):
         """
         return self.post("/v2/endpoints", data=data)
 
-    def get_endpoint(self, endpoint_id: UUIDLike) -> GlobusHTTPResponse:
+    def get_endpoint(self, endpoint_id: uuid.UUID | str) -> GlobusHTTPResponse:
         """Get information about a registered endpoint.
 
         :param endpoint_id: The ID of the Globus Compute endpoint.
@@ -86,7 +86,7 @@ class ComputeClientV2(client.BaseClient):
         """  # noqa: E501
         return self.get(f"/v2/endpoints/{endpoint_id}")
 
-    def get_endpoint_status(self, endpoint_id: UUIDLike) -> GlobusHTTPResponse:
+    def get_endpoint_status(self, endpoint_id: uuid.UUID | str) -> GlobusHTTPResponse:
         """Get the status of a registered endpoint.
 
         :param endpoint_id: The ID of the Globus Compute endpoint.
@@ -117,7 +117,7 @@ class ComputeClientV2(client.BaseClient):
         query_params = {"role": role}
         return self.get("/v2/endpoints", query_params=query_params)
 
-    def delete_endpoint(self, endpoint_id: UUIDLike) -> GlobusHTTPResponse:
+    def delete_endpoint(self, endpoint_id: uuid.UUID | str) -> GlobusHTTPResponse:
         """Delete a registered endpoint.
 
         :param endpoint_id: The ID of the Globus Compute endpoint.
@@ -132,7 +132,7 @@ class ComputeClientV2(client.BaseClient):
         """  # noqa: E501
         return self.delete(f"/v2/endpoints/{endpoint_id}")
 
-    def lock_endpoint(self, endpoint_id: UUIDLike) -> GlobusHTTPResponse:
+    def lock_endpoint(self, endpoint_id: uuid.UUID | str) -> GlobusHTTPResponse:
         """Temporarily block registration requests for the endpoint.
 
         :param endpoint_id: The ID of the Globus Compute endpoint.
@@ -165,7 +165,7 @@ class ComputeClientV2(client.BaseClient):
         """  # noqa: E501
         return self.post("/v2/functions", data=function_data)
 
-    def get_function(self, function_id: UUIDLike) -> GlobusHTTPResponse:
+    def get_function(self, function_id: uuid.UUID | str) -> GlobusHTTPResponse:
         """Get information about a registered function.
 
         :param function_id: The ID of the function.
@@ -180,7 +180,7 @@ class ComputeClientV2(client.BaseClient):
         """  # noqa: E501
         return self.get(f"/v2/functions/{function_id}")
 
-    def delete_function(self, function_id: UUIDLike) -> GlobusHTTPResponse:
+    def delete_function(self, function_id: uuid.UUID | str) -> GlobusHTTPResponse:
         """Delete a registered function.
 
         :param function_id: The ID of the function.
@@ -195,7 +195,7 @@ class ComputeClientV2(client.BaseClient):
         """  # noqa: E501
         return self.delete(f"/v2/functions/{function_id}")
 
-    def get_task(self, task_id: UUIDLike) -> GlobusHTTPResponse:
+    def get_task(self, task_id: uuid.UUID | str) -> GlobusHTTPResponse:
         """Get information about a task.
 
         :param task_id: The ID of the task.
@@ -211,7 +211,7 @@ class ComputeClientV2(client.BaseClient):
         return self.get(f"/v2/tasks/{task_id}")
 
     def get_task_batch(
-        self, task_ids: UUIDLike | t.Iterable[UUIDLike]
+        self, task_ids: uuid.UUID | str | t.Iterable[uuid.UUID | str]
     ) -> GlobusHTTPResponse:
         """Get information about a batch of tasks.
 
@@ -228,7 +228,7 @@ class ComputeClientV2(client.BaseClient):
         task_ids = list(utils.safe_strseq_iter(task_ids))
         return self.post("/v2/batch_status", data={"task_ids": task_ids})
 
-    def get_task_group(self, task_group_id: UUIDLike) -> GlobusHTTPResponse:
+    def get_task_group(self, task_group_id: uuid.UUID | str) -> GlobusHTTPResponse:
         """Get a list of task IDs associated with a task group.
 
         :param task_group_id: The ID of the task group.
@@ -287,7 +287,7 @@ class ComputeClientV3(client.BaseClient):
         return self.post("/v3/endpoints", data=data)
 
     def update_endpoint(
-        self, endpoint_id: UUIDLike, data: dict[str, t.Any]
+        self, endpoint_id: uuid.UUID | str, data: dict[str, t.Any]
     ) -> GlobusHTTPResponse:
         """Update an endpoint.
 
@@ -304,7 +304,7 @@ class ComputeClientV3(client.BaseClient):
         """  # noqa: E501
         return self.put(f"/v3/endpoints/{endpoint_id}", data=data)
 
-    def lock_endpoint(self, endpoint_id: UUIDLike) -> GlobusHTTPResponse:
+    def lock_endpoint(self, endpoint_id: uuid.UUID | str) -> GlobusHTTPResponse:
         """Temporarily block registration requests for the endpoint.
 
         :param endpoint_id: The ID of the Globus Compute endpoint.
@@ -319,7 +319,9 @@ class ComputeClientV3(client.BaseClient):
         """  # noqa: E501
         return self.post(f"/v3/endpoints/{endpoint_id}/lock")
 
-    def get_endpoint_allowlist(self, endpoint_id: UUIDLike) -> GlobusHTTPResponse:
+    def get_endpoint_allowlist(
+        self, endpoint_id: uuid.UUID | str
+    ) -> GlobusHTTPResponse:
         """Get a list of IDs for functions allowed to run on an endpoint.
 
         :param endpoint_id: The ID of the Globus Compute endpoint.
@@ -350,7 +352,7 @@ class ComputeClientV3(client.BaseClient):
         return self.post("/v3/functions", data=data)
 
     def submit(
-        self, endpoint_id: UUIDLike, data: dict[str, t.Any]
+        self, endpoint_id: uuid.UUID | str, data: dict[str, t.Any]
     ) -> GlobusHTTPResponse:
         """Submit a batch of tasks to a Globus Compute endpoint.
 

--- a/src/globus_sdk/services/compute/data.py
+++ b/src/globus_sdk/services/compute/data.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+import uuid
+
 from globus_sdk import utils
-from globus_sdk._types import UUIDLike
 from globus_sdk.exc import warn_deprecated
 from globus_sdk.utils import MISSING, MissingType
 
@@ -53,7 +54,7 @@ class ComputeFunctionDocument(utils.PayloadWrapper):
         function_code: str,
         description: str | MissingType = MISSING,
         metadata: ComputeFunctionMetadata | MissingType = MISSING,
-        group: UUIDLike | MissingType = MISSING,
+        group: uuid.UUID | str | MissingType = MISSING,
         public: bool = False,
     ) -> None:
         warn_deprecated("ComputeFunctionDocument is deprecated.")

--- a/src/globus_sdk/services/flows/client.py
+++ b/src/globus_sdk/services/flows/client.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import typing as t
+import uuid
 
 from globus_sdk import (
     GlobusHTTPResponse,
@@ -11,7 +12,6 @@ from globus_sdk import (
     paging,
     utils,
 )
-from globus_sdk._types import UUIDLike
 from globus_sdk.authorizers import GlobusAuthorizer
 from globus_sdk.globus_app import GlobusApp
 from globus_sdk.scopes import FlowsScopes, Scope, ScopeBuilder, SpecificFlowScopeBuilder
@@ -55,7 +55,7 @@ class FlowsClient(client.BaseClient):
         run_managers: list[str] | None = None,
         run_monitors: list[str] | None = None,
         keywords: list[str] | None = None,
-        subscription_id: UUIDLike | None = None,
+        subscription_id: uuid.UUID | str | None = None,
         additional_fields: dict[str, t.Any] | None = None,
     ) -> GlobusHTTPResponse:
         """
@@ -209,7 +209,7 @@ class FlowsClient(client.BaseClient):
 
     def get_flow(
         self,
-        flow_id: UUIDLike,
+        flow_id: uuid.UUID | str,
         *,
         query_params: dict[str, t.Any] | None = None,
     ) -> GlobusHTTPResponse:
@@ -377,7 +377,7 @@ class FlowsClient(client.BaseClient):
 
     def update_flow(
         self,
-        flow_id: UUIDLike,
+        flow_id: uuid.UUID | str,
         *,
         title: str | None = None,
         definition: dict[str, t.Any] | None = None,
@@ -391,7 +391,7 @@ class FlowsClient(client.BaseClient):
         run_managers: list[str] | None = None,
         run_monitors: list[str] | None = None,
         keywords: list[str] | None = None,
-        subscription_id: UUIDLike | t.Literal["DEFAULT"] | MissingType = MISSING,
+        subscription_id: uuid.UUID | str | t.Literal["DEFAULT"] | MissingType = MISSING,
         additional_fields: dict[str, t.Any] | None = None,
     ) -> GlobusHTTPResponse:
         """
@@ -538,7 +538,7 @@ class FlowsClient(client.BaseClient):
 
     def delete_flow(
         self,
-        flow_id: UUIDLike,
+        flow_id: uuid.UUID | str,
         *,
         query_params: dict[str, t.Any] | None = None,
     ) -> GlobusHTTPResponse:
@@ -618,7 +618,7 @@ class FlowsClient(client.BaseClient):
     def list_runs(
         self,
         *,
-        filter_flow_id: t.Iterable[UUIDLike] | UUIDLike | None = None,
+        filter_flow_id: t.Iterable[uuid.UUID | str] | uuid.UUID | str | None = None,
         filter_roles: str | t.Iterable[str] | None = None,
         marker: str | None = None,
         query_params: dict[str, t.Any] | None = None,
@@ -676,7 +676,7 @@ class FlowsClient(client.BaseClient):
     @paging.has_paginator(paging.MarkerPaginator, items_key="entries")
     def get_run_logs(
         self,
-        run_id: UUIDLike,
+        run_id: uuid.UUID | str,
         *,
         limit: int | None = None,
         reverse_order: bool | None = None,
@@ -727,7 +727,7 @@ class FlowsClient(client.BaseClient):
 
     def get_run(
         self,
-        run_id: UUIDLike,
+        run_id: uuid.UUID | str,
         *,
         include_flow_description: bool | None = None,
         query_params: dict[str, t.Any] | None = None,
@@ -772,7 +772,7 @@ class FlowsClient(client.BaseClient):
 
     def get_run_definition(
         self,
-        run_id: UUIDLike,
+        run_id: uuid.UUID | str,
     ) -> GlobusHTTPResponse:
         """
         Get the flow definition and input schema at the time the run was started.
@@ -803,7 +803,7 @@ class FlowsClient(client.BaseClient):
 
         return self.get(f"/runs/{run_id}/definition")
 
-    def cancel_run(self, run_id: UUIDLike) -> GlobusHTTPResponse:
+    def cancel_run(self, run_id: uuid.UUID | str) -> GlobusHTTPResponse:
         """
         Cancel a run.
 
@@ -836,7 +836,7 @@ class FlowsClient(client.BaseClient):
 
     def update_run(
         self,
-        run_id: UUIDLike,
+        run_id: uuid.UUID | str,
         *,
         label: str | None = None,
         tags: list[str] | None = None,
@@ -899,7 +899,7 @@ class FlowsClient(client.BaseClient):
 
         return self.put(f"/runs/{run_id}", data=data)
 
-    def delete_run(self, run_id: UUIDLike) -> GlobusHTTPResponse:
+    def delete_run(self, run_id: uuid.UUID | str) -> GlobusHTTPResponse:
         """
         Delete a run.
 
@@ -951,7 +951,7 @@ class SpecificFlowClient(client.BaseClient):
 
     def __init__(
         self,
-        flow_id: UUIDLike,
+        flow_id: uuid.UUID | str,
         *,
         environment: str | None = None,
         app: GlobusApp | None = None,
@@ -1029,7 +1029,7 @@ class SpecificFlowClient(client.BaseClient):
 
         return self.post(f"/flows/{self._flow_id}/run", data=data)
 
-    def resume_run(self, run_id: UUIDLike) -> GlobusHTTPResponse:
+    def resume_run(self, run_id: uuid.UUID | str) -> GlobusHTTPResponse:
         """
         :param run_id: The ID of the run to resume
 

--- a/src/globus_sdk/services/gcs/client.py
+++ b/src/globus_sdk/services/gcs/client.py
@@ -4,7 +4,6 @@ import typing as t
 import uuid
 
 from globus_sdk import client, exc, paging, response, scopes, utils
-from globus_sdk._types import UUIDLike
 from globus_sdk.authorizers import GlobusAuthorizer
 from globus_sdk.globus_app import GlobusApp
 from globus_sdk.scopes import Scope
@@ -106,7 +105,7 @@ class GCSClient(client.BaseClient):
         return scopes.GCSCollectionScopeBuilder(str(collection_id))
 
     @staticmethod
-    def connector_id_to_name(connector_id: UUIDLike) -> str | None:
+    def connector_id_to_name(connector_id: uuid.UUID | str) -> str | None:
         """
         .. warning::
 
@@ -280,7 +279,7 @@ class GCSClient(client.BaseClient):
     def get_collection_list(
         self,
         *,
-        mapped_collection_id: UUIDLike | None = None,
+        mapped_collection_id: uuid.UUID | str | None = None,
         filter: (  # pylint: disable=redefined-builtin
             str | t.Iterable[str] | None
         ) = None,
@@ -331,7 +330,7 @@ class GCSClient(client.BaseClient):
 
     def get_collection(
         self,
-        collection_id: UUIDLike,
+        collection_id: uuid.UUID | str,
         *,
         query_params: dict[str, t.Any] | None = None,
     ) -> UnpackingGCSResponse:
@@ -389,7 +388,7 @@ class GCSClient(client.BaseClient):
 
     def update_collection(
         self,
-        collection_id: UUIDLike,
+        collection_id: uuid.UUID | str,
         collection_data: dict[str, t.Any] | CollectionDocument,
         *,
         query_params: dict[str, t.Any] | None = None,
@@ -422,7 +421,7 @@ class GCSClient(client.BaseClient):
 
     def delete_collection(
         self,
-        collection_id: UUIDLike,
+        collection_id: uuid.UUID | str,
         *,
         query_params: dict[str, t.Any] | None = None,
     ) -> response.GlobusHTTPResponse:
@@ -528,7 +527,7 @@ class GCSClient(client.BaseClient):
 
     def get_storage_gateway(
         self,
-        storage_gateway_id: UUIDLike,
+        storage_gateway_id: uuid.UUID | str,
         *,
         include: None | str | t.Iterable[str] = None,
         query_params: dict[str, t.Any] | None = None,
@@ -568,7 +567,7 @@ class GCSClient(client.BaseClient):
 
     def update_storage_gateway(
         self,
-        storage_gateway_id: UUIDLike,
+        storage_gateway_id: uuid.UUID | str,
         data: dict[str, t.Any] | StorageGatewayDocument,
         *,
         query_params: dict[str, t.Any] | None = None,
@@ -633,7 +632,7 @@ class GCSClient(client.BaseClient):
     )
     def get_role_list(
         self,
-        collection_id: UUIDLike | None = None,
+        collection_id: uuid.UUID | str | None = None,
         include: str | None = None,
         page_size: int | None = None,
         marker: str | None = None,
@@ -707,7 +706,7 @@ class GCSClient(client.BaseClient):
 
     def get_role(
         self,
-        role_id: UUIDLike,
+        role_id: uuid.UUID | str,
         query_params: dict[str, t.Any] | None = None,
     ) -> UnpackingGCSResponse:
         """
@@ -731,7 +730,7 @@ class GCSClient(client.BaseClient):
 
     def delete_role(
         self,
-        role_id: UUIDLike,
+        role_id: uuid.UUID | str,
         query_params: dict[str, t.Any] | None = None,
     ) -> response.GlobusHTTPResponse:
         """
@@ -759,7 +758,7 @@ class GCSClient(client.BaseClient):
     )
     def get_user_credential_list(
         self,
-        storage_gateway: UUIDLike | None = None,
+        storage_gateway: uuid.UUID | str | None = None,
         query_params: dict[str, t.Any] | None = None,
         page_size: int | None = None,
         marker: str | None = None,
@@ -825,7 +824,7 @@ class GCSClient(client.BaseClient):
 
     def get_user_credential(
         self,
-        user_credential_id: UUIDLike,
+        user_credential_id: uuid.UUID | str,
         query_params: dict[str, t.Any] | None = None,
     ) -> UnpackingGCSResponse:
         """
@@ -851,7 +850,7 @@ class GCSClient(client.BaseClient):
 
     def update_user_credential(
         self,
-        user_credential_id: UUIDLike,
+        user_credential_id: uuid.UUID | str,
         data: dict[str, t.Any] | UserCredentialDocument,
         query_params: dict[str, t.Any] | None = None,
     ) -> UnpackingGCSResponse:
@@ -880,7 +879,7 @@ class GCSClient(client.BaseClient):
 
     def delete_user_credential(
         self,
-        user_credential_id: UUIDLike,
+        user_credential_id: uuid.UUID | str,
         query_params: dict[str, t.Any] | None = None,
     ) -> response.GlobusHTTPResponse:
         """

--- a/src/globus_sdk/services/gcs/connector_table.py
+++ b/src/globus_sdk/services/gcs/connector_table.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 import dataclasses
 import re
 import typing as t
-
-from globus_sdk._types import UUIDLike
+import uuid
 
 _NORMALIZATION_PATTERN = re.compile(r"[_\- ]+")
 
@@ -96,7 +95,7 @@ class ConnectorTable:
             yield item
 
     @classmethod
-    def lookup(cls, name_or_id: UUIDLike) -> GlobusConnectServerConnector | None:
+    def lookup(cls, name_or_id: uuid.UUID | str) -> GlobusConnectServerConnector | None:
         """
         Convert a name or ID into a connector object.
         Returns None if the name or ID is not recognized.
@@ -121,7 +120,7 @@ class ConnectorTable:
         cls,
         *,
         connector_name: str,
-        connector_id: UUIDLike,
+        connector_id: uuid.UUID | str,
         attribute_name: str | None = None,
     ) -> type[ConnectorTable]:
         """

--- a/src/globus_sdk/services/gcs/data/collection.py
+++ b/src/globus_sdk/services/gcs/data/collection.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import abc
 import typing as t
+import uuid
 
 from globus_sdk import utils
-from globus_sdk._types import UUIDLike
 
 from ._common import (
     DatatypeCallback,
@@ -153,7 +153,7 @@ class CollectionDocument(utils.PayloadWrapper, abc.ABC):
         department: str | None = None,
         description: str | None = None,
         display_name: str | None = None,
-        identity_id: UUIDLike | None = None,
+        identity_id: uuid.UUID | str | None = None,
         info_link: str | None = None,
         organization: str | None = None,
         restrict_transfers_to_high_assurance: (
@@ -276,7 +276,7 @@ class MappedCollectionDocument(CollectionDocument):
         department: str | None = None,
         description: str | None = None,
         display_name: str | None = None,
-        identity_id: UUIDLike | None = None,
+        identity_id: uuid.UUID | str | None = None,
         info_link: str | None = None,
         organization: str | None = None,
         restrict_transfers_to_high_assurance: (
@@ -298,8 +298,8 @@ class MappedCollectionDocument(CollectionDocument):
         # > specific args start <
         # strs
         domain_name: str | None = None,
-        guest_auth_policy_id: UUIDLike | None = None,
-        storage_gateway_id: UUIDLike | None = None,
+        guest_auth_policy_id: uuid.UUID | str | None = None,
+        storage_gateway_id: uuid.UUID | str | None = None,
         # str lists
         sharing_users_allow: t.Iterable[str] | None = None,
         sharing_users_deny: t.Iterable[str] | None = None,
@@ -420,7 +420,7 @@ class GuestCollectionDocument(CollectionDocument):
         department: str | None = None,
         description: str | None = None,
         display_name: str | None = None,
-        identity_id: UUIDLike | None = None,
+        identity_id: uuid.UUID | str | None = None,
         info_link: str | None = None,
         organization: str | None = None,
         restrict_transfers_to_high_assurance: (
@@ -442,8 +442,8 @@ class GuestCollectionDocument(CollectionDocument):
         associated_flow_policy: dict[str, t.Any] | None = None,
         # > common args end <
         # > specific args start <
-        mapped_collection_id: UUIDLike | None = None,
-        user_credential_id: UUIDLike | None = None,
+        mapped_collection_id: uuid.UUID | str | None = None,
+        user_credential_id: uuid.UUID | str | None = None,
         skip_auto_delete: bool | None = None,
         activity_notification_policy: dict[str, list[str]] | None = None,
         # > specific args end <

--- a/src/globus_sdk/services/gcs/data/role.py
+++ b/src/globus_sdk/services/gcs/data/role.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import typing as t
+import uuid
 
 from globus_sdk import utils
-from globus_sdk._types import UUIDLike
 
 
 class GCSRoleDocument(utils.PayloadWrapper):
@@ -24,7 +24,7 @@ class GCSRoleDocument(utils.PayloadWrapper):
     def __init__(
         self,
         DATA_TYPE: str = "role#1.0.0",
-        collection: UUIDLike | None = None,
+        collection: uuid.UUID | str | None = None,
         principal: str | None = None,
         role: str | None = None,
         additional_fields: dict[str, t.Any] | None = None,

--- a/src/globus_sdk/services/gcs/data/storage_gateway.py
+++ b/src/globus_sdk/services/gcs/data/storage_gateway.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import abc
 import typing as t
+import uuid
 
 from globus_sdk import utils
-from globus_sdk._types import UUIDLike
 
 from ._common import DatatypeCallback, ensure_datatype
 
@@ -58,7 +58,7 @@ class StorageGatewayDocument(utils.PayloadWrapper):
         self,
         DATA_TYPE: str | None = None,
         display_name: str | None = None,
-        connector_id: UUIDLike | None = None,
+        connector_id: uuid.UUID | str | None = None,
         root: str | None = None,
         identity_mappings: None | t.Iterable[dict[str, t.Any]] = None,
         policies: StorageGatewayPolicies | dict[str, t.Any] | None = None,

--- a/src/globus_sdk/services/gcs/data/user_credential.py
+++ b/src/globus_sdk/services/gcs/data/user_credential.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import typing as t
+import uuid
 
 from globus_sdk import utils
-from globus_sdk._types import UUIDLike
 
 
 class UserCredentialDocument(utils.PayloadWrapper):
@@ -27,11 +27,11 @@ class UserCredentialDocument(utils.PayloadWrapper):
     def __init__(
         self,
         DATA_TYPE: str = "user_credential#1.0.0",
-        identity_id: UUIDLike | None = None,
-        connector_id: UUIDLike | None = None,
+        identity_id: uuid.UUID | str | None = None,
+        connector_id: uuid.UUID | str | None = None,
         username: str | None = None,
         display_name: str | None = None,
-        storage_gateway_id: UUIDLike | None = None,
+        storage_gateway_id: uuid.UUID | str | None = None,
         policies: dict[str, t.Any] | None = None,
         additional_fields: dict[str, t.Any] | None = None,
     ) -> None:

--- a/src/globus_sdk/services/groups/client.py
+++ b/src/globus_sdk/services/groups/client.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import typing as t
+import uuid
 
 from globus_sdk import client, response, utils
-from globus_sdk._types import UUIDLike
 from globus_sdk.scopes import GroupsScopes, Scope
 
 from .data import BatchMembershipActions, GroupPolicies
@@ -59,7 +59,7 @@ class GroupsClient(client.BaseClient):
 
     def get_group(
         self,
-        group_id: UUIDLike,
+        group_id: uuid.UUID | str,
         *,
         include: None | str | t.Iterable[str] = None,
         query_params: dict[str, t.Any] | None = None,
@@ -90,7 +90,7 @@ class GroupsClient(client.BaseClient):
         return self.get(f"/groups/{group_id}", query_params=query_params)
 
     def get_group_by_subscription_id(
-        self, subscription_id: UUIDLike
+        self, subscription_id: uuid.UUID | str
     ) -> response.GlobusHTTPResponse:
         """
         Using a subscription ID, find the group which provides that subscription.
@@ -124,7 +124,7 @@ class GroupsClient(client.BaseClient):
 
     def delete_group(
         self,
-        group_id: UUIDLike,
+        group_id: uuid.UUID | str,
         *,
         query_params: dict[str, t.Any] | None = None,
     ) -> response.GlobusHTTPResponse:
@@ -172,7 +172,7 @@ class GroupsClient(client.BaseClient):
 
     def update_group(
         self,
-        group_id: UUIDLike,
+        group_id: uuid.UUID | str,
         data: dict[str, t.Any],
         *,
         query_params: dict[str, t.Any] | None = None,
@@ -198,7 +198,7 @@ class GroupsClient(client.BaseClient):
 
     def get_group_policies(
         self,
-        group_id: UUIDLike,
+        group_id: uuid.UUID | str,
         *,
         query_params: dict[str, t.Any] | None = None,
     ) -> response.GlobusHTTPResponse:
@@ -222,7 +222,7 @@ class GroupsClient(client.BaseClient):
 
     def set_group_policies(
         self,
-        group_id: UUIDLike,
+        group_id: uuid.UUID | str,
         data: dict[str, t.Any] | GroupPolicies,
         *,
         query_params: dict[str, t.Any] | None = None,
@@ -303,7 +303,7 @@ class GroupsClient(client.BaseClient):
 
     def get_membership_fields(
         self,
-        group_id: UUIDLike,
+        group_id: uuid.UUID | str,
         *,
         query_params: dict[str, t.Any] | None = None,
     ) -> response.GlobusHTTPResponse:
@@ -329,7 +329,7 @@ class GroupsClient(client.BaseClient):
 
     def set_membership_fields(
         self,
-        group_id: UUIDLike,
+        group_id: uuid.UUID | str,
         data: dict[t.Any, str],
         *,
         query_params: dict[str, t.Any] | None = None,
@@ -359,7 +359,7 @@ class GroupsClient(client.BaseClient):
 
     def batch_membership_action(
         self,
-        group_id: UUIDLike,
+        group_id: uuid.UUID | str,
         actions: dict[str, t.Any] | BatchMembershipActions,
         *,
         query_params: dict[str, t.Any] | None = None,

--- a/src/globus_sdk/services/groups/data.py
+++ b/src/globus_sdk/services/groups/data.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import enum
 import typing as t
+import uuid
 
 from globus_sdk import utils
-from globus_sdk._types import UUIDLike
 
 T = t.TypeVar("T")
 
@@ -105,7 +105,7 @@ class BatchMembershipActions(utils.PayloadWrapper):
     """
 
     def accept_invites(
-        self, identity_ids: t.Iterable[UUIDLike]
+        self, identity_ids: t.Iterable[uuid.UUID | str]
     ) -> BatchMembershipActions:
         """
         Accept invites for identities.  The identities must belong to
@@ -121,7 +121,7 @@ class BatchMembershipActions(utils.PayloadWrapper):
 
     def add_members(
         self,
-        identity_ids: t.Iterable[UUIDLike],
+        identity_ids: t.Iterable[uuid.UUID | str],
         *,
         role: _GROUP_ROLE_T = "member",
     ) -> BatchMembershipActions:
@@ -138,7 +138,7 @@ class BatchMembershipActions(utils.PayloadWrapper):
         return self
 
     def approve_pending(
-        self, identity_ids: t.Iterable[UUIDLike]
+        self, identity_ids: t.Iterable[uuid.UUID | str]
     ) -> BatchMembershipActions:
         """
         Approve a list of identities with pending join requests.
@@ -152,7 +152,7 @@ class BatchMembershipActions(utils.PayloadWrapper):
         return self
 
     def decline_invites(
-        self, identity_ids: t.Iterable[UUIDLike]
+        self, identity_ids: t.Iterable[uuid.UUID | str]
     ) -> BatchMembershipActions:
         """
         Decline an invitation for a given set of identities.
@@ -167,7 +167,7 @@ class BatchMembershipActions(utils.PayloadWrapper):
 
     def invite_members(
         self,
-        identity_ids: t.Iterable[UUIDLike],
+        identity_ids: t.Iterable[uuid.UUID | str],
         *,
         role: _GROUP_ROLE_T = "member",
     ) -> BatchMembershipActions:
@@ -183,7 +183,7 @@ class BatchMembershipActions(utils.PayloadWrapper):
         )
         return self
 
-    def join(self, identity_ids: t.Iterable[UUIDLike]) -> BatchMembershipActions:
+    def join(self, identity_ids: t.Iterable[uuid.UUID | str]) -> BatchMembershipActions:
         """
         Join a group with the given identities.  The identities must be in the
         authenticated users identity set.
@@ -196,7 +196,9 @@ class BatchMembershipActions(utils.PayloadWrapper):
         )
         return self
 
-    def leave(self, identity_ids: t.Iterable[UUIDLike]) -> BatchMembershipActions:
+    def leave(
+        self, identity_ids: t.Iterable[uuid.UUID | str]
+    ) -> BatchMembershipActions:
         """
         Leave a group that one of the identities in the authenticated user's
         identity set is a member of.
@@ -210,7 +212,7 @@ class BatchMembershipActions(utils.PayloadWrapper):
         return self
 
     def reject_join_requests(
-        self, identity_ids: t.Iterable[UUIDLike]
+        self, identity_ids: t.Iterable[uuid.UUID | str]
     ) -> BatchMembershipActions:
         """
         Reject identities which have requested to join the group.
@@ -224,7 +226,7 @@ class BatchMembershipActions(utils.PayloadWrapper):
         return self
 
     def remove_members(
-        self, identity_ids: t.Iterable[UUIDLike]
+        self, identity_ids: t.Iterable[uuid.UUID | str]
     ) -> BatchMembershipActions:
         """
         Remove members from a group.  This must be done as an admin or manager
@@ -239,7 +241,7 @@ class BatchMembershipActions(utils.PayloadWrapper):
         return self
 
     def request_join(
-        self, identity_ids: t.Iterable[UUIDLike]
+        self, identity_ids: t.Iterable[uuid.UUID | str]
     ) -> BatchMembershipActions:
         """
         Request to join a group.

--- a/src/globus_sdk/services/groups/manager.py
+++ b/src/globus_sdk/services/groups/manager.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import typing as t
+import uuid
 
 from globus_sdk import response
-from globus_sdk._types import UUIDLike
 
 from .client import GroupsClient
 from .data import (
@@ -32,7 +32,7 @@ class GroupsManager:
         name: str,
         description: str,
         *,
-        parent_id: UUIDLike | None = None,
+        parent_id: uuid.UUID | str | None = None,
     ) -> response.GlobusHTTPResponse:
         """
         Create a group with the given name.  If a parent ID is included, the
@@ -51,7 +51,7 @@ class GroupsManager:
 
     def set_group_policies(
         self,
-        group_id: UUIDLike,
+        group_id: uuid.UUID | str,
         *,
         is_high_assurance: bool,
         group_visibility: _GROUP_VISIBILITY_T,
@@ -84,7 +84,7 @@ class GroupsManager:
         return self.client.set_group_policies(group_id, data=data)
 
     def accept_invite(
-        self, group_id: UUIDLike, identity_id: UUIDLike
+        self, group_id: uuid.UUID | str, identity_id: uuid.UUID | str
     ) -> response.GlobusHTTPResponse:
         """
         Accept invite for an identity.  The identity must belong to
@@ -98,8 +98,8 @@ class GroupsManager:
 
     def add_member(
         self,
-        group_id: UUIDLike,
-        identity_id: UUIDLike,
+        group_id: uuid.UUID | str,
+        identity_id: uuid.UUID | str,
         *,
         role: _GROUP_ROLE_T = "member",
     ) -> response.GlobusHTTPResponse:
@@ -114,7 +114,7 @@ class GroupsManager:
         return self.client.batch_membership_action(group_id, actions)
 
     def approve_pending(
-        self, group_id: UUIDLike, identity_id: UUIDLike
+        self, group_id: uuid.UUID | str, identity_id: uuid.UUID | str
     ) -> response.GlobusHTTPResponse:
         """
         Approve an identity with a pending join request.
@@ -126,7 +126,7 @@ class GroupsManager:
         return self.client.batch_membership_action(group_id, actions)
 
     def decline_invite(
-        self, group_id: UUIDLike, identity_id: UUIDLike
+        self, group_id: uuid.UUID | str, identity_id: uuid.UUID | str
     ) -> response.GlobusHTTPResponse:
         """
         Decline an invitation for a given identity.
@@ -139,8 +139,8 @@ class GroupsManager:
 
     def invite_member(
         self,
-        group_id: UUIDLike,
-        identity_id: UUIDLike,
+        group_id: uuid.UUID | str,
+        identity_id: uuid.UUID | str,
         *,
         role: _GROUP_ROLE_T = "member",
     ) -> response.GlobusHTTPResponse:
@@ -155,7 +155,7 @@ class GroupsManager:
         return self.client.batch_membership_action(group_id, actions)
 
     def join(
-        self, group_id: UUIDLike, identity_id: UUIDLike
+        self, group_id: uuid.UUID | str, identity_id: uuid.UUID | str
     ) -> response.GlobusHTTPResponse:
         """
         Join a group with the given identity.  The identity must be in the
@@ -168,7 +168,7 @@ class GroupsManager:
         return self.client.batch_membership_action(group_id, actions)
 
     def leave(
-        self, group_id: UUIDLike, identity_id: UUIDLike
+        self, group_id: uuid.UUID | str, identity_id: uuid.UUID | str
     ) -> response.GlobusHTTPResponse:
         """
         Leave a group that one of the identities in the authenticated user's
@@ -181,7 +181,7 @@ class GroupsManager:
         return self.client.batch_membership_action(group_id, actions)
 
     def reject_join_request(
-        self, group_id: UUIDLike, identity_id: UUIDLike
+        self, group_id: uuid.UUID | str, identity_id: uuid.UUID | str
     ) -> response.GlobusHTTPResponse:
         """
         Reject a member that has requested to join the group.
@@ -193,7 +193,7 @@ class GroupsManager:
         return self.client.batch_membership_action(group_id, actions)
 
     def remove_member(
-        self, group_id: UUIDLike, identity_id: UUIDLike
+        self, group_id: uuid.UUID | str, identity_id: uuid.UUID | str
     ) -> response.GlobusHTTPResponse:
         """
         Remove a member from a group.  This must be done as an admin or manager
@@ -206,7 +206,7 @@ class GroupsManager:
         return self.client.batch_membership_action(group_id, actions)
 
     def request_join(
-        self, group_id: UUIDLike, identity_id: UUIDLike
+        self, group_id: uuid.UUID | str, identity_id: uuid.UUID | str
     ) -> response.GlobusHTTPResponse:
         """
         Request to join a group.

--- a/src/globus_sdk/services/search/client.py
+++ b/src/globus_sdk/services/search/client.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import logging
 import typing as t
+import uuid
 
 from globus_sdk import client, paging, response, utils
-from globus_sdk._types import UUIDLike
 from globus_sdk.exc.warnings import warn_deprecated
 from globus_sdk.scopes import Scope, SearchScopes
 
@@ -81,7 +81,7 @@ class SearchClient(client.BaseClient):
             "/v1/index", data={"display_name": display_name, "description": description}
         )
 
-    def delete_index(self, index_id: UUIDLike) -> response.GlobusHTTPResponse:
+    def delete_index(self, index_id: uuid.UUID | str) -> response.GlobusHTTPResponse:
         """
         Mark an index for deletion.
 
@@ -120,7 +120,7 @@ class SearchClient(client.BaseClient):
         log.debug(f"SearchClient.delete_index({index_id!r}, ...)")
         return self.delete(f"/v1/index/{index_id}")
 
-    def reopen_index(self, index_id: UUIDLike) -> response.GlobusHTTPResponse:
+    def reopen_index(self, index_id: uuid.UUID | str) -> response.GlobusHTTPResponse:
         """
         Reopen an index that has been marked for deletion, cancelling the deletion.
 
@@ -151,7 +151,7 @@ class SearchClient(client.BaseClient):
 
     def get_index(
         self,
-        index_id: UUIDLike,
+        index_id: uuid.UUID | str,
         *,
         query_params: dict[str, t.Any] | None = None,
     ) -> response.GlobusHTTPResponse:
@@ -231,7 +231,7 @@ class SearchClient(client.BaseClient):
     )
     def search(
         self,
-        index_id: UUIDLike,
+        index_id: uuid.UUID | str,
         q: str,
         *,
         offset: int = 0,
@@ -301,7 +301,7 @@ class SearchClient(client.BaseClient):
     )
     def post_search(
         self,
-        index_id: UUIDLike,
+        index_id: uuid.UUID | str,
         data: dict[str, t.Any] | SearchQuery,
         *,
         offset: int | None = None,
@@ -371,7 +371,7 @@ class SearchClient(client.BaseClient):
     @paging.has_paginator(paging.MarkerPaginator, items_key="gmeta")
     def scroll(
         self,
-        index_id: UUIDLike,
+        index_id: uuid.UUID | str,
         data: dict[str, t.Any] | SearchScrollQuery,
         *,
         marker: str | None = None,
@@ -423,7 +423,7 @@ class SearchClient(client.BaseClient):
     #
 
     def ingest(
-        self, index_id: UUIDLike, data: dict[str, t.Any]
+        self, index_id: uuid.UUID | str, data: dict[str, t.Any]
     ) -> response.GlobusHTTPResponse:
         """
         Write data to a Search index as an asynchronous task.
@@ -490,7 +490,7 @@ class SearchClient(client.BaseClient):
     #
 
     def delete_by_query(
-        self, index_id: UUIDLike, data: dict[str, t.Any]
+        self, index_id: uuid.UUID | str, data: dict[str, t.Any]
     ) -> response.GlobusHTTPResponse:
         """
         Delete data in a Search index as an asynchronous task, deleting all documents
@@ -534,7 +534,7 @@ class SearchClient(client.BaseClient):
 
     def batch_delete_by_subject(
         self,
-        index_id: UUIDLike,
+        index_id: uuid.UUID | str,
         subjects: t.Iterable[str],
         additional_params: dict[str, t.Any] | None = None,
     ) -> response.GlobusHTTPResponse:
@@ -590,7 +590,7 @@ class SearchClient(client.BaseClient):
 
     def get_subject(
         self,
-        index_id: UUIDLike,
+        index_id: uuid.UUID | str,
         subject: str,
         *,
         query_params: dict[str, t.Any] | None = None,
@@ -629,7 +629,7 @@ class SearchClient(client.BaseClient):
 
     def delete_subject(
         self,
-        index_id: UUIDLike,
+        index_id: uuid.UUID | str,
         subject: str,
         *,
         query_params: dict[str, t.Any] | None = None,
@@ -677,7 +677,7 @@ class SearchClient(client.BaseClient):
 
     def get_entry(
         self,
-        index_id: UUIDLike,
+        index_id: uuid.UUID | str,
         subject: str,
         *,
         entry_id: str | None = None,
@@ -734,7 +734,7 @@ class SearchClient(client.BaseClient):
         return self.get(f"/v1/index/{index_id}/entry", query_params=query_params)
 
     def create_entry(
-        self, index_id: UUIDLike, data: dict[str, t.Any]
+        self, index_id: uuid.UUID | str, data: dict[str, t.Any]
     ) -> response.GlobusHTTPResponse:
         """
         This API method is in effect an alias of ingest and is deprecated.
@@ -798,7 +798,7 @@ class SearchClient(client.BaseClient):
         return self.post(f"/v1/index/{index_id}/entry", data=data)
 
     def update_entry(
-        self, index_id: UUIDLike, data: dict[str, t.Any]
+        self, index_id: uuid.UUID | str, data: dict[str, t.Any]
     ) -> response.GlobusHTTPResponse:
         """
         This API method is in effect an alias of ingest and is deprecated.
@@ -846,7 +846,7 @@ class SearchClient(client.BaseClient):
 
     def delete_entry(
         self,
-        index_id: UUIDLike,
+        index_id: uuid.UUID | str,
         subject: str,
         *,
         entry_id: str | None = None,
@@ -907,7 +907,7 @@ class SearchClient(client.BaseClient):
 
     def get_task(
         self,
-        task_id: UUIDLike,
+        task_id: uuid.UUID | str,
         *,
         query_params: dict[str, t.Any] | None = None,
     ) -> response.GlobusHTTPResponse:
@@ -940,7 +940,7 @@ class SearchClient(client.BaseClient):
 
     def get_task_list(
         self,
-        index_id: UUIDLike,
+        index_id: uuid.UUID | str,
         *,
         query_params: dict[str, t.Any] | None = None,
     ) -> response.GlobusHTTPResponse:
@@ -978,7 +978,7 @@ class SearchClient(client.BaseClient):
 
     def create_role(
         self,
-        index_id: UUIDLike,
+        index_id: uuid.UUID | str,
         data: dict[str, t.Any],
         *,
         query_params: dict[str, t.Any] | None = None,
@@ -1022,7 +1022,7 @@ class SearchClient(client.BaseClient):
 
     def get_role_list(
         self,
-        index_id: UUIDLike,
+        index_id: uuid.UUID | str,
         *,
         query_params: dict[str, t.Any] | None = None,
     ) -> response.GlobusHTTPResponse:
@@ -1047,7 +1047,7 @@ class SearchClient(client.BaseClient):
 
     def delete_role(
         self,
-        index_id: UUIDLike,
+        index_id: uuid.UUID | str,
         role_id: str,
         *,
         query_params: dict[str, t.Any] | None = None,

--- a/src/globus_sdk/services/timers/client.py
+++ b/src/globus_sdk/services/timers/client.py
@@ -5,7 +5,6 @@ import typing as t
 import uuid
 
 from globus_sdk import _guards, client, exc, response
-from globus_sdk._types import UUIDLike
 from globus_sdk.scopes import (
     GCSCollectionScopeBuilder,
     Scope,
@@ -34,7 +33,7 @@ class TimersClient(client.BaseClient):
     default_scope_requirements = [Scope(TimersScopes.timer)]
 
     def add_app_transfer_data_access_scope(
-        self, collection_ids: UUIDLike | t.Iterable[UUIDLike]
+        self, collection_ids: uuid.UUID | str | t.Iterable[uuid.UUID | str]
     ) -> TimersClient:
         """
         Add a dependent ``data_access`` scope for one or more given ``collection_ids``
@@ -119,7 +118,7 @@ class TimersClient(client.BaseClient):
 
     def get_job(
         self,
-        job_id: UUIDLike,
+        job_id: uuid.UUID | str,
         *,
         query_params: dict[str, t.Any] | None = None,
     ) -> response.GlobusHTTPResponse:
@@ -212,7 +211,7 @@ class TimersClient(client.BaseClient):
         return self.post("/jobs/", data=data)
 
     def update_job(
-        self, job_id: UUIDLike, data: dict[str, t.Any]
+        self, job_id: uuid.UUID | str, data: dict[str, t.Any]
     ) -> response.GlobusHTTPResponse:
         """
         ``PATCH /jobs/<job_id>``
@@ -230,7 +229,7 @@ class TimersClient(client.BaseClient):
 
     def delete_job(
         self,
-        job_id: UUIDLike,
+        job_id: uuid.UUID | str,
     ) -> response.GlobusHTTPResponse:
         """
         ``DELETE /jobs/<job_id>``
@@ -247,7 +246,7 @@ class TimersClient(client.BaseClient):
 
     def pause_job(
         self,
-        job_id: UUIDLike,
+        job_id: uuid.UUID | str,
     ) -> response.GlobusHTTPResponse:
         """
         Make a timer job inactive, preventing it from running until it is resumed.
@@ -264,7 +263,7 @@ class TimersClient(client.BaseClient):
 
     def resume_job(
         self,
-        job_id: UUIDLike,
+        job_id: uuid.UUID | str,
         *,
         update_credentials: bool | None = None,
     ) -> response.GlobusHTTPResponse:

--- a/src/globus_sdk/services/transfer/client.py
+++ b/src/globus_sdk/services/transfer/client.py
@@ -6,7 +6,7 @@ import typing as t
 import uuid
 
 from globus_sdk import _guards, client, exc, paging, response, utils
-from globus_sdk._types import DateLike, IntLike, UUIDLike
+from globus_sdk._types import DateLike, IntLike
 from globus_sdk.scopes import GCSCollectionScopeBuilder, Scope, TransferScopes
 
 from .data import DeleteData, TransferData
@@ -112,7 +112,7 @@ class TransferClient(client.BaseClient):
     default_scope_requirements = [Scope(TransferScopes.all)]
 
     def add_app_data_access_scope(
-        self, collection_ids: UUIDLike | t.Iterable[UUIDLike]
+        self, collection_ids: uuid.UUID | str | t.Iterable[uuid.UUID | str]
     ) -> TransferClient:
         """
         Add a dependent ``data_access`` scope for one or more given ``collection_ids``
@@ -195,7 +195,7 @@ class TransferClient(client.BaseClient):
 
     def get_endpoint(
         self,
-        endpoint_id: UUIDLike,
+        endpoint_id: uuid.UUID | str,
         *,
         query_params: dict[str, t.Any] | None = None,
     ) -> response.GlobusHTTPResponse:
@@ -226,7 +226,7 @@ class TransferClient(client.BaseClient):
 
     def update_endpoint(
         self,
-        endpoint_id: UUIDLike,
+        endpoint_id: uuid.UUID | str,
         data: dict[str, t.Any],
         *,
         query_params: dict[str, t.Any] | None = None,
@@ -274,8 +274,8 @@ class TransferClient(client.BaseClient):
 
     def set_subscription_id(
         self,
-        collection_id: UUIDLike,
-        subscription_id: UUIDLike | t.Literal["DEFAULT"] | None,
+        collection_id: uuid.UUID | str,
+        subscription_id: uuid.UUID | str | t.Literal["DEFAULT"] | None,
     ) -> response.GlobusHTTPResponse:
         """
         Set the ``subscription_id`` on a mapped collection.
@@ -333,7 +333,7 @@ class TransferClient(client.BaseClient):
 
     def set_subscription_admin_verified(
         self,
-        collection_id: UUIDLike,
+        collection_id: uuid.UUID | str,
         subscription_admin_verified: bool,
     ) -> response.GlobusHTTPResponse:
         """
@@ -404,7 +404,9 @@ class TransferClient(client.BaseClient):
         log.debug("TransferClient.create_endpoint(...)")
         return self.post("endpoint", data=data)
 
-    def delete_endpoint(self, endpoint_id: UUIDLike) -> response.GlobusHTTPResponse:
+    def delete_endpoint(
+        self, endpoint_id: uuid.UUID | str
+    ) -> response.GlobusHTTPResponse:
         """
         :param endpoint_id: ID of endpoint to delete
 
@@ -440,7 +442,7 @@ class TransferClient(client.BaseClient):
         *,
         filter_scope: str | None = None,
         filter_owner_id: str | None = None,
-        filter_host_endpoint: UUIDLike | None = None,
+        filter_host_endpoint: uuid.UUID | str | None = None,
         filter_non_functional: bool | None = None,
         filter_entity_type: (
             t.Literal[
@@ -541,7 +543,7 @@ class TransferClient(client.BaseClient):
 
     def endpoint_autoactivate(
         self,
-        endpoint_id: UUIDLike,
+        endpoint_id: uuid.UUID | str,
         *,
         if_expires_in: int | None = None,
         query_params: dict[str, t.Any] | None = None,
@@ -570,7 +572,7 @@ class TransferClient(client.BaseClient):
 
     def endpoint_deactivate(
         self,
-        endpoint_id: UUIDLike,
+        endpoint_id: uuid.UUID | str,
         *,
         query_params: dict[str, t.Any] | None = None,
     ) -> response.GlobusHTTPResponse:
@@ -591,7 +593,7 @@ class TransferClient(client.BaseClient):
 
     def endpoint_activate(
         self,
-        endpoint_id: UUIDLike,
+        endpoint_id: uuid.UUID | str,
         *,
         requirements_data: dict[str, t.Any] | None,
         query_params: dict[str, t.Any] | None = None,
@@ -619,7 +621,7 @@ class TransferClient(client.BaseClient):
 
     def endpoint_get_activation_requirements(
         self,
-        endpoint_id: UUIDLike,
+        endpoint_id: uuid.UUID | str,
         *,
         query_params: dict[str, t.Any] | None = None,
     ) -> ActivationRequirementsResponse:
@@ -643,7 +645,7 @@ class TransferClient(client.BaseClient):
 
     def my_effective_pause_rule_list(
         self,
-        endpoint_id: UUIDLike,
+        endpoint_id: uuid.UUID | str,
         *,
         query_params: dict[str, t.Any] | None = None,
     ) -> IterableTransferResponse:
@@ -673,7 +675,7 @@ class TransferClient(client.BaseClient):
 
     def my_shared_endpoint_list(
         self,
-        endpoint_id: UUIDLike,
+        endpoint_id: uuid.UUID | str,
         *,
         query_params: dict[str, t.Any] | None = None,
     ) -> IterableTransferResponse:
@@ -704,7 +706,7 @@ class TransferClient(client.BaseClient):
     @paging.has_paginator(paging.NextTokenPaginator, items_key="shared_endpoints")
     def get_shared_endpoint_list(
         self,
-        endpoint_id: UUIDLike,
+        endpoint_id: uuid.UUID | str,
         *,
         max_results: int | None = None,
         next_token: str | None = None,
@@ -785,7 +787,7 @@ class TransferClient(client.BaseClient):
 
     def endpoint_server_list(
         self,
-        endpoint_id: UUIDLike,
+        endpoint_id: uuid.UUID | str,
         *,
         query_params: dict[str, t.Any] | None = None,
     ) -> IterableTransferResponse:
@@ -810,7 +812,7 @@ class TransferClient(client.BaseClient):
 
     def get_endpoint_server(
         self,
-        endpoint_id: UUIDLike,
+        endpoint_id: uuid.UUID | str,
         server_id: IntLike,
         *,
         query_params: dict[str, t.Any] | None = None,
@@ -837,7 +839,7 @@ class TransferClient(client.BaseClient):
         )
 
     def add_endpoint_server(
-        self, endpoint_id: UUIDLike, server_data: dict[str, t.Any]
+        self, endpoint_id: uuid.UUID | str, server_data: dict[str, t.Any]
     ) -> response.GlobusHTTPResponse:
         """
         .. warning::
@@ -853,7 +855,7 @@ class TransferClient(client.BaseClient):
 
     def update_endpoint_server(
         self,
-        endpoint_id: UUIDLike,
+        endpoint_id: uuid.UUID | str,
         server_id: IntLike,
         server_data: dict[str, t.Any],
     ) -> response.GlobusHTTPResponse:
@@ -875,7 +877,7 @@ class TransferClient(client.BaseClient):
         return self.put(f"endpoint/{endpoint_id}/server/{server_id}", data=server_data)
 
     def delete_endpoint_server(
-        self, endpoint_id: UUIDLike, server_id: IntLike
+        self, endpoint_id: uuid.UUID | str, server_id: IntLike
     ) -> response.GlobusHTTPResponse:
         """
         .. warning::
@@ -897,7 +899,7 @@ class TransferClient(client.BaseClient):
 
     def endpoint_role_list(
         self,
-        endpoint_id: UUIDLike,
+        endpoint_id: uuid.UUID | str,
         *,
         query_params: dict[str, t.Any] | None = None,
     ) -> IterableTransferResponse:
@@ -921,7 +923,7 @@ class TransferClient(client.BaseClient):
         )
 
     def add_endpoint_role(
-        self, endpoint_id: UUIDLike, role_data: dict[str, t.Any]
+        self, endpoint_id: uuid.UUID | str, role_data: dict[str, t.Any]
     ) -> response.GlobusHTTPResponse:
         """
         :param endpoint_id: The endpoint on which the role is being added
@@ -941,7 +943,7 @@ class TransferClient(client.BaseClient):
 
     def get_endpoint_role(
         self,
-        endpoint_id: UUIDLike,
+        endpoint_id: uuid.UUID | str,
         role_id: str,
         *,
         query_params: dict[str, t.Any] | None = None,
@@ -966,7 +968,7 @@ class TransferClient(client.BaseClient):
         )
 
     def delete_endpoint_role(
-        self, endpoint_id: UUIDLike, role_id: str
+        self, endpoint_id: uuid.UUID | str, role_id: str
     ) -> response.GlobusHTTPResponse:
         """
         :param endpoint_id: The endpoint on which the role applies
@@ -990,7 +992,7 @@ class TransferClient(client.BaseClient):
 
     def endpoint_acl_list(
         self,
-        endpoint_id: UUIDLike,
+        endpoint_id: uuid.UUID | str,
         *,
         query_params: dict[str, t.Any] | None = None,
     ) -> IterableTransferResponse:
@@ -1014,7 +1016,7 @@ class TransferClient(client.BaseClient):
 
     def get_endpoint_acl_rule(
         self,
-        endpoint_id: UUIDLike,
+        endpoint_id: uuid.UUID | str,
         rule_id: str,
         *,
         query_params: dict[str, t.Any] | None = None,
@@ -1041,7 +1043,7 @@ class TransferClient(client.BaseClient):
         )
 
     def add_endpoint_acl_rule(
-        self, endpoint_id: UUIDLike, rule_data: dict[str, t.Any]
+        self, endpoint_id: uuid.UUID | str, rule_data: dict[str, t.Any]
     ) -> response.GlobusHTTPResponse:
         """
         :param endpoint_id: ID of endpoint to which to add the acl
@@ -1079,7 +1081,7 @@ class TransferClient(client.BaseClient):
 
     def update_endpoint_acl_rule(
         self,
-        endpoint_id: UUIDLike,
+        endpoint_id: uuid.UUID | str,
         rule_id: str,
         rule_data: dict[str, t.Any],
     ) -> response.GlobusHTTPResponse:
@@ -1105,7 +1107,7 @@ class TransferClient(client.BaseClient):
         return self.put(f"endpoint/{endpoint_id}/access/{rule_id}", data=rule_data)
 
     def delete_endpoint_acl_rule(
-        self, endpoint_id: UUIDLike, rule_id: str
+        self, endpoint_id: uuid.UUID | str, rule_id: str
     ) -> response.GlobusHTTPResponse:
         """
         :param endpoint_id: The endpoint on which the access rule applies
@@ -1169,7 +1171,7 @@ class TransferClient(client.BaseClient):
 
     def get_bookmark(
         self,
-        bookmark_id: UUIDLike,
+        bookmark_id: uuid.UUID | str,
         *,
         query_params: dict[str, t.Any] | None = None,
     ) -> response.GlobusHTTPResponse:
@@ -1190,7 +1192,7 @@ class TransferClient(client.BaseClient):
         return self.get(f"bookmark/{bookmark_id}", query_params=query_params)
 
     def update_bookmark(
-        self, bookmark_id: UUIDLike, bookmark_data: dict[str, t.Any]
+        self, bookmark_id: uuid.UUID | str, bookmark_data: dict[str, t.Any]
     ) -> response.GlobusHTTPResponse:
         """
         :param bookmark_id: The ID of the bookmark to modify
@@ -1208,7 +1210,9 @@ class TransferClient(client.BaseClient):
         log.debug(f"TransferClient.update_bookmark({bookmark_id})")
         return self.put(f"bookmark/{bookmark_id}", data=bookmark_data)
 
-    def delete_bookmark(self, bookmark_id: UUIDLike) -> response.GlobusHTTPResponse:
+    def delete_bookmark(
+        self, bookmark_id: uuid.UUID | str
+    ) -> response.GlobusHTTPResponse:
         """
         :param bookmark_id: The ID of the bookmark to delete
 
@@ -1230,7 +1234,7 @@ class TransferClient(client.BaseClient):
 
     def operation_ls(
         self,
-        endpoint_id: UUIDLike,
+        endpoint_id: uuid.UUID | str,
         path: str | None = None,
         *,
         show_hidden: bool | None = None,
@@ -1342,7 +1346,7 @@ class TransferClient(client.BaseClient):
 
     def operation_mkdir(
         self,
-        endpoint_id: UUIDLike,
+        endpoint_id: uuid.UUID | str,
         path: str,
         *,
         local_user: str | None = None,
@@ -1388,7 +1392,7 @@ class TransferClient(client.BaseClient):
 
     def operation_rename(
         self,
-        endpoint_id: UUIDLike,
+        endpoint_id: uuid.UUID | str,
         oldpath: str,
         newpath: str,
         *,
@@ -1440,7 +1444,7 @@ class TransferClient(client.BaseClient):
 
     def operation_stat(
         self,
-        endpoint_id: UUIDLike,
+        endpoint_id: uuid.UUID | str,
         path: str | None = None,
         *,
         local_user: str | None = None,
@@ -1488,7 +1492,7 @@ class TransferClient(client.BaseClient):
 
     def operation_symlink(
         self,
-        endpoint_id: UUIDLike,
+        endpoint_id: uuid.UUID | str,
         symlink_target: str,
         path: str,
         *,
@@ -1770,7 +1774,7 @@ class TransferClient(client.BaseClient):
     )
     def task_event_list(
         self,
-        task_id: UUIDLike,
+        task_id: uuid.UUID | str,
         *,
         limit: int | None = None,
         offset: int | None = None,
@@ -1821,7 +1825,7 @@ class TransferClient(client.BaseClient):
 
     def get_task(
         self,
-        task_id: UUIDLike,
+        task_id: uuid.UUID | str,
         *,
         query_params: dict[str, t.Any] | None = None,
     ) -> response.GlobusHTTPResponse:
@@ -1843,7 +1847,7 @@ class TransferClient(client.BaseClient):
 
     def update_task(
         self,
-        task_id: UUIDLike,
+        task_id: uuid.UUID | str,
         data: dict[str, t.Any],
         *,
         query_params: dict[str, t.Any] | None = None,
@@ -1868,7 +1872,7 @@ class TransferClient(client.BaseClient):
         log.debug(f"TransferClient.update_task({task_id}, ...)")
         return self.put(f"task/{task_id}", data=data, query_params=query_params)
 
-    def cancel_task(self, task_id: UUIDLike) -> response.GlobusHTTPResponse:
+    def cancel_task(self, task_id: uuid.UUID | str) -> response.GlobusHTTPResponse:
         """
         Cancel a task which is still running.
 
@@ -1887,7 +1891,7 @@ class TransferClient(client.BaseClient):
         return self.post(f"task/{task_id}/cancel")
 
     def task_wait(
-        self, task_id: UUIDLike, *, timeout: int = 10, polling_interval: int = 10
+        self, task_id: uuid.UUID | str, *, timeout: int = 10, polling_interval: int = 10
     ) -> bool:
         r"""
         Wait until a Task is complete or fails, with a time limit. If the task
@@ -1991,7 +1995,7 @@ class TransferClient(client.BaseClient):
 
     def task_pause_info(
         self,
-        task_id: UUIDLike,
+        task_id: uuid.UUID | str,
         *,
         query_params: dict[str, t.Any] | None = None,
     ) -> response.GlobusHTTPResponse:
@@ -2018,7 +2022,7 @@ class TransferClient(client.BaseClient):
     )
     def task_successful_transfers(
         self,
-        task_id: UUIDLike,
+        task_id: uuid.UUID | str,
         *,
         marker: str | None = None,
         query_params: dict[str, t.Any] | None = None,
@@ -2075,7 +2079,7 @@ class TransferClient(client.BaseClient):
     )
     def task_skipped_errors(
         self,
-        task_id: UUIDLike,
+        task_id: uuid.UUID | str,
         *,
         marker: str | None = None,
         query_params: dict[str, t.Any] | None = None,
@@ -2151,7 +2155,7 @@ class TransferClient(client.BaseClient):
 
     def endpoint_manager_hosted_endpoint_list(
         self,
-        endpoint_id: UUIDLike,
+        endpoint_id: uuid.UUID | str,
         *,
         query_params: dict[str, t.Any] | None = None,
     ) -> IterableTransferResponse:
@@ -2182,7 +2186,7 @@ class TransferClient(client.BaseClient):
 
     def endpoint_manager_get_endpoint(
         self,
-        endpoint_id: UUIDLike,
+        endpoint_id: uuid.UUID | str,
         *,
         query_params: dict[str, t.Any] | None = None,
     ) -> response.GlobusHTTPResponse:
@@ -2208,7 +2212,7 @@ class TransferClient(client.BaseClient):
 
     def endpoint_manager_acl_list(
         self,
-        endpoint_id: UUIDLike,
+        endpoint_id: uuid.UUID | str,
         *,
         query_params: dict[str, t.Any] | None = None,
     ) -> IterableTransferResponse:
@@ -2246,9 +2250,9 @@ class TransferClient(client.BaseClient):
         self,
         *,
         filter_status: None | str | t.Iterable[str] = None,
-        filter_task_id: None | UUIDLike | t.Iterable[UUIDLike] = None,
-        filter_owner_id: UUIDLike | None = None,
-        filter_endpoint: UUIDLike | None = None,
+        filter_task_id: None | uuid.UUID | str | t.Iterable[uuid.UUID | str] = None,
+        filter_owner_id: uuid.UUID | str | None = None,
+        filter_endpoint: uuid.UUID | str | None = None,
         filter_endpoint_use: t.Literal["source", "destination"] | None = None,
         filter_is_paused: bool | None = None,
         filter_completion_time: None | str | tuple[DateLike, DateLike] = None,
@@ -2401,7 +2405,7 @@ class TransferClient(client.BaseClient):
 
     def endpoint_manager_get_task(
         self,
-        task_id: UUIDLike,
+        task_id: uuid.UUID | str,
         *,
         query_params: dict[str, t.Any] | None = None,
     ) -> response.GlobusHTTPResponse:
@@ -2433,7 +2437,7 @@ class TransferClient(client.BaseClient):
     )
     def endpoint_manager_task_event_list(
         self,
-        task_id: UUIDLike,
+        task_id: uuid.UUID | str,
         *,
         limit: int | None = None,
         offset: int | None = None,
@@ -2483,7 +2487,7 @@ class TransferClient(client.BaseClient):
 
     def endpoint_manager_task_pause_info(
         self,
-        task_id: UUIDLike,
+        task_id: uuid.UUID | str,
         *,
         query_params: dict[str, t.Any] | None = None,
     ) -> response.GlobusHTTPResponse:
@@ -2513,7 +2517,7 @@ class TransferClient(client.BaseClient):
     )
     def endpoint_manager_task_successful_transfers(
         self,
-        task_id: UUIDLike,
+        task_id: uuid.UUID | str,
         *,
         marker: str | None = None,
         query_params: dict[str, t.Any] | None = None,
@@ -2559,7 +2563,7 @@ class TransferClient(client.BaseClient):
     )
     def endpoint_manager_task_skipped_errors(
         self,
-        task_id: UUIDLike,
+        task_id: uuid.UUID | str,
         *,
         marker: str | None = None,
         query_params: dict[str, t.Any] | None = None,
@@ -2601,7 +2605,7 @@ class TransferClient(client.BaseClient):
 
     def endpoint_manager_cancel_tasks(
         self,
-        task_ids: t.Iterable[UUIDLike],
+        task_ids: t.Iterable[uuid.UUID | str],
         message: str,
         *,
         query_params: dict[str, t.Any] | None = None,
@@ -2634,7 +2638,7 @@ class TransferClient(client.BaseClient):
 
     def endpoint_manager_cancel_status(
         self,
-        admin_cancel_id: UUIDLike,
+        admin_cancel_id: uuid.UUID | str,
         *,
         query_params: dict[str, t.Any] | None = None,
     ) -> response.GlobusHTTPResponse:
@@ -2662,7 +2666,7 @@ class TransferClient(client.BaseClient):
 
     def endpoint_manager_pause_tasks(
         self,
-        task_ids: t.Iterable[UUIDLike],
+        task_ids: t.Iterable[uuid.UUID | str],
         message: str,
         *,
         query_params: dict[str, t.Any] | None = None,
@@ -2695,7 +2699,7 @@ class TransferClient(client.BaseClient):
 
     def endpoint_manager_resume_tasks(
         self,
-        task_ids: t.Iterable[UUIDLike],
+        task_ids: t.Iterable[uuid.UUID | str],
         *,
         query_params: dict[str, t.Any] | None = None,
     ) -> response.GlobusHTTPResponse:
@@ -2729,7 +2733,7 @@ class TransferClient(client.BaseClient):
     def endpoint_manager_pause_rule_list(
         self,
         *,
-        filter_endpoint: UUIDLike | None = None,
+        filter_endpoint: uuid.UUID | str | None = None,
         query_params: dict[str, t.Any] | None = None,
     ) -> IterableTransferResponse:
         """
@@ -2797,7 +2801,7 @@ class TransferClient(client.BaseClient):
 
     def endpoint_manager_get_pause_rule(
         self,
-        pause_rule_id: UUIDLike,
+        pause_rule_id: uuid.UUID | str,
         *,
         query_params: dict[str, t.Any] | None = None,
     ) -> response.GlobusHTTPResponse:
@@ -2824,7 +2828,7 @@ class TransferClient(client.BaseClient):
 
     def endpoint_manager_update_pause_rule(
         self,
-        pause_rule_id: UUIDLike,
+        pause_rule_id: uuid.UUID | str,
         data: dict[str, t.Any] | None,
     ) -> response.GlobusHTTPResponse:
         """
@@ -2861,7 +2865,7 @@ class TransferClient(client.BaseClient):
 
     def endpoint_manager_delete_pause_rule(
         self,
-        pause_rule_id: UUIDLike,
+        pause_rule_id: uuid.UUID | str,
         *,
         query_params: dict[str, t.Any] | None = None,
     ) -> response.GlobusHTTPResponse:

--- a/src/globus_sdk/services/transfer/data/delete_data.py
+++ b/src/globus_sdk/services/transfer/data/delete_data.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import datetime
 import logging
 import typing as t
+import uuid
 
 from globus_sdk import exc, utils
-from globus_sdk._types import UUIDLike
 
 if t.TYPE_CHECKING:
     import globus_sdk
@@ -87,10 +87,10 @@ class DeleteData(utils.PayloadWrapper):
     def __init__(
         self,
         transfer_client: globus_sdk.TransferClient | None = None,
-        endpoint: UUIDLike | None = None,
+        endpoint: uuid.UUID | str | None = None,
         *,
         label: str | None = None,
-        submission_id: UUIDLike | None = None,
+        submission_id: uuid.UUID | str | None = None,
         recursive: bool = False,
         ignore_missing: bool = False,
         interpret_globs: bool = False,

--- a/src/globus_sdk/services/transfer/data/transfer_data.py
+++ b/src/globus_sdk/services/transfer/data/transfer_data.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import datetime
 import logging
 import typing as t
+import uuid
 
 from globus_sdk import exc, utils
-from globus_sdk._types import UUIDLike
 
 if t.TYPE_CHECKING:
     import globus_sdk
@@ -164,11 +164,11 @@ class TransferData(utils.PayloadWrapper):
     def __init__(
         self,
         transfer_client: globus_sdk.TransferClient | None = None,
-        source_endpoint: UUIDLike | None = None,
-        destination_endpoint: UUIDLike | None = None,
+        source_endpoint: uuid.UUID | str | None = None,
+        destination_endpoint: uuid.UUID | str | None = None,
         *,
         label: str | None = None,
-        submission_id: UUIDLike | None = None,
+        submission_id: uuid.UUID | str | None = None,
         sync_level: (
             int | None | t.Literal["exists", "size", "mtime", "checksum"]
         ) = None,

--- a/src/globus_sdk/tokenstorage/v2/base.py
+++ b/src/globus_sdk/tokenstorage/v2/base.py
@@ -7,9 +7,9 @@ import pathlib
 import re
 import sys
 import typing as t
+import uuid
 
 import globus_sdk
-from globus_sdk._types import UUIDLike
 
 from .token_data import TokenStorageData
 
@@ -168,7 +168,7 @@ class FileTokenStorage(TokenStorage, metaclass=abc.ABCMeta):
     @classmethod
     def for_globus_app(
         cls,
-        client_id: UUIDLike,
+        client_id: uuid.UUID | str,
         app_name: str,
         config: GlobusAppConfig,
         namespace: str,
@@ -219,7 +219,7 @@ class FileTokenStorage(TokenStorage, metaclass=abc.ABCMeta):
 
 
 def _default_globus_app_filepath(
-    client_id: UUIDLike, app_name: str, environment: str
+    client_id: uuid.UUID | str, app_name: str, environment: str
 ) -> str:
     r"""
     Construct a default TokenStorage filepath for a GlobusApp.

--- a/src/globus_sdk/tokenstorage/v2/memory.py
+++ b/src/globus_sdk/tokenstorage/v2/memory.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 import typing as t
+import uuid
 
 from .base import TokenStorage
 from .token_data import TokenStorageData
 
 if t.TYPE_CHECKING:
-    from globus_sdk._types import UUIDLike
     from globus_sdk.globus_app import GlobusAppConfig
 
 
@@ -28,7 +28,7 @@ class MemoryTokenStorage(TokenStorage):
     def for_globus_app(
         cls,
         # pylint: disable=unused-argument
-        client_id: UUIDLike,
+        client_id: uuid.UUID | str,
         app_name: str,
         config: GlobusAppConfig,
         # pylint: enable=unused-argument

--- a/src/globus_sdk/tokenstorage/v2/validating_token_storage/errors.py
+++ b/src/globus_sdk/tokenstorage/v2/validating_token_storage/errors.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
+import uuid
 from datetime import datetime
 
 from globus_sdk import GlobusError, Scope
-from globus_sdk._types import UUIDLike
 
 
 class TokenValidationError(GlobusError):
@@ -24,7 +24,9 @@ class MissingIdentityError(IdentityValidationError, LookupError):
 class IdentityMismatchError(IdentityValidationError, ValueError):
     """The identity in a token response did not match the expected identity."""
 
-    def __init__(self, message: str, stored_id: UUIDLike, new_id: UUIDLike) -> None:
+    def __init__(
+        self, message: str, stored_id: uuid.UUID | str, new_id: uuid.UUID | str
+    ) -> None:
         super().__init__(message)
         self.stored_id = stored_id
         self.new_id = new_id

--- a/src/globus_sdk/utils.py
+++ b/src/globus_sdk/utils.py
@@ -10,8 +10,6 @@ import typing as t
 import uuid
 from base64 import b64encode
 
-from globus_sdk._types import UUIDLike
-
 T = t.TypeVar("T")
 R = t.TypeVar("R")
 
@@ -131,7 +129,7 @@ def safe_strseq_iter(
             yield str(x)
 
 
-def commajoin(val: UUIDLike | t.Iterable[UUIDLike]) -> str:
+def commajoin(val: uuid.UUID | str | t.Iterable[uuid.UUID | str]) -> str:
     # note that this explicit handling of Iterable allows for string-like objects to be
     # passed to this function and be stringified by the `str()` call
     if isinstance(val, collections.abc.Iterable):

--- a/tests/common/consents.py
+++ b/tests/common/consents.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 
 from globus_sdk import Scope
-from globus_sdk._types import UUIDLike
 from globus_sdk.scopes.consents import Consent, ConsentForest
 
 ScopeRepr = namedtuple("Scope", ["id", "name"])
@@ -21,11 +20,11 @@ class ConsentTest(Consent):
     Required fields: client, scope, scope_name
     """
 
-    client: UUIDLike
-    scope: UUIDLike
+    client: uuid.UUID | str
+    scope: uuid.UUID | str
     scope_name: str
     id: int = field(default_factory=lambda: uuid.uuid1().int)
-    effective_identity: UUIDLike = str(uuid.uuid4())
+    effective_identity: uuid.UUID | str = str(uuid.uuid4())
     dependency_path: list[int] = field(default_factory=list)
     created: datetime = field(
         default_factory=lambda: datetime.now() - timedelta(days=1)


### PR DESCRIPTION
This is not strictly necessary and importantly it isn't interpreted as
we'd like by Sphinx, so users are seeing the `UUIDLike` name in our
docs instead of the union.


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1258.org.readthedocs.build/en/1258/

<!-- readthedocs-preview globus-sdk-python end -->