### PR TITLE
Add support for Search's Index Update API

### DIFF
--- a/changelog.d/20250917_144837_sirosen_support_search_index_patch.rst
+++ b/changelog.d/20250917_144837_sirosen_support_search_index_patch.rst
@@ -1,0 +1,5 @@
+Added
+-----
+
+- Added ``SearchClient.update_index`` as a method for modifying index names and
+  descriptions. (:pr:`NUMBER`)

--- a/src/globus_sdk/_testing/data/search/update_index.py
+++ b/src/globus_sdk/_testing/data/search/update_index.py
@@ -1,0 +1,58 @@
+import uuid
+
+from globus_sdk._testing.models import RegisteredResponse, ResponseSet
+
+INDEX_ID = str(uuid.uuid4())
+
+_default_display_name = "Awesome Index of Awesomeness"
+_default_description = "An index so awesome that it simply cannot be described"
+
+RESPONSES = ResponseSet(
+    default=RegisteredResponse(
+        service="search",
+        method="PATCH",
+        path=f"/v1/index/{INDEX_ID}",
+        json={
+            "@datatype": "GSearchIndex",
+            "@version": "2017-09-01",
+            "creation_date": "2021-04-05 15:05:18",
+            "display_name": _default_display_name,
+            "description": _default_description,
+            "id": INDEX_ID,
+            "is_trial": True,
+            "subscription_id": None,
+            "max_size_in_mb": 1,
+            "num_entries": 0,
+            "num_subjects": 0,
+            "size_in_mb": 0,
+            "status": "open",
+        },
+        metadata={"index_id": INDEX_ID, "display_name": _default_display_name},
+    ),
+    forbidden=RegisteredResponse(
+        service="search",
+        method="PATCH",
+        path=f"/v1/index/{INDEX_ID}",
+        status=403,
+        json={
+            "@datatype": "GError",
+            "@version": "2017-09-01",
+            "status": 403,
+            "code": "Forbidden.Generic",
+            "message": "index_update request denied by service",
+            "request_id": "0e73b6a61e53468684f86c7993336a72",
+            "error_data": {
+                "cause": (
+                    "You do not have the proper roles "
+                    "to perform the index_update operation."
+                ),
+                "recommended_resolution": (
+                    "Ensure you are making a call authenticated with "
+                    "a valid Search token and that you have been granted "
+                    "the required roles for this operation"
+                ),
+            },
+        },
+        metadata={"index_id": INDEX_ID},
+    ),
+)

--- a/src/globus_sdk/services/search/client.py
+++ b/src/globus_sdk/services/search/client.py
@@ -7,6 +7,7 @@ import uuid
 from globus_sdk import client, paging, response, utils
 from globus_sdk.exc.warnings import warn_deprecated
 from globus_sdk.scopes import Scope, SearchScopes
+from globus_sdk.utils import MISSING, MissingType
 
 from .data import SearchQuery, SearchScrollQuery
 from .errors import SearchAPIError
@@ -79,6 +80,52 @@ class SearchClient(client.BaseClient):
         log.debug(f"SearchClient.create_index({display_name!r}, ...)")
         return self.post(
             "/v1/index", data={"display_name": display_name, "description": description}
+        )
+
+    def update_index(
+        self,
+        index_id: uuid.UUID | str,
+        *,
+        display_name: str | MissingType = MISSING,
+        description: str | MissingType = MISSING,
+    ) -> response.GlobusHTTPResponse:
+        """
+        Update index metadata.
+
+        :param index_id: the ID of the index
+        :param display_name: the name of the index
+        :param description: a description of the index
+
+        .. tab-set::
+
+            .. tab-item:: Example Usage
+
+                .. code-block:: python
+
+                    sc = globus_sdk.SearchClient(...)
+                    MY_INDEX_ID = ...
+                    r = sc.update_index(
+                        MY_INDEX_ID,
+                        display_name="My Awesome Index",
+                        description="Very awesome searchable data",
+                    )
+                    print(f"index ID: {r['id']}")
+
+            .. tab-item:: Example Response Data
+
+                .. expandtestfixture:: search.create_index
+
+            .. tab-item:: API Info
+
+                ``PATCH /v1/index/<index_id>``
+
+                .. extdoclink:: Index Update
+                    :ref: search/reference/index_update/
+        """
+        log.debug(f"SearchClient.update_index({index_id!r}, ...)")
+        return self.patch(
+            f"/v1/index/{index_id}",
+            data={"display_name": display_name, "description": description},
         )
 
     def delete_index(self, index_id: uuid.UUID | str) -> response.GlobusHTTPResponse:

--- a/tests/functional/services/search/test_update_index.py
+++ b/tests/functional/services/search/test_update_index.py
@@ -1,0 +1,24 @@
+import pytest
+
+import globus_sdk
+from globus_sdk._testing import load_response
+
+
+def test_update_index(client):
+    meta = load_response(client.update_index).metadata
+
+    res = client.update_index(meta["index_id"], display_name="foo")
+    assert res.http_status == 200
+    assert res["display_name"] == meta["display_name"]
+
+
+def test_update_index_forbidden_error(client):
+    meta = load_response(client.update_index, case="forbidden").metadata
+
+    with pytest.raises(globus_sdk.SearchAPIError) as excinfo:
+        client.update_index(meta["index_id"])
+
+    err = excinfo.value
+
+    assert err.http_status == 403
+    assert err.code == "Forbidden.Generic"


### PR DESCRIPTION
The SDK method is named `update_index` to be consistent with other
methods like `create_index` and `delete_index`. Some of the test data
and Search docs reveal that service-side, this is being called
"index_update" in some cases. Weighing the pro/con around this
discrepancy, consistency with other SDK methods seems more important than
matching the exact string used by the service in some cases.
