### PR TITLE
Merge v3.62.0 back to 4.x-dev

### DIFF
--- a/changelog.rst
+++ b/changelog.rst
@@ -270,6 +270,14 @@ Breaking Changes
 
 - Updated MappedCollectionDoc and GuestCollectionDoc with MissingType. (:pr:`1189`)
 
+.. _changelog-3.62.0:
+
+v3.62.0 (2025-07-31)
+====================
+
+- Added support for setting a group's ``subscription_id``
+  via ``GroupsClient.set_subscription_admin_verified_id``. (:pr:`1287`)
+
 .. _changelog-3.61.0:
 
 v3.61.0 (2025-07-23)

--- a/src/globus_sdk/services/groups/client.py
+++ b/src/globus_sdk/services/groups/client.py
@@ -199,7 +199,7 @@ class GroupsClient(client.BaseClient):
         query_params: dict[str, t.Any] | None = None,
     ) -> response.GlobusHTTPResponse:
         """
-        Get policies for the given group
+        Get policies for the given group.
 
         :param group_id: the ID of the group
         :param query_params: additional passthrough query parameters
@@ -391,4 +391,37 @@ class GroupsClient(client.BaseClient):
         """
         return self.post(
             f"/v2/groups/{group_id}", data=actions, query_params=query_params
+        )
+
+    def set_subscription_admin_verified_id(
+        self,
+        group_id: uuid.UUID | str,
+        subscription_id: uuid.UUID | str | None,
+        *,
+        query_params: dict[str, t.Any] | None = None,
+    ) -> response.GlobusHTTPResponse:
+        """
+        Verify a group as belonging to a subscription or disassociate a verified group
+            from a subscription.
+
+        :param group_id: the ID of the group
+        :param subscription_id: the ID of the subscription to which the group belongs,
+            or ``None`` to disassociate the group from a subscription
+        :param query_params: additional passthrough query parameters
+
+        .. tab-set::
+
+            .. tab-item:: API Info
+
+                ``PUT /v2/groups/<group_id>/subscription_admin_verified``
+
+                .. extdoclink:: Update the group's subscription admin verified ID
+                    :service: groups
+                    :ref: update_subscription_admin_verified_id_v2_groups__group_id__
+                        subscription_admin_verified_put
+        """
+        return self.put(
+            f"/v2/groups/{group_id}/subscription_admin_verified",
+            data={"subscription_admin_verified_id": subscription_id},
+            query_params=query_params,
         )

--- a/src/globus_sdk/testing/data/groups/set_subscription_admin_verified_id.py
+++ b/src/globus_sdk/testing/data/groups/set_subscription_admin_verified_id.py
@@ -1,0 +1,16 @@
+from globus_sdk.testing.models import RegisteredResponse, ResponseSet
+
+from ._common import GROUP_ID, SUBSCRIPTION_ID
+
+RESPONSES = ResponseSet(
+    metadata={"group_id": GROUP_ID, "subscription_id": SUBSCRIPTION_ID},
+    default=RegisteredResponse(
+        service="groups",
+        path=f"/v2/groups/{GROUP_ID}/subscription_admin_verified",
+        method="PUT",
+        json={
+            "group_id": GROUP_ID,
+            "subscription_admin_verified_id": SUBSCRIPTION_ID,
+        },
+    ),
+)

--- a/tests/functional/services/groups/test_set_subscription_admin_verified_id.py
+++ b/tests/functional/services/groups/test_set_subscription_admin_verified_id.py
@@ -1,0 +1,19 @@
+import json
+
+from globus_sdk.testing import get_last_request, load_response
+
+
+def test_set_subscription_admin_verified_id(groups_client):
+    meta = load_response(groups_client.set_subscription_admin_verified_id).metadata
+
+    res = groups_client.set_subscription_admin_verified_id(
+        group_id=meta["group_id"],
+        subscription_id=meta["subscription_id"],
+    )
+    assert res.http_status == 200
+    assert res.data["group_id"] == meta["group_id"]
+    assert res.data["subscription_admin_verified_id"] == meta["subscription_id"]
+
+    req = get_last_request()
+    req = json.loads(req.body)
+    assert req == {"subscription_admin_verified_id": meta["subscription_id"]}


### PR DESCRIPTION
- Support setting a group's `subscription_admin_verified_id` with the GroupsClient
- Include scriv changelog entry
- Use load_response instead of deprecated testing method
- Bump version and changelog for release


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1297.org.readthedocs.build/en/1297/

<!-- readthedocs-preview globus-sdk-python end -->