### PR TITLE
Split the RequestsTransport into two parts, introducing RetryConfiguration

### DIFF
--- a/changelog.d/20250721_202834_sirosen_change_transport_passing_style.rst
+++ b/changelog.d/20250721_202834_sirosen_change_transport_passing_style.rst
@@ -1,0 +1,25 @@
+Breaking Changes
+----------------
+
+- The ``RequestsTransport`` object has been refactored to separate it from
+  configuration which controls request retries. A new ``RetryConfiguration``
+  object is introduced and provided as ``client.retry_configuration`` on
+  all client types. The interface for controlling these configurations has been
+  updated. (:pr:`NUMBER`)
+
+  - The ``transport_class`` attribute has been removed from client classes.
+
+  - Clients now accept ``transport``, an instance of ``RequestsTransport``,
+    instead of ``transport_params``.
+
+  - Users seeking to customize the retry backoff, sleep maximum, and max
+    retries should now use ``retry_configuration``, as these are no longer
+    controlled through ``transport``.
+
+  - The capabilities of the ``RequestsTransport.tune()`` context manager have
+    been divided between ``RequestsTransport.tune()`` and
+    ``RetryConfiguration.tune()``.
+
+  - The retry configuration is exposed to retry checks as an attribute of the
+    ``RequestCallerInfo``, which is provided on the ``RetryContext``. As a
+    result, checks can examine the configuration.

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -321,6 +321,75 @@ Change:
     auth_client.oauth2_start_flow(requested_scopes=globus_sdk.TransferClient.scopes.all)
     authorize_url = auth_client.oauth2_get_authorize_url()
 
+Customizing the Transport Has Changed
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In version 3, SDK users could customize the ``RequestsTransport`` object
+contained within a client in two ways.
+One was to customize a client class by setting the ``transport_class`` class
+attribute, and the other was to pass ``transport_params`` to the client
+initializer.
+
+In version 4, these mechanisms have both been replaced.
+Client initialization now accepts a fully instantiated ``RequestsTransport``
+object, instead of ``transport_params``.
+And client classes now define a ``default_transport_factory`` attribute, which is a
+callable which returns a transport object.
+
+For users who are customizing the parameters to the transport class, either explicitly
+instantiate the transport object:
+
+.. code-block:: python
+
+    # globus-sdk v3
+    import globus_sdk
+
+    client = globus_sdk.GroupsClient(transport_params={"http_timeout": 120.0})
+
+    # globus-sdk v4
+    import globus_sdk
+    from globus_sdk.transport import RequestsTransport
+
+    client = globus_sdk.GroupsClient(transport=RequestsTransport(http_timeout=120.0))
+
+or use the ``tune()`` context manager:
+
+.. code-block:: python
+
+    # globus-sdk v3
+    import globus_sdk
+
+    client = globus_sdk.GroupsClient(transport_params={"http_timeout": 120.0})
+    my_groups = client.get_my_groups()
+
+    # globus-sdk v4
+    import globus_sdk
+
+    client = globus_sdk.GroupsClient()
+    with client.transport.tune(http_timeout=120.0):
+        my_groups = client.get_my_groups()
+
+For users who are customizing the transport class for a custom client, update like so:
+
+.. code-block:: python
+
+    # globus-sdk v3
+    import globus_sdk
+    from .mylibrary import CustomTransport
+
+
+    class MyClient(globus_sdk.GroupsClient):
+        transport_class = CustomTransport
+
+
+    # globus-sdk v4
+    import globus_sdk
+    from .mylibrary import CustomTransport
+
+
+    class MyClient(globus_sdk.GroupsClient):
+        default_transport_factory = CustomTransport
+
 From 1.x or 2.x to 3.0
 -----------------------
 

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -366,28 +366,21 @@ or use the ``tune()`` context manager:
     with client.transport.tune(http_timeout=120.0):
         my_groups = client.get_my_groups()
 
-Retry Check Mechanisms Moved to ``request_retry_checks``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Retry Check Configuration Moved to ``retry_configuration``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 In Globus SDK v3, a client's ``transport`` contained all of its retry
 behaviors, including the checks which are run on each request, the
 configuration of those checks, and the sleep and backoff behaviors.
 
 Under v4, the configuration of checks has been split off into a separate
-attribute of the client, ``request_retry_checks``. These can be directly
-inspected and modified, and separate per-service configuration of these checks
-from the user-instantiable ``transport`` object.
+attribute of the client, ``retry_configuration``.
 
-These changes impact users who were using a custom ``RequestsTransport`` class.
-The transport class no longer defines the HTTP status codes which drive the
-default retry checks.
-These capabilities have been moved to
-``globus_sdk.transport.DefaultRetryCheckCollection``, a new object which is
-configured on clients and which can be reconfigured in order to change these
-check behaviors.
+These changes primarily impact users who were using a custom
+``RequestsTransport`` class, and should simplify their usage.
 
-For example, users could previously declare a custom transport type which
-treats only 502s as transient errors which may resolve with a simple retry.
+For example, in order to treat only 502s as retriable transient errors, users
+previously had a custom transport type.
 This could then be configured on a custom client class:
 
 .. code-block:: python
@@ -407,10 +400,8 @@ This could then be configured on a custom client class:
 
     client = MyClientClass()
 
-Because the ``transport_class`` has been removed from clients, this mechanism
-has changed.
-In order to customize the same information, users should first instantiate a
-client and then modify the attributes of the ``request_retry_checks`` object:
+Under SDK v4, in order to customize the same information, users can simply
+client and then modify the attributes of the ``retry_configuration`` object:
 
 .. code-block:: python
 
@@ -418,13 +409,24 @@ client and then modify the attributes of the ``request_retry_checks`` object:
     import globus_sdk
 
     client = globus_sdk.GroupsClient()
-    client.request_retry_checks.transient_error_status_codes = (502,)
+    client.retry_configuration.transient_error_status_codes = (502,)
 
-.. note::
+Similar to the ``tune()`` context manager of ``RequestsTransport``, there is
+also a ``tune()`` context manager for the retry configuration. ``tune()``
+supports the ``max_sleep``, ``max_retries``, and ``backoff`` configurations,
+which users of ``RequestsTransport.tune()`` may already recognize.
+For example, users can suppress retries:
 
-    Client classes may use types for ``request_retry_checks`` other than
-    ``DefaultRetryCheckCollection``, but all SDK-defined clients use subclasses
-    of this type.
+.. code-block:: python
+
+    # globus-sdk v4
+    import globus_sdk
+
+    client = globus_sdk.GroupsClient()
+    with client.retry_configuration.tune(max_retries=1):
+        my_groups = client.get_my_groups()
+
+
 
 From 1.x or 2.x to 3.0
 -----------------------

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -330,14 +330,11 @@ One was to customize a client class by setting the ``transport_class`` class
 attribute, and the other was to pass ``transport_params`` to the client
 initializer.
 
-In version 4, these mechanisms have both been replaced.
-Client initialization now accepts a fully instantiated ``RequestsTransport``
-object, instead of ``transport_params``.
-And client classes now define a ``default_transport_factory`` attribute, which is a
-callable which returns a transport object.
+In version 4, these mechanisms have been replaced with support for passing a
+``RequestsTransport`` object directly to the initializer.
 
-For users who are customizing the parameters to the transport class, either explicitly
-instantiate the transport object:
+For users who are customizing the parameters to the transport class, they
+should now explicitly instantiate the transport object:
 
 .. code-block:: python
 
@@ -369,26 +366,65 @@ or use the ``tune()`` context manager:
     with client.transport.tune(http_timeout=120.0):
         my_groups = client.get_my_groups()
 
-For users who are customizing the transport class for a custom client, update like so:
+Retry Check Mechanisms Moved to ``request_retry_checks``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In Globus SDK v3, a client's ``transport`` contained all of its retry
+behaviors, including the checks which are run on each request, the
+configuration of those checks, and the sleep and backoff behaviors.
+
+Under v4, the configuration of checks has been split off into a separate
+attribute of the client, ``request_retry_checks``. These can be directly
+inspected and modified, and separate per-service configuration of these checks
+from the user-instantiable ``transport`` object.
+
+These changes impact users who were using a custom ``RequestsTransport`` class.
+The transport class no longer defines the HTTP status codes which drive the
+default retry checks.
+These capabilities have been moved to
+``globus_sdk.transport.DefaultRetryCheckCollection``, a new object which is
+configured on clients and which can be reconfigured in order to change these
+check behaviors.
+
+For example, users could previously declare a custom transport type which
+treats only 502s as transient errors which may resolve with a simple retry.
+This could then be configured on a custom client class:
 
 .. code-block:: python
 
     # globus-sdk v3
     import globus_sdk
-    from .mylibrary import CustomTransport
+    from globus_sdk.transport import RequestsTransport
 
 
-    class MyClient(globus_sdk.GroupsClient):
-        transport_class = CustomTransport
+    class MyTransport(RequestsTransport):
+        TRANSIENT_ERROR_STATUS_CODES = (502,)
 
+
+    class MyClientClass(globus_sdk.GroupsClient):
+        transport_class = MyTransport
+
+
+    client = MyClientClass()
+
+Because the ``transport_class`` has been removed from clients, this mechanism
+has changed.
+In order to customize the same information, users should first instantiate a
+client and then modify the attributes of the ``request_retry_checks`` object:
+
+.. code-block:: python
 
     # globus-sdk v4
     import globus_sdk
-    from .mylibrary import CustomTransport
 
+    client = globus_sdk.GroupsClient()
+    client.request_retry_checks.transient_error_status_codes = (502,)
 
-    class MyClient(globus_sdk.GroupsClient):
-        default_transport_factory = CustomTransport
+.. note::
+
+    Client classes may use types for ``request_retry_checks`` other than
+    ``DefaultRetryCheckCollection``, but all SDK-defined clients use subclasses
+    of this type.
 
 From 1.x or 2.x to 3.0
 -----------------------

--- a/src/globus_sdk/services/auth/client/base_login_client.py
+++ b/src/globus_sdk/services/auth/client/base_login_client.py
@@ -12,6 +12,7 @@ from globus_sdk._missing import MISSING, MissingType
 from globus_sdk.authorizers import GlobusAuthorizer, NullAuthorizer
 from globus_sdk.response import GlobusHTTPResponse
 from globus_sdk.scopes import AuthScopes, Scope
+from globus_sdk.transport import RequestsTransport
 
 from .._common import get_jwk_data, pem_decode_jwk_data
 from ..errors import AuthAPIError
@@ -52,14 +53,14 @@ class AuthLoginClient(client.BaseClient):
         base_url: str | None = None,
         authorizer: GlobusAuthorizer | None = None,
         app_name: str | None = None,
-        transport_params: dict[str, t.Any] | None = None,
+        transport: RequestsTransport | None = None,
     ) -> None:
         super().__init__(
             environment=environment,
             base_url=base_url,
             authorizer=authorizer,
             app_name=app_name,
-            transport_params=transport_params,
+            transport=transport,
         )
         self.client_id: str | None = str(client_id) if client_id is not None else None
         # an AuthClient may contain a GlobusOAuth2FlowManager in order to

--- a/src/globus_sdk/services/auth/client/confidential_client.py
+++ b/src/globus_sdk/services/auth/client/confidential_client.py
@@ -10,6 +10,7 @@ from globus_sdk._missing import MISSING, MissingType
 from globus_sdk.authorizers import BasicAuthorizer
 from globus_sdk.response import GlobusHTTPResponse
 from globus_sdk.scopes import Scope
