### PR TITLE
Fix a Poetry deprecation warning in the test suite

### DIFF
--- a/changelog.d/20250929_110643_kurtmckee_fix_poetry_check.rst
+++ b/changelog.d/20250929_110643_kurtmckee_fix_poetry_check.rst
@@ -1,0 +1,4 @@
+Development
+-----------
+
+- Fix a Poetry deprecation warning in the test suite. (:pr:`NUMBER`)

--- a/tests/non-pytest/poetry-lock-test/pyproject.toml
+++ b/tests/non-pytest/poetry-lock-test/pyproject.toml
@@ -8,8 +8,6 @@ authors = ["Stephen Rosen <sirosen@globus.org>"]
 python = "^3.8"
 globus-sdk = { path = "../../.." }
 
-[tool.poetry.dev-dependencies]
-
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
The test suite warning is:

```
The "poetry.dev-dependencies" section is deprecated
and will be removed in a future version.
Use "poetry.group.dev.dependencies" instead.
```