### PR TITLE
Set pytest-xdist parallelism to 0 under `tox p`

### DIFF
--- a/toxfile.py
+++ b/toxfile.py
@@ -52,6 +52,15 @@ def tox_add_env_config(env_conf: EnvConfigSet, state: State) -> None:
 
 @impl
 def tox_before_run_commands(tox_env: ToxEnv) -> None:
+    # determine if it was a parallel invocation by examining the CLI command
+    parallel_detected = tox_env.options.command in ("p", "run-parallel")
+    if parallel_detected:
+        # tox is running parallel, set an indicator env var
+        # and effectively disable pytest-xdist by setting xdist-workers to 0
+        # -- 0 means tests will run in the main process, not even in a worker
+        setenv = tox_env.conf.load("set_env")
+        setenv.update({"TOX_PARALLEL": "1", "PYTEST_XDIST_AUTO_NUM_WORKERS": "0"})
+
     sdk_rmtree = tox_env.conf.load("globus_sdk_rmtree")
     for name in sdk_rmtree:
         path = pathlib.Path(name)


### PR DESCRIPTION
When tox parallel invocation is used, disable parallel execution under
xdist. Having two layers of parallelism results in slower test
executions because it increases contention.

For example, on a 4 processor machine, running 4 jobs under
`tox run-parallel`, the nested structure spawns 20 parallel processes:
(4 xdist workers + 1 xdist main process) * 4 tox workers

A more appropriate level of parallelism for 4 processors with
CPU-bound work would be closer to 4.

This configuration is already in use in globus-cli, and makes our
configuration select parallelism at "the appropriate level".


<!-- readthedocs-preview globus-sdk-python start -->
----
📚 Documentation preview 📚: https://globus-sdk-python--1301.org.readthedocs.build/en/1301/

<!-- readthedocs-preview globus-sdk-python end -->