### PR TITLE
Post 4.0 cleanup

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - "main"
-      - "4.x-dev"
   pull_request: null
   # build weekly at 4:00 AM UTC
   schedule:

--- a/.github/workflows/update_pr_references.yaml
+++ b/.github/workflows/update_pr_references.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - 4.x-dev
 
 jobs:
   update_pr_numbers_in_change_fragments:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -60,25 +60,3 @@ or create the release via the GitHub CLI
   changes and a link to the GitHub release page.
   (If the Globus CLI is releasing within a short interval,
   combine both announcements into a single email notice.)
-
-- Ensure the 4.x-dev branch is updated with the latest changes from main
-  by creating a PR:
-    ```
-    git checkout 4.x-dev
-    git pull
-    git checkout -b merge-main-to-4x-dev-$(date +%Y%m%d)
-    git merge origin/main
-    # Resolve any conflicts if they occur
-    git push -u origin merge-main-to-4x-dev-$(date +%Y%m%d)
-    gh pr create --base 4.x-dev --title "Merge main into 4.x-dev" \
-      --body "Merging latest changes from main branch into 4.x-dev"
-    ```
-    After the PR is reviewed and merged, the 4.x-dev branch will be updated.
-
-## Publish Pre-release 4.x packages to PyPi
-
-The steps above for deploying a package to PyPI can be used to push pre-release packages by:
-
-* Using the 4.x-dev branch instead of the main branch
-* Creating and pushing a tag on the 4.x-dev branch
-* Publishing the release through GitHub using the 4.x-dev branch


### PR DESCRIPTION
After the 4.0.0 release, we can remove any references to the 4.x-dev
branch.
