### PR TITLE
Add shellcheck as an additional dependency for actionlint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,7 +66,8 @@ repos:
   rev: v1.7.7
   hooks:
     - id: actionlint
-
+      additional_dependencies:
+        - github.com/wasilibs/go-shellcheck/cmd/shellcheck@v0.11.1
 # custom local hooks
 - repo: local
   hooks:


### PR DESCRIPTION

The actionlint pre-commit hook relies on shellcheck for some functionality,
so this PR introduces shellcheck as an `additional_dependency` for the hook.

<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>