### PR TITLE
Remove a `.utcnow()` usage in a docstring

### DIFF
--- a/src/globus_sdk/services/timers/client.py
+++ b/src/globus_sdk/services/timers/client.py
@@ -190,13 +190,13 @@ class TimersClient(client.BaseClient):
 
         **Examples**
 
-        >>> from datetime import datetime, timedelta
+        >>> from datetime import datetime, timedelta, timezone
         >>> transfer_client = TransferClient(...)
         >>> transfer_data = TransferData(transfer_client, ...)
         >>> timer_client = globus_sdk.TimersClient(...)
         >>> job = TimerJob.from_transfer_data(
         ...     transfer_data,
-        ...     datetime.utcnow(),
+        ...     datetime.now(tz=timezone.utc).replace(tzinfo=None),
         ...     timedelta(days=14),
         ...     name="my-timer-job"
         ... )


### PR DESCRIPTION
I've been staring at this while working on another feature and decided to remove it in a separate PR.

This change still results in a timezone-unaware object, which matches what `.utcnow()` was producing.

<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1260.org.readthedocs.build/en/1260/

<!-- readthedocs-preview globus-sdk-python end -->