+from globus_sdk.transport import RequestsTransport
 
 from .._common import stringify_requested_scopes
 from ..flow_managers import GlobusAuthorizationCodeFlowManager
@@ -52,7 +53,7 @@ class ConfidentialAppAuthClient(AuthLoginClient):
         environment: str | None = None,
         base_url: str | None = None,
         app_name: str | None = None,
-        transport_params: dict[str, t.Any] | None = None,
+        transport: RequestsTransport | None = None,
     ) -> None:
         super().__init__(
             client_id=client_id,
@@ -60,7 +61,7 @@ class ConfidentialAppAuthClient(AuthLoginClient):
             environment=environment,
             base_url=base_url,
             app_name=app_name,
-            transport_params=transport_params,
+            transport=transport,
         )
 
     def get_identities(

--- a/src/globus_sdk/services/auth/client/native_client.py
+++ b/src/globus_sdk/services/auth/client/native_client.py
@@ -8,6 +8,7 @@ from globus_sdk._missing import MISSING, MissingType
 from globus_sdk.authorizers import NullAuthorizer
 from globus_sdk.response import GlobusHTTPResponse
 from globus_sdk.scopes import Scope
+from globus_sdk.transport import RequestsTransport
 
 from ..flow_managers import GlobusNativeAppFlowManager
 from ..response import OAuthRefreshTokenResponse
@@ -39,7 +40,7 @@ class NativeAppAuthClient(AuthLoginClient):
         environment: str | None = None,
         base_url: str | None = None,
         app_name: str | None = None,
-        transport_params: dict[str, t.Any] | None = None,
+        transport: RequestsTransport | None = None,
     ) -> None:
         super().__init__(
             client_id=client_id,
@@ -47,7 +48,7 @@ class NativeAppAuthClient(AuthLoginClient):
             environment=environment,
             base_url=base_url,
             app_name=app_name,
-            transport_params=transport_params,
+            transport=transport,
         )
 
     def oauth2_start_flow(

--- a/src/globus_sdk/services/auth/client/service_client.py
+++ b/src/globus_sdk/services/auth/client/service_client.py
@@ -12,6 +12,7 @@ from globus_sdk._missing import MISSING, MissingType
 from globus_sdk.authorizers import GlobusAuthorizer
 from globus_sdk.response import GlobusHTTPResponse, IterableResponse
 from globus_sdk.scopes import AuthScopes, Scope
+from globus_sdk.transport import RequestsTransport
 
 if t.TYPE_CHECKING:
     from globus_sdk.globus_app import GlobusApp
@@ -79,7 +80,7 @@ class AuthClient(client.BaseClient):
         app_scopes: list[Scope] | None = None,
         authorizer: GlobusAuthorizer | None = None,
         app_name: str | None = None,
-        transport_params: dict[str, t.Any] | None = None,
+        transport: RequestsTransport | None = None,
     ) -> None:
         super().__init__(
             environment=environment,
@@ -88,7 +89,7 @@ class AuthClient(client.BaseClient):
             app_scopes=app_scopes,
             authorizer=authorizer,
             app_name=app_name,
-            transport_params=transport_params,
+            transport=transport,
         )
 
         self._client_id = str(client_id) if client_id is not None else None

--- a/src/globus_sdk/services/flows/client.py
+++ b/src/globus_sdk/services/flows/client.py
@@ -24,6 +24,7 @@ from globus_sdk.scopes import (
     SpecificFlowScopes,
     TransferScopes,
 )
+from globus_sdk.transport import RequestsTransport
 
 from .data import RunActivityNotificationPolicy
 from .errors import FlowsAPIError
@@ -936,7 +937,7 @@ class SpecificFlowClient(client.BaseClient):
         app_scopes: list[Scope] | None = None,
         authorizer: GlobusAuthorizer | None = None,
         app_name: str | None = None,
-        transport_params: dict[str, t.Any] | None = None,
+        transport: RequestsTransport | None = None,
     ) -> None:
         self._flow_id = flow_id
         self.scopes = SpecificFlowScopes(flow_id)
@@ -946,7 +947,7 @@ class SpecificFlowClient(client.BaseClient):
             environment=environment,
             authorizer=authorizer,
             app_name=app_name,
-            transport_params=transport_params,
+            transport=transport,
         )
 
     @property

--- a/src/globus_sdk/services/gcs/client.py
+++ b/src/globus_sdk/services/gcs/client.py
@@ -11,6 +11,7 @@ from globus_sdk._missing import MISSING, MissingType
 from globus_sdk.authorizers import GlobusAuthorizer
 from globus_sdk.globus_app import GlobusApp
 from globus_sdk.scopes import GCSCollectionScopes, GCSEndpointScopes, Scope
+from globus_sdk.transport import RequestsTransport
 
 from .connector_table import ConnectorTable
 from .data import (
@@ -57,7 +58,7 @@ class GCSClient(client.BaseClient):
         environment: str | None = None,
         authorizer: GlobusAuthorizer | None = None,
         app_name: str | None = None,
-        transport_params: dict[str, t.Any] | None = None,
+        transport: RequestsTransport | None = None,
     ) -> None:
         # check if the provided address was a DNS name or an HTTPS URL
         if not gcs_address.startswith("https://"):
@@ -77,7 +78,7 @@ class GCSClient(client.BaseClient):
             app_scopes=app_scopes,
             authorizer=authorizer,
             app_name=app_name,
-            transport_params=transport_params,
+            transport=transport,
         )
 
     @staticmethod

--- a/src/globus_sdk/services/transfer/client.py
+++ b/src/globus_sdk/services/transfer/client.py
@@ -129,7 +129,9 @@ class TransferClient(client.BaseClient):
     """
 
     service_name = "transfer"
-    transport_class: type[TransferRequestsTransport] = TransferRequestsTransport
+    default_transport_factory: t.Callable[[], TransferRequestsTransport] = (
+        TransferRequestsTransport
+    )
     error_class = TransferAPIError
     scopes = TransferScopes
     default_scope_requirements = [TransferScopes.all]

--- a/src/globus_sdk/services/transfer/client.py
+++ b/src/globus_sdk/services/transfer/client.py
@@ -15,7 +15,7 @@ from globus_sdk.scopes import GCSCollectionScopes, Scope, TransferScopes
 from .data import DeleteData, TransferData
 from .errors import TransferAPIError
 from .response import ActivationRequirementsResponse, IterableTransferResponse
-from .transport import TransferRequestsTransport
+from .transport import TransferDefaultRetryCheckCollection
 
 log = logging.getLogger(__name__)
 
@@ -129,12 +129,13 @@ class TransferClient(client.BaseClient):
     """
 
     service_name = "transfer"
-    default_transport_factory: t.Callable[[], TransferRequestsTransport] = (
-        TransferRequestsTransport
-    )
     error_class = TransferAPIError
     scopes = TransferScopes
     default_scope_requirements = [TransferScopes.all]
