### PR TITLE
Add a fixture and test for Transfer cancel_task

### DIFF
--- a/src/globus_sdk/testing/data/transfer/cancel_task.py
+++ b/src/globus_sdk/testing/data/transfer/cancel_task.py
@@ -1,0 +1,21 @@
+import uuid
+
+from globus_sdk.testing.models import RegisteredResponse, ResponseSet
+
+TASK_ID = str(uuid.uuid4())
+
+RESPONSES = ResponseSet(
+    metadata={"task_id": TASK_ID},
+    default=RegisteredResponse(
+        service="transfer",
+        path=f"/v0.10/task/{TASK_ID}/cancel",
+        method="POST",
+        json={
+            "DATA_TYPE": "result",
+            "code": "Canceled",
+            "message": "The task has been cancelled successfully.",
+            "resource": f"/task/{TASK_ID}/cancel",
+            "request_id": "ABCdef789",
+        },
+    ),
+)

--- a/tests/functional/services/transfer/test_cancel_task.py
+++ b/tests/functional/services/transfer/test_cancel_task.py
@@ -1,6 +1,11 @@
-import pytest
+from globus_sdk.testing import get_last_request, load_response
 
 
-@pytest.mark.xfail
-def test_cancel_task():
-    raise NotImplementedError
+def test_cancel_task(client):
+    meta = load_response(client.cancel_task).metadata
+
+    res = client.cancel_task(meta["task_id"])
+    assert res.http_status == 200
+
+    req = get_last_request()
+    assert req.body is None


### PR DESCRIPTION
I noticed this was missing while doing some cleanup in globus-cli.
It's a simple addition of one test and a relevant fixture.
