### PR TITLE
Fix the route for 'set_subscription_admin_verified'

### DIFF
--- a/changelog.d/20251012_155618_sirosen_fix_set_subscription_admin_verified.rst
+++ b/changelog.d/20251012_155618_sirosen_fix_set_subscription_admin_verified.rst
@@ -1,0 +1,4 @@
+Fixed
+-----
+
+- Fix the route for ``TransferClient.set_subscription_admin_verified()`` (:pr:`NUMBER`)

--- a/src/globus_sdk/services/transfer/client.py
+++ b/src/globus_sdk/services/transfer/client.py
@@ -399,7 +399,7 @@ class TransferClient(client.BaseClient):
                     :ref: transfer/gcp_management/#set_subscription_admin_verified
         """  # noqa: E501
         return self.put(
-            f"/endpoint/{collection_id}/subscription_admin_verified",
+            f"/v0.10/endpoint/{collection_id}/subscription_admin_verified",
             data={"subscription_admin_verified": subscription_admin_verified},
         )
 

--- a/src/globus_sdk/testing/data/transfer/set_subscription_admin_verified.py
+++ b/src/globus_sdk/testing/data/transfer/set_subscription_admin_verified.py
@@ -10,7 +10,7 @@ NO_IDENTITIES_IN_SESSION_ENDPOINT_ID = str(uuid.UUID(int=12))
 
 
 def _format_verify_route(epid: str) -> str:
-    return f"/endpoint/{epid}/subscription_admin_verified"
+    return f"/v0.10/endpoint/{epid}/subscription_admin_verified"
 
 
 RESPONSES = ResponseSet(


### PR DESCRIPTION
This was added in SDK v3, ported to the v4 dev branch, but not adjusted
in the process. This is a post-4.0 fix to make the route correct.
