### PR TITLE
Deprecate the ComputeClient class

### DIFF
--- a/changelog.d/20250722_225557_sirosen_deprecate_canonical_compute_client.rst
+++ b/changelog.d/20250722_225557_sirosen_deprecate_canonical_compute_client.rst
@@ -1,0 +1,6 @@
+Deprecated
+----------
+
+- The ``ComputeClient`` alias for ``ComputeClientV2`` is now deprecated. Users
+  of Globus Compute are encouraged to use ``ComputeClientV2`` or
+  ``ComputeClientV3`` instead. (:pr:`NUMBER`)

--- a/docs/core/utils.rst
+++ b/docs/core/utils.rst
@@ -32,8 +32,7 @@ request, it will be removed before the request is sent to the service.
 As a result, where ``MISSING`` is used as the default for a value, ``None`` can
 be used to explicitly pass the value ``null``.
 
-.. class:: globus_sdk.MissingType
-    :canonical: globus_sdk.utils.MissingType
+.. py:class:: globus_sdk.MissingType
 
     This is the type of ``MISSING``.
 

--- a/docs/services/compute.rst
+++ b/docs/services/compute.rst
@@ -10,16 +10,10 @@ Under the hood, the Globus Compute SDK uses the following clients to interact wi
 the Globus Compute API. Advanced users may choose to work directly with these clients
 for custom implementations.
 
-The canonical :class:`ComputeClient` is a subclass of :class:`ComputeClientV2`,
-which supports version 2 of the Globus Compute API. When feasible, new projects
-should use :class:`ComputeClientV3`, which supports version 3 and includes the
-latest API features and improvements.
-
-..  autoclass:: ComputeClient
-    :members:
-    :member-order: bysource
-    :show-inheritance:
-    :exclude-members: error_class, scopes
+There are two client classes, supporting versions 2 and 3 of the Globus Compute
+API.
+Where feasible, new projects should use :class:`ComputeClientV3`, which
+includes the latest API features and improvements.
 
 ..  autoclass:: ComputeClientV2
     :members:
@@ -30,7 +24,7 @@ latest API features and improvements.
     ..  attribute:: scopes
 
         ..  listknownscopes:: globus_sdk.scopes.ComputeScopes
-            :base_name: ComputeClient.scopes
+            :base_name: ComputeClientV2.scopes
 
 ..  autoclass:: ComputeClientV3
     :members:
@@ -41,13 +35,23 @@ latest API features and improvements.
     ..  attribute:: scopes
 
         ..  listknownscopes:: globus_sdk.scopes.ComputeScopes
-            :base_name: ComputeClient.scopes
+            :base_name: ComputeClientV3.scopes
 
+
+..  py:class:: ComputeClient
+
+    A deprecated alias for :class:`ComputeClientV2`.
+
+    ..  warning::
+
+        Users should prefer the explicitly versioned class whenever possible.
+        This class will be removed in ``globus-sdk`` version 4.
 
 Client Errors
 -------------
 
-When an error occurs, a :class:`ComputeClient` will raise a ``ComputeAPIError``.
+When an API error occurs, :class:`ComputeClientV2` and :class:`ComputeClientV3`
+will raise ``ComputeAPIError``.
 
 .. autoclass:: ComputeAPIError
    :members:

--- a/docs/services/compute.rst
+++ b/docs/services/compute.rst
@@ -13,7 +13,7 @@ for custom implementations.
 There are two client classes, supporting versions 2 and 3 of the Globus Compute
 API.
 Where feasible, new projects should use :class:`ComputeClientV3`, which
-includes the latest API features and improvements.
+supports the latest API features and improvements.
 
 ..  autoclass:: ComputeClientV2
     :members:
@@ -44,8 +44,8 @@ includes the latest API features and improvements.
 
     ..  warning::
 
-        Users should prefer the explicitly versioned class whenever possible.
         This class will be removed in ``globus-sdk`` version 4.
+        Users should migrate to one of the explicitly-versioned classes.
 
 Client Errors
 -------------

--- a/scripts/ensure_exports_are_documented.py
+++ b/scripts/ensure_exports_are_documented.py
@@ -58,10 +58,12 @@ def iter_all_documented_names() -> t.Iterable[str]:
     # names under these directives
     #
     #   .. class:: <name>