+
+    def _get_default_retry_checks(self) -> TransferDefaultRetryCheckCollection:
+        """Override the default retry checks."""
+        return TransferDefaultRetryCheckCollection()
 
     def add_app_data_access_scope(
         self, collection_ids: uuid.UUID | str | t.Iterable[uuid.UUID | str]

--- a/src/globus_sdk/services/transfer/transport.py
+++ b/src/globus_sdk/services/transfer/transport.py
@@ -20,8 +20,9 @@ class TransferDefaultRetryCheckCollection(DefaultRetryCheckCollection):
         :param ctx: The context object which describes the state of the request and the
             retries which may already have been attempted
         """
+        retry_config = ctx.caller_info.retry_configuration
         if ctx.response is not None and (
-            ctx.response.status_code in self.transient_error_status_codes
+            ctx.response.status_code in retry_config.transient_error_status_codes
         ):
             try:
                 code = ctx.response.json()["code"]

--- a/src/globus_sdk/services/transfer/transport.py
+++ b/src/globus_sdk/services/transfer/transport.py
@@ -1,13 +1,17 @@
 """
-Custom Transport class for the TransferClient that overrides
-default_check_transient_error
+Custom retry check collection for the TransferClient that overrides
+the default check_transient_error
 """
 
-from globus_sdk.transport import RequestsTransport, RetryCheckResult, RetryContext
+from globus_sdk.transport import (
+    DefaultRetryCheckCollection,
+    RetryCheckResult,
+    RetryContext,
+)
 
 
-class TransferRequestsTransport(RequestsTransport):
-    def default_check_transient_error(self, ctx: RetryContext) -> RetryCheckResult:
+class TransferDefaultRetryCheckCollection(DefaultRetryCheckCollection):
+    def check_transient_error(self, ctx: RetryContext) -> RetryCheckResult:
         """
         check for transient error status codes which could be resolved by
         retrying the request. Does not retry ExternalErrors or EndpointErrors
@@ -17,7 +21,7 @@ class TransferRequestsTransport(RequestsTransport):
             retries which may already have been attempted
         """
         if ctx.response is not None and (
-            ctx.response.status_code in self.TRANSIENT_ERROR_STATUS_CODES
+            ctx.response.status_code in self.transient_error_status_codes
         ):
             try:
                 code = ctx.response.json()["code"]

--- a/src/globus_sdk/transport/__init__.py
+++ b/src/globus_sdk/transport/__init__.py
@@ -1,8 +1,11 @@
 from ._clientinfo import GlobusClientInfo
+from .caller_info import RequestCallerInfo
+from .default_retry_checks import DefaultRetryCheckCollection
 from .encoders import FormRequestEncoder, JSONRequestEncoder, RequestEncoder
-from .requests import RequestCallerInfo, RequestsTransport
+from .requests import RequestsTransport
 from .retry import (
     RetryCheck,
+    RetryCheckCollection,
     RetryCheckFlags,
     RetryCheckResult,
     RetryCheckRunner,
@@ -14,11 +17,13 @@ __all__ = (
     "RequestsTransport",
     "RequestCallerInfo",
     "RetryCheck",
+    "RetryCheckCollection",
     "RetryCheckFlags",
     "RetryCheckResult",
     "RetryCheckRunner",
     "set_retry_check_flags",
     "RetryContext",
+    "DefaultRetryCheckCollection",
     "RequestEncoder",
     "JSONRequestEncoder",
     "FormRequestEncoder",

--- a/src/globus_sdk/transport/__init__.py
+++ b/src/globus_sdk/transport/__init__.py
@@ -8,10 +8,11 @@ from .retry import (
     RetryCheckCollection,
     RetryCheckFlags,
     RetryCheckResult,
-    RetryCheckRunner,
     RetryContext,
     set_retry_check_flags,
 )
+from .retry_check_runner import RetryCheckRunner
+from .retry_config import RetryConfiguration
 
 __all__ = (
     "RequestsTransport",
@@ -23,6 +24,7 @@ __all__ = (
     "RetryCheckRunner",
     "set_retry_check_flags",
     "RetryContext",
+    "RetryConfiguration",
     "DefaultRetryCheckCollection",
     "RequestEncoder",
     "JSONRequestEncoder",

--- a/src/globus_sdk/transport/caller_info.py
+++ b/src/globus_sdk/transport/caller_info.py
@@ -2,22 +2,22 @@ from __future__ import annotations
 
 from globus_sdk.authorizers import GlobusAuthorizer
 
-from .retry import RetryCheckCollection
+from .retry_config import RetryConfiguration
 
 
 class RequestCallerInfo:
     """
     Data object that holds contextual information about the caller of a request.
 
-    :param retry_checks: The configured retry checks for the call
+    :param retry_config: The configuration of retry checks for the call
     :param authorizer: The authorizer object from the client making the request
     """
 
     def __init__(
         self,
         *,
-        retry_checks: RetryCheckCollection,
+        retry_configuration: RetryConfiguration,
         authorizer: GlobusAuthorizer | None = None,
     ) -> None:
         self.authorizer = authorizer
-        self.retry_checks = retry_checks
+        self.retry_configuration = retry_configuration

--- a/src/globus_sdk/transport/caller_info.py
+++ b/src/globus_sdk/transport/caller_info.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from globus_sdk.authorizers import GlobusAuthorizer
+
+from .retry import RetryCheckCollection
+
+
+class RequestCallerInfo:
+    """
+    Data object that holds contextual information about the caller of a request.
+
+    :param retry_checks: The configured retry checks for the call
+    :param authorizer: The authorizer object from the client making the request
+    """
+
+    def __init__(
+        self,
+        *,
+        retry_checks: RetryCheckCollection,
+        authorizer: GlobusAuthorizer | None = None,
+    ) -> None:
+        self.authorizer = authorizer
+        self.retry_checks = retry_checks

--- a/src/globus_sdk/transport/default_retry_checks.py
+++ b/src/globus_sdk/transport/default_retry_checks.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import requests
+
+from .retry import (
+    RetryCheckCollection,
+    RetryCheckFlags,
+    RetryCheckResult,
+    RetryContext,
+    set_retry_check_flags,
+)
+
+
+class DefaultRetryCheckCollection(RetryCheckCollection):
+    """The default checks for the SDK.
+
+    :param retry_after_status_codes: status codes for responses which may have
+        a Retry-After header
+    :param transient_error_status_codes: status codes for error responses which
+        should generally be retried
+    :param expired_authorization_status_codes: status codes indicating that
+        authorization info was missing or expired
+    """
+
+    def __init__(
+        self,
+        *,
+        retry_after_status_codes: tuple[int, ...] = (429, 503),
+        transient_error_status_codes: tuple[int, ...] = (429, 500, 502, 503, 504),
+        expired_authorization_status_codes: tuple[int, ...] = (401,),
+    ) -> None:
+        super().__init__()
+
+        self.retry_after_status_codes = retry_after_status_codes
+        self.transient_error_status_codes = transient_error_status_codes
+        self.expired_authorization_status_codes = expired_authorization_status_codes
+
+        self.register_check(self.check_expired_authorization)
+        self.register_check(self.check_request_exception)
+        self.register_check(self.check_retry_after_header)
+        self.register_check(self.check_transient_error)
+
+    def check_request_exception(self, ctx: RetryContext) -> RetryCheckResult:
+        """
+        Check if a network error was encountered
+
+        :param ctx: The context object which describes the state of the request and the
+            retries which may already have been attempted.
+        """
+        if ctx.exception and isinstance(ctx.exception, requests.RequestException):
+            return RetryCheckResult.do_retry
+        return RetryCheckResult.no_decision
+
+    def check_retry_after_header(self, ctx: RetryContext) -> RetryCheckResult:
+        """
+        Check for a retry-after header if the response had a matching status
+
+        :param ctx: The context object which describes the state of the request and the
+            retries which may already have been attempted.
+        """
+        if (
+            ctx.response is None
+            or ctx.response.status_code not in self.retry_after_status_codes
+        ):
+            return RetryCheckResult.no_decision
+        retry_after = self.parse_retry_after(ctx.response)
+        if retry_after:
+            ctx.backoff = float(retry_after)
+        return RetryCheckResult.do_retry
+
+    def check_transient_error(self, ctx: RetryContext) -> RetryCheckResult:
+        """
+        Check for transient error status codes which could be resolved by retrying
+        the request
+
+        :param ctx: The context object which describes the state of the request and the
+            retries which may already have been attempted.
+        """
+        if ctx.response is not None and (
+            ctx.response.status_code in self.transient_error_status_codes
+        ):
+            return RetryCheckResult.do_retry
+        return RetryCheckResult.no_decision
+
+    @set_retry_check_flags(RetryCheckFlags.RUN_ONCE)
+    def check_expired_authorization(self, ctx: RetryContext) -> RetryCheckResult:
+        """
+        This check evaluates whether or not there is invalid or expired authorization
+        information which could be updated with some action -- most typically a token
+        refresh for an expired access token.
+
+        The check is flagged to only run once per request.
+
+        :param ctx: The context object which describes the state of the request and the
+            retries which may already have been attempted.
+        """
+        if (  # is the current check applicable?
+            ctx.response is None
+            or ctx.caller_info is None
+            or ctx.caller_info.authorizer is None
+            or ctx.response.status_code not in self.expired_authorization_status_codes
+        ):
+            return RetryCheckResult.no_decision
+
+        # run the authorizer's handler, and 'do_retry' if the handler indicated
+        # that it was able to make a change which should make the request retryable
+        if ctx.caller_info.authorizer.handle_missing_authorization():
+            return RetryCheckResult.do_retry
+        return RetryCheckResult.no_decision
+
+    def parse_retry_after(self, response: requests.Response) -> int | None:
+        """Get the 'Retry-After' header as an int."""
+        val = response.headers.get("Retry-After")
+        if not val:
+            return None
+        try:
+            return int(val)
+        except ValueError:
+            return None

--- a/src/globus_sdk/transport/requests.py
+++ b/src/globus_sdk/transport/requests.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import contextlib
 import logging
 import pathlib
-import random
 import time
 import typing as t
 
@@ -19,20 +18,11 @@ from globus_sdk.transport.encoders import (
 
 from ._clientinfo import GlobusClientInfo
 from .caller_info import RequestCallerInfo
-from .retry import (
-    RetryCheckRunner,
-    RetryContext,
-)
+from .retry import RetryContext
+from .retry_check_runner import RetryCheckRunner
+from .retry_config import RetryConfiguration
 
 log = logging.getLogger(__name__)
-
-
-def _exponential_backoff(ctx: RetryContext) -> float:
-    # respect any explicit backoff set on the context
-    if ctx.backoff is not None:
-        return ctx.backoff
-    # exponential backoff with jitter
-    return t.cast(float, (0.25 + 0.5 * random.random()) * (2**ctx.attempt))
 
 
 class RequestsTransport:
@@ -42,12 +32,8 @@ class RequestsTransport:
     It receives raw request information from a client class, and then performs the
     following steps
     - encode the data in a prepared request
-    - repeatedly send the request until no retry is requested
+    - repeatedly send the request until no retry is requested by the configured hooks
     - return the last response or reraise the last exception
-
-    Retry checks are registered as hooks on the Transport. Additional hooks can be
-    passed to the constructor via `retry_checks`. Or hooks can be added to an existing
-    transport via a decorator.
 
     If the maximum number of retries is reached, the final response or exception will
     be returned or raised.
@@ -58,13 +44,6 @@ class RequestsTransport:
         defaults to 60s but can be set via the ``GLOBUS_SDK_HTTP_TIMEOUT`` environment
         variable. Any value set via this parameter takes precedence over the environment
         variable.
-    :param retry_backoff: A function which determines how long to sleep between calls
-        based on the RetryContext. Defaults to exponential backoff with jitter based on
-        the context ``attempt`` number.
-    :param max_sleep: The maximum sleep time between retries (in seconds). If the
-        computed sleep time or the backoff requested by a retry check exceeds this
-        value, this amount of time will be used instead
-    :param max_retries: The maximum number of retries allowed by this transport
 
     :ivar dict[str, str] headers: The headers which are sent on every request. These
         may be augmented by the transport when sending requests.
@@ -86,9 +65,6 @@ class RequestsTransport:
         self,
         verify_ssl: bool | str | pathlib.Path | None = None,
         http_timeout: float | None = None,
-        retry_backoff: t.Callable[[RetryContext], float] = _exponential_backoff,
-        max_sleep: float | int = 10,
-        max_retries: int | None = None,
     ) -> None:
         self.session = requests.Session()
         self.verify_ssl = config.get_ssl_verify(verify_ssl)
@@ -102,13 +78,6 @@ class RequestsTransport:
             "User-Agent": self.user_agent,
             "X-Globus-Client-Info": self.globus_client_info.format(),
         }
-
-        # retry parameters
-        self.retry_backoff = retry_backoff
-        self.max_sleep = max_sleep
-        self.max_retries = (
-            max_retries if max_retries is not None else self.DEFAULT_MAX_RETRIES
-        )
 
     def close(self) -> None:
         """
@@ -154,29 +123,17 @@ class RequestsTransport:
         *,
         verify_ssl: bool | str | pathlib.Path | None = None,
         http_timeout: float | None = None,
-        retry_backoff: t.Callable[[RetryContext], float] | None = None,
-        max_sleep: float | int | None = None,
-        max_retries: int | None = None,
     ) -> t.Iterator[None]:
         """
         Temporarily adjust some of the request sending settings of the transport.
         This method works as a context manager, and will reset settings to their
         original values after it exits.
 
-        In particular, this can be used to temporarily adjust request-sending minutiae
-        like the ``http_timeout`` used.
-
         :param verify_ssl: Explicitly enable or disable SSL verification,
             or configure the path to a CA certificate bundle to use for SSL verification
         :param http_timeout: Explicitly set an HTTP timeout value in seconds
-        :param retry_backoff: A function which determines how long to sleep between
-            calls based on the RetryContext
-        :param max_sleep: The maximum sleep time between retries (in seconds). If the
-            computed sleep time or the backoff requested by a retry check exceeds this
-            value, this amount of time will be used instead
-        :param max_retries: The maximum number of retries allowed by this transport
 
-        **Examples**
+        **Example Usage**
 
         This can be used with any client class to temporarily set values in the context
         of one or more HTTP requests. To increase the HTTP request timeout from the
@@ -186,19 +143,11 @@ class RequestsTransport:
         >>> with client.transport.tune(http_timeout=120):
         >>>     foo = client.get_foo()
 
-        or to disable retries (note that this also disables the retry on
-        expired-and-refreshed credentials):
-
-        >>> client = ...  # any client class
-        >>> with client.transport.tune(max_retries=0):
-        >>>     foo = client.get_foo()
+        See also: :meth:`RetryConfiguration.tune`.
         """
         saved_settings = (
             self.verify_ssl,
             self.http_timeout,
-            self.retry_backoff,
-            self.max_sleep,
-            self.max_retries,
         )
         if verify_ssl is not None:
             if isinstance(verify_ssl, bool):
@@ -207,19 +156,10 @@ class RequestsTransport:
                 self.verify_ssl = str(verify_ssl)
         if http_timeout is not None:
             self.http_timeout = http_timeout
