### PR TITLE
Replace `ScopeCollectionType` alias with explicit expansion of types

### DIFF
--- a/src/globus_sdk/_types.py
+++ b/src/globus_sdk/_types.py
@@ -4,20 +4,10 @@ import datetime
 import typing as t
 import uuid
 
-if t.TYPE_CHECKING:
-    from globus_sdk.scopes import Scope
-
-
 # these types are aliases meant for internal use
 IntLike = t.Union[int, str]
 UUIDLike = t.Union[uuid.UUID, str]
 DateLike = t.Union[str, datetime.datetime]
-
-ScopeCollectionType = t.Union[
-    str,
-    "Scope",
-    t.Iterable["ScopeCollectionType"],
-]
 
 
 class ResponseLike(t.Protocol):

--- a/src/globus_sdk/authorizers/client_credentials.py
+++ b/src/globus_sdk/authorizers/client_credentials.py
@@ -4,8 +4,7 @@ import logging
 import typing as t
 
 import globus_sdk
-from globus_sdk._types import ScopeCollectionType
-from globus_sdk.scopes import scopes_to_str
+from globus_sdk.scopes import Scope, scopes_to_str
 
 from .renewing import RenewingAuthorizer
 
@@ -58,7 +57,7 @@ class ClientCredentialsAuthorizer(
     def __init__(
         self,
         confidential_client: globus_sdk.ConfidentialAppAuthClient,
-        scopes: ScopeCollectionType,
+        scopes: str | Scope | t.Iterable[str | Scope],
         *,
         access_token: str | None = None,
         expires_at: int | None = None,

--- a/src/globus_sdk/client.py
+++ b/src/globus_sdk/client.py
@@ -7,7 +7,6 @@ import urllib.parse
 
 from globus_sdk import GlobusSDKUsageError, config, exc
 from globus_sdk._classproperty import classproperty
-from globus_sdk._types import ScopeCollectionType
 from globus_sdk._utils import slash_join
 from globus_sdk.authorizers import GlobusAuthorizer
 from globus_sdk.paging import PaginatorTable
@@ -252,7 +251,9 @@ class BaseClient:
         # finally, register the scope requirements on the app side
         self._app.add_scope_requirements({self.resource_server: self.app_scopes})
 
-    def add_app_scope(self, scope_collection: ScopeCollectionType) -> BaseClient:
+    def add_app_scope(
+        self, scope_collection: str | Scope | t.Iterable[str | Scope]
+    ) -> BaseClient:
         """
         Add a given scope collection to this client's ``GlobusApp`` scope requirements
         for this client's ``resource_server``. This allows defining additional scope
@@ -263,8 +264,9 @@ class BaseClient:
         Raises ``GlobusSDKUsageError`` if this client was not initialized with a
             ``GlobusApp``.
 
-        :param scope_collection: A scope or scopes of ``ScopeCollectionType`` to be
-            added to the app's required scopes.
+        :param scope_collection: A scope or scopes of
+            ``str | Scope | t.Iterable[str | Scope]`` to be added to
+            the app's required scopes.
 
         .. tab-set::
 

--- a/src/globus_sdk/globus_app/app.py
+++ b/src/globus_sdk/globus_app/app.py
@@ -11,7 +11,7 @@ from globus_sdk import (
     GlobusSDKUsageError,
     IDTokenDecoder,
 )
-from globus_sdk._types import ScopeCollectionType, UUIDLike
+from globus_sdk._types import UUIDLike
 from globus_sdk.authorizers import GlobusAuthorizer
 from globus_sdk.gare import GlobusAuthorizationParameters
 from globus_sdk.scopes import AuthScopes, Scope, ScopeParser, scopes_to_scope_list
@@ -66,7 +66,9 @@ class GlobusApp(metaclass=abc.ABCMeta):
         login_client: AuthLoginClient | None = None,
         client_id: UUIDLike | None = None,
         client_secret: str | None = None,
-        scope_requirements: t.Mapping[str, ScopeCollectionType] | None = None,
+        scope_requirements: (
+            t.Mapping[str, str | Scope | t.Iterable[str | Scope]] | None
+        ) = None,
         config: GlobusAppConfig = DEFAULT_CONFIG,
     ) -> None:
         self.app_name = app_name
@@ -119,7 +121,10 @@ class GlobusApp(metaclass=abc.ABCMeta):
         consent_client.attach_globus_app(self, app_scopes=[AuthScopes.openid])
 
     def _resolve_scope_requirements(
-        self, scope_requirements: t.Mapping[str, ScopeCollectionType] | None
+        self,
+        scope_requirements: (
+            t.Mapping[str, str | Scope | t.Iterable[str | Scope]] | None
+        ),
     ) -> dict[str, list[Scope]]:
         if scope_requirements is None:
             return {}
@@ -408,7 +413,7 @@ class GlobusApp(metaclass=abc.ABCMeta):
             self._token_validation_error_handling_enabled = initial_val
 
     def add_scope_requirements(
-        self, scope_requirements: t.Mapping[str, ScopeCollectionType]
+        self, scope_requirements: t.Mapping[str, str | Scope | t.Iterable[str | Scope]]
     ) -> None:
         """
         Add given scope requirements to the app's scope requirements. Any duplicate

--- a/src/globus_sdk/globus_app/client_app.py
+++ b/src/globus_sdk/globus_app/client_app.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import typing as t
+
 from globus_sdk import AuthLoginClient, ConfidentialAppAuthClient, GlobusSDKUsageError
-from globus_sdk._types import ScopeCollectionType, UUIDLike
+from globus_sdk._types import UUIDLike
 from globus_sdk.gare import GlobusAuthorizationParameters
+from globus_sdk.scopes import Scope
 
 from .app import GlobusApp
 from .authorizer_factory import ClientCredentialsAuthorizerFactory
@@ -57,7 +60,9 @@ class ClientApp(GlobusApp):
         login_client: ConfidentialAppAuthClient | None = None,
         client_id: UUIDLike | None = None,
         client_secret: str | None = None,
-        scope_requirements: dict[str, ScopeCollectionType] | None = None,
+        scope_requirements: (
+            dict[str, str | Scope | t.Iterable[str | Scope]] | None
+        ) = None,
         config: GlobusAppConfig = DEFAULT_CONFIG,
     ) -> None:
         if config.login_flow_manager is not None:

--- a/src/globus_sdk/globus_app/user_app.py
+++ b/src/globus_sdk/globus_app/user_app.py
@@ -10,7 +10,7 @@ from globus_sdk import (
     NativeAppAuthClient,
     Scope,
 )
-from globus_sdk._types import ScopeCollectionType, UUIDLike
+from globus_sdk._types import UUIDLike
 from globus_sdk.gare import GlobusAuthorizationParameters
 from globus_sdk.login_flows import CommandLineLoginFlowManager, LoginFlowManager
 from globus_sdk.token_storage import (
@@ -80,7 +80,9 @@ class UserApp(GlobusApp):
         login_client: AuthLoginClient | None = None,
         client_id: UUIDLike | None = None,
         client_secret: str | None = None,
-        scope_requirements: t.Mapping[str, ScopeCollectionType] | None = None,
+        scope_requirements: (
+            t.Mapping[str, str | Scope | t.Iterable[str | Scope]] | None
+        ) = None,
         config: GlobusAppConfig = DEFAULT_CONFIG,
     ) -> None:
         super().__init__(

--- a/src/globus_sdk/services/auth/_common.py
+++ b/src/globus_sdk/services/auth/_common.py
@@ -8,15 +8,16 @@ import jwt
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 
 from globus_sdk._missing import MISSING, MissingType
-from globus_sdk._types import ScopeCollectionType
 from globus_sdk.exc import GlobusSDKUsageError
 from globus_sdk.response import GlobusHTTPResponse
-from globus_sdk.scopes import scopes_to_str
+from globus_sdk.scopes import Scope, scopes_to_str
 
 log = logging.getLogger(__name__)
 
 
-def stringify_requested_scopes(requested_scopes: ScopeCollectionType) -> str:
+def stringify_requested_scopes(
+    requested_scopes: str | Scope | t.Iterable[str | Scope],
+) -> str:
     requested_scopes_string: str = scopes_to_str(requested_scopes)
     if requested_scopes_string == "":
         raise GlobusSDKUsageError(

--- a/src/globus_sdk/services/auth/client/confidential_client.py
+++ b/src/globus_sdk/services/auth/client/confidential_client.py
@@ -6,9 +6,10 @@ import typing as t
 from globus_sdk import exc
 from globus_sdk._missing import MISSING, MissingType
 from globus_sdk._remarshal import commajoin, strseq_iter, strseq_listify
-from globus_sdk._types import ScopeCollectionType, UUIDLike
+from globus_sdk._types import UUIDLike
 from globus_sdk.authorizers import BasicAuthorizer
 from globus_sdk.response import GlobusHTTPResponse
+from globus_sdk.scopes import Scope
 
 from .._common import stringify_requested_scopes
 from ..flow_managers import GlobusAuthorizationCodeFlowManager
@@ -106,7 +107,7 @@ class ConfidentialAppAuthClient(AuthLoginClient):
         )
 
     def oauth2_client_credentials_tokens(
-        self, requested_scopes: ScopeCollectionType
+        self, requested_scopes: str | Scope | t.Iterable[str | Scope]
     ) -> OAuthClientCredentialsResponse:
         r"""
         Perform an OAuth2 Client Credentials Grant to get access tokens which
@@ -142,7 +143,7 @@ class ConfidentialAppAuthClient(AuthLoginClient):
     def oauth2_start_flow(
         self,
         redirect_uri: str,
-        requested_scopes: ScopeCollectionType,
+        requested_scopes: str | Scope | t.Iterable[str | Scope],
         *,
         state: str = "_default",
         refresh_tokens: bool = False,

--- a/src/globus_sdk/services/auth/client/native_client.py
+++ b/src/globus_sdk/services/auth/client/native_client.py
@@ -4,9 +4,10 @@ import logging
 import typing as t
 
 from globus_sdk._missing import MISSING, MissingType
-from globus_sdk._types import ScopeCollectionType, UUIDLike
+from globus_sdk._types import UUIDLike
 from globus_sdk.authorizers import NullAuthorizer
 from globus_sdk.response import GlobusHTTPResponse
+from globus_sdk.scopes import Scope
 
 from ..flow_managers import GlobusNativeAppFlowManager
 from ..response import OAuthRefreshTokenResponse
@@ -51,7 +52,7 @@ class NativeAppAuthClient(AuthLoginClient):
 
     def oauth2_start_flow(
         self,
-        requested_scopes: ScopeCollectionType,
+        requested_scopes: str | Scope | t.Iterable[str | Scope],
         *,
         redirect_uri: str | MissingType = MISSING,
         state: str = "_default",

--- a/src/globus_sdk/services/auth/flow_managers/authorization_code.py
+++ b/src/globus_sdk/services/auth/flow_managers/authorization_code.py
@@ -5,8 +5,8 @@ import typing as t
 import urllib.parse
 
 from globus_sdk._missing import filter_missing
-from globus_sdk._types import ScopeCollectionType
 from globus_sdk._utils import slash_join
+from globus_sdk.scopes import Scope
 
 from .._common import stringify_requested_scopes
 from ..response import OAuthAuthorizationCodeResponse
@@ -50,7 +50,7 @@ class GlobusAuthorizationCodeFlowManager(GlobusOAuthFlowManager):
         self,
         auth_client: globus_sdk.ConfidentialAppAuthClient,
         redirect_uri: str,
-        requested_scopes: ScopeCollectionType,
+        requested_scopes: str | Scope | t.Iterable[str | Scope],
         state: str = "_default",
         refresh_tokens: bool = False,
     ) -> None:

--- a/src/globus_sdk/services/auth/flow_managers/native_app.py
+++ b/src/globus_sdk/services/auth/flow_managers/native_app.py
@@ -9,9 +9,9 @@ import typing as t
 import urllib.parse
 
 from globus_sdk._missing import MISSING, MissingType, filter_missing
-from globus_sdk._types import ScopeCollectionType
 from globus_sdk._utils import slash_join
 from globus_sdk.exc import GlobusSDKUsageError
+from globus_sdk.scopes import Scope
 
 from .._common import stringify_requested_scopes
 from ..response import OAuthAuthorizationCodeResponse
@@ -103,7 +103,7 @@ class GlobusNativeAppFlowManager(GlobusOAuthFlowManager):
     def __init__(
         self,
         auth_client: globus_sdk.NativeAppAuthClient,
-        requested_scopes: ScopeCollectionType,
+        requested_scopes: str | Scope | t.Iterable[str | Scope],
         redirect_uri: str | MissingType = MISSING,
         state: str = "_default",
         verifier: str | MissingType = MISSING,

--- a/tests/non-pytest/mypy-ignore-tests/app_scope_requirements.py
+++ b/tests/non-pytest/mypy-ignore-tests/app_scope_requirements.py
@@ -1,12 +1,13 @@
 from globus_sdk import UserApp
 
-# declare scope data in the form of a subtype of the ScopeCollectionType (`list[str]`)
-# indexed in a dict, this is meant to be a subtype of the requirements data accepted
-# by `GlobusApp.add_scope_requirements`
+# declare scope data in the form of a subtype of the
+# `str | Scope | t.Iterable[str | Scope]` (`list[str]`) indexed in a dict,
+# this is meant to be a subtype of the requirements data accepted by
+# `GlobusApp.add_scope_requirements`
 #
-# this is a regression test for that being annotated as `dict[str, ScopeCollectionType]`
-# which will reject the input type because `dict` is a mutable container, and therefore
-# invariant
+# this is a regression test for that being annotated as
+# `dict[str, str | Scope | t.Iterable[str | Scope]]` which will reject the input
+# type because `dict` is a mutable container, and therefore invariant
 scopes: dict[str, list[str]] = {"foo": ["bar"]}
 my_app = UserApp("...", client_id="...")
 my_app.add_scope_requirements(scopes)

--- a/tests/non-pytest/mypy-ignore-tests/scope_collection_type.py
+++ b/tests/non-pytest/mypy-ignore-tests/scope_collection_type.py
@@ -1,5 +1,6 @@
+import typing as t
+
 import globus_sdk
-from globus_sdk._types import ScopeCollectionType
 from globus_sdk.scopes import Scope, scopes_to_str
 from globus_sdk.services.auth import (
     GlobusAuthorizationCodeFlowManager,
@@ -22,7 +23,7 @@ cc_client = globus_sdk.ConfidentialAppAuthClient(
 
 
 # this function should type-check okay
-def foo(x: ScopeCollectionType) -> str:
+def foo(x: str | Scope | t.Iterable[str | Scope]) -> str:
     return scopes_to_str(x)
 
 

--- a/tests/unit/scopes/test_scope_normalization.py
+++ b/tests/unit/scopes/test_scope_normalization.py
@@ -31,14 +31,26 @@ def test_scopes_to_str_roundtrip_simple_str_in_collection(scope_collection):
         ((Scope("scope1"), Scope("scope2")), "scope1 scope2"),
         ((Scope("scope1"), Scope("scope2"), "scope3"), "scope1 scope2 scope3"),
         (
-            ((Scope("scope1"), Scope("scope2")), "scope3 scope4"),
+            (Scope("scope1"), Scope("scope2"), "scope3 scope4"),
             "scope1 scope2 scope3 scope4",
         ),
-        (([[["bar"]]],), "bar"),
+        ([Scope("scope1"), "scope2", "scope3 scope4"], "scope1 scope2 scope3 scope4"),
     ),
 )
 def test_scopes_to_str_handles_mixed_data(scope_collection, expect_str):
     assert scopes_to_str(scope_collection) == expect_str
+
+
+@pytest.mark.parametrize(
+    "scope_collection",
+    (
+        ((Scope("scope1"), Scope("scope2")), "scope3 scope4"),
+        [["bar"]],
+    ),
+)
+def test_scopes_to_str_rejects_nested_iterables(scope_collection):
+    with pytest.raises(TypeError):
+        scopes_to_str(scope_collection)
 
 
 @pytest.mark.parametrize(
@@ -61,10 +73,10 @@ def test_scopes_to_scope_list_simple(scope_collection):
         ((Scope("scope1"), Scope("scope2")), "scope1 scope2"),
         ((Scope("scope1"), Scope("scope2"), "scope3"), "scope1 scope2 scope3"),
         (
-            ((Scope("scope1"), Scope("scope2")), "scope3 scope4"),
+            (Scope("scope1"), Scope("scope2"), "scope3 scope4"),
             "scope1 scope2 scope3 scope4",
         ),
-        (([[["bar"]]],), "bar"),
+        ([Scope("scope1"), "scope2", "scope3 scope4"], "scope1 scope2 scope3 scope4"),
     ),
 )
 def test_scopes_to_scope_list_handles_mixed_data(scope_collection, expect_str):
@@ -72,6 +84,18 @@ def test_scopes_to_scope_list_handles_mixed_data(scope_collection, expect_str):
 
     assert all(isinstance(scope, Scope) for scope in actual_list)
     assert _as_sorted_string(actual_list) == expect_str
+
+
+@pytest.mark.parametrize(
+    "scope_collection",
+    (
+        ((Scope("scope1"), Scope("scope2")), "scope3 scope4"),
+        [["bar"]],
+    ),
+)
+def test_scopes_to_list_rejects_nested_iterables(scope_collection):
+    with pytest.raises(TypeError):
+        scopes_to_scope_list(scope_collection)
 
 
 def test_scopes_to_scope_list_handles_dependent_scopes():


### PR DESCRIPTION
[sc-41884](https://app.shortcut.com/globus/story/41884/sdk-replace-scopecollectiontype-alias-with-explicit-expansion-of-types)

### Changes
- Removed `ScopeCollectionType` type alias.
- Replaced all usage sites of `ScopeCollectionType` with explicit `str | Scope | t.Iterable[str | Scope]` type annotations.
- Removed support for the former recursive scope definition in `globus_sdk.scopes.scopes_to_str` and `globus_sdk.scopes.scopes_to_scope_list`. Since all codepaths that previously supported recursive scope definitions rely on these helpers for scope normalization, this change removes recursive scope support across the entire SDK.
- Added tests to `tests/unit/scopes/test_scope_normalization.py` verifying `scopes_to_str` and `scopes_to_scope_list` now raise `TypeError` for nested iterables.
- Updated unit tests appropriately. 

Note: I opted not to remove `tests/non-pytest/mypy-ignore-tests/scope_collection_type.py` as it still validates there is consistent `requested_scopes` typing across the SDK. Happy to remove it though if reviewers feel it's redundant.