### PR TITLE
Raise TypeError on invalid Scope constructions

### DIFF
--- a/changelog.d/20250809_120120_sirosen_scopes_strict_at_runtime.rst
+++ b/changelog.d/20250809_120120_sirosen_scopes_strict_at_runtime.rst
@@ -1,0 +1,6 @@
+Changed
+-------
+
+- Passing non-``Scope`` types to ``Scope.with_dependency`` and
+  ``Scope.with_dependencies`` now raises a ``TypeError``. Previously, this was
+  allowed at runtime but created an invalid ``Scope`` object. (:pr:`NUMBER`)

--- a/src/globus_sdk/scopes/representation.py
+++ b/src/globus_sdk/scopes/representation.py
@@ -77,6 +77,11 @@ class Scope:
 
         :param other_scope: The scope upon which the current scope depends.
         """
+        if not isinstance(other_scope, Scope):
+            raise TypeError(
+                "Scope.with_dependency() takes a Scope as its input. "
+                f"Got: '{type(other_scope).__qualname__}'"
+            )
         return dataclasses.replace(
             self, dependencies=self.dependencies + (other_scope,)
         )
@@ -89,8 +94,16 @@ class Scope:
 
         :param other_scopes: The scopes upon which the current scope depends.
         """
+        other_scopes_tuple = tuple(other_scopes)
+        for i, item in enumerate(other_scopes_tuple):
+            if not isinstance(item, Scope):
+                raise TypeError(
+                    "Scope.with_dependencies() takes "
+                    "an iterable of Scopes as its input. "
+                    f"At position {i}, got: '{type(item).__qualname__}'"
+                )
         return dataclasses.replace(
-            self, dependencies=self.dependencies + tuple(other_scopes)
+            self, dependencies=self.dependencies + other_scopes_tuple
         )
 
     def with_optional(self, optional: bool) -> Scope:

--- a/tests/unit/authorizers/test_client_credentials_authorizer.py
+++ b/tests/unit/authorizers/test_client_credentials_authorizer.py
@@ -67,6 +67,6 @@ def test_can_create_authorizer_from_scope_objects(client):
     assert a1.scopes == "foo"
 
     a2 = ClientCredentialsAuthorizer(
-        client, [Scope("foo"), "bar", Scope("baz").with_dependency("buzz")]
+        client, [Scope("foo"), "bar", Scope("baz").with_dependency(Scope("buzz"))]
     )
     assert a2.scopes == "foo bar baz[buzz]"

--- a/tests/unit/scopes/test_merge_scopes.py
+++ b/tests/unit/scopes/test_merge_scopes.py
@@ -25,8 +25,8 @@ def test_mixed_optional_dependencies():
 
 
 def test_different_dependencies():
-    s1 = [Scope("foo").with_dependency("bar")]
-    s2 = [Scope("foo").with_dependency("baz")]
+    s1 = [Scope("foo").with_dependency(Scope("bar"))]
+    s2 = [Scope("foo").with_dependency(Scope("baz"))]
     merged = ScopeParser.merge_scopes(s1, s2)
     assert len(merged) == 1
     assert merged[0].scope_string == "foo"
@@ -38,8 +38,8 @@ def test_different_dependencies():
 
 
 def test_optional_dependencies():
-    s1 = [Scope("foo").with_dependency("bar")]
-    s2 = [Scope("foo").with_dependency("*bar")]
+    s1 = [Scope("foo").with_dependency(Scope("bar"))]
+    s2 = [Scope("foo").with_dependency(Scope("bar", optional=True))]
     merged = ScopeParser.merge_scopes(s1, s2)
     assert len(merged) == 1
     assert merged[0].scope_string == "foo"
@@ -50,8 +50,8 @@ def test_optional_dependencies():
 
 
 def test_different_dependencies_on_mixed_optional_base():
-    s1 = [Scope("foo").with_dependency("bar")]
-    s2 = [Scope("foo", optional=True).with_dependency("baz")]
+    s1 = [Scope("foo").with_dependency(Scope("bar"))]
+    s2 = [Scope("foo", optional=True).with_dependency(Scope("baz"))]
     merged = ScopeParser.merge_scopes(s1, s2)
     assert len(merged) == 2
 

--- a/tests/unit/scopes/test_scope_model.py
+++ b/tests/unit/scopes/test_scope_model.py
@@ -1,5 +1,7 @@
 import uuid
 
+import pytest
+
 from globus_sdk.scopes import Scope
 
 
@@ -37,3 +39,36 @@ def test_scope_with_optional_leaves_original_unchanged():
     assert not s1.optional
     assert s2.optional
     assert not s3.optional
+
+
+def test_scope_with_string_dependency_gets_typeerror():
+    s = Scope("x")
+    with pytest.raises(
+        TypeError,
+        match=r"Scope\.with_dependency\(\) takes a Scope as its input\. Got: 'str'",
+    ):
+        s.with_dependency("y")
+
+
+def test_scope_with_string_dependencies_gets_typeerror():
+    s = Scope("x")
+    with pytest.raises(
+        TypeError,
+        match=(
+            r"Scope\.with_dependencies\(\) takes an iterable of Scopes as its input\. "
+            "At position 0, got: 'str'"
+        ),
+    ):
+        s.with_dependencies(["y"])
+
+
+def test_scope_with_mixed_dependencies_gets_typeerror():
+    s = Scope("x")
+    with pytest.raises(
+        TypeError,
+        match=(
+            r"Scope\.with_dependencies\(\) takes an iterable of Scopes as its input\. "
+            "At position 1, got: 'str'"
+        ),
+    ):
+        s.with_dependencies([Scope("y"), "z"])


### PR DESCRIPTION
Type hints declare that `Scope.with_dependency` and
`Scope.with_dependencies` require `Scope` objects as their input.
This new requirement makes construction simpler, with fewer cases, but
is easy to accidentally violate when manipulating Scopes and strings
together.

Some existing tests were actually constructing invalid scopes by
passing strings and only incidentally passing.

A Scope containing dependencies which are strings is invalid -- we
offer no guarantees around how such an object might behave.

To fix, TypeErrors are added to `with_dependency()` and
`with_dependencies()` in order to catch string inputs.


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1300.org.readthedocs.build/en/1300/

<!-- readthedocs-preview globus-sdk-python end -->