### PR TITLE
Document that GlobusApp always requests `openid`

### DIFF
--- a/src/globus_sdk/globus_app/app.py
+++ b/src/globus_sdk/globus_app/app.py
@@ -535,6 +535,13 @@ class GlobusApp(metaclass=abc.ABCMeta):
 
         Modifying the returned dict will not affect the app's scope requirements.
         To add scope requirements, use ``GlobusApp.add_scope_requirements()``.
+
+        .. note::
+
+            Users may observe that Globus Auth (``'auth.globus.org'``) is always
+            present, and always maps to the ``openid`` scope, even when the user has
+            not added this scope. This mapping is expected, as the ``openid`` scope is
+            needed internally for the functionality provided by ``GlobusApp``.
         """
         # Scopes are mutable objects so we return a deepcopy
         return copy.deepcopy(self._scope_requirements)


### PR DESCRIPTION
This is noted in property documentation for ``scope_requirements``. This
is one of a few ways in which users may observe the presence of this
scope, but the choices are either to document this on the property or on
the top-level class doc. The property is guessed to be more likely to be
seen by a user exploring to try to understand their scope requirements.

For reference and motivation, see #1359
