### PR TITLE
Deprecate 'skip_activation_check'

### DIFF
--- a/changelog.d/20250916_161316_sirosen_deprecate_skip_activation_check.rst
+++ b/changelog.d/20250916_161316_sirosen_deprecate_skip_activation_check.rst
@@ -1,0 +1,5 @@
+Deprecated
+----------
+
+- The ``skip_activation_check`` parameter to ``TransferData`` and ``DeleteData``
+  has been deprecated. This parameter no longer has any effect when set. (:pr:`NUMBER`)

--- a/src/globus_sdk/services/transfer/data/delete_data.py
+++ b/src/globus_sdk/services/transfer/data/delete_data.py
@@ -49,8 +49,8 @@ class DeleteData(utils.PayloadWrapper):
         timestamp is in UTC to avoid confusion and ambiguity. Examples of ISO-8601
         timestamps include ``2017-10-12 09:30Z``, ``2017-10-12 12:33:54+00:00``, and
         ``2017-10-12``
-    :param skip_activation_check: When true, allow submission even if the endpoint
-        isn't currently activated
+    :param skip_activation_check: This argument is deprecated, as 'activation' is no
+        longer supported by Globus Collections.
     :param notify_on_succeeded: Send a notification email when the delete task
         completes with a status of SUCCEEDED.
         [default: ``True``]
@@ -107,6 +107,12 @@ class DeleteData(utils.PayloadWrapper):
         # the first arg
         if endpoint is None:
             raise exc.GlobusSDKUsageError("endpoint is required")
+
+        if skip_activation_check is not None:
+            exc.warn_deprecated(
+                "`skip_activation_check` is no longer supported by Globus Collections, "
+                "and has no effect when set."
+            )
 
         self["DATA_TYPE"] = "delete"
         self["DATA"] = []

--- a/src/globus_sdk/services/transfer/data/transfer_data.py
+++ b/src/globus_sdk/services/transfer/data/transfer_data.py
@@ -79,8 +79,8 @@ class TransferData(utils.PayloadWrapper):
         ``2017-10-12``
     :param recursive_symlinks: This keyword argument is deprecated as not collections
         support it.
-    :param skip_activation_check: When true, allow submission even if the endpoints
-        aren't currently activated
+    :param skip_activation_check: This argument is deprecated, as 'activation' is no
+        longer supported by Globus Collections.
     :param skip_source_errors: When true, source permission denied and file
         not found errors from the source endpoint will cause the offending
         path to be skipped.
@@ -196,6 +196,12 @@ class TransferData(utils.PayloadWrapper):
             exc.warn_deprecated(
                 "`recursive_symlinks` is not currently supported by any collections. "
                 "To reduce confusion, this keyword argument will be removed."
+            )
+
+        if skip_activation_check is not None:
+            exc.warn_deprecated(
+                "`skip_activation_check` is no longer supported by Globus Collections, "
+                "and has no effect when set."
             )
 
         log.debug("Creating a new TransferData object")

--- a/tests/unit/helpers/test_timer.py
+++ b/tests/unit/helpers/test_timer.py
@@ -1,3 +1,4 @@
+import contextlib
 import datetime
 
 import pytest
@@ -30,7 +31,16 @@ def test_timer_from_transfer_data_ok():
     "badkey, value", (("submission_id", "foo"), ("skip_activation_check", True))
 )
 def test_timer_from_transfer_data_rejects_forbidden_keys(badkey, value):
-    tdata = TransferData(None, GO_EP1_ID, GO_EP2_ID, **{badkey: value})
+    if badkey == "skip_activation_check":
+        ctx = pytest.warns(
+            exc.RemovedInV4Warning,
+            match="`skip_activation_check` is no longer supported",
+        )
+    else:
+        ctx = contextlib.nullcontext()
+
+    with ctx:
+        tdata = TransferData(None, GO_EP1_ID, GO_EP2_ID, **{badkey: value})
     with pytest.raises(ValueError):
         with pytest.warns(exc.RemovedInV4Warning, match="Prefer TransferTimer"):
             TimerJob.from_transfer_data(tdata, "2022-01-01T00:00:00Z", 600)

--- a/tests/unit/helpers/test_transfer.py
+++ b/tests/unit/helpers/test_transfer.py
@@ -1,6 +1,12 @@
 import pytest
 
-from globus_sdk import DeleteData, GlobusSDKUsageError, TransferClient, TransferData
+from globus_sdk import (
+    DeleteData,
+    GlobusSDKUsageError,
+    TransferClient,
+    TransferData,
+    exc,
+)
 from globus_sdk._testing import load_response
 from globus_sdk.services.transfer.client import _format_filter
 from tests.common import GO_EP1_ID, GO_EP2_ID
@@ -337,11 +343,19 @@ def test_skip_activation_check_supported(datatype, value):
         # not present if not provided as a param or provided as explicit None
         assert "skip_activation_check" not in create()
     elif value:
-        data = create(skip_activation_check=True)
+        with pytest.warns(
+            exc.RemovedInV4Warning,
+            match="`skip_activation_check` is no longer supported",
+        ):
+            data = create(skip_activation_check=True)
         assert "skip_activation_check" in data
         assert data["skip_activation_check"] is True
     else:
-        data = create(skip_activation_check=False)
+        with pytest.warns(
+            exc.RemovedInV4Warning,
+            match="`skip_activation_check` is no longer supported",
+        ):
+            data = create(skip_activation_check=False)
         assert "skip_activation_check" in data
         assert data["skip_activation_check"] is False
 


### PR DESCRIPTION
Per conversation with the Transfer team, this parameter is no longer
meaningful and has no effect. It is now deprecated and will be removed
in SDK v4.
