### PR TITLE
Implement a model of resource ownership which allows apps to be used as context managers, triggering resource teardown on close

### DIFF
--- a/changelog.d/20251002_135923_sirosen_resource_ownership.rst
+++ b/changelog.d/20251002_135923_sirosen_resource_ownership.rst
@@ -1,0 +1,21 @@
+Added
+-----
+
+- ``GlobusApp`` usages now support resource tracking in which they will close
+  the transports used by registered clients and the underlying token storage
+  when via a ``close()`` method. (:pr:`NUMBER`)
+
+  - ``GlobusApp`` now features a ``close()`` method for doing imperative
+    resource cleanup.
+
+  - ``GlobusApp`` can be used as a context manager, and calls ``close()`` on
+    exit.
+
+  - Transports which are created by clients, and token storages which
+    are created by apps, are subject to this cleanup behavior. Imperatively
+    created ones which are passed in to clients and apps are not.
+
+  - The SDK internally tracks the relationships between apps, clients,
+    transports, and token storages for these purposes.
+    `Weak references <docs.python.org/3/library/weakref.html>`_ are used to
+    minimize the impact of resource tracking on garbage collection.

--- a/docs/authorization/globus_app/apps.rst
+++ b/docs/authorization/globus_app/apps.rst
@@ -82,6 +82,57 @@ The following table provides a comparison of these two options:
     a user be the primary data access actor. In these cases, a ``ClientApp``
     will be rejected and a ``UserApp`` must be used instead.
 
+
+Closing Resources via GlobusApps
+--------------------------------
+
+When used as context managers, ``GlobusApp``\s automatically call their
+``close()`` method on exit.
+
+Closing an app closes the resources owned by it.
+This covers any token storage created by the app on init, and any clients which
+are registered with the app.
+
+When token storages and transports are created explicitly, they are exempt from
+the close behavior.
+For example,
+
+.. code-block:: python
+
+    from globus_sdk import GlobusAppConfig, UserApp
+    from globus_sdk.token_storage import SQLiteTokenStorage
+
+    # this manually created storage will not be automatically closed
+    sql_storage = SQLiteTokenStorage("tokens.sqlite")
+
+    # create an app configured to use this storage
+    config = GlobusAppConfig(token_storage=sql_storage)
+    app = UserApp("sample-app", client_id="FILL_IN_HERE", config=config)
+
+    # close the app
+    app.close()
+
+    # at this stage, the storage will still not be closed
+    # it can be explicitly closed
+    sql_storage.close()
+
+For most use-cases, users are recommended to use the context manager form, which
+ensures that ``close()`` will be called, and to allow ``GlobusApp`` to maintain ownership
+of token storage.
+For example,
+
+.. code-block:: python
+
+    from globus_sdk import GlobusAppConfig, UserApp
+
+    # create an app configured to create its own sqlite storage
+    config = GlobusAppConfig(token_storage="sqlite")
+    with UserApp("sample-app", client_id="FILL_IN_HERE", config=config) as app:
+        ...  # any clients, usage, etc.
+
+    # after the context manager, any storage is implicitly closed
+
+
 Reference
 ---------
 

--- a/docs/user_guide/getting_started/list_groups_with_login.py
+++ b/docs/user_guide/getting_started/list_groups_with_login.py
@@ -5,20 +5,19 @@ import globus_sdk
 CLIENT_ID = "61338d24-54d5-408f-a10d-66c06b59f6d2"
 
 # create your app
-my_app = globus_sdk.UserApp("my-user-app", client_id=CLIENT_ID)
+with globus_sdk.UserApp("my-user-app", client_id=CLIENT_ID) as my_app:
+    # create a client with your app
+    groups_client = globus_sdk.GroupsClient(app=my_app)
 
-# create a client with your app
-groups_client = globus_sdk.GroupsClient(app=my_app)
+    # Important! The login step needs to happen after the `groups_client` is created
+    # so that the app will know that you need credentials for Globus Groups
+    my_app.login()
 
-# Important! The login step needs to happen after the `groups_client` is created
-# so that the app will know that you need credentials for Globus Groups
-my_app.login()
+    # call out to the Groups service to get a listing
+    my_groups = groups_client.get_my_groups()
 
-# call out to the Groups service to get a listing
-my_groups = groups_client.get_my_groups()
-
-# print in CSV format
-print("ID,Name,Roles")
-for group in my_groups:
-    roles = "|".join({m["role"] for m in group["my_memberships"]})
-    print(",".join([group["id"], f'"{group["name"]}"', roles]))
+    # print in CSV format
+    print("ID,Name,Roles")
+    for group in my_groups:
+        roles = "|".join({m["role"] for m in group["my_memberships"]})
+        print(",".join([group["id"], f'"{group["name"]}"', roles]))

--- a/docs/user_guide/getting_started/minimal_script.rst
+++ b/docs/user_guide/getting_started/minimal_script.rst
@@ -95,8 +95,11 @@ Summary: Complete Examples
 For ease of use, here are a pair of examples.
 
 One of them is exactly the same as the tutorial steps above, in a single block.
