### PR TITLE
Remove support for symlinks and 'skip_activation_check' from TransferData and DeleteData (merge 3.x main to 4.x-dev)

### DIFF
--- a/changelog.d/20250916_190714_sirosen_merge_back_main.rst
+++ b/changelog.d/20250916_190714_sirosen_merge_back_main.rst
@@ -1,0 +1,9 @@
+Removed
+-------
+
+- The following methods and parameters, which were deprecated in globus-sdk v3,
+  have been removed (:pr:`NUMBER`):
+
+  - The ``skip_activation_check`` parameter for ``TransferData`` and ``DeleteData``.
+  - The ``recursive_symlinks`` parameter for ``TransferData``.
+  - The ``add_symlink_item`` method of ``TransferData``.

--- a/src/globus_sdk/services/transfer/data/delete_data.py
+++ b/src/globus_sdk/services/transfer/data/delete_data.py
@@ -40,8 +40,6 @@ class DeleteData(GlobusPayload):
         timestamp is in UTC to avoid confusion and ambiguity. Examples of ISO-8601
         timestamps include ``2017-10-12 09:30Z``, ``2017-10-12 12:33:54+00:00``, and
         ``2017-10-12``
-    :param skip_activation_check: When true, allow submission even if the endpoint
-        isn't currently activated
     :param notify_on_succeeded: Send a notification email when the delete task
         completes with a status of SUCCEEDED.
         [default: ``True``]
@@ -85,7 +83,6 @@ class DeleteData(GlobusPayload):
         ignore_missing: bool | MissingType = MISSING,
         interpret_globs: bool | MissingType = MISSING,
         deadline: str | datetime.datetime | MissingType = MISSING,
-        skip_activation_check: bool | MissingType = MISSING,
         notify_on_succeeded: bool | MissingType = MISSING,
         notify_on_failed: bool | MissingType = MISSING,
         notify_on_inactive: bool | MissingType = MISSING,
@@ -103,7 +100,6 @@ class DeleteData(GlobusPayload):
         self["recursive"] = recursive
         self["ignore_missing"] = ignore_missing
         self["interpret_globs"] = interpret_globs
-        self["skip_activation_check"] = skip_activation_check
         self["notify_on_succeeded"] = notify_on_succeeded
         self["notify_on_failed"] = notify_on_failed
         self["notify_on_inactive"] = notify_on_inactive

--- a/tests/functional/services/transfer/test_task_submit.py
+++ b/tests/functional/services/transfer/test_task_submit.py
@@ -41,7 +41,6 @@ def test_transfer_submit_success(client):
     assert tdata["sync_level"] == 0
 
     tdata.add_item("/path/to/foo", "/path/to/bar")
-    tdata.add_symlink_item("linkfoo", "linkbar")
 
     res = client.submit_transfer(tdata)
 

--- a/tests/unit/helpers/test_transfer.py
+++ b/tests/unit/helpers/test_transfer.py
@@ -97,23 +97,6 @@ def test_transfer_add_item():
     assert all(fields_data[k] == v for k, v in addfields.items())
 
 
-def test_transfer_add_symlink_item():
-    """
-    Adds a transfer_symlink_item to TransferData, verifies results
-    """
-    tdata = TransferData(GO_EP1_ID, GO_EP2_ID)
-    # add item
-    source_path = "source/path/"
-    dest_path = "dest/path/"
-    tdata.add_symlink_item(source_path, dest_path)
-    # verify results
-    assert len(tdata["DATA"]) == 1
-    data = tdata["DATA"][0]
-    assert data["DATA_TYPE"] == "transfer_symlink_item"
-    assert data["source_path"] == source_path
-    assert data["destination_path"] == dest_path
-
-
 @pytest.mark.parametrize(
     "args, kwargs",
     (
@@ -274,28 +257,6 @@ def test_transfer_sync_levels_result(sync_level, result):
     else:
         tdata = TransferData(GO_EP1_ID, GO_EP2_ID, sync_level=sync_level)
         assert tdata["sync_level"] == result
-
-
-@pytest.mark.parametrize("datatype", ("transfer", "delete"))
-@pytest.mark.parametrize("value", (None, True, False))
-def test_skip_activation_check_supported(datatype, value):
-    def create(**kwargs):
-        if datatype == "transfer":
-            return TransferData(GO_EP1_ID, GO_EP2_ID, **kwargs)
-        else:
-            return DeleteData(GO_EP1_ID, **kwargs)
-
-    if value is None:
-        # not present if not provided as a param or provided as explicit None
-        assert create()["skip_activation_check"] is MISSING
-    elif value:
-        data = create(skip_activation_check=True)
-        assert "skip_activation_check" in data
-        assert data["skip_activation_check"] is True
-    else:
-        data = create(skip_activation_check=False)
-        assert "skip_activation_check" in data
-        assert data["skip_activation_check"] is False
 
 
 def test_add_filter_rule():


### PR DESCRIPTION
This is a merge-back process to bring the latest changes from 3.x main (#1307 and #1308) back into the 4.x-dev branch.
The dedicated merge will help keep the intent of these changes well aligned ahead of the next release.

Unlike #1307 and #1308, which deprecate features, this changeset does the "logical merge" against 4.x and follows those deprecations with the relevant removals.
