### PR TITLE
Reduce Dependabot toil; configure cooldowns

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "semiannually"
+    cooldown:
+      default-days: 20
     groups:
       github-actions:
         patterns:


### PR DESCRIPTION

This PR introduces the following changes:

* Configure Dependabot to run once every six months
* Configure Dependabot to use a 20-day cooldown period

<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>