+
 The other example includes an explicit login step, so you can control when that
 login flow happens!
+It also converts the app to be used as a context manager, which will make it
+automatically close network connections and the token storage on exit.
 
 *These examples are complete. They should run without errors "as is".*
 

--- a/docs/user_guide/usage_patterns/data_transfer/create_guest_collection/create_guest_collection_client_owned.py
+++ b/docs/user_guide/usage_patterns/data_transfer/create_guest_collection/create_guest_collection_client_owned.py
@@ -4,12 +4,6 @@ from globus_sdk.globus_app import ClientApp
 # Confidential Client ID/Secret - <replace these with real client values>
 CONFIDENTIAL_CLIENT_ID = "..."
 CONFIDENTIAL_CLIENT_SECRET = "..."
-CLIENT_APP = ClientApp(
-    "my-simple-client-collection",
-    client_id=CONFIDENTIAL_CLIENT_ID,
-    client_secret=CONFIDENTIAL_CLIENT_SECRET,
-)
-
 
 # Globus Tutorial Collection 1
 # https://app.globus.org/file-manager/collections/6c54cade-bde5-45c1-bdea-f4bd71dba2cc
@@ -19,22 +13,27 @@ MAPPED_COLLECTION_ID = "6c54cade-bde5-45c1-bdea-f4bd71dba2cc"
 
 
 def main():
-    gcs_client = globus_sdk.GCSClient(ENDPOINT_HOSTNAME, app=CLIENT_APP)
+    with ClientApp(
+        "my-simple-client-collection",
+        client_id=CONFIDENTIAL_CLIENT_ID,
+        client_secret=CONFIDENTIAL_CLIENT_SECRET,
+    ) as app:
+        gcs_client = globus_sdk.GCSClient(ENDPOINT_HOSTNAME, app=app)
 
-    # Comment out this line if the mapped collection is high assurance
-    attach_data_access_scope(gcs_client, MAPPED_COLLECTION_ID)
+        # Comment out this line if the mapped collection is high assurance
+        attach_data_access_scope(gcs_client, MAPPED_COLLECTION_ID)
 
-    ensure_user_credential(gcs_client)
+        ensure_user_credential(gcs_client)
 
-    collection_request = globus_sdk.GuestCollectionDocument(
-        public=True,
-        collection_base_path="/",
-        display_name="example_guest_collection",
-        mapped_collection_id=MAPPED_COLLECTION_ID,
-    )
+        collection_request = globus_sdk.GuestCollectionDocument(
+            public=True,
+            collection_base_path="/",
+            display_name="example_guest_collection",
+            mapped_collection_id=MAPPED_COLLECTION_ID,
+        )
 
-    collection = gcs_client.create_collection(collection_request)
-    print(f"Created guest collection. Collection ID: {collection['id']}")
+        collection = gcs_client.create_collection(collection_request)
+        print(f"Created guest collection. Collection ID: {collection['id']}")
 
 
 def attach_data_access_scope(gcs_client, collection_id):

--- a/docs/user_guide/usage_patterns/data_transfer/detecting_data_access/index.rst
+++ b/docs/user_guide/usage_patterns/data_transfer/detecting_data_access/index.rst
@@ -36,16 +36,18 @@ the service:
 
     # Tutorial Client ID - <replace this with your own client>
     NATIVE_CLIENT_ID = "61338d24-54d5-408f-a10d-66c06b59f6d2"
-    USER_APP = globus_sdk.UserApp("detect-data-access-example", client_id=NATIVE_CLIENT_ID)
 
     # Globus Tutorial Collection 1
     # https://app.globus.org/file-manager/collections/6c54cade-bde5-45c1-bdea-f4bd71dba2cc
     # replace with your own COLLECTION_ID
     COLLECTION_ID = "6c54cade-bde5-45c1-bdea-f4bd71dba2cc"
 
-    transfer_client = globus_sdk.TransferClient(app=USER_APP)
 
-    collection_doc = transfer_client.get_endpoint(COLLECTION_ID)
+    with globus_sdk.UserApp(
+        "detect-data-access-example", client_id=NATIVE_CLIENT_ID
+    ) as app:
+        transfer_client = globus_sdk.TransferClient(app=app)
+        collection_doc = transfer_client.get_endpoint(COLLECTION_ID)
 
 .. note::
 