+    #   .. py:class:: <name>
+    #   .. data:: <name>
     #   .. py:data:: <name>
     pydoc_pattern = re.compile(
         r"""
-        ^\.\.\s+(?:py:data|class)::\s+ # directive
+        ^\.\.\s+(?:py:)?(?:data|class)::\s+ # directive
         (?:\w+\.)*(\w+)(?:\(.*\))?$    # symbol name (captured)
         """,
         flags=re.MULTILINE | re.X,

--- a/scripts/ensure_exports_are_documented.py
+++ b/scripts/ensure_exports_are_documented.py
@@ -57,13 +57,11 @@ def iter_all_documented_names() -> t.Iterable[str]:
     )
     # names under these directives
     #
-    #   .. class:: <name>
     #   .. py:class:: <name>
-    #   .. data:: <name>
     #   .. py:data:: <name>
     pydoc_pattern = re.compile(
         r"""
-        ^\.\.\s+(?:py:)?(?:data|class)::\s+ # directive
+        ^\.\.\s+py:(?:data|class)::\s+ # directive
         (?:\w+\.)*(\w+)(?:\(.*\))?$    # symbol name (captured)
         """,
         flags=re.MULTILINE | re.X,

--- a/src/globus_sdk/__init__.pyi
+++ b/src/globus_sdk/__init__.pyi
@@ -45,12 +45,12 @@ from .services.auth import (
 )
 from .services.compute import (
     ComputeAPIError,
-    ComputeClient,
     ComputeClientV2,
     ComputeClientV3,
     ComputeFunctionDocument,
     ComputeFunctionMetadata,
 )
+from .services.compute.deprecated_client import ComputeClient
 from .services.flows import (
     FlowsAPIError,
     FlowsClient,

--- a/src/globus_sdk/services/compute/__init__.py
+++ b/src/globus_sdk/services/compute/__init__.py
@@ -1,10 +1,9 @@
-from .client import ComputeClient, ComputeClientV2, ComputeClientV3
+from .client import ComputeClientV2, ComputeClientV3
 from .data import ComputeFunctionDocument, ComputeFunctionMetadata
 from .errors import ComputeAPIError
 
 __all__ = (
     "ComputeAPIError",
-    "ComputeClient",
     "ComputeClientV2",
     "ComputeClientV3",
     "ComputeFunctionDocument",

--- a/src/globus_sdk/services/compute/client.py
+++ b/src/globus_sdk/services/compute/client.py
@@ -368,12 +368,3 @@ class ComputeClientV3(client.BaseClient):
                     :ref: Endpoints/operation/submit_batch_v3_endpoints__endpoint_uuid__submit_post
         """  # noqa: E501
         return self.post(f"/v3/endpoints/{endpoint_id}/submit", data=data)
-
-
-class ComputeClient(ComputeClientV2):
-    r"""
-    Canonical client for the Globus Compute API, with support exclusively for
-    API version 2.
-
-    .. sdk-sphinx-copy-params:: BaseClient
-    """

--- a/src/globus_sdk/services/compute/deprecated_client.py
+++ b/src/globus_sdk/services/compute/deprecated_client.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import sys
+import typing as t
+
+from globus_sdk.exc import warn_deprecated
+
+from .client import ComputeClientV2
+
+__all__ = ("ComputeClient",)
+
+if t.TYPE_CHECKING:
+
+    class ComputeClient(ComputeClientV2):
+        pass
+
+else:
+
+    def __getattr__(name: str) -> t.Any:
+        if name == "ComputeClient":
+            warn_deprecated(
+                "'globus_sdk.ComputeClient' is deprecated but is supported as "
+                "an alias for now. Prefer 'globus_sdk.ComputeClientV2'."
+            )
+
+            class ComputeClient(ComputeClientV2):
+                """A deprecated alias for 'globus_sdk.ComputeClientV2'."""
+
+            setattr(sys.modules[__name__], name, ComputeClient)
+            return ComputeClient
+
+        raise AttributeError(f"module {__name__} has no attribute {name}")

--- a/src/globus_sdk/services/compute/deprecated_client.py
+++ b/src/globus_sdk/services/compute/deprecated_client.py
@@ -19,8 +19,8 @@ else:
     def __getattr__(name: str) -> t.Any:
         if name == "ComputeClient":
             warn_deprecated(
-                "'globus_sdk.ComputeClient' is deprecated but is supported as "
-                "an alias for now. Prefer 'globus_sdk.ComputeClientV2'."
+                "'globus_sdk.ComputeClient' is deprecated and will be removed "
+                "in the future. Prefer 'globus_sdk.ComputeClientV2'."
             )
 
             class ComputeClient(ComputeClientV2):

--- a/tests/unit/services/compute/test_canononical_client.py
+++ b/tests/unit/services/compute/test_canononical_client.py
@@ -1,6 +1,0 @@
-from globus_sdk.services.compute.client import ComputeClient, ComputeClientV2
-
-
-def test_canonical_client_is_v2():
-    client = ComputeClient()
-    assert isinstance(client, ComputeClientV2)

--- a/tests/unit/services/compute/test_deprecated_client_alias.py
+++ b/tests/unit/services/compute/test_deprecated_client_alias.py
@@ -1,0 +1,27 @@
+import pytest
+
+import globus_sdk
+from globus_sdk import ComputeClientV2, RemovedInV4Warning
+
+
+def test_legacy_client_warns_on_import():
+    from globus_sdk.services.compute import (
+        deprecated_client as deprecated_client_module,
+    )
+
+    # first, remove the object from the module's `__dict__` if it was there
+    # ensures that access will run `__getattr__`
+    if "ComputeClient" in deprecated_client_module.__dict__:
+        del deprecated_client_module.__dict__["ComputeClient"]
+    # and, similarly, remove it from 'globus_sdk'
+    if "ComputeClient" in globus_sdk.__dict__:
+        del globus_sdk.__dict__["ComputeClient"]
+
+    with pytest.warns(RemovedInV4Warning, match="deprecated"):
+        from globus_sdk import ComputeClient  # noqa: F401
+
+
+@pytest.mark.filterwarnings("ignore::globus_sdk.RemovedInV4Warning")
+def test_legacy_client_is_v2():
+    client = globus_sdk.ComputeClient()
+    assert isinstance(client, ComputeClientV2)

--- a/tests/unit/test_lazy_imports.py
+++ b/tests/unit/test_lazy_imports.py
@@ -8,6 +8,7 @@ def test_explicit_dir_func_works():
     assert "__all__" in dir(globus_sdk)
 
 
+@pytest.mark.filterwarnings("ignore::globus_sdk.RemovedInV4Warning")
 def test_force_eager_imports_can_run():
     # this check will not do much, other than ensuring that this does not crash
     globus_sdk._force_eager_imports()

--- a/tests/unit/test_paginator_signature_matching.py
+++ b/tests/unit/test_paginator_signature_matching.py
@@ -4,18 +4,21 @@ attached paginator requirements.
 """
 
 import inspect
+import warnings
 
 import pytest
 
 import globus_sdk
 
 _CLIENTS_TO_CHECK = []
-for attrname in dir(globus_sdk):
-    obj = getattr(globus_sdk, attrname)
-    if obj is globus_sdk.BaseClient:
-        continue
-    if isinstance(obj, type) and issubclass(obj, globus_sdk.BaseClient):
-        _CLIENTS_TO_CHECK.append(obj)
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", category=globus_sdk.RemovedInV4Warning)
+    for attrname in dir(globus_sdk):
+        obj = getattr(globus_sdk, attrname)
+        if obj is globus_sdk.BaseClient:
+            continue
+        if isinstance(obj, type) and issubclass(obj, globus_sdk.BaseClient):
+            _CLIENTS_TO_CHECK.append(obj)
 
 _METHODS_TO_CHECK = []
 for cls in _CLIENTS_TO_CHECK:


### PR DESCRIPTION
This class (implemented as a subclass but functionally an alias) is moved to a dedicated module to provide warn-on-import semantics.
It is now documented without autodoc, so that we can prcisely control the content shown to users.

Tests are updated to catch and ignore the deprecation warnings.

A minor flaw in the 'ensure_expores_are_documented.py' script is corrected, so that it will see the `.. py:class::` directive.

Because this is the first element in `__init__.pyi` with an associated import-time deprecation warning, some new handling of warning suppression is needed (vs prior examples).


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1278.org.readthedocs.build/en/1278/

<!-- readthedocs-preview globus-sdk-python end -->