### PR TITLE
Add guidance on 'base_path' to upgrading doc

### DIFF
--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -609,11 +609,12 @@ snippet has the same effect in both versions:
 Clients with a ``base_path`` and the values they defined in version 3 are listed
 below.
 
-..  csv-table::
-    :header: "Client Class", "base_path"
-
-    "``TransferClient``", "``"v0.10"``"
-    "``GroupsClient``", "``"v2"``"
+==================  ===========
+Client Class        base_path
+==================  ===========
+``TransferClient``  ``"v0.10"``
+``GroupsClient``    ``"v2"``
+==================  ===========
 
 
 From 1.x or 2.x to 3.0


### PR DESCRIPTION
Because this only impacts users who are directly using HTTP methods, the
expected impact of this change is somewhat limited. As such, it is
placed at the end of the guide.

In brief, the guide lists which clients and which methods of said
clients are impacted, as well as giving notes on:

- how the mapping of usages to URIs has changed
- impact to the testing tools
- compatible usage which does the same thing on both versions

---

This change to the doc was prompted by an experience testing the upgrade.
This was one of the only changes which was visible and was not noted in the doc.
