### PR TITLE
Release v4.1.0

### DIFF
--- a/changelog.d/20251017_174013_max.tuecke_sc_45515_flows_auth_policy.rst
+++ b/changelog.d/20251017_174013_max.tuecke_sc_45515_flows_auth_policy.rst
@@ -1,4 +1,0 @@
-Added
------
-
-- Updated ``create_flow`` and ``update_flow`` to accept an authentication policy to assign to a flow. (:pr:`1334`)

--- a/changelog.rst
+++ b/changelog.rst
@@ -12,6 +12,17 @@ to a major new version of the SDK.
 
 .. scriv-insert-here
 
+.. _changelog-4.1.0:
+
+v4.1.0 (2025-10-23)
+===================
+
+Added
+-----
+
+- Updated ``create_flow`` and ``update_flow`` to accept an authentication policy to assign to a flow. (:pr:`1334`)
+    - Note: SDK support for this feature is being released in advance of service support, which will follow at a later time.
+
 .. _changelog-4.0.1:
 
 v4.0.1 (2025-10-13)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "globus-sdk"
-version = "4.0.1"
+version = "4.1.0"
 authors = [
     { name = "Globus Team", email = "support@globus.org" },
 ]


### PR DESCRIPTION
Changelog:

- Updated ``create_flow`` and ``update_flow`` to accept an authentication policy to assign to a flow. (:pr:`1334`)
    - Note: SDK support for this feature is being released in advance of service support, which will follow at a later time.