### PR TITLE
Fix the PR autofixer job to use fetch-depth=0

### DIFF
--- a/.github/workflows/update_pr_references.yaml
+++ b/.github/workflows/update_pr_references.yaml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.x'

--- a/changelog.d/20250716_105609_8730430+m1yag1_sc_43037_caller_info.rst
+++ b/changelog.d/20250716_105609_8730430+m1yag1_sc_43037_caller_info.rst
@@ -1,4 +1,4 @@
 Added
 -----
 
-- Add ``RequestCallerInfo`` data object to ``RequestsTransport.request`` for passing caller context information.
+- Add ``RequestCallerInfo`` data object to ``RequestsTransport.request`` for passing caller context information. (:pr:`1261`)


### PR DESCRIPTION
This fixer recently made a bad edit because it didn't observe the repo
correctly. The changelog fragment is also fixed here.

Attempting to reproduce the bad behavior, it seemed only to be
possible based on a shallow clone of the repo.


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1266.org.readthedocs.build/en/1266/

<!-- readthedocs-preview globus-sdk-python end -->