-        if retry_backoff is not None:
-            self.retry_backoff = retry_backoff
-        if max_sleep is not None:
-            self.max_sleep = max_sleep
-        if max_retries is not None:
-            self.max_retries = max_retries
         yield
         (
             self.verify_ssl,
             self.http_timeout,
-            self.retry_backoff,
-            self.max_sleep,
-            self.max_retries,
         ) = saved_settings
 
     def _encode(
@@ -259,7 +199,9 @@ class RequestsTransport:
             else:
                 req.headers.pop("Authorization", None)  # remove any possible value
 
-    def _retry_sleep(self, ctx: RetryContext) -> None:
+    def _retry_sleep(
+        self, retry_configuration: RetryConfiguration, ctx: RetryContext
+    ) -> None:
         """
         Given a retry context, compute the amount of time to sleep and sleep that much
         This is always the minimum of the backoff (run on the context) and the
@@ -268,8 +210,14 @@ class RequestsTransport:
         :param ctx: The context object which describes the state of the request and the
             retries which may already have been attempted.
         """
-        sleep_period = min(self.retry_backoff(ctx), self.max_sleep)
-        log.debug("request retry_sleep(%s) [max=%s]", sleep_period, self.max_sleep)
+        sleep_period = min(
+            retry_configuration.backoff(ctx), retry_configuration.max_sleep
+        )
+        log.debug(
+            "request retry_sleep(%s) [max=%s]",
+            sleep_period,
+            retry_configuration.max_sleep,
+        )
         time.sleep(sleep_period)
 
     def request(
@@ -291,7 +239,7 @@ class RequestsTransport:
         :param url: URL for the request
         :param method: HTTP request method, as an all caps string
         :param caller_info: Contextual information about the caller of the request,
-            including the authorizer.
+            including the authorizer and retry configuration.
         :param query_params: Parameters to be encoded as a query string
         :param headers: HTTP headers to add to the request
         :param data: Data to send as the request body. May pass through encoding.
@@ -309,10 +257,11 @@ class RequestsTransport:
         log.debug("starting request for %s", url)
         resp: requests.Response | None = None
         req = self._encode(method, url, query_params, data, headers, encoding)
-        checker = RetryCheckRunner(caller_info.retry_checks.checks)
+        retry_configuration = caller_info.retry_configuration
+        checker = RetryCheckRunner(retry_configuration.checks)
 
         log.debug("transport request state initialized")
-        for attempt in range(self.max_retries + 1):
+        for attempt in range(retry_configuration.max_retries + 1):
             log.debug("transport request retry cycle. attempt=%d", attempt)
             # add Authorization header, or (if it's a NullAuthorizer) possibly
             # explicitly remove the Authorization header
@@ -332,7 +281,10 @@ class RequestsTransport:
             except requests.RequestException as err:
                 log.debug("request hit error (RequestException)")
                 ctx.exception = err
-                if attempt >= self.max_retries or not checker.should_retry(ctx):
+                if (
+                    attempt >= retry_configuration.max_retries
+                    or not checker.should_retry(ctx)
+                ):
                     log.warning("request done (fail, error)")
                     raise exc.convert_request_exception(err)
                 log.debug("request may retry (should-retry=true)")
@@ -344,9 +296,9 @@ class RequestsTransport:
                 log.debug("request may retry, will check attempts")
 
             # the request will be retried, so sleep...
-            if attempt < self.max_retries:
+            if attempt < retry_configuration.max_retries:
                 log.debug("under attempt limit, will sleep")
-                self._retry_sleep(ctx)
+                self._retry_sleep(retry_configuration, ctx)
         if resp is None:
             raise ValueError("Somehow, retries ended without a response")
         log.warning("request reached max retries, done (fail, response)")

--- a/src/globus_sdk/transport/retry.py
+++ b/src/globus_sdk/transport/retry.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import enum
-import logging
 import typing as t
 
 import requests
@@ -9,9 +8,11 @@ import requests
 if t.TYPE_CHECKING:
     from .caller_info import RequestCallerInfo
 
-log = logging.getLogger(__name__)
-
 C = t.TypeVar("C", bound=t.Callable[..., t.Any])
+
+
+# alias useful for declaring retry-related types
+RetryCheck = t.Callable[["RetryContext"], "RetryCheckResult"]
 
 
 class RetryContext:
@@ -90,65 +91,6 @@ def set_retry_check_flags(flag: RetryCheckFlags) -> t.Callable[[C], C]:
     return decorator
 
 
-# types useful for declaring RetryCheckRunner and related types
-RetryCheck = t.Callable[[RetryContext], RetryCheckResult]
-
-
-class RetryCheckRunner:
-    """
-    A RetryCheckRunner is an object responsible for running retry checks over the
-    lifetime of a request. Unlike the checks or the retry context, the runner persists
-    between retries. It can therefore implement special logic for checks like "only try
-    this check once".
-
-    Its primary responsibility is to answer the question "should_retry(context)?" with a
-    boolean.
-
-    It takes as its input a list of checks. Checks may be paired with flags to indicate
-    their configuration options. When not paired with flags, the flags are taken to be
-    "NONE".
-
-    Supported flags:
-
-    ``RUN_ONCE``
-      The check will run at most once for a given request. Once it has run, it is
-      recorded as "has_run" and will not be run again on that request.
-    """
-
-    # check configs: a list of pairs, (check, flags)
-    # a check without flags is assumed to have flags=NONE
-    def __init__(self, checks: t.Iterable[RetryCheck]) -> None:
-        self._checks: list[RetryCheck] = []
-        self._check_data: dict[RetryCheck, dict[str, t.Any]] = {}
-        for check in checks:
-            self._checks.append(check)
-            self._check_data[check] = {}
-
-    def should_retry(self, context: RetryContext) -> bool:
-        for check in self._checks:
-            flags = getattr(check, "_retry_check_flags", RetryCheckFlags.NONE)
-
-            if flags & RetryCheckFlags.RUN_ONCE:
-                if self._check_data[check].get("has_run"):
-                    continue
-                else:
-                    self._check_data[check]["has_run"] = True
-
-            result = check(context)
-            log.debug(  # try to get name but don't fail if it's not a function...
-                "ran retry check (%s) => %s", getattr(check, "__name__", check), result
-            )
-            if result is RetryCheckResult.no_decision:
-                continue
-            elif result is RetryCheckResult.do_not_retry:
-                return False
-            else:
-                return True
-
-        # fallthrough: don't retry any request which isn't marked for retry
-        return False
-
-
 class RetryCheckCollection:
     """
     A RetryCheckCollection is an ordered collection of retry checks which are
@@ -160,7 +102,7 @@ class RetryCheckCollection:
       (except via the backoff which may be set)
     - what kinds of request parameters (e.g., timeouts) are used
 
-    It *only* contains `RetryCheck` methods which can look at a response or
+    It *only* contains ``RetryCheck`` methods which can look at a response or
     error and decide whether or not to retry.
     """
 

--- a/src/globus_sdk/transport/retry_check_runner.py
+++ b/src/globus_sdk/transport/retry_check_runner.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import logging
+import typing as t
+
+from .retry import RetryCheck, RetryCheckFlags, RetryCheckResult, RetryContext
+
+log = logging.getLogger(__name__)
+
+
+class RetryCheckRunner:
+    """
+    A RetryCheckRunner is an object responsible for running retry checks over the
+    lifetime of a request. Unlike the checks or the retry context, the runner persists
+    between retries. It can therefore implement special logic for checks like "only try
+    this check once".
+
+    Its primary responsibility is to answer the question "should_retry(context)?" with a
+    boolean.
+
+    It takes as its input a list of checks. Checks may be paired with flags to indicate
+    their configuration options. When not paired with flags, the flags are taken to be
+    "NONE".
+
+    Supported flags:
+
+    ``RUN_ONCE``
+      The check will run at most once for a given request. Once it has run, it is
+      recorded as "has_run" and will not be run again on that request.
+    """
+
+    # check configs: a list of pairs, (check, flags)
+    # a check without flags is assumed to have flags=NONE
+    def __init__(self, checks: t.Iterable[RetryCheck]) -> None:
+        self._checks: list[RetryCheck] = []
+        self._check_data: dict[RetryCheck, dict[str, t.Any]] = {}
+        for check in checks:
+            self._checks.append(check)
+            self._check_data[check] = {}
+
+    def should_retry(self, context: RetryContext) -> bool:
+        for check in self._checks:
+            flags = getattr(check, "_retry_check_flags", RetryCheckFlags.NONE)
+
+            if flags & RetryCheckFlags.RUN_ONCE:
+                if self._check_data[check].get("has_run"):
+                    continue
+                else:
+                    self._check_data[check]["has_run"] = True
+
+            result = check(context)
+            log.debug(  # try to get name but don't fail if it's not a function...
+                "ran retry check (%s) => %s", getattr(check, "__name__", check), result
+            )
+            if result is RetryCheckResult.no_decision:
+                continue
+            elif result is RetryCheckResult.do_not_retry:
+                return False
+            else:
+                return True
+
+        # fallthrough: don't retry any request which isn't marked for retry
+        return False

--- a/src/globus_sdk/transport/retry_config.py
+++ b/src/globus_sdk/transport/retry_config.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import contextlib
+import dataclasses
+import random
+import typing as t
+
+from .retry import RetryCheckCollection, RetryContext
+
+
+def _exponential_backoff(ctx: RetryContext) -> float:
+    # respect any explicit backoff set on the context
+    if ctx.backoff is not None:
+        return ctx.backoff
+    # exponential backoff with jitter
+    return t.cast(float, (0.25 + 0.5 * random.random()) * (2**ctx.attempt))
+
+
+@dataclasses.dataclass
+class RetryConfiguration:
+    """
+    Configuration for a client which is going to retry requests.
+
+    :param max_retries: The maximum number of retries allowed.
+    :param max_sleep: The maximum sleep time between retries (in seconds). If the
+        computed sleep time or the backoff requested by a retry check exceeds this
+        value, this amount of time will be used instead.
+    :param retry_backoff: A function which determines how long to sleep between calls
+        based on the RetryContext. Defaults to exponential backoff with jitter based on
+        the context ``attempt`` number.
+    :param retry_after_status_codes: HTTP status codes for responses which may have
+        a Retry-After header.
+    :param transient_error_status_codes: HTTP status codes for error responses which
+        should generally be retried.
+    :param expired_authorization_status_codes: HTTP status codes indicating that
+        authorization info was missing or expired.
+    :param checks: The check callbacks which will run in order to evaluate
+        responses and exceptions, as a ``RetryCheckCollection``.
+    """
+
+    checks: RetryCheckCollection
+
+    max_retries: int = 5
+    max_sleep: float | int = 10
+    backoff: t.Callable[[RetryContext], float] = _exponential_backoff
+    retry_after_status_codes: tuple[int, ...] = (429, 503)
+    transient_error_status_codes: tuple[int, ...] = (429, 500, 502, 503, 504)
+    expired_authorization_status_codes: tuple[int, ...] = (401,)
+
+    @contextlib.contextmanager
+    def tune(
+        self,
+        *,
+        backoff: t.Callable[[RetryContext], float] | None = None,
+        max_sleep: float | int | None = None,
+        max_retries: int | None = None,
+    ) -> t.Iterator[None]:
+        """
+        Temporarily adjust some of the request retry settings.
+        This method works as a context manager, and will reset settings to their
+        original values after it exits.
+
+        :param backoff: A function which determines how long to sleep between
+            calls based on the RetryContext
+        :param max_sleep: The maximum sleep time between retries (in seconds). If the
+            computed sleep time or the backoff requested by a retry check exceeds this
+            value, this amount of time will be used instead
+        :param max_retries: The maximum number of retries allowed by this transport
+
+        **Example Usage**
+
+        This can be used with any client class to temporarily set values in the context
+        of one or more HTTP requests. For example, to disable retries:
+
+        >>> client = ...  # any client class
+        >>> with client.retry_config.tune(max_retries=0):
+        >>>     foo = client.get_foo()
+
+        See also: :meth:`RequestsTransport.tune`.
+        """
+        saved_settings = (
+            self.backoff,
+            self.max_sleep,
+            self.max_retries,
+        )
+        if backoff is not None:
+            self.backoff = backoff
+        if max_sleep is not None:
+            self.max_sleep = max_sleep
+        if max_retries is not None:
+            self.max_retries = max_retries
+        yield
+        (
+            self.backoff,
+            self.max_sleep,
+            self.max_retries,
+        ) = saved_settings

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,18 +4,12 @@ import pytest
 import responses
 
 import globus_sdk
-from globus_sdk.transport import RequestsTransport
 
 
 @pytest.fixture(autouse=True)
 def mocksleep():
     with mock.patch("time.sleep") as m:
         yield m
-
-
-@pytest.fixture
-def no_retry_transport():
-    return RequestsTransport(max_retries=0)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,10 +15,7 @@ def mocksleep():
 
 @pytest.fixture
 def no_retry_transport():
-    class NoRetryTransport(RequestsTransport):
-        DEFAULT_MAX_RETRIES = 0
-
-    return NoRetryTransport
+    return RequestsTransport(max_retries=0)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/functional/base_client/test_retry_behavior.py
+++ b/tests/functional/base_client/test_retry_behavior.py
@@ -38,7 +38,7 @@ def test_retry_disabled_via_tune(client, mocksleep):
 
     # the error is seen by the client (automatic retry does not hide it)
     with pytest.raises(globus_sdk.GlobusAPIError) as excinfo:
-        with client.transport.tune(max_retries=0):
+        with client.retry_configuration.tune(max_retries=0):
             client.get("/bar")
     assert excinfo.value.http_status == 500
 
@@ -96,7 +96,7 @@ def test_retry_limit(client, mocksleep, num_errors, expect_err):
 
 def test_transport_retry_limit(client, mocksleep):
     # this limit is a safety to protect against a bad policy causing infinite retries
-    client.transport.max_retries = 2
+    client.retry_configuration.max_retries = 2
 
     for _i in range(3):
         load_response(
@@ -115,11 +115,11 @@ def test_transport_retry_limit(client, mocksleep):
 
 
 def test_bad_max_retries_causes_error(client):
-    # this test exploits the fact that we loop to (transport.max_retries + 1) in order
+    # this test exploits the fact that we loop to (max_retries + 1) in order
     # to ensure that no requests are ever sent
     # the transport should throw an error in this case, since it doesn't have a response
     # value to return
-    client.transport.max_retries = -1
+    client.retry_configuration.max_retries = -1
 
     with pytest.raises(ValueError):
         client.get("/bar")
@@ -294,7 +294,7 @@ def test_transport_caller_info_with_retry(client):
 
     authorizer = DummyAuthorizer()
     caller_info = RequestCallerInfo(
-        retry_checks=client.request_retry_checks, authorizer=authorizer
+        retry_configuration=client.retry_configuration, authorizer=authorizer
     )
 
     # Test direct transport usage with caller_info

--- a/tests/functional/base_client/test_retry_behavior.py
+++ b/tests/functional/base_client/test_retry_behavior.py
@@ -293,7 +293,9 @@ def test_transport_caller_info_with_retry(client):
             return True
 
     authorizer = DummyAuthorizer()
-    caller_info = RequestCallerInfo(authorizer=authorizer)
+    caller_info = RequestCallerInfo(
+        retry_checks=client.request_retry_checks, authorizer=authorizer
+    )
 
     # Test direct transport usage with caller_info
     response = client.transport.request(

--- a/tests/functional/services/auth/confidential_client/conftest.py
+++ b/tests/functional/services/auth/confidential_client/conftest.py
@@ -4,7 +4,9 @@ import globus_sdk
 
 
 @pytest.fixture
-def auth_client(no_retry_transport):
-    return globus_sdk.ConfidentialAppAuthClient(
-        "dummy_client_id", "dummy_client_secret", transport=no_retry_transport
+def auth_client():
+    client = globus_sdk.ConfidentialAppAuthClient(
+        "dummy_client_id", "dummy_client_secret"
     )
+    with client.retry_configuration.tune(max_retries=0):
+        yield client

--- a/tests/functional/services/auth/confidential_client/conftest.py
+++ b/tests/functional/services/auth/confidential_client/conftest.py
@@ -5,7 +5,6 @@ import globus_sdk
 
 @pytest.fixture
 def auth_client(no_retry_transport):
-    class CustomAuthClient(globus_sdk.ConfidentialAppAuthClient):
-        default_transport_factory = no_retry_transport
-
-    return CustomAuthClient("dummy_client_id", "dummy_client_secret")
+    return globus_sdk.ConfidentialAppAuthClient(
+        "dummy_client_id", "dummy_client_secret", transport=no_retry_transport
+    )

--- a/tests/functional/services/auth/confidential_client/conftest.py
+++ b/tests/functional/services/auth/confidential_client/conftest.py
@@ -6,6 +6,6 @@ import globus_sdk
 @pytest.fixture
 def auth_client(no_retry_transport):
     class CustomAuthClient(globus_sdk.ConfidentialAppAuthClient):
-        transport_class = no_retry_transport
+        default_transport_factory = no_retry_transport
 
     return CustomAuthClient("dummy_client_id", "dummy_client_secret")

--- a/tests/functional/services/auth/conftest.py
+++ b/tests/functional/services/auth/conftest.py
@@ -4,10 +4,14 @@ import globus_sdk
 
 
 @pytest.fixture
-def login_client(no_retry_transport):
-    return globus_sdk.AuthLoginClient(transport=no_retry_transport)
+def login_client():
+    client = globus_sdk.AuthLoginClient()
+    with client.retry_configuration.tune(max_retries=0):
+        yield client
 
 
 @pytest.fixture
-def service_client(no_retry_transport):
-    return globus_sdk.AuthClient(transport=no_retry_transport)
+def service_client():
+    client = globus_sdk.AuthClient()
+    with client.retry_configuration.tune(max_retries=0):
+        yield client

--- a/tests/functional/services/auth/conftest.py
+++ b/tests/functional/services/auth/conftest.py
@@ -5,15 +5,9 @@ import globus_sdk
 
 @pytest.fixture
 def login_client(no_retry_transport):
-    class CustomAuthClient(globus_sdk.AuthLoginClient):
-        default_transport_factory = no_retry_transport
-
-    return CustomAuthClient()
+    return globus_sdk.AuthLoginClient(transport=no_retry_transport)
 
 
 @pytest.fixture
 def service_client(no_retry_transport):
-    class CustomAuthClient(globus_sdk.AuthClient):
-        default_transport_factory = no_retry_transport
-
-    return CustomAuthClient()
+    return globus_sdk.AuthClient(transport=no_retry_transport)

--- a/tests/functional/services/auth/conftest.py
+++ b/tests/functional/services/auth/conftest.py
@@ -6,7 +6,7 @@ import globus_sdk
 @pytest.fixture
 def login_client(no_retry_transport):
     class CustomAuthClient(globus_sdk.AuthLoginClient):
-        transport_class = no_retry_transport
+        default_transport_factory = no_retry_transport
 
     return CustomAuthClient()
 
@@ -14,6 +14,6 @@ def login_client(no_retry_transport):
 @pytest.fixture
 def service_client(no_retry_transport):
     class CustomAuthClient(globus_sdk.AuthClient):
-        transport_class = no_retry_transport
+        default_transport_factory = no_retry_transport
 
     return CustomAuthClient()

--- a/tests/functional/services/auth/native_client/conftest.py
+++ b/tests/functional/services/auth/native_client/conftest.py
@@ -4,7 +4,7 @@ import globus_sdk
 
 
 @pytest.fixture
-def auth_client(no_retry_transport):
-    return globus_sdk.NativeAppAuthClient(
-        "dummy_client_id", transport=no_retry_transport
-    )
+def auth_client():
+    client = globus_sdk.NativeAppAuthClient("dummy_client_id")
+    with client.retry_configuration.tune(max_retries=0):
+        yield client

--- a/tests/functional/services/auth/native_client/conftest.py
+++ b/tests/functional/services/auth/native_client/conftest.py
@@ -6,6 +6,6 @@ import globus_sdk
 @pytest.fixture
 def auth_client(no_retry_transport):
     class CustomAuthClient(globus_sdk.NativeAppAuthClient):
-        transport_class = no_retry_transport
+        default_transport_factory = no_retry_transport
 
     return CustomAuthClient("dummy_client_id")

--- a/tests/functional/services/auth/native_client/conftest.py
+++ b/tests/functional/services/auth/native_client/conftest.py
@@ -5,7 +5,6 @@ import globus_sdk
 
 @pytest.fixture
 def auth_client(no_retry_transport):
-    class CustomAuthClient(globus_sdk.NativeAppAuthClient):
-        default_transport_factory = no_retry_transport
-
-    return CustomAuthClient("dummy_client_id")
+    return globus_sdk.NativeAppAuthClient(
+        "dummy_client_id", transport=no_retry_transport
+    )

--- a/tests/functional/services/auth/test_auth_client_flow.py
+++ b/tests/functional/services/auth/test_auth_client_flow.py
@@ -14,19 +14,17 @@ CLIENT_ID = "d0f1d9b0-bd81-4108-be74-ea981664453a"
 
 @pytest.fixture
 def native_client(no_retry_transport):
-    class CustomAuthClient(globus_sdk.NativeAppAuthClient):
-        default_transport_factory = no_retry_transport
-
-    return CustomAuthClient(client_id=CLIENT_ID)
+    return globus_sdk.NativeAppAuthClient(
+        client_id=CLIENT_ID, transport=no_retry_transport
+    )
 
 
 @pytest.fixture
 def confidential_client(no_retry_transport):
-    class CustomAuthClient(globus_sdk.ConfidentialAppAuthClient):
-        default_transport_factory = no_retry_transport
-
-    return CustomAuthClient(
-        client_id=CLIENT_ID, client_secret="SECRET_SECRET_HES_GOT_A_SECRET"
+    return globus_sdk.ConfidentialAppAuthClient(
+        client_id=CLIENT_ID,
+        client_secret="SECRET_SECRET_HES_GOT_A_SECRET",
+        transport=no_retry_transport,
     )
 
 

--- a/tests/functional/services/auth/test_auth_client_flow.py
+++ b/tests/functional/services/auth/test_auth_client_flow.py
@@ -13,19 +13,19 @@ CLIENT_ID = "d0f1d9b0-bd81-4108-be74-ea981664453a"
 
 
 @pytest.fixture
-def native_client(no_retry_transport):
-    return globus_sdk.NativeAppAuthClient(
-        client_id=CLIENT_ID, transport=no_retry_transport
-    )
+def native_client():
+    client = globus_sdk.NativeAppAuthClient(client_id=CLIENT_ID)
+    with client.retry_configuration.tune(max_retries=0):
+        yield client
 
 
 @pytest.fixture
-def confidential_client(no_retry_transport):
-    return globus_sdk.ConfidentialAppAuthClient(
-        client_id=CLIENT_ID,
-        client_secret="SECRET_SECRET_HES_GOT_A_SECRET",
-        transport=no_retry_transport,
+def confidential_client():
+    client = globus_sdk.ConfidentialAppAuthClient(
+        client_id=CLIENT_ID, client_secret="SECRET_SECRET_HES_GOT_A_SECRET"
     )
+    with client.retry_configuration.tune(max_retries=0):
+        yield client
 
 
 # build a nearly-diagonal matrix over

--- a/tests/functional/services/auth/test_auth_client_flow.py
+++ b/tests/functional/services/auth/test_auth_client_flow.py
@@ -15,7 +15,7 @@ CLIENT_ID = "d0f1d9b0-bd81-4108-be74-ea981664453a"
 @pytest.fixture
 def native_client(no_retry_transport):
     class CustomAuthClient(globus_sdk.NativeAppAuthClient):
-        transport_class = no_retry_transport
+        default_transport_factory = no_retry_transport
 
     return CustomAuthClient(client_id=CLIENT_ID)
 
@@ -23,7 +23,7 @@ def native_client(no_retry_transport):
 @pytest.fixture
 def confidential_client(no_retry_transport):
     class CustomAuthClient(globus_sdk.ConfidentialAppAuthClient):
-        transport_class = no_retry_transport
+        default_transport_factory = no_retry_transport
 
     return CustomAuthClient(
         client_id=CLIENT_ID, client_secret="SECRET_SECRET_HES_GOT_A_SECRET"

--- a/tests/functional/services/compute/conftest.py
+++ b/tests/functional/services/compute/conftest.py
@@ -4,10 +4,14 @@ import globus_sdk
 
 
 @pytest.fixture
-def compute_client_v2(no_retry_transport):
-    return globus_sdk.ComputeClientV2(transport=no_retry_transport)
+def compute_client_v2():
+    client = globus_sdk.ComputeClientV2()
+    with client.retry_configuration.tune(max_retries=0):
+        yield client
 
 
 @pytest.fixture
-def compute_client_v3(no_retry_transport):
-    return globus_sdk.ComputeClientV3(transport=no_retry_transport)
+def compute_client_v3():
+    client = globus_sdk.ComputeClientV3()
+    with client.retry_configuration.tune(max_retries=0):
+        yield client

--- a/tests/functional/services/compute/conftest.py
+++ b/tests/functional/services/compute/conftest.py
@@ -6,7 +6,7 @@ import globus_sdk
 @pytest.fixture
 def compute_client_v2(no_retry_transport):
     class CustomComputeClientV2(globus_sdk.ComputeClientV2):
-        transport_class = no_retry_transport
+        default_transport_factory = no_retry_transport
 
     return CustomComputeClientV2()
 
@@ -14,6 +14,6 @@ def compute_client_v2(no_retry_transport):
 @pytest.fixture
 def compute_client_v3(no_retry_transport):
     class CustomComputeClientV3(globus_sdk.ComputeClientV3):
-        transport_class = no_retry_transport
+        default_transport_factory = no_retry_transport
 
     return CustomComputeClientV3()

--- a/tests/functional/services/compute/conftest.py
+++ b/tests/functional/services/compute/conftest.py
@@ -5,15 +5,9 @@ import globus_sdk
 
 @pytest.fixture
 def compute_client_v2(no_retry_transport):
-    class CustomComputeClientV2(globus_sdk.ComputeClientV2):
-        default_transport_factory = no_retry_transport
-
-    return CustomComputeClientV2()
+    return globus_sdk.ComputeClientV2(transport=no_retry_transport)
 
 
 @pytest.fixture
 def compute_client_v3(no_retry_transport):
-    class CustomComputeClientV3(globus_sdk.ComputeClientV3):
-        default_transport_factory = no_retry_transport
-
-    return CustomComputeClientV3()
+    return globus_sdk.ComputeClientV3(transport=no_retry_transport)

--- a/tests/functional/services/flows/conftest.py
+++ b/tests/functional/services/flows/conftest.py
@@ -8,7 +8,7 @@ import globus_sdk
 @pytest.fixture
 def flows_client(no_retry_transport):
     class CustomFlowsClient(globus_sdk.FlowsClient):
-        transport_class = no_retry_transport
+        default_transport_factory = no_retry_transport
 
     return CustomFlowsClient()
 
@@ -18,6 +18,6 @@ def specific_flow_client_class(
     no_retry_transport,
 ) -> t.Type[globus_sdk.SpecificFlowClient]:
     class CustomSpecificFlowClient(globus_sdk.SpecificFlowClient):
-        transport_class = no_retry_transport
+        default_transport_factory = no_retry_transport
 
     return CustomSpecificFlowClient

--- a/tests/functional/services/flows/conftest.py
+++ b/tests/functional/services/flows/conftest.py
@@ -7,10 +7,7 @@ import globus_sdk
 
 @pytest.fixture
 def flows_client(no_retry_transport):
-    class CustomFlowsClient(globus_sdk.FlowsClient):
-        default_transport_factory = no_retry_transport
-
-    return CustomFlowsClient()
+    return globus_sdk.FlowsClient(transport=no_retry_transport)
 
 
 @pytest.fixture
@@ -18,6 +15,8 @@ def specific_flow_client_class(
     no_retry_transport,
 ) -> t.Type[globus_sdk.SpecificFlowClient]:
     class CustomSpecificFlowClient(globus_sdk.SpecificFlowClient):
-        default_transport_factory = no_retry_transport
+        def __init__(self, **kwargs) -> None:
+            kwargs["transport"] = no_retry_transport
+            super().__init__(**kwargs)
 
     return CustomSpecificFlowClient

--- a/tests/functional/services/flows/conftest.py
+++ b/tests/functional/services/flows/conftest.py
@@ -6,17 +6,17 @@ import globus_sdk
 
 
 @pytest.fixture
-def flows_client(no_retry_transport):
-    return globus_sdk.FlowsClient(transport=no_retry_transport)
+def flows_client():
+    client = globus_sdk.FlowsClient()
+    with client.retry_configuration.tune(max_retries=0):
+        yield client
 
 
 @pytest.fixture
-def specific_flow_client_class(
-    no_retry_transport,
-) -> t.Type[globus_sdk.SpecificFlowClient]:
+def specific_flow_client_class() -> t.Type[globus_sdk.SpecificFlowClient]:
     class CustomSpecificFlowClient(globus_sdk.SpecificFlowClient):
         def __init__(self, **kwargs) -> None:
-            kwargs["transport"] = no_retry_transport
             super().__init__(**kwargs)
+            self.retry_configuration.max_retries = 0
 
     return CustomSpecificFlowClient

--- a/tests/functional/services/gcs/conftest.py
+++ b/tests/functional/services/gcs/conftest.py
@@ -6,7 +6,7 @@ from globus_sdk import GCSClient
 @pytest.fixture
 def client(no_retry_transport):
     class CustomGCSClient(GCSClient):
-        transport_class = no_retry_transport
+        default_transport_factory = no_retry_transport
 
     # default fqdn for GCS client testing
     return CustomGCSClient("abc.xyz.data.globus.org")

--- a/tests/functional/services/gcs/conftest.py
+++ b/tests/functional/services/gcs/conftest.py
@@ -1,12 +1,9 @@
 import pytest
 
-from globus_sdk import GCSClient
+import globus_sdk
 
 
 @pytest.fixture
 def client(no_retry_transport):
-    class CustomGCSClient(GCSClient):
-        default_transport_factory = no_retry_transport
-
     # default fqdn for GCS client testing
-    return CustomGCSClient("abc.xyz.data.globus.org")
+    return globus_sdk.GCSClient("abc.xyz.data.globus.org", transport=no_retry_transport)

--- a/tests/functional/services/gcs/conftest.py
+++ b/tests/functional/services/gcs/conftest.py
@@ -4,6 +4,8 @@ import globus_sdk
 
 
 @pytest.fixture
-def client(no_retry_transport):
+def client():
     # default fqdn for GCS client testing
-    return globus_sdk.GCSClient("abc.xyz.data.globus.org", transport=no_retry_transport)
+    client = globus_sdk.GCSClient("abc.xyz.data.globus.org")
+    with client.retry_configuration.tune(max_retries=0):
+        yield client

--- a/tests/functional/services/groups/conftest.py
+++ b/tests/functional/services/groups/conftest.py
@@ -4,8 +4,10 @@ import globus_sdk
 
 
 @pytest.fixture
-def groups_client(no_retry_transport):
-    return globus_sdk.GroupsClient(transport=no_retry_transport)
+def groups_client():
+    client = globus_sdk.GroupsClient()
+    with client.retry_configuration.tune(max_retries=0):
+        yield client
 
 
 @pytest.fixture

--- a/tests/functional/services/groups/conftest.py
+++ b/tests/functional/services/groups/conftest.py
@@ -6,7 +6,7 @@ import globus_sdk
 @pytest.fixture
 def groups_client(no_retry_transport):
     class CustomGroupsClient(globus_sdk.GroupsClient):
-        transport_class = no_retry_transport
+        default_transport_factory = no_retry_transport
 
     return CustomGroupsClient()
 

--- a/tests/functional/services/groups/conftest.py
+++ b/tests/functional/services/groups/conftest.py
@@ -5,10 +5,7 @@ import globus_sdk
 
 @pytest.fixture
 def groups_client(no_retry_transport):
-    class CustomGroupsClient(globus_sdk.GroupsClient):
-        default_transport_factory = no_retry_transport
-
-    return CustomGroupsClient()
+    return globus_sdk.GroupsClient(transport=no_retry_transport)
 
 
 @pytest.fixture

--- a/tests/functional/services/search/conftest.py
+++ b/tests/functional/services/search/conftest.py
@@ -6,6 +6,6 @@ import globus_sdk
 @pytest.fixture
 def client(no_retry_transport):
     class CustomSearchClient(globus_sdk.SearchClient):
-        transport_class = no_retry_transport
+        default_transport_factory = no_retry_transport
 
     return CustomSearchClient()

--- a/tests/functional/services/search/conftest.py
+++ b/tests/functional/services/search/conftest.py
@@ -5,7 +5,4 @@ import globus_sdk
 
 @pytest.fixture
 def client(no_retry_transport):
-    class CustomSearchClient(globus_sdk.SearchClient):
-        default_transport_factory = no_retry_transport
-
-    return CustomSearchClient()
+    return globus_sdk.SearchClient(transport=no_retry_transport)

--- a/tests/functional/services/search/conftest.py
+++ b/tests/functional/services/search/conftest.py
@@ -4,5 +4,7 @@ import globus_sdk
 
 
 @pytest.fixture
-def client(no_retry_transport):
-    return globus_sdk.SearchClient(transport=no_retry_transport)
+def client():
+    client = globus_sdk.SearchClient()
+    with client.retry_configuration.tune(max_retries=0):
+        yield client

--- a/tests/functional/services/search/test_search.py
+++ b/tests/functional/services/search/test_search.py
@@ -14,7 +14,7 @@ from tests.common import register_api_route_fixture_file
 @pytest.fixture
 def search_client(no_retry_transport):
     class CustomSearchClient(globus_sdk.SearchClient):
-        transport_class = no_retry_transport
+        default_transport_factory = no_retry_transport
 
     return CustomSearchClient()
 

--- a/tests/functional/services/search/test_search.py
+++ b/tests/functional/services/search/test_search.py
@@ -12,8 +12,10 @@ from tests.common import register_api_route_fixture_file
 
 
 @pytest.fixture
-def search_client(no_retry_transport):
-    return globus_sdk.SearchClient(transport=no_retry_transport)
+def search_client():
+    client = globus_sdk.SearchClient()
+    with client.retry_configuration.tune(max_retries=0):
+        yield client
 
 
 def test_search_query_simple(search_client):

--- a/tests/functional/services/search/test_search.py
+++ b/tests/functional/services/search/test_search.py
@@ -13,10 +13,7 @@ from tests.common import register_api_route_fixture_file
 
 @pytest.fixture
 def search_client(no_retry_transport):
-    class CustomSearchClient(globus_sdk.SearchClient):
-        default_transport_factory = no_retry_transport
-
-    return CustomSearchClient()
+    return globus_sdk.SearchClient(transport=no_retry_transport)
 
 
 def test_search_query_simple(search_client):

--- a/tests/functional/services/search/test_search_roles.py
+++ b/tests/functional/services/search/test_search_roles.py
@@ -9,7 +9,7 @@ from globus_sdk.testing import get_last_request, load_response
 @pytest.fixture
 def search_client(no_retry_transport):
     class CustomSearchClient(globus_sdk.SearchClient):
-        transport_class = no_retry_transport
+        default_transport_factory = no_retry_transport
 
     return CustomSearchClient()
 

--- a/tests/functional/services/search/test_search_roles.py
+++ b/tests/functional/services/search/test_search_roles.py
@@ -8,10 +8,7 @@ from globus_sdk.testing import get_last_request, load_response
 
 @pytest.fixture
 def search_client(no_retry_transport):
-    class CustomSearchClient(globus_sdk.SearchClient):
-        default_transport_factory = no_retry_transport
-
-    return CustomSearchClient()
+    return globus_sdk.SearchClient(transport=no_retry_transport)
 
 
 def test_search_role_create(search_client):

--- a/tests/functional/services/search/test_search_roles.py
+++ b/tests/functional/services/search/test_search_roles.py
@@ -7,8 +7,10 @@ from globus_sdk.testing import get_last_request, load_response
 
 
 @pytest.fixture
-def search_client(no_retry_transport):
-    return globus_sdk.SearchClient(transport=no_retry_transport)
+def search_client():
+    client = globus_sdk.SearchClient()
+    with client.retry_configuration.tune(max_retries=0):
+        yield client
 
 
 def test_search_role_create(search_client):

--- a/tests/functional/services/transfer/conftest.py
+++ b/tests/functional/services/transfer/conftest.py
@@ -6,6 +6,6 @@ import globus_sdk
 @pytest.fixture
 def client(no_retry_transport):
     class CustomTransferClient(globus_sdk.TransferClient):
-        transport_class = no_retry_transport
+        default_transport_factory = no_retry_transport
 
     return CustomTransferClient()

--- a/tests/functional/services/transfer/conftest.py
+++ b/tests/functional/services/transfer/conftest.py
@@ -4,5 +4,7 @@ import globus_sdk
 
 
 @pytest.fixture
-def client(no_retry_transport):
-    return globus_sdk.TransferClient(transport=no_retry_transport)
+def client():
+    client = globus_sdk.TransferClient()
+    with client.retry_configuration.tune(max_retries=0):
+        yield client

--- a/tests/functional/services/transfer/conftest.py
+++ b/tests/functional/services/transfer/conftest.py
@@ -5,7 +5,4 @@ import globus_sdk
 
 @pytest.fixture
 def client(no_retry_transport):
-    class CustomTransferClient(globus_sdk.TransferClient):
-        default_transport_factory = no_retry_transport
-
-    return CustomTransferClient()
+    return globus_sdk.TransferClient(transport=no_retry_transport)

--- a/tests/functional/tokenstorage/v2/conftest.py
+++ b/tests/functional/tokenstorage/v2/conftest.py
@@ -17,7 +17,7 @@ def id_token_sub():
 @pytest.fixture
 def cc_auth_client(no_retry_transport):
     class CustomAuthClient(globus_sdk.ConfidentialAppAuthClient):
-        transport_class = no_retry_transport
+        default_transport_factory = no_retry_transport
 
     return CustomAuthClient("dummy_id", "dummy_secret")
 

--- a/tests/functional/tokenstorage/v2/conftest.py
+++ b/tests/functional/tokenstorage/v2/conftest.py
@@ -15,10 +15,10 @@ def id_token_sub():
 
 
 @pytest.fixture
-def cc_auth_client(no_retry_transport):
-    return globus_sdk.ConfidentialAppAuthClient(
-        "dummy_id", "dummy_secret", transport=no_retry_transport
-    )
+def cc_auth_client():
+    client = globus_sdk.ConfidentialAppAuthClient("dummy_id", "dummy_secret")
+    with client.retry_configuration.tune(max_retries=0):
+        yield client
 
 
 @pytest.fixture

--- a/tests/functional/tokenstorage/v2/conftest.py
+++ b/tests/functional/tokenstorage/v2/conftest.py
@@ -16,10 +16,9 @@ def id_token_sub():
 
 @pytest.fixture
 def cc_auth_client(no_retry_transport):
-    class CustomAuthClient(globus_sdk.ConfidentialAppAuthClient):
-        default_transport_factory = no_retry_transport
-
-    return CustomAuthClient("dummy_id", "dummy_secret")
+    return globus_sdk.ConfidentialAppAuthClient(
+        "dummy_id", "dummy_secret", transport=no_retry_transport
+    )
 
 
 @pytest.fixture

--- a/tests/unit/sphinxext/test_copyparams_directive.py
+++ b/tests/unit/sphinxext/test_copyparams_directive.py
@@ -11,7 +11,7 @@ BASE_CLIENT_PARAMS = (
     "authorizer",
     "app_name",
     "base_url",
-    "transport_params",
+    "transport",
 )
 
 

--- a/tests/unit/test_base_client.py
+++ b/tests/unit/test_base_client.py
@@ -20,15 +20,15 @@ def auth_client():
 
 
 @pytest.fixture
-def base_client_class(no_retry_transport):
+def base_client_class():
     class CustomClient(globus_sdk.BaseClient):
         service_name = "transfer"
         scopes = TransferScopes
         default_scope_requirements = [TransferScopes.all]
 
         def __init__(self, **kwargs) -> None:
-            kwargs["transport"] = no_retry_transport
             super().__init__(**kwargs)
+            self.retry_configuration.max_retries = 0
 
     return CustomClient
 

--- a/tests/unit/test_base_client.py
+++ b/tests/unit/test_base_client.py
@@ -23,9 +23,12 @@ def auth_client():
 def base_client_class(no_retry_transport):
     class CustomClient(globus_sdk.BaseClient):
         service_name = "transfer"
-        default_transport_factory = no_retry_transport
         scopes = TransferScopes
         default_scope_requirements = [TransferScopes.all]
+
+        def __init__(self, **kwargs) -> None:
+            kwargs["transport"] = no_retry_transport
+            super().__init__(**kwargs)
 
     return CustomClient
 

--- a/tests/unit/test_base_client.py
+++ b/tests/unit/test_base_client.py
@@ -11,6 +11,7 @@ from globus_sdk.authorizers import NullAuthorizer
 from globus_sdk.scopes import Scope, TransferScopes
 from globus_sdk.testing import RegisteredResponse, get_last_request
 from globus_sdk.token_storage import TokenValidationError
+from globus_sdk.transport import RequestsTransport
 
 
 @pytest.fixture
@@ -22,7 +23,7 @@ def auth_client():
 def base_client_class(no_retry_transport):
     class CustomClient(globus_sdk.BaseClient):
         service_name = "transfer"
-        transport_class = no_retry_transport
+        default_transport_factory = no_retry_transport
         scopes = TransferScopes
         default_scope_requirements = [TransferScopes.all]
 
@@ -89,10 +90,10 @@ def test_set_http_timeout(base_client):
         client = FooClient()
         assert client.transport.http_timeout == 60.0
 
-        client = FooClient(transport_params={"http_timeout": None})
+        client = FooClient(transport=RequestsTransport(http_timeout=None))
         assert client.transport.http_timeout == 60.0
 
-        client = FooClient(transport_params={"http_timeout": -1})
+        client = FooClient(transport=RequestsTransport(http_timeout=-1))
         assert client.transport.http_timeout is None
 
         os.environ["GLOBUS_SDK_HTTP_TIMEOUT"] = "120"

--- a/tests/unit/transport/test_default_retry_policy.py
+++ b/tests/unit/transport/test_default_retry_policy.py
@@ -3,6 +3,7 @@ from unittest import mock
 import pytest
 
 from globus_sdk.transport import (
+    DefaultRetryCheckCollection,
     RequestCallerInfo,
     RequestsTransport,
     RetryCheckResult,
@@ -13,13 +14,14 @@ from globus_sdk.transport import (
 
 @pytest.mark.parametrize("http_status", (429, 503))
 def test_retry_policy_respects_retry_after(mocksleep, http_status):
+    retry_checks = DefaultRetryCheckCollection()
     transport = RequestsTransport()
-    checker = RetryCheckRunner(transport.retry_checks)
+    checker = RetryCheckRunner(retry_checks)
 
     dummy_response = mock.Mock()
     dummy_response.headers = {"Retry-After": "5"}
     dummy_response.status_code = http_status
-    caller_info = RequestCallerInfo(authorizer=None)
+    caller_info = RequestCallerInfo(retry_checks=retry_checks)
     ctx = RetryContext(1, caller_info=caller_info, response=dummy_response)
 
     assert checker.should_retry(ctx) is True
@@ -32,12 +34,13 @@ def test_retry_policy_respects_retry_after(mocksleep, http_status):
 def test_retry_policy_ignores_retry_after_too_high(mocksleep, http_status):
     # set explicit max sleep to confirm that the value is capped here
     transport = RequestsTransport(max_sleep=5)
-    checker = RetryCheckRunner(transport.retry_checks)
+    retry_checks = DefaultRetryCheckCollection()
+    checker = RetryCheckRunner(retry_checks)
 
     dummy_response = mock.Mock()
     dummy_response.headers = {"Retry-After": "20"}
     dummy_response.status_code = http_status
-    caller_info = RequestCallerInfo(authorizer=None)
+    caller_info = RequestCallerInfo(retry_checks=retry_checks)
     ctx = RetryContext(1, caller_info=caller_info, response=dummy_response)
 
     assert checker.should_retry(ctx) is True
@@ -49,12 +52,13 @@ def test_retry_policy_ignores_retry_after_too_high(mocksleep, http_status):
 @pytest.mark.parametrize("http_status", (429, 503))
 def test_retry_policy_ignores_malformed_retry_after(mocksleep, http_status):
     transport = RequestsTransport()
-    checker = RetryCheckRunner(transport.retry_checks)
+    retry_checks = DefaultRetryCheckCollection()
+    checker = RetryCheckRunner(retry_checks)
 
     dummy_response = mock.Mock()
     dummy_response.headers = {"Retry-After": "not-an-integer"}
     dummy_response.status_code = http_status
-    caller_info = RequestCallerInfo(authorizer=None)
+    caller_info = RequestCallerInfo(retry_checks=retry_checks)
     ctx = RetryContext(1, caller_info=caller_info, response=dummy_response)
 
     assert checker.should_retry(ctx) is True
@@ -66,29 +70,13 @@ def test_retry_policy_ignores_malformed_retry_after(mocksleep, http_status):
 @pytest.mark.parametrize(
     "checkname",
     [
-        "default_check_retry_after_header",
-        "default_check_transient_error",
+        "check_retry_after_header",
+        "check_transient_error",
     ],
 )
 def test_default_retry_check_noop_on_exception(checkname, mocksleep):
-    transport = RequestsTransport()
-    method = getattr(transport, checkname)
-    caller_info = RequestCallerInfo(authorizer=None)
+    retry_checks = DefaultRetryCheckCollection()
+    method = getattr(retry_checks, checkname)
+    caller_info = RequestCallerInfo(retry_checks=retry_checks)
     ctx = RetryContext(1, caller_info=caller_info, exception=Exception("foo"))
     assert method(ctx) is RetryCheckResult.no_decision
-
-
-def test_retry_context_accepts_caller_info():
-    mock_authorizer = mock.Mock()
-    caller_info = RequestCallerInfo(authorizer=mock_authorizer)
-
-    ctx = RetryContext(1, caller_info=caller_info)
-
-    assert ctx.caller_info is caller_info
-    assert ctx.caller_info.authorizer is mock_authorizer
-
-
-def test_retry_context_caller_info_none():
-    ctx = RetryContext(1, caller_info=None)
-
-    assert ctx.caller_info is None

--- a/tests/unit/transport/test_default_retry_policy.py
+++ b/tests/unit/transport/test_default_retry_policy.py
@@ -8,62 +8,63 @@ from globus_sdk.transport import (
     RequestsTransport,
     RetryCheckResult,
     RetryCheckRunner,
+    RetryConfiguration,
     RetryContext,
 )
 
 
 @pytest.mark.parametrize("http_status", (429, 503))
 def test_retry_policy_respects_retry_after(mocksleep, http_status):
-    retry_checks = DefaultRetryCheckCollection()
+    retry_config = RetryConfiguration(checks=DefaultRetryCheckCollection())
     transport = RequestsTransport()
-    checker = RetryCheckRunner(retry_checks)
+    checker = RetryCheckRunner(retry_config.checks)
 
     dummy_response = mock.Mock()
     dummy_response.headers = {"Retry-After": "5"}
     dummy_response.status_code = http_status
-    caller_info = RequestCallerInfo(retry_checks=retry_checks)
+    caller_info = RequestCallerInfo(retry_configuration=retry_config)
     ctx = RetryContext(1, caller_info=caller_info, response=dummy_response)
 
     assert checker.should_retry(ctx) is True
     mocksleep.assert_not_called()
-    transport._retry_sleep(ctx)
+    transport._retry_sleep(retry_config, ctx)
     mocksleep.assert_called_once_with(5)
 
 
 @pytest.mark.parametrize("http_status", (429, 503))
 def test_retry_policy_ignores_retry_after_too_high(mocksleep, http_status):
     # set explicit max sleep to confirm that the value is capped here
-    transport = RequestsTransport(max_sleep=5)
-    retry_checks = DefaultRetryCheckCollection()
-    checker = RetryCheckRunner(retry_checks)
+    retry_config = RetryConfiguration(max_sleep=5, checks=DefaultRetryCheckCollection())
+    transport = RequestsTransport()
+    checker = RetryCheckRunner(retry_config.checks)
 
     dummy_response = mock.Mock()
     dummy_response.headers = {"Retry-After": "20"}
     dummy_response.status_code = http_status
-    caller_info = RequestCallerInfo(retry_checks=retry_checks)
+    caller_info = RequestCallerInfo(retry_configuration=retry_config)
     ctx = RetryContext(1, caller_info=caller_info, response=dummy_response)
 
     assert checker.should_retry(ctx) is True
     mocksleep.assert_not_called()
-    transport._retry_sleep(ctx)
+    transport._retry_sleep(retry_config, ctx)
     mocksleep.assert_called_once_with(5)
 
 
 @pytest.mark.parametrize("http_status", (429, 503))
 def test_retry_policy_ignores_malformed_retry_after(mocksleep, http_status):
+    retry_config = RetryConfiguration(checks=DefaultRetryCheckCollection())
     transport = RequestsTransport()
-    retry_checks = DefaultRetryCheckCollection()
-    checker = RetryCheckRunner(retry_checks)
+    checker = RetryCheckRunner(retry_config.checks)
 
     dummy_response = mock.Mock()
     dummy_response.headers = {"Retry-After": "not-an-integer"}
     dummy_response.status_code = http_status
-    caller_info = RequestCallerInfo(retry_checks=retry_checks)
+    caller_info = RequestCallerInfo(retry_configuration=retry_config)
     ctx = RetryContext(1, caller_info=caller_info, response=dummy_response)
 
     assert checker.should_retry(ctx) is True
     mocksleep.assert_not_called()
-    transport._retry_sleep(ctx)
+    transport._retry_sleep(retry_config, ctx)
     mocksleep.assert_called_once()
 
 
@@ -75,8 +76,8 @@ def test_retry_policy_ignores_malformed_retry_after(mocksleep, http_status):
     ],
 )
 def test_default_retry_check_noop_on_exception(checkname, mocksleep):
-    retry_checks = DefaultRetryCheckCollection()
-    method = getattr(retry_checks, checkname)
-    caller_info = RequestCallerInfo(retry_checks=retry_checks)
+    retry_config = RetryConfiguration(checks=DefaultRetryCheckCollection())
+    method = getattr(retry_config.checks, checkname)
+    caller_info = RequestCallerInfo(retry_configuration=retry_config)
     ctx = RetryContext(1, caller_info=caller_info, exception=Exception("foo"))
     assert method(ctx) is RetryCheckResult.no_decision

--- a/tests/unit/transport/test_retry_check_runner.py
+++ b/tests/unit/transport/test_retry_check_runner.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 from globus_sdk.transport import (
+    DefaultRetryCheckCollection,
     RequestCallerInfo,
     RetryCheckResult,
     RetryCheckRunner,
@@ -9,7 +10,7 @@ from globus_sdk.transport import (
 
 
 def _make_test_retry_context(*, status=200, exception=None, response=None):
-    caller_info = RequestCallerInfo(authorizer=None)
+    caller_info = RequestCallerInfo(retry_checks=DefaultRetryCheckCollection())
     if exception:
         return RetryContext(1, caller_info=caller_info, exception=exception)
     elif response:

--- a/tests/unit/transport/test_retry_check_runner.py
+++ b/tests/unit/transport/test_retry_check_runner.py
@@ -5,12 +5,14 @@ from globus_sdk.transport import (
     RequestCallerInfo,
     RetryCheckResult,
     RetryCheckRunner,
+    RetryConfiguration,
     RetryContext,
 )
 
 
 def _make_test_retry_context(*, status=200, exception=None, response=None):
-    caller_info = RequestCallerInfo(retry_checks=DefaultRetryCheckCollection())
+    retry_config = RetryConfiguration(checks=DefaultRetryCheckCollection())
+    caller_info = RequestCallerInfo(retry_configuration=retry_config)
     if exception:
         return RetryContext(1, caller_info=caller_info, exception=exception)
     elif response:

--- a/tests/unit/transport/test_transport.py
+++ b/tests/unit/transport/test_transport.py
@@ -3,8 +3,13 @@ from unittest import mock
 
 import pytest
 
-from globus_sdk.transport import RequestsTransport, RetryContext
-from globus_sdk.transport.requests import _exponential_backoff
+from globus_sdk.transport import (
+    DefaultRetryCheckCollection,
+    RequestsTransport,
+    RetryConfiguration,
+    RetryContext,
+)
+from globus_sdk.transport.retry_config import _exponential_backoff
 
 
 def _linear_backoff(ctx: RetryContext) -> float:
@@ -30,11 +35,6 @@ ca_bundle_non_existent = ca_bundle_directory / "bogus.bogus"
         ("verify_ssl", True, ca_bundle_non_existent),
         ("verify_ssl", True, str(ca_bundle_non_existent)),
         ("http_timeout", 60, 120),
-        ("retry_backoff", _exponential_backoff, _linear_backoff),
-        ("max_sleep", 10, 10),
-        ("max_sleep", 10, 1),
-        ("max_retries", 0, 5),
-        ("max_retries", 10, 0),
     ],
 )
 def test_transport_tuning(param_name, init_value, tune_value):
@@ -51,6 +51,29 @@ def test_transport_tuning(param_name, init_value, tune_value):
         assert getattr(transport, param_name) == expected_value
 
     assert getattr(transport, param_name) == init_value
+
+
+@pytest.mark.parametrize(
+    "param_name, init_value, tune_value",
+    [
+        ("backoff", _exponential_backoff, _linear_backoff),
+        ("max_sleep", 10, 10),
+        ("max_sleep", 10, 1),
+        ("max_retries", 0, 5),
+        ("max_retries", 10, 0),
+    ],
+)
+def test_retry_tuning(param_name, init_value, tune_value):
+    init_kwargs = {param_name: init_value}
+    config = RetryConfiguration(DefaultRetryCheckCollection(), **init_kwargs)
+
+    assert getattr(config, param_name) == init_value
+
+    tune_kwargs = {param_name: tune_value}
+    with config.tune(**tune_kwargs):
+        assert getattr(config, param_name) == tune_value
+
+    assert getattr(config, param_name) == init_value
 
 
 def test_transport_can_manipulate_user_agent():

--- a/tests/unit/transport/test_transport_authz_handling.py
+++ b/tests/unit/transport/test_transport_authz_handling.py
@@ -7,6 +7,7 @@ from globus_sdk.transport import (
     DefaultRetryCheckCollection,
     RequestCallerInfo,
     RequestsTransport,
+    RetryConfiguration,
 )
 
 
@@ -37,11 +38,12 @@ def test_will_null_authz_header_with_null_authorizer():
 
 
 def test_requests_transport_accepts_caller_info():
+    retry_config = RetryConfiguration(checks=DefaultRetryCheckCollection())
     transport = RequestsTransport()
     mock_authorizer = mock.Mock()
     mock_authorizer.get_authorization_header.return_value = "Bearer token"
     caller_info = RequestCallerInfo(
-        retry_checks=DefaultRetryCheckCollection(), authorizer=mock_authorizer
+        retry_configuration=retry_config, authorizer=mock_authorizer
     )
 
     with mock.patch.object(transport, "session") as mock_session:
@@ -66,8 +68,9 @@ def test_requests_transport_caller_info_required():
 
 
 def test_requests_transport_keyword_only():
+    retry_config = RetryConfiguration(checks=DefaultRetryCheckCollection())
     transport = RequestsTransport()
-    caller_info = RequestCallerInfo(retry_checks=DefaultRetryCheckCollection())
+    caller_info = RequestCallerInfo(retry_configuration=retry_config)
 
     with pytest.raises(TypeError):
         transport.request("GET", "https://example.com", caller_info)


### PR DESCRIPTION
The overall goal of this change is to alter how `RequestsTransport` is modified by users and passed to clients to be more direct, allowing users to pass a transport instance.

In order to achieve this, the transport is split into two pieces, separating out the `RetryConfiguration` which is also attached to client classes.
This allows the TransferClient to declare its custom configuration -- with an altered retry check -- without interfering with the user's ability to pass a transport in from the outside.

The upgrading doc and changelog detail what users should see with this change.
