### PR TITLE
Put error text in `__notes__` where supported

### DIFF
--- a/changelog.d/20250805_143650_sirosen_exception_add_note.rst
+++ b/changelog.d/20250805_143650_sirosen_exception_add_note.rst
@@ -1,0 +1,6 @@
+Added
+-----
+
+- On Python 3.11+, the SDK will populate the ``__notes__`` of API errors with a
+  message containing the full body of the error response.
+  ``__notes__`` is part of the default presentation of a traceback. (:pr:`NUMBER`)

--- a/src/globus_sdk/exc/api.py
+++ b/src/globus_sdk/exc/api.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import enum
 import logging
+import sys
+import textwrap
 import typing as t
 
 from globus_sdk._internal import guards
@@ -53,6 +55,15 @@ class GlobusAPIError(GlobusError):
         self._info: ErrorInfoContainer | None = None
         self._underlying_response = r
         self._parse_response()
+
+        if sys.version_info >= (3, 11):
+            self.add_note(
+                (
+                    "This exception was caused by an API error. "
+                    "The response body is as follows:\n\n"
+                )
+                + textwrap.indent(self.text, "    ")
+            )
         super().__init__(*self._get_args())
 
     @property

--- a/tests/unit/errors/test_common_functionality.py
+++ b/tests/unit/errors/test_common_functionality.py
@@ -1,4 +1,6 @@
 import itertools
+import sys
+import uuid
 
 import pytest
 import requests
@@ -50,6 +52,17 @@ def test_binary_content_property():
     body_text = "some data"
     err = construct_error(body=body_text, http_status=400)
     assert err.binary_content == body_text.encode("utf-8")
+
+
+# `add_note()` and `__notes__` are new in Python 3.11
+@pytest.mark.skipif(
+    sys.version_info < (3, 11), reason="Exception.add_note() is new in Python 3.11"
+)
+def test_notes_are_populated_with_text():
+    text_body = f"some error: {uuid.uuid4()}"
+    err = construct_error(body=text_body, http_status=400)
+    assert err.text == text_body
+    assert any(text_body in note for note in err.__notes__)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
For Python 3.11+, `add_note()` and `__notes__` provide a mechanism for us to greatly enhance the representation of an error.

---

This enhancement is motivated by the frequency with which users building scripts and applications on top of the SDK handle a traceback (e.g., in logs) well removed from the actual error context.
In some cases, we are asking users to retrieve `err.text` in order to get detailed information on what went wrong.

Instead of reactively looking for this data, the library can proactively push it into tracebacks without impacting programmatic usage.
With large errors, this can make tracebacks very long, but traces are already diagnostic info and contain exception chains, so I'm not worried about the downsides here.


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1299.org.readthedocs.build/en/1299/

<!-- readthedocs-preview globus-sdk-python end -->