### PR TITLE
Support setting a group's `subscription_admin_verified_id`

### DIFF
--- a/changelog.d/20250725_123218_charlie_support_updates_to_group_subscription_verified_id.rst
+++ b/changelog.d/20250725_123218_charlie_support_updates_to_group_subscription_verified_id.rst
@@ -1,0 +1,5 @@
+Added
+-----
+
+- Added support for setting a group's ``subscription_admin_verified_id``
+  with the ``GroupsClient``. (:pr:`1287`)

--- a/src/globus_sdk/_testing/data/groups/set_subscription_admin_verified_id.py
+++ b/src/globus_sdk/_testing/data/groups/set_subscription_admin_verified_id.py
@@ -1,0 +1,16 @@
+from globus_sdk._testing.models import RegisteredResponse, ResponseSet
+
+from ._common import GROUP_ID, SUBSCRIPTION_ID
+
+RESPONSES = ResponseSet(
+    metadata={"group_id": GROUP_ID, "subscription_id": SUBSCRIPTION_ID},
+    default=RegisteredResponse(
+        service="groups",
+        path=f"/groups/{GROUP_ID}/subscription_admin_verified",
+        method="PUT",
+        json={
+            "group_id": GROUP_ID,
+            "subscription_admin_verified_id": SUBSCRIPTION_ID,
+        },
+    ),
+)

--- a/src/globus_sdk/services/groups/client.py
+++ b/src/globus_sdk/services/groups/client.py
@@ -203,7 +203,7 @@ class GroupsClient(client.BaseClient):
         query_params: dict[str, t.Any] | None = None,
     ) -> response.GlobusHTTPResponse:
         """
-        Get policies for the given group
+        Get policies for the given group.
 
         :param group_id: the ID of the group
         :param query_params: additional passthrough query parameters
@@ -394,3 +394,36 @@ class GroupsClient(client.BaseClient):
                     :ref: group_membership_post_actions_v2_groups__group_id__post
         """
         return self.post(f"/groups/{group_id}", data=actions, query_params=query_params)
+
+    def set_subscription_admin_verified_id(
+        self,
+        group_id: uuid.UUID | str,
+        subscription_id: uuid.UUID | str | None,
+        *,
+        query_params: dict[str, t.Any] | None = None,
+    ) -> response.GlobusHTTPResponse:
+        """
+        Verify a group as belonging to a subscription or disassociate a verified group
+            from a subscription.
+
+        :param group_id: the ID of the group
+        :param subscription_id: the ID of the subscription to which the group belongs,
+            or ``None`` to disassociate the group from a subscription
+        :param query_params: additional passthrough query parameters
+
+        .. tab-set::
+
+            .. tab-item:: API Info
+
+                ``PUT /v2/groups/<group_id>/subscription_admin_verified``
+
+                .. extdoclink:: Update the group's subscription admin verified ID
+                    :service: groups
+                    :ref: update_subscription_admin_verified_id_v2_groups__group_id__
+                        subscription_admin_verified_put
+        """
+        return self.put(
+            f"/groups/{group_id}/subscription_admin_verified",
+            data={"subscription_admin_verified_id": subscription_id},
+            query_params=query_params,
+        )

--- a/tests/functional/services/groups/fixture_data/set_subscription_admin_verified_id.json
+++ b/tests/functional/services/groups/fixture_data/set_subscription_admin_verified_id.json
@@ -1,4 +1,0 @@
-{
-    "group_id": "d3974728-6458-11e4-b72d-123139141556",
-    "subscription_admin_verified_id": "43db2f9f-601b-4c36-bbaa-26a97555935c"
-}

--- a/tests/functional/services/groups/fixture_data/set_subscription_admin_verified_id.json
+++ b/tests/functional/services/groups/fixture_data/set_subscription_admin_verified_id.json
@@ -1,0 +1,4 @@
+{
+    "group_id": "d3974728-6458-11e4-b72d-123139141556",
+    "subscription_admin_verified_id": "43db2f9f-601b-4c36-bbaa-26a97555935c"
+}

--- a/tests/functional/services/groups/test_set_subscription_admin_verified_id.py
+++ b/tests/functional/services/groups/test_set_subscription_admin_verified_id.py
@@ -1,21 +1,19 @@
-from tests.common import register_api_route_fixture_file
+import json
+
+from globus_sdk._testing import get_last_request, load_response
 
 
 def test_set_subscription_admin_verified_id(groups_client):
-    register_api_route_fixture_file(
-        "groups",
-        "/v2/groups/d3974728-6458-11e4-b72d-123139141556/subscription_admin_verified",
-        "set_subscription_admin_verified_id.json",
-        method="PUT",
-    )
+    meta = load_response(groups_client.set_subscription_admin_verified_id).metadata
 
     res = groups_client.set_subscription_admin_verified_id(
-        group_id="d3974728-6458-11e4-b72d-123139141556",
-        subscription_id="43db2f9f-601b-4c36-bbaa-26a97555935c",
+        group_id=meta["group_id"],
+        subscription_id=meta["subscription_id"],
     )
     assert res.http_status == 200
-    assert res.data["group_id"] == "d3974728-6458-11e4-b72d-123139141556"
-    assert (
-        res.data["subscription_admin_verified_id"]
-        == "43db2f9f-601b-4c36-bbaa-26a97555935c"
-    )
+    assert res.data["group_id"] == meta["group_id"]
+    assert res.data["subscription_admin_verified_id"] == meta["subscription_id"]
+
+    req = get_last_request()
+    req = json.loads(req.body)
+    assert req == {"subscription_admin_verified_id": meta["subscription_id"]}

--- a/tests/functional/services/groups/test_set_subscription_admin_verified_id.py
+++ b/tests/functional/services/groups/test_set_subscription_admin_verified_id.py
@@ -1,0 +1,21 @@
+from tests.common import register_api_route_fixture_file
+
+
+def test_set_subscription_admin_verified_id(groups_client):
+    register_api_route_fixture_file(
+        "groups",
+        "/v2/groups/d3974728-6458-11e4-b72d-123139141556/subscription_admin_verified",
+        "set_subscription_admin_verified_id.json",
+        method="PUT",
+    )
+
+    res = groups_client.set_subscription_admin_verified_id(
+        group_id="d3974728-6458-11e4-b72d-123139141556",
+        subscription_id="43db2f9f-601b-4c36-bbaa-26a97555935c",
+    )
+    assert res.http_status == 200
+    assert res.data["group_id"] == "d3974728-6458-11e4-b72d-123139141556"
+    assert (
+        res.data["subscription_admin_verified_id"]
+        == "43db2f9f-601b-4c36-bbaa-26a97555935c"
+    )


### PR DESCRIPTION
This change is intended to support setting a group's `subscription_admin_verified_id` through the Globus SDK. This leverages the groups route added as part of [sc-38858](https://app.shortcut.com/globus/story/38858/add-support-for-marking-groups-as-subscription-admin-verified).

- New `GroupsClient` method
  - Required Arguments:
    - `group_id`
    - `subscription_id` (can be `None` to unverify a group)
- Test to confirm behavior

<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1287.org.readthedocs.build/en/1287/

<!-- readthedocs-preview globus-sdk-python end -->