--- a/docs/user_guide/usage_patterns/data_transfer/detecting_data_access/submit_transfer_detect_data_access.py
+++ b/docs/user_guide/usage_patterns/data_transfer/detecting_data_access/submit_transfer_detect_data_access.py
@@ -20,8 +20,6 @@ def uses_data_access(
 
 # Tutorial Client ID - <replace this with your own client>
 NATIVE_CLIENT_ID = "61338d24-54d5-408f-a10d-66c06b59f6d2"
-USER_APP = globus_sdk.UserApp("detect-data-access-example", client_id=NATIVE_CLIENT_ID)
-
 
 # Globus Tutorial Collection 1 & 2
 # https://app.globus.org/file-manager/collections/6c54cade-bde5-45c1-bdea-f4bd71dba2cc
@@ -33,17 +31,21 @@ DST_COLLECTION = "31ce9ba0-176d-45a5-add3-f37d233ba47d"
 SRC_PATH = "/home/share/godata/file1.txt"
 DST_PATH = "/~/example-transfer-script-destination.txt"
 
-transfer_client = globus_sdk.TransferClient(app=USER_APP)
 
-# check if either source or dest needs data_access, and if so add the relevant
-# requirement
-if uses_data_access(transfer_client, SRC_COLLECTION):
-    transfer_client.add_app_data_access_scope(SRC_COLLECTION)
-if uses_data_access(transfer_client, DST_COLLECTION):
-    transfer_client.add_app_data_access_scope(DST_COLLECTION)
+with globus_sdk.UserApp(
+    "detect-data-access-example", client_id=NATIVE_CLIENT_ID
+) as app:
+    transfer_client = globus_sdk.TransferClient(app=app)
 
-transfer_request = globus_sdk.TransferData(SRC_COLLECTION, DST_COLLECTION)
-transfer_request.add_item(SRC_PATH, DST_PATH)
+    # check if either source or dest needs data_access, and if so add the relevant
+    # requirement
+    if uses_data_access(transfer_client, SRC_COLLECTION):
+        transfer_client.add_app_data_access_scope(SRC_COLLECTION)
+    if uses_data_access(transfer_client, DST_COLLECTION):
+        transfer_client.add_app_data_access_scope(DST_COLLECTION)
 
-task = transfer_client.submit_transfer(transfer_request)
-print(f"Submitted transfer. Task ID: {task['task_id']}.")
+    transfer_request = globus_sdk.TransferData(SRC_COLLECTION, DST_COLLECTION)
+    transfer_request.add_item(SRC_PATH, DST_PATH)
+
+    task = transfer_client.submit_transfer(transfer_request)
+    print(f"Submitted transfer. Task ID: {task['task_id']}.")

--- a/docs/user_guide/usage_patterns/data_transfer/scheduled_transfers/create_timer.py
+++ b/docs/user_guide/usage_patterns/data_transfer/scheduled_transfers/create_timer.py
@@ -5,7 +5,6 @@ from globus_sdk.experimental.globus_app import UserApp
 
 # Tutorial Client ID - <replace this with your own client>
 NATIVE_CLIENT_ID = "61338d24-54d5-408f-a10d-66c06b59f6d2"
-USER_APP = UserApp("manage-timers-example", client_id=NATIVE_CLIENT_ID)
 
 # Globus Tutorial Collection 1
 # https://app.globus.org/file-manager/collections/6c54cade-bde5-45c1-bdea-f4bd71dba2cc
@@ -36,24 +35,25 @@ schedule = globus_sdk.RecurringTimerSchedule(
     },
 )
 
-# create a TimersClient to interact with the service, and register any data_access
-# scopes for the collections
-timers_client = globus_sdk.TimersClient(app=USER_APP)
-# Omit this step if the collections are either
-#   (1) A guest collection or (2) high assurance.
-timers_client.add_app_transfer_data_access_scope((SRC_COLLECTION, DST_COLLECTION))
+with UserApp("manage-timers-example", client_id=NATIVE_CLIENT_ID) as app:
+    # create a TimersClient to interact with the service, and register any data_access
+    # scopes for the collections
+    timers_client = globus_sdk.TimersClient(app=app)
+    # Omit this step if the collections are either
+    #   (1) A guest collection or (2) high assurance.
+    timers_client.add_app_transfer_data_access_scope((SRC_COLLECTION, DST_COLLECTION))
 
-# submit the creation request to the service, printing out the ID of your new timer
-# after it's created -- you can find it in https://app.globus.org/activity/timers
-timer = timers_client.create_timer(
-    globus_sdk.TransferTimer(
-        name=(
-            "create-timer-example "
-            f"[created at {datetime.datetime.now().isoformat()}]"
-        ),
-        body=transfer_request,
-        schedule=schedule,
+    # submit the creation request to the service, printing out the ID of your new timer
+    # after it's created -- you can find it in https://app.globus.org/activity/timers
+    timer = timers_client.create_timer(
+        globus_sdk.TransferTimer(
+            name=(
+                "create-timer-example "
+                f"[created at {datetime.datetime.now().isoformat()}]"
+            ),
+            body=transfer_request,
+            schedule=schedule,
+        )
     )
-)
-print("Finished submitting timer.")
-print(f"timer_id: {timer['timer']['job_id']}")
+    print("Finished submitting timer.")
+    print(f"timer_id: {timer['timer']['job_id']}")

--- a/docs/user_guide/usage_patterns/data_transfer/scheduled_transfers/create_timer_detect_data_access.py
+++ b/docs/user_guide/usage_patterns/data_transfer/scheduled_transfers/create_timer_detect_data_access.py
@@ -5,8 +5,6 @@ from globus_sdk.experimental.globus_app import UserApp
 
 # Tutorial Client ID - <replace this with your own client>
 NATIVE_CLIENT_ID = "61338d24-54d5-408f-a10d-66c06b59f6d2"
-USER_APP = UserApp("manage-timers-example", client_id=NATIVE_CLIENT_ID)
-
 
 # Globus Tutorial Collection 1
 # https://app.globus.org/file-manager/collections/6c54cade-bde5-45c1-bdea-f4bd71dba2cc
@@ -18,20 +16,14 @@ SRC_PATH = "/home/share/godata/file1.txt"
 DST_COLLECTION = "31ce9ba0-176d-45a5-add3-f37d233ba47d"
 DST_PATH = "/~/example-timer-destination.txt"
 
-# we need a TransferClient in this case
-# see how it is used in the `uses_data_access` helper
-transfer_client = globus_sdk.TransferClient(app=USER_APP)
 
-
-def uses_data_access(collection_id: str) -> bool:
+def uses_data_access(client: globus_sdk.TransferClient, collection_id: str) -> bool:
     """
-    Use the `transfer_client` associated with the app to lookup the given
-    collection ID.
-
+    Lookup the given collection ID.
     Having looked up the record, return `True` if it uses a `data_access` scope
     and `False` otherwise.
     """
-    doc = transfer_client.get_endpoint(collection_id)
+    doc = client.get_endpoint(collection_id)
     if doc["entity_type"] != "GCSv5_mapped_collection":
         return False
     if doc["high_assurance"]:
@@ -39,47 +31,52 @@ def uses_data_access(collection_id: str) -> bool:
     return True
 
 
-# as with an immediate data transfer, we take our input data and wrap them in
-# a TransferData object, representing the transfer task
-transfer_request = globus_sdk.TransferData(SRC_COLLECTION, DST_COLLECTION)
-transfer_request.add_item(SRC_PATH, DST_PATH)
+with UserApp("manage-timers-example", client_id=NATIVE_CLIENT_ID) as app:
+    # we need a TransferClient in this case
+    # see how it is used in the `uses_data_access` helper
+    transfer_client = globus_sdk.TransferClient(app=app)
 
-# we'll define the timer as one which runs every hour for 3 days
-# declare these data in the form of a "schedule" for the timer
-#
-# a wide variety of schedules are possible here; to setup a recurring timer:
-# - you MUST declare an interval for the timer (`interval_seconds`)
-# - you MAY declare an end condition (`end`)
-schedule = globus_sdk.RecurringTimerSchedule(
-    interval_seconds=3600,
-    end={
-        "condition": "time",
-        "datetime": datetime.datetime.now() + datetime.timedelta(days=3),
-    },
-)
+    # as with an immediate data transfer, we take our input data and wrap them in
+    # a TransferData object, representing the transfer task
+    transfer_request = globus_sdk.TransferData(SRC_COLLECTION, DST_COLLECTION)
+    transfer_request.add_item(SRC_PATH, DST_PATH)
 
-# create a TimersClient to interact with the service, and register any data_access
-# scopes for the collections
-timers_client = globus_sdk.TimersClient(app=USER_APP)
-
-# Detect on each collection whether or not we need `data_access` scopes and apply
-# if necessary
-if uses_data_access(SRC_COLLECTION):
-    timers_client.add_app_transfer_data_access_scope(SRC_COLLECTION)
-if uses_data_access(DST_COLLECTION):
-    timers_client.add_app_transfer_data_access_scope(DST_COLLECTION)
-
-# submit the creation request to the service, printing out the ID of your new timer
-# after it's created -- you can find it in https://app.globus.org/activity/timers
-timer = timers_client.create_timer(
-    globus_sdk.TransferTimer(
-        name=(
-            "create-timer-example "
-            f"[created at {datetime.datetime.now().isoformat()}]"
-        ),
-        body=transfer_request,
-        schedule=schedule,
+    # we'll define the timer as one which runs every hour for 3 days
+    # declare these data in the form of a "schedule" for the timer
+    #
+    # a wide variety of schedules are possible here; to setup a recurring timer:
+    # - you MUST declare an interval for the timer (`interval_seconds`)
+    # - you MAY declare an end condition (`end`)
+    schedule = globus_sdk.RecurringTimerSchedule(
+        interval_seconds=3600,
+        end={
+            "condition": "time",
+            "datetime": datetime.datetime.now() + datetime.timedelta(days=3),
+        },
     )
-)
-print("Finished submitting timer.")
-print(f"timer_id: {timer['timer']['job_id']}")
+
+    # create a TimersClient to interact with the service, and register any data_access
+    # scopes for the collections
+    timers_client = globus_sdk.TimersClient(app=app)
+
+    # Detect on each collection whether or not we need `data_access` scopes and apply
+    # if necessary
+    if uses_data_access(transfer_client, SRC_COLLECTION):
+        timers_client.add_app_transfer_data_access_scope(SRC_COLLECTION)
+    if uses_data_access(transfer_client, DST_COLLECTION):
+        timers_client.add_app_transfer_data_access_scope(DST_COLLECTION)
+
+    # submit the creation request to the service, printing out the ID of your new timer
+    # after it's created -- you can find it in https://app.globus.org/activity/timers
+    timer = timers_client.create_timer(
+        globus_sdk.TransferTimer(
+            name=(
+                "create-timer-example "
+                f"[created at {datetime.datetime.now().isoformat()}]"
+            ),
+            body=transfer_request,
+            schedule=schedule,
+        )
+    )
+    print("Finished submitting timer.")
+    print(f"timer_id: {timer['timer']['job_id']}")

--- a/docs/user_guide/usage_patterns/data_transfer/scheduled_transfers/index.rst
+++ b/docs/user_guide/usage_patterns/data_transfer/scheduled_transfers/index.rst
@@ -39,11 +39,9 @@ We'll do this with a new ``uses_data_access`` helper and a :class:`TransferClien
     transfer_client = globus_sdk.TransferClient(app=USER_APP)
 
 
-    def uses_data_access(collection_id: str) -> bool:
+    def uses_data_access(client: globus_sdk.TransferClient, collection_id: str) -> bool:
         """
-        Use the `transfer_client` associated with the app to lookup the given
-        collection ID.
-
+        Lookup the given collection ID.
         Having looked up the record, return `True` if it uses a `data_access` scope
         and `False` otherwise.
         """
@@ -58,9 +56,9 @@ This will allow us to guard our use of the ``data_access`` scope thusly:
 
 .. code-block:: python
 
-    if uses_data_access(SRC_COLLECTION):
+    if uses_data_access(transfer_client, SRC_COLLECTION):
         timers_client.add_app_transfer_data_access_scope(SRC_COLLECTION)
-    if uses_data_access(DST_COLLECTION):
+    if uses_data_access(transfer_client, DST_COLLECTION):
         timers_client.add_app_transfer_data_access_scope(DST_COLLECTION)
 
 .. note::

--- a/docs/user_guide/usage_patterns/data_transfer/submit_transfer/submit_transfer_collections_known.py
+++ b/docs/user_guide/usage_patterns/data_transfer/submit_transfer/submit_transfer_collections_known.py
@@ -3,7 +3,6 @@ from globus_sdk.globus_app import UserApp
 
 # Tutorial Client ID - <replace this with your own client>
 NATIVE_CLIENT_ID = "61338d24-54d5-408f-a10d-66c06b59f6d2"
-USER_APP = UserApp("my-simple-transfer", client_id=NATIVE_CLIENT_ID)
 
 # Globus Tutorial Collection 1
 # https://app.globus.org/file-manager/collections/6c54cade-bde5-45c1-bdea-f4bd71dba2cc
@@ -17,18 +16,19 @@ DST_PATH = "/~/example-transfer-script-destination.txt"
 
 
 def main():
-    transfer_client = globus_sdk.TransferClient(app=USER_APP)
+    with UserApp("my-simple-transfer", client_id=NATIVE_CLIENT_ID) as app:
+        transfer_client = globus_sdk.TransferClient(app=app)
 
-    # Comment out each of these lines if the referenced collection is either
-    #   (1) A guest collection or (2) high assurance.
-    transfer_client.add_app_data_access_scope(SRC_COLLECTION)
-    transfer_client.add_app_data_access_scope(DST_COLLECTION)
+        # Comment out each of these lines if the referenced collection is either
+        #   (1) A guest collection or (2) high assurance.
+        transfer_client.add_app_data_access_scope(SRC_COLLECTION)
+        transfer_client.add_app_data_access_scope(DST_COLLECTION)
 
-    transfer_request = globus_sdk.TransferData(SRC_COLLECTION, DST_COLLECTION)
-    transfer_request.add_item(SRC_PATH, DST_PATH)
+        transfer_request = globus_sdk.TransferData(SRC_COLLECTION, DST_COLLECTION)
+        transfer_request.add_item(SRC_PATH, DST_PATH)
 
-    task = transfer_client.submit_transfer(transfer_request)
-    print(f"Submitted transfer. Task ID: {task['task_id']}.")
+        task = transfer_client.submit_transfer(transfer_request)
+        print(f"Submitted transfer. Task ID: {task['task_id']}.")
 
 
 if __name__ == "__main__":

--- a/docs/user_guide/usage_patterns/data_transfer/submit_transfer/submit_transfer_collections_unknown.py
+++ b/docs/user_guide/usage_patterns/data_transfer/submit_transfer/submit_transfer_collections_unknown.py
@@ -3,7 +3,6 @@ from globus_sdk.globus_app import UserApp
 
 # Tutorial Client ID - <replace this with your own client>
 NATIVE_CLIENT_ID = "61338d24-54d5-408f-a10d-66c06b59f6d2"
-USER_APP = UserApp("my-simple-transfer", client_id=NATIVE_CLIENT_ID)
 
 # Globus Tutorial Collection 1
 # https://app.globus.org/file-manager/collections/6c54cade-bde5-45c1-bdea-f4bd71dba2cc
@@ -17,22 +16,23 @@ DST_PATH = "/~/example-transfer-script-destination.txt"
 
 
 def main():
-    transfer_client = globus_sdk.TransferClient(app=USER_APP)
+    with UserApp("my-simple-transfer", client_id=NATIVE_CLIENT_ID) as app:
+        transfer_client = globus_sdk.TransferClient(app=app)
 
-    transfer_request = globus_sdk.TransferData(SRC_COLLECTION, DST_COLLECTION)
-    transfer_request.add_item(SRC_PATH, DST_PATH)
+        transfer_request = globus_sdk.TransferData(SRC_COLLECTION, DST_COLLECTION)
+        transfer_request.add_item(SRC_PATH, DST_PATH)
 
-    try:
-        task = transfer_client.submit_transfer(transfer_request)
-    except globus_sdk.TransferAPIError as err:
-        if not err.info.consent_required:
-            raise
+        try:
+            task = transfer_client.submit_transfer(transfer_request)
+        except globus_sdk.TransferAPIError as err:
+            if not err.info.consent_required:
+                raise
 
-        print("Additional consent required.")
-        transfer_client.add_app_scope(err.info.consent_required.required_scopes)
+            print("Additional consent required.")
+            transfer_client.add_app_scope(err.info.consent_required.required_scopes)
 
-        task = transfer_client.submit_transfer(transfer_request)
-    print(f"Submitted transfer. Task ID: {task['task_id']}.")
+            task = transfer_client.submit_transfer(transfer_request)
+        print(f"Submitted transfer. Task ID: {task['task_id']}.")
 
 
 if __name__ == "__main__":

--- a/docs/user_guide/usage_patterns/data_transfer/transfer_relative_deadline/submit_transfer_relative_deadline.py
+++ b/docs/user_guide/usage_patterns/data_transfer/transfer_relative_deadline/submit_transfer_relative_deadline.py
@@ -5,7 +5,6 @@ from globus_sdk.globus_app import UserApp
 
 # Tutorial Client ID - <replace this with your own client>
 NATIVE_CLIENT_ID = "61338d24-54d5-408f-a10d-66c06b59f6d2"
-USER_APP = UserApp("relative-deadline-transfer", client_id=NATIVE_CLIENT_ID)
 
 # Globus Tutorial Collection 1
 # https://app.globus.org/file-manager/collections/6c54cade-bde5-45c1-bdea-f4bd71dba2cc
@@ -24,19 +23,20 @@ def make_relative_deadline(offset: datetime.timedelta) -> str:
     return deadline.isoformat()
 
 
-transfer_client = globus_sdk.TransferClient(app=USER_APP)
+with UserApp("relative-deadline-transfer", client_id=NATIVE_CLIENT_ID) as app:
+    transfer_client = globus_sdk.TransferClient(app=app)
 
-# Comment out each of these lines if the referenced collection is either
-#   (1) A guest collection or (2) high assurance.
-transfer_client.add_app_data_access_scope(SRC_COLLECTION)
-transfer_client.add_app_data_access_scope(DST_COLLECTION)
+    # Comment out each of these lines if the referenced collection is either
+    #   (1) A guest collection or (2) high assurance.
+    transfer_client.add_app_data_access_scope(SRC_COLLECTION)
+    transfer_client.add_app_data_access_scope(DST_COLLECTION)
 
-transfer_request = globus_sdk.TransferData(
-    SRC_COLLECTION,
-    DST_COLLECTION,
-    deadline=make_relative_deadline(datetime.timedelta(hours=1)),
-)
-transfer_request.add_item(SRC_PATH, DST_PATH)
+    transfer_request = globus_sdk.TransferData(
+        SRC_COLLECTION,
+        DST_COLLECTION,
+        deadline=make_relative_deadline(datetime.timedelta(hours=1)),
+    )
+    transfer_request.add_item(SRC_PATH, DST_PATH)
 
-task = transfer_client.submit_transfer(transfer_request)
-print(f"Submitted transfer. Task ID: {task['task_id']}")
+    task = transfer_client.submit_transfer(transfer_request)
+    print(f"Submitted transfer. Task ID: {task['task_id']}")

--- a/docs/user_guide/usage_patterns/sessions_and_consents/handling_transfer_auth_params/ls_with_session_handling.py
+++ b/docs/user_guide/usage_patterns/sessions_and_consents/handling_transfer_auth_params/ls_with_session_handling.py
@@ -5,19 +5,9 @@ import globus_sdk.gare
 NATIVE_CLIENT_ID = "61338d24-54d5-408f-a10d-66c06b59f6d2"
 # set the collection ID to your test collection
 COLLECTION_ID = "..."
-USER_APP = globus_sdk.UserApp("ls-session", client_id=NATIVE_CLIENT_ID)
 
 
-client = globus_sdk.TransferClient(app=USER_APP)
-
-# because the recommended test configuration uses a mapped collection
-# without High Assurance capabilities, it will have a data_access scope
-# requirement
-# comment out this line if your collection does not use data_access
-client.add_app_data_access_scope(COLLECTION_ID)
-
-
-def print_ls_data():
+def print_ls_data(client):
     ls_result = client.operation_ls(COLLECTION_ID)
     for item in ls_result:
         name = item["name"]
@@ -26,28 +16,37 @@ def print_ls_data():
         print(name)
 
 
-# try to run the desired operation (`print_ls_data`)
-try:
-    print_ls_data()
-# catch the possible API error
-except globus_sdk.TransferAPIError as err:
-    # if there are authorization parameters data in the error,
-    # use it to redrive login
-    if err.info.authorization_parameters:
-        print("An authorization requirement was not met. Logging in again...")
+with globus_sdk.UserApp("ls-session", client_id=NATIVE_CLIENT_ID) as app:
+    client = globus_sdk.TransferClient(app=app)
 
-        gare = globus_sdk.gare.to_gare(err)
-        params = gare.authorization_parameters
-        # set 'prompt=login', which guarantees a fresh login without
-        # reliance on the browser session
-        params.prompt = "login"
+    # because the recommended test configuration uses a mapped collection
+    # without High Assurance capabilities, it will have a data_access scope
+    # requirement
+    # comment out this line if your collection does not use data_access
+    client.add_app_data_access_scope(COLLECTION_ID)
 
-        # pass these parameters into a login flow
-        USER_APP.login(auth_params=params)
+    # try to run the desired operation (`print_ls_data`)
+    try:
+        print_ls_data(client)
+    # catch the possible API error
+    except globus_sdk.TransferAPIError as err:
+        # if there are authorization parameters data in the error,
+        # use it to redrive login
+        if err.info.authorization_parameters:
+            print("An authorization requirement was not met. Logging in again...")
 
-        # rerun the desired print_ls_data() operation
-        print_ls_data()
+            gare = globus_sdk.gare.to_gare(err)
+            params = gare.authorization_parameters
+            # set 'prompt=login', which guarantees a fresh login without
+            # reliance on the browser session
+            params.prompt = "login"
 
-    # otherwise, there are no authorization parameters, so reraise the error
-    else:
-        raise
+            # pass these parameters into a login flow
+            app.login(auth_params=params)
+
+            # rerun the desired print_ls_data() operation
+            print_ls_data(client)
+
+        # otherwise, there are no authorization parameters, so reraise the error
+        else:
+            raise

--- a/src/globus_sdk/client.py
+++ b/src/globus_sdk/client.py
@@ -105,13 +105,25 @@ class BaseClient:
         else:
             self.environment = config.get_environment_name()
 
+        # by default, there is no owner for a client
+        # if an app is attached, it will be made into the owner in attach_globus_app()
+        # therefore, if an app is passed in, it will be "late bound" to this
+        self._resource_owner: GlobusApp | None = None
+
         # resolve the base_url for the client (see docstring for resolution precedence)
         self.base_url = self._resolve_base_url(base_url, self.environment)
 
         self.retry_config: RetryConfig = retry_config or RetryConfig()
         self._register_standard_retry_checks(self.retry_config)
 
-        self.transport = transport if transport is not None else RequestsTransport()
+        # the resource_owner for a Transport is implicitly this client if and only if
+        # the client creates the Transport
+        if transport is not None:
+            self.transport = transport
+        else:
+            self.transport = RequestsTransport()
+            self.transport._resource_owner = self
+
         log.debug(f"initialized transport of type {type(self.transport)}")
 
         # setup paginated methods
@@ -260,6 +272,10 @@ class BaseClient:
         if self.app_name is None:
             self.app_name = app.app_name
 
+        # notate that the app owns the client
+        self._resource_owner = app
+        app._owned_clients.add(self)
+
         # finally, register the scope requirements on the app side
         self._app.add_scope_requirements({self.resource_server: self.app_scopes})
 
@@ -330,6 +346,20 @@ class BaseClient:
         if self_or_cls.scopes is None:
             return None
         return self_or_cls.scopes.resource_server
+
+    def _close(self) -> None:
+        """
+        Close all resources which are owned by this client.
+
+        This method is private to the SDK and is intended to be called by GlobusApp when
+        an app is closed.
+
+        This closes any transport object attached to the client which lists the client
+        as its owner.
+        """
+        if self.transport._resource_owner is self:
+            log.debug(f"closing transport for {type(self).__name__}")
+            self.transport.close()
 
     def get(  # pylint: disable=missing-param-doc
         self,

--- a/src/globus_sdk/token_storage/base.py
+++ b/src/globus_sdk/token_storage/base.py
@@ -14,7 +14,7 @@ import globus_sdk
 from .token_data import TokenStorageData
 
 if t.TYPE_CHECKING:
-    from globus_sdk.globus_app import GlobusAppConfig
+    from globus_sdk.globus_app import GlobusApp, GlobusAppConfig
 
 
 class TokenStorage(metaclass=abc.ABCMeta):
@@ -32,6 +32,7 @@ class TokenStorage(metaclass=abc.ABCMeta):
     """
 
     def __init__(self, namespace: str = "DEFAULT") -> None:
+        self._resource_owner: GlobusApp | None = None
         self.namespace = namespace
         self.id_token_decoder: globus_sdk.IDTokenDecoder | None = None
 
@@ -124,6 +125,13 @@ class TokenStorage(metaclass=abc.ABCMeta):
             return decoded_id_token["sub"]  # type: ignore[no-any-return]
         else:
             return None
+
+    def close(self) -> None:  # noqa: B027
+        """
+        Close any resources associated with this token storage.
+
+        By default, this does nothing, but subclasses may override it.
+        """
 
 
 class FileTokenStorage(TokenStorage, metaclass=abc.ABCMeta):

--- a/src/globus_sdk/token_storage/validating_token_storage/storage.py
+++ b/src/globus_sdk/token_storage/validating_token_storage/storage.py
@@ -40,6 +40,10 @@ class ValidatingTokenStorage(TokenStorage):
         )
         super().__init__(namespace=token_storage.namespace)
 
+    def close(self) -> None:
+        """Closing a validating storage closes the storage it contains."""
+        self.token_storage.close()
+
     def _make_context(
         self, token_data_by_resource_server: t.Mapping[str, TokenStorageData]
     ) -> TokenValidationContext:

--- a/src/globus_sdk/transport/requests.py
+++ b/src/globus_sdk/transport/requests.py
@@ -22,6 +22,9 @@ from .retry import RetryContext
 from .retry_check_runner import RetryCheckRunner
 from .retry_config import RetryConfig
 
+if t.TYPE_CHECKING:
+    from globus_sdk import BaseClient
+
 log = logging.getLogger(__name__)
 
 
@@ -66,6 +69,7 @@ class RequestsTransport:
         verify_ssl: bool | str | pathlib.Path | None = None,
         http_timeout: float | None = None,
     ) -> None:
+        self._resource_owner: BaseClient | None = None
         self.session = requests.Session()
         self.verify_ssl = config.get_ssl_verify(verify_ssl)
         self.http_timeout = config.get_http_timeout(http_timeout)

--- a/tests/unit/globus_app/test_client_integration.py
+++ b/tests/unit/globus_app/test_client_integration.py
@@ -1,4 +1,5 @@
 import uuid
+from unittest import mock
 
 import pytest
 
@@ -222,3 +223,15 @@ def test_gcs_client_default_scopes(app):
     assert [str(s) for s in app.scope_requirements[endpoint_client_id]] == [
         f"urn:globus:auth:scope:{endpoint_client_id}:manage_collections"
     ]
+
+
+def test_closing_app_closes_client():
+    config = GlobusAppConfig(token_storage=MemoryTokenStorage(), environment="sandbox")
+    app = UserApp("test-app", client_id="client_id", config=config)
+
+    client = globus_sdk.AuthClient(app=app)
+
+    with mock.patch.object(client, "_close") as client_close:
+        app.close()
+
+        client_close.assert_called_once()

--- a/tests/unit/test_base_client.py
+++ b/tests/unit/test_base_client.py
@@ -356,3 +356,21 @@ def test_cannot_attach_app_with_mismatched_environment(base_client_class):
         ),
     ):
         c.attach_globus_app(app)
+
+
+def test_client_close_implicitly_closes_internal_transport(base_client_class):
+    # test the private _close() method directly
+    client = base_client_class()
+    with mock.patch.object(client.transport, "close") as transport_close:
+        client._close()
+
+        transport_close.assert_called_once()
+
+
+def test_client_close_does_not_close_explicitly_passed_transport(base_client_class):
+    # test the private _close() method directly
+    client = base_client_class(transport=RequestsTransport())
+    with mock.patch.object(client.transport, "close") as transport_close:
+        client._close()
+
+        transport_close.assert_not_called()


### PR DESCRIPTION
Introduce the '_resource_owner' internal protocol

Several resources in the SDK now define a tracking protocol to allow
resources to participate in a cascading `close()` via a GlobusApp.

The design breaks down into two major sections.

## Ownership Tracking

- `_resource_owner: BaseClient | None` is a new property of transports
- `_resource_owner: GlobusApp | None` is a new property of token storage
- `_resource_owner: GlobusApp | None` is a new property of clients
- `_owned_clients: MutableSet[BaseClient]` is a new property of apps

These are the storage mechanisms being used. The `_owned_clients` set is
defined as a `weakref.WeakSet`, meaning that membership in the set will
not prevent garbage collection of the members (which implicitly removes
them).

Each resource "may know its owner" by having the `_resource_owner`
assigned, and apps keep tabs on "owned clients" (which are otherwise
not associated).

The rules for when these are set are as follows:
- When an app is attached to a client (as through init) it is stored as
  `_resource_owner`
- When an app is attached to a client, the client is added to the app's
  `_owned_clients`
- When a client creates a transport, it sets itself as the transport's
  `_resource_owner`
- When an app creates a token storage, it sets itself as the token
  storage's `_resource_owner`

## Close Semantics

- All token storages now define `close()`, but it is still only
  meaningful for some -- the base version is a no-op
- `BaseClient._close()` is a new (private) method which closes the
  underlying transport IFF the client is the owner
- `GlobusApp.close()` is a new (public) method which closes (`_close()`)
  all apps owned by the client and any token storage owned by the client
- `GlobusApp` supports use as a context manager, with `close()` on exit

-----

- Introduce the '_resource_owner' internal protocol
- Add unit tests for resource ownership + close
- Make User Guide use GlobusApp context managers
- Add explicit narrative doc for GlobusApp.close()
