### PR TITLE
Add `change_role` methods to two Globus Groups classes

### DIFF
--- a/changelog.d/20250929_094724_kurtmckee_update_auth_batch_membership_action.rst
+++ b/changelog.d/20250929_094724_kurtmckee_update_auth_batch_membership_action.rst
@@ -1,0 +1,5 @@
+Added
+-----
+
+- Add ``.change_role()`` to the Globus Groups ``BatchMembershipActions`` helper class. (:pr:`NUMBER`)
+- Add ``.change_roles()`` to the Globus Groups ``GroupsManager`` class. (:pr:`NUMBER`)

--- a/src/globus_sdk/services/groups/data.py
+++ b/src/globus_sdk/services/groups/data.py
@@ -151,6 +151,22 @@ class BatchMembershipActions(utils.PayloadWrapper):
         )
         return self
 
+    def change_roles(
+        self,
+        role: _GROUP_ROLE_T,
+        identity_ids: t.Iterable[uuid.UUID | str],
+    ) -> BatchMembershipActions:
+        """
+        Assign a new role to a list of identities.
+
+        :param role: The new role to assign.
+        :param identity_ids: The identities to assign to the new role.
+        """
+        self.setdefault("change_role", []).extend(
+            {"role": role, "identity_id": identity_id} for identity_id in identity_ids
+        )
+        return self
+
     def decline_invites(
         self, identity_ids: t.Iterable[uuid.UUID | str]
     ) -> BatchMembershipActions:

--- a/src/globus_sdk/services/groups/manager.py
+++ b/src/globus_sdk/services/groups/manager.py
@@ -125,6 +125,22 @@ class GroupsManager:
         actions = BatchMembershipActions().approve_pending([identity_id])
         return self.client.batch_membership_action(group_id, actions)
 
+    def change_role(
+        self,
+        group_id: uuid.UUID | str,
+        identity_id: uuid.UUID | str,
+        role: _GROUP_ROLE_T,
+    ) -> response.GlobusHTTPResponse:
+        """
+        Change the role of the given identity in the given group.
+
+        :param group_id: The ID of the group
+        :param identity_id: The identity to assign the *role* to
+        :param role: The role that will be assigned to the *identity_id*
+        """
+        actions = BatchMembershipActions().change_roles(role, [identity_id])
+        return self.client.batch_membership_action(group_id, actions)
+
     def decline_invite(
         self, group_id: uuid.UUID | str, identity_id: uuid.UUID | str
     ) -> response.GlobusHTTPResponse:

--- a/tests/functional/services/groups/test_group_memberships.py
+++ b/tests/functional/services/groups/test_group_memberships.py
@@ -75,6 +75,7 @@ def test_batch_action_payload(groups_client, role):
             [uuid.uuid1(), uuid.uuid1()],
             role=role,
         )
+        .change_roles("admin", [uuid.uuid1(), uuid.uuid1()])
         .invite_members([uuid.uuid1(), uuid.uuid1()])
         .join([uuid.uuid1(), uuid.uuid1()])
     )
@@ -85,6 +86,11 @@ def test_batch_action_payload(groups_client, role):
 
     assert "accept" in batch_action
     assert len(batch_action["accept"]) == 1
+
+    assert "change_role" in batch_action
+    assert len(batch_action["change_role"]) == 2
+    for change_role in batch_action["change_role"]:
+        assert change_role["role"] == "admin"
 
     assert "invite" in batch_action
     assert len(batch_action["invite"]) == 2


### PR DESCRIPTION
Added
-----

- Add ``.change_role()`` to the Globus Groups ``BatchMembershipActions`` helper class.
- Add ``.change_roles()`` to the Globus Groups ``GroupsManager`` class.
