### PR TITLE
Update `warn_deprecated` to emit `RemovedInV5Warning`

### DIFF
--- a/changelog.d/20250731_113700_8730430+m1yag1_sc_43139_update_warn_deprecated.rst
+++ b/changelog.d/20250731_113700_8730430+m1yag1_sc_43139_update_warn_deprecated.rst
@@ -1,0 +1,5 @@
+Changed
+-------
+
+- Update ``warn_deprecated`` to emit ``RemovedInV5Warning`` and remove
+  ``RemovedInV4Warning`` class (:pr:`NUMBER`)

--- a/docs/core/warnings.rst
+++ b/docs/core/warnings.rst
@@ -4,7 +4,7 @@ Warnings
 The following warnings can be emitted by the Globus SDK to indicate a
 problem, or a future change, which is not necessarily an error.
 
-.. autoclass:: globus_sdk.RemovedInV4Warning
+.. autoclass:: globus_sdk.RemovedInV5Warning
     :members:
     :show-inheritance:
 

--- a/src/globus_sdk/__init__.pyi
+++ b/src/globus_sdk/__init__.pyi
@@ -16,7 +16,7 @@ from .exc import (
     GlobusSDKUsageError,
     GlobusTimeoutError,
     NetworkError,
-    RemovedInV4Warning,
+    RemovedInV5Warning,
     ValidationError,
 )
 from .globus_app import ClientApp, GlobusApp, GlobusAppConfig, UserApp
@@ -141,7 +141,7 @@ __all__ = (
     "GlobusSDKUsageError",
     "GlobusTimeoutError",
     "NetworkError",
-    "RemovedInV4Warning",
+    "RemovedInV5Warning",
     "ValidationError",
     "ClientApp",
     "GlobusApp",

--- a/src/globus_sdk/exc/__init__.py
+++ b/src/globus_sdk/exc/__init__.py
@@ -10,7 +10,7 @@ from .err_info import (
     ErrorInfo,
     ErrorInfoContainer,
 )
-from .warnings import RemovedInV4Warning, warn_deprecated
+from .warnings import RemovedInV5Warning, warn_deprecated
 
 __all__ = (
     "GlobusError",
@@ -27,14 +27,14 @@ __all__ = (
     "ErrorInfoContainer",
     "AuthorizationParameterInfo",
     "ConsentRequiredInfo",
-    "RemovedInV4Warning",
+    "RemovedInV5Warning",
     "warn_deprecated",
 )
 
 # imports from `globus_sdk.exc.convert` are done lazily
 #
 # this ensures that we do not eagerly import `requests` when attempting to use SDK
-# components which do not need it, but which do need errors (e.g., RemovedInV4Warning)
+# components which do not need it, but which do need errors (e.g., RemovedInV5Warning)
 # and we avoid paying the performance penalty for importing the relevant dependencies
 if t.TYPE_CHECKING:
     from .convert import (

--- a/src/globus_sdk/exc/warnings.py
+++ b/src/globus_sdk/exc/warnings.py
@@ -3,14 +3,14 @@ from __future__ import annotations
 import warnings
 
 
-class RemovedInV4Warning(DeprecationWarning):
+class RemovedInV5Warning(DeprecationWarning):
     """
     This warning indicates that a feature or usage was detected which will be
-    unsupported in globus-sdk version 4.
+    unsupported in globus-sdk version 5.
 
     Users are encouraged to resolve these warnings when possible.
     """
 
 
 def warn_deprecated(message: str, stacklevel: int = 2) -> None:
-    warnings.warn(message, RemovedInV4Warning, stacklevel=stacklevel)
+    warnings.warn(message, RemovedInV5Warning, stacklevel=stacklevel)


### PR DESCRIPTION
**Shortcut Link**: https://app.shortcut.com/globus/story/43139

## What
Update `warn_deprecated` to emit `RemovedInV5Warning` and remove `RemovedInV4Warning` class.

## Why
SDK 4.x should use V5 deprecation warnings, not V4 warnings.

## How
Replace `RemovedInV4Warning` with `RemovedInV5Warning` class and update function usage.

<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1295.org.readthedocs.build/en/1295/

<!-- readthedocs-preview globus-sdk-python end -->