### PR TITLE
feat: [sc-47448] implement bookmark methods in Transfer v2 client

### DIFF
--- a/changelog.d/20260408_210055_pjhinton_sc_47448_transfer_v2_bookmark_sdk_support.rst
+++ b/changelog.d/20260408_210055_pjhinton_sc_47448_transfer_v2_bookmark_sdk_support.rst
@@ -1,0 +1,4 @@
+Added
+-----
+
+- Support for managing bookmarks via the Transfer v2 client (:pr:`NUMBER`)

--- a/src/globus_sdk/experimental/__init__.py
+++ b/src/globus_sdk/experimental/__init__.py
@@ -3,6 +3,8 @@ import sys
 import typing as t
 
 __all__ = (
+    "BookmarkCreateDocument",
+    "BookmarkUpdateDocument",
     "TransferClientV2",
     "TunnelCreateDocument",
     "TunnelUpdateDocument",
@@ -14,6 +16,8 @@ __all__ = (
 # components which do not need it
 if t.TYPE_CHECKING:
     from .transfer_v2 import (
+        BookmarkCreateDocument,
+        BookmarkUpdateDocument,
         TransferClientV2,
         TunnelCreateDocument,
         TunnelUpdateDocument,
@@ -21,6 +25,8 @@ if t.TYPE_CHECKING:
 else:
     _LAZY_IMPORT_TABLE = {
         "transfer_v2": {
+            "BookmarkCreateDocument",
+            "BookmarkUpdateDocument",
             "TransferClientV2",
             "TunnelCreateDocument",
             "TunnelUpdateDocument",

--- a/src/globus_sdk/experimental/transfer_v2/__init__.py
+++ b/src/globus_sdk/experimental/transfer_v2/__init__.py
@@ -1,7 +1,14 @@
 from .client import TransferClientV2
-from .data import TunnelCreateDocument, TunnelUpdateDocument
+from .data import (
+    BookmarkCreateDocument,
+    BookmarkUpdateDocument,
+    TunnelCreateDocument,
+    TunnelUpdateDocument,
+)
 
 __all__ = (
+    "BookmarkCreateDocument",
+    "BookmarkUpdateDocument",
     "TransferClientV2",
     "TunnelCreateDocument",
     "TunnelUpdateDocument",

--- a/src/globus_sdk/experimental/transfer_v2/client.py
+++ b/src/globus_sdk/experimental/transfer_v2/client.py
@@ -10,7 +10,12 @@ from globus_sdk.scopes import TransferScopes
 from globus_sdk.services.transfer.errors import TransferAPIError
 from globus_sdk.transport import RetryConfig
 
-from .data import TunnelCreateDocument, TunnelUpdateDocument
+from .data import (
+    BookmarkCreateDocument,
+    BookmarkUpdateDocument,
+    TunnelCreateDocument,
+    TunnelUpdateDocument,
+)
 from .transport import TRANSFER_V2_DEFAULT_RETRY_CHECKS
 
 log = logging.getLogger(__name__)
@@ -131,7 +136,7 @@ class TransferClientV2(client.BaseClient):
                 .. code-block:: python
 
                     tc = globus_sdk.experimental.TrasferClientV2(...)
-                    result = tc.show_tunnel(tunnel_id)
+                    result = tc.get_tunnel(tunnel_id)
                     print(result["data"])
 
             .. tab-item:: API Info
@@ -289,4 +294,141 @@ class TransferClientV2(client.BaseClient):
         """
         log.debug(f"TransferClientV2.list_stream_access_points({query_params})")
         r = self.get("/v2/stream_access_points", query_params=query_params)
+        return IterableJSONAPIResponse(r)
+
+    def create_bookmark(
+        self, data: dict[str, t.Any] | BookmarkCreateDocument
+    ) -> response.GlobusHTTPResponse:
+        """
+        :param data: Parameters for bookmark creation
+
+        .. tab-set::
+
+            .. tab-item:: Example Usage
+
+                .. code-block:: python
+
+                    tc = globus_sdk.experimental.TrasferClientV2(...)
+                    data = globus_sdk.experimental.BookmarkCreateDocument(...)
+                    result = tc.create_bookmark(data)
+                    print(result["data"]["id"])
+
+            .. tab-item:: API Info
+
+                ``POST /v2/bookmarks``
+        """
+        log.debug("TransferClientV2.create_bookmark(...)")
+        r = self.post("/v2/bookmarks", data=data)
+        return r
+
+    def update_bookmark(
+        self,
+        bookmark_id: uuid.UUID | str,
+        update_document: dict[str, t.Any] | BookmarkUpdateDocument,
+    ) -> response.GlobusHTTPResponse:
+        r"""
+        :param bookmark_id: The ID of the Bookmark.
+        :param update_document: The document that will be sent to the patch API.
+
+        .. tab-set::
+
+            .. tab-item:: Example Usage
+
+                .. code-block:: python
+
+                    tc = globus_sdk.experimental.TrasferClientV2(...)
+                    data = globus_sdk.experimental.BookmarkUpdateDocument(...)
+                    result = tc.update_bookmark(bookmark_id, data)
+                    print(result["data"])
+
+            .. tab-item:: API Info
+
+                ``PATCH /v2/bookmarks/<bookmark_id>``
+        """
+        log.debug(f"TransferClientV2.update_bookmark({bookmark_id}, {update_document})")
+        r = self.patch(f"/v2/bookmarks/{bookmark_id}", data=update_document)
+        return r
+
+    def get_bookmark(
+        self,
+        bookmark_id: uuid.UUID | str,
+        *,
+        query_params: dict[str, t.Any] | None = None,
+    ) -> response.GlobusHTTPResponse:
+        """
+        :param bookmark_id: The ID of the Bookmark for which we are fetching details.
+        :param query_params: Any additional parameters will be passed through
+            as request parameters on the URL.
+
+        .. tab-set::
+
+            .. tab-item:: Example Usage
+
+                .. code-block:: python
+
+                    tc = globus_sdk.experimental.TrasferClientV2(...)
+                    query_params = {"include": "collection"}
+                    result = tc.get_bookmark(bookmark_id, query_params)
+                    print(result["data"])
+
+            .. tab-item:: API Info
+
+                ``GET /v2/bookmarks/<bookmark_id>``
+        """
+        log.debug(f"TransferClientV2.get_bookmark({bookmark_id}, {query_params})")
+        r = self.get(f"/v2/bookmarks/{bookmark_id}", query_params=query_params)
+        return r
+
+    def delete_bookmark(
+        self,
+        bookmark_id: uuid.UUID | str,
+    ) -> response.GlobusHTTPResponse:
+        """
+        :param bookmark_id: The ID of the Bookmark to be deleted.
+
+        .. tab-set::
+
+            .. tab-item:: Example Usage
+
+                .. code-block:: python
+
+                    tc = globus_sdk.experimental.TrasferClientV2(...)
+                    tc.delete_bookmark(bookmark_id)
+
+            .. tab-item:: API Info
+
+                ``DELETE /v2/bookmarks/<bookmark_id>``
+        """
+        log.debug(f"TransferClientV2.delete_bookmark({bookmark_id})")
+        r = self.delete(f"/v2/bookmarks/{bookmark_id}")
+        return r
+
+    def list_bookmarks(
+        self,
+        *,
+        query_params: dict[str, t.Any] | None = None,
+    ) -> IterableJSONAPIResponse:
+        """
+        :param query_params: Any additional parameters will be passed through
+            as request parameters on the URL.
+
+        This will list all Bookmarks created by the authenticated user's primary
+            and linked identities.
+
+        .. tab-set::
+
+            .. tab-item:: Example Usage
+
+                .. code-block:: python
+
+                    tc = globus_sdk.experimental.TrasferClientV2(...)
+                    query_params = {"include": "collection"}
+                    tc.list_bookmarks(query_params)
+
+            .. tab-item:: API Info
+
+                ``GET /v2/bookmarks``
+        """
+        log.debug("TransferClientV2.list_bookmarks({query_params})")
+        r = self.get("/v2/bookmarks", query_params=query_params)
         return IterableJSONAPIResponse(r)

--- a/src/globus_sdk/experimental/transfer_v2/client.py
+++ b/src/globus_sdk/experimental/transfer_v2/client.py
@@ -77,7 +77,7 @@ class TransferClientV2(client.BaseClient):
 
                 .. code-block:: python
 
-                    tc = globus_sdk.experimental.TrasferClientV2(...)
+                    tc = globus_sdk.experimental.TransferClientV2(...)
                     data = globus_sdk.experimental.TunnelCreateDocument(...)
                     result = tc.create_tunnel(data)
                     print(result["data"]["id"])
@@ -86,7 +86,7 @@ class TransferClientV2(client.BaseClient):
 
                 ``POST /v2/tunnels``
         """
-        log.debug("TransferClientV2.create_tunnel(...)")
+        log.debug(f"{self.__class__.__name__}.create_tunnel(...)")
         r = self.post("/v2/tunnels", data=data)
         return r
 
@@ -105,7 +105,7 @@ class TransferClientV2(client.BaseClient):
 
                 .. code-block:: python
 
-                    tc = globus_sdk.experimental.TrasferClientV2(...)
+                    tc = globus_sdk.experimental.TransferClientV2(...)
                     data = globus_sdk.experimental.TunnelUpdateDocument(...)
                     result = tc.update_tunnel(tunnel_id, data)
                     print(result["data"])
@@ -114,7 +114,7 @@ class TransferClientV2(client.BaseClient):
 
                 ``PATCH /v2/tunnels/<tunnel_id>``
         """
-        log.debug(f"TransferClientV2.update_tunnel({tunnel_id}, {update_doc})")
+        log.debug(f"{self.__class__.__name__}.update_tunnel({tunnel_id}, {update_doc})")
         r = self.patch(f"/v2/tunnels/{tunnel_id}", data=update_doc)
         return r
 
@@ -135,7 +135,7 @@ class TransferClientV2(client.BaseClient):
 
                 .. code-block:: python
 
-                    tc = globus_sdk.experimental.TrasferClientV2(...)
+                    tc = globus_sdk.experimental.TransferClientV2(...)
                     result = tc.get_tunnel(tunnel_id)
                     print(result["data"])
 
@@ -143,7 +143,7 @@ class TransferClientV2(client.BaseClient):
 
                 ``GET /v2/tunnels/<tunnel_id>``
         """
-        log.debug("TransferClientV2.get_tunnel({tunnel_id}, {query_params})")
+        log.debug(f"{self.__class__.__name__}.get_tunnel({tunnel_id}, {query_params})")
         r = self.get(f"/v2/tunnels/{tunnel_id}", query_params=query_params)
         return r
 
@@ -163,14 +163,14 @@ class TransferClientV2(client.BaseClient):
 
                 .. code-block:: python
 
-                    tc = globus_sdk.experimental.TrasferClientV2(...)
+                    tc = globus_sdk.experimental.TransferClientV2(...)
                     tc.delete_tunnel(tunnel_id)
 
             .. tab-item:: API Info
 
                 ``DELETE /v2/tunnels/<tunnel_id>``
         """
-        log.debug(f"TransferClientV2.delete_tunnel({tunnel_id})")
+        log.debug(f"{self.__class__.__name__}.delete_tunnel({tunnel_id})")
         r = self.delete(f"/v2/tunnels/{tunnel_id}")
         return r
 
@@ -191,14 +191,14 @@ class TransferClientV2(client.BaseClient):
 
                 .. code-block:: python
 
-                    tc = globus_sdk.experimental.TrasferClientV2(...)
+                    tc = globus_sdk.experimental.TransferClientV2(...)
                     tc.list_tunnels(tunnel_id)
 
             .. tab-item:: API Info
 
                 ``GET /v2/tunnels/``
         """
-        log.debug(f"TransferClientV2.list_tunnels({query_params})")
+        log.debug(f"{self.__class__.__name__}.list_tunnels({query_params})")
         r = self.get("/v2/tunnels", query_params=query_params)
         return IterableJSONAPIResponse(r)
 
@@ -219,7 +219,7 @@ class TransferClientV2(client.BaseClient):
 
                 .. code-block:: python
 
-                    tc = globus_sdk.experimental.TrasferClientV2(...)
+                    tc = globus_sdk.experimental.TransferClientV2(...)
                     result = tc.get_tunnel_events(tunnel_id)
                     print(result["data"])
 
@@ -227,7 +227,9 @@ class TransferClientV2(client.BaseClient):
 
                 ``GET /v2/tunnels/<tunnel_id>/events``
         """
-        log.debug(f"TransferClientV2.get_tunnel_events({tunnel_id}, {query_params})")
+        log.debug(
+            f"{self.__class__.__name__}.get_tunnel_events({tunnel_id}, {query_params})"
+        )
         r = self.get(f"/v2/tunnels/{tunnel_id}/events", query_params=query_params)
         return IterableJSONAPIResponse(r)
 
@@ -252,7 +254,7 @@ class TransferClientV2(client.BaseClient):
 
                 .. code-block:: python
 
-                    tc = globus_sdk.experimental.TrasferClientV2(...)
+                    tc = globus_sdk.experimental.TransferClientV2(...)
                     tc.get_stream_access_point(stream_ap_id)
 
             .. tab-item:: API Info
@@ -260,7 +262,8 @@ class TransferClientV2(client.BaseClient):
                 ``GET /v2/stream_access_points/<stream_ap_id>``
         """
         log.debug(
-            f"TransferClientV2.get_stream_access_point({stream_ap_id}, {query_params})"
+            f"{self.__class__.__name__}."
+            f"get_stream_access_point({stream_ap_id}, {query_params})"
         )
         r = self.get(
             f"/v2/stream_access_points/{stream_ap_id}", query_params=query_params
@@ -285,14 +288,16 @@ class TransferClientV2(client.BaseClient):
 
                 .. code-block:: python
 
-                    tc = globus_sdk.experimental.TrasferClientV2(...)
+                    tc = globus_sdk.experimental.TransferClientV2(...)
                     tc.list_stream_access_points()
 
             .. tab-item:: API Info
 
                 ``GET /v2/stream_access_points``
         """
-        log.debug(f"TransferClientV2.list_stream_access_points({query_params})")
+        log.debug(
+            f"{self.__class__.__name__}.list_stream_access_points({query_params})"
+        )
         r = self.get("/v2/stream_access_points", query_params=query_params)
         return IterableJSONAPIResponse(r)
 
@@ -308,7 +313,7 @@ class TransferClientV2(client.BaseClient):
 
                 .. code-block:: python
 
-                    tc = globus_sdk.experimental.TrasferClientV2(...)
+                    tc = globus_sdk.experimental.TransferClientV2(...)
                     data = globus_sdk.experimental.BookmarkCreateDocument(...)
                     result = tc.create_bookmark(data)
                     print(result["data"]["id"])
@@ -317,7 +322,7 @@ class TransferClientV2(client.BaseClient):
 
                 ``POST /v2/bookmarks``
         """
-        log.debug("TransferClientV2.create_bookmark(...)")
+        log.debug(f"{self.__class__.__name__}.create_bookmark(...)")
         r = self.post("/v2/bookmarks", data=data)
         return r
 
@@ -336,7 +341,7 @@ class TransferClientV2(client.BaseClient):
 
                 .. code-block:: python
 
-                    tc = globus_sdk.experimental.TrasferClientV2(...)
+                    tc = globus_sdk.experimental.TransferClientV2(...)
                     data = globus_sdk.experimental.BookmarkUpdateDocument(...)
                     result = tc.update_bookmark(bookmark_id, data)
                     print(result["data"])
@@ -345,7 +350,10 @@ class TransferClientV2(client.BaseClient):
 
                 ``PATCH /v2/bookmarks/<bookmark_id>``
         """
-        log.debug(f"TransferClientV2.update_bookmark({bookmark_id}, {update_document})")
+        log.debug(
+            f"{self.__class__.__name__}."
+            f"update_bookmark({bookmark_id}, {update_document})"
+        )
         r = self.patch(f"/v2/bookmarks/{bookmark_id}", data=update_document)
         return r
 
@@ -366,7 +374,7 @@ class TransferClientV2(client.BaseClient):
 
                 .. code-block:: python
 
-                    tc = globus_sdk.experimental.TrasferClientV2(...)
+                    tc = globus_sdk.experimental.TransferClientV2(...)
                     query_params = {"include": "collection"}
                     result = tc.get_bookmark(bookmark_id, query_params)
                     print(result["data"])
@@ -375,7 +383,9 @@ class TransferClientV2(client.BaseClient):
 
                 ``GET /v2/bookmarks/<bookmark_id>``
         """
-        log.debug(f"TransferClientV2.get_bookmark({bookmark_id}, {query_params})")
+        log.debug(
+            f"{self.__class__.__name__}.get_bookmark({bookmark_id}, {query_params})"
+        )
         r = self.get(f"/v2/bookmarks/{bookmark_id}", query_params=query_params)
         return r
 
@@ -392,14 +402,14 @@ class TransferClientV2(client.BaseClient):
 
                 .. code-block:: python
 
-                    tc = globus_sdk.experimental.TrasferClientV2(...)
+                    tc = globus_sdk.experimental.TransferClientV2(...)
                     tc.delete_bookmark(bookmark_id)
 
             .. tab-item:: API Info
 
                 ``DELETE /v2/bookmarks/<bookmark_id>``
         """
-        log.debug(f"TransferClientV2.delete_bookmark({bookmark_id})")
+        log.debug(f"{self.__class__.__name__}.delete_bookmark({bookmark_id})")
         r = self.delete(f"/v2/bookmarks/{bookmark_id}")
         return r
 
@@ -421,7 +431,7 @@ class TransferClientV2(client.BaseClient):
 
                 .. code-block:: python
 
-                    tc = globus_sdk.experimental.TrasferClientV2(...)
+                    tc = globus_sdk.experimental.TransferClientV2(...)
                     query_params = {"include": "collection"}
                     tc.list_bookmarks(query_params)
 
@@ -429,6 +439,6 @@ class TransferClientV2(client.BaseClient):
 
                 ``GET /v2/bookmarks``
         """
-        log.debug("TransferClientV2.list_bookmarks({query_params})")
+        log.debug(f"{self.__class__.__name__}.list_bookmarks({query_params})")
         r = self.get("/v2/bookmarks", query_params=query_params)
         return IterableJSONAPIResponse(r)

--- a/src/globus_sdk/experimental/transfer_v2/data/__init__.py
+++ b/src/globus_sdk/experimental/transfer_v2/data/__init__.py
@@ -4,6 +4,12 @@ be Payload types, so they can be passed seamlessly to
 :class:`TransferClient <globus_sdk.TransferClient>` methods without conversion.
 """
 
+from .bookmark_documents import BookmarkCreateDocument, BookmarkUpdateDocument
 from .tunnel_documents import TunnelCreateDocument, TunnelUpdateDocument
 
-__all__ = ("TunnelCreateDocument", "TunnelUpdateDocument")
+__all__ = (
+    "BookmarkCreateDocument",
+    "BookmarkUpdateDocument",
+    "TunnelCreateDocument",
+    "TunnelUpdateDocument",
+)

--- a/src/globus_sdk/experimental/transfer_v2/data/bookmark_documents.py
+++ b/src/globus_sdk/experimental/transfer_v2/data/bookmark_documents.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import logging
+import typing as t
+import uuid
+
+from globus_sdk._missing import MISSING, MissingType
+from globus_sdk._payload import GlobusPayload
+
+log = logging.getLogger(__name__)
+
+
+class BookmarkCreateDocument(GlobusPayload):
+    """
+    Convenience class for constructing a bookmark document to use as the
+    ``data`` parameter to
+    :meth:`create_bookmark <globus_sdk.TransferClientV2.create_bookmark>`.
+    """
+
+    def __init__(
+        self,
+        collection: uuid.UUID | str,
+        name: str,
+        path: str,
+        *,
+        pinned: bool | MissingType = MISSING,
+        additional_fields: dict[str, t.Any] | None = None,
+    ) -> None:
+        super().__init__()
+        log.debug("Creating a new BookmarkCreateDocument object")
+
+        relationships = {
+            "collection": {
+                "data": {
+                    "type": "Collection",
+                    "id": collection,
+                }
+            }
+        }
+
+        attributes = {
+            "name": name,
+            "path": path,
+            "pinned": pinned,
+        }
+
+        if additional_fields is not None:
+            attributes.update(additional_fields)
+
+        self["data"] = {
+            "type": "Bookmark",
+            "attributes": attributes,
+            "relationships": relationships,
+        }
+
+
+class BookmarkUpdateDocument(GlobusPayload):
+    """
+    Convenience class for constructing a bookmark document to use as the
+    ``data`` parameter to
+    :meth:`update_bookmark <globus_sdk.TransferClientV2.update_bookmark>`.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        path: str,
+        *,
+        pinned: bool | MissingType = MISSING,
+        additional_fields: dict[str, t.Any] | None = None,
+    ) -> None:
+        super().__init__()
+        log.debug("Creating a new BookmarkUpdateDocument")
+
+        attributes = {
+            "name": name,
+            "path": path,
+            "pinned": pinned,
+        }
+
+        if additional_fields is not None:
+            attributes.update(additional_fields)
+
+        self["data"] = {
+            "type": "Bookmark",
+            "attributes": attributes,
+        }

--- a/src/globus_sdk/experimental/transfer_v2/data/bookmark_documents.py
+++ b/src/globus_sdk/experimental/transfer_v2/data/bookmark_documents.py
@@ -14,7 +14,7 @@ class BookmarkCreateDocument(GlobusPayload):
     """
     Convenience class for constructing a bookmark document to use as the
     ``data`` parameter to
-    :meth:`create_bookmark <globus_sdk.TransferClientV2.create_bookmark>`.
+    :meth:`~globus_sdk.TransferClientV2.create_bookmark`.
     """
 
     def __init__(
@@ -58,7 +58,7 @@ class BookmarkUpdateDocument(GlobusPayload):
     """
     Convenience class for constructing a bookmark document to use as the
     ``data`` parameter to
-    :meth:`update_bookmark <globus_sdk.TransferClientV2.update_bookmark>`.
+    :meth:`~globus_sdk.TransferClientV2.update_bookmark>`.
     """
 
     def __init__(

--- a/src/globus_sdk/experimental/transfer_v2/data/bookmark_documents.py
+++ b/src/globus_sdk/experimental/transfer_v2/data/bookmark_documents.py
@@ -58,7 +58,7 @@ class BookmarkUpdateDocument(GlobusPayload):
     """
     Convenience class for constructing a bookmark document to use as the
     ``data`` parameter to
-    :meth:`~globus_sdk.TransferClientV2.update_bookmark>`.
+    :meth:`~globus_sdk.TransferClientV2.update_bookmark`.
     """
 
     def __init__(

--- a/src/globus_sdk/testing/data/transfer/v2/create_bookmark.py
+++ b/src/globus_sdk/testing/data/transfer/v2/create_bookmark.py
@@ -1,0 +1,45 @@
+import uuid
+
+from globus_sdk.testing.models import RegisteredResponse, ResponseSet
+
+BOOKMARK_ID = str(uuid.uuid4())
+
+_collection_id = str(uuid.uuid4())
+_name = "public datasets"
+_path = "/data_repository/public"
+
+
+RESPONSES = ResponseSet(
+    default=RegisteredResponse(
+        service="transfer",
+        method="POST",
+        path="/v2/bookmarks",
+        status=201,
+        json={
+            "meta": {"request_id": "nDZoeEMPI"},
+            "data": {
+                "type": "Bookmark",
+                "id": BOOKMARK_ID,
+                "attributes": {
+                    "name": _name,
+                    "path": _path,
+                    "pinned": False,
+                },
+                "relationships": {
+                    "collection": {
+                        "data": {
+                            "type": "Collection",
+                            "id": _collection_id,
+                        }
+                    }
+                },
+            },
+        },
+        metadata={
+            "bookmark_id": BOOKMARK_ID,
+            "collection": _collection_id,
+            "name": _name,
+            "path": _path,
+        },
+    )
+)

--- a/src/globus_sdk/testing/data/transfer/v2/delete_bookmark.py
+++ b/src/globus_sdk/testing/data/transfer/v2/delete_bookmark.py
@@ -1,0 +1,19 @@
+import uuid
+
+from globus_sdk.testing.models import RegisteredResponse, ResponseSet
+
+BOOKMARK_ID = str(uuid.uuid4())
+
+
+RESPONSES = ResponseSet(
+    default=RegisteredResponse(
+        service="transfer",
+        method="DELETE",
+        path=f"/v2/bookmarks/{BOOKMARK_ID}",
+        status=200,
+        json={"meta": {"request_id": "nH45vUMpD"}},
+        metadata={
+            "bookmark_id": BOOKMARK_ID,
+        },
+    )
+)

--- a/src/globus_sdk/testing/data/transfer/v2/get_bookmark.py
+++ b/src/globus_sdk/testing/data/transfer/v2/get_bookmark.py
@@ -1,0 +1,50 @@
+import uuid
+
+from globus_sdk.testing.models import RegisteredResponse, ResponseSet
+
+BOOKMARK_ID = str(uuid.uuid4())
+
+_collection_id = str(uuid.uuid4())
+_name = "public datasets"
+_path = "/data_repository/public"
+
+
+RESPONSES = ResponseSet(
+    default=RegisteredResponse(
+        service="transfer",
+        method="GET",
+        path=f"/v2/bookmarks/{BOOKMARK_ID}",
+        json={
+            "meta": {"request_id": "HKsv2T65H"},
+            "data": {
+                "type": "Bookmark",
+                "id": BOOKMARK_ID,
+                "attributes": {"name": _name, "path": _path, "pinned": True},
+                "relationships": {
+                    "collection": {
+                        "data": {
+                            "type": "Collection",
+                            "id": _collection_id,
+                        }
+                    }
+                },
+            },
+            "included": [
+                {
+                    "type": "Collection",
+                    "id": _collection_id,
+                    "attributes": {
+                        "display_name": "GCP High Assurance Mapped Collection",
+                        "high_assurance": True,
+                    },
+                }
+            ],
+        },
+        metadata={
+            "bookmark_id": BOOKMARK_ID,
+            "collection": _collection_id,
+            "name": _name,
+            "path": _path,
+        },
+    )
+)

--- a/src/globus_sdk/testing/data/transfer/v2/list_bookmarks.py
+++ b/src/globus_sdk/testing/data/transfer/v2/list_bookmarks.py
@@ -1,0 +1,65 @@
+import uuid
+
+from globus_sdk.testing.models import RegisteredResponse, ResponseSet
+
+_bookmarks = [
+    {
+        "bookmark_id": str(uuid.uuid4()),
+        "collection_id": str(uuid.uuid4()),
+        "name": "public datasets",
+        "path": "/data_repository/public",
+        "pinned": True,
+    },
+    {
+        "bookmark_id": str(uuid.uuid4()),
+        "collection_id": str(uuid.uuid4()),
+        "name": "private datasets",
+        "path": "/data_repository/private",
+        "pinned": False,
+    },
+]
+
+RESPONSES = ResponseSet(
+    default=RegisteredResponse(
+        service="transfer",
+        method="GET",
+        path="/v2/bookmarks",
+        json={
+            "data": [
+                {
+                    "type": "Bookmark",
+                    "id": b["bookmark_id"],
+                    "attributes": {
+                        "name": b["name"],
+                        "path": b["path"],
+                        "pinned": b["pinned"],
+                    },
+                    "relationships": {
+                        "collection": {
+                            "data": {
+                                "type": "Collection",
+                                "id": b["collection_id"],
+                            }
+                        }
+                    },
+                }
+                for b in _bookmarks
+            ],
+            "meta": {
+                "request_id": "xj8AWyQr8",
+            },
+            "included": [
+                {
+                    "type": "Collection",
+                    "id": b["collection_id"],
+                    "attributes": {
+                        "display_name": "Wotsomatta U Dataset Collection",
+                        "high_assurance": False,
+                    },
+                }
+                for b in _bookmarks
+            ],
+        },
+    ),
+    metadata={"bookmarks": _bookmarks},
+)

--- a/src/globus_sdk/testing/data/transfer/v2/update_bookmark.py
+++ b/src/globus_sdk/testing/data/transfer/v2/update_bookmark.py
@@ -1,0 +1,47 @@
+import uuid
+
+from globus_sdk.testing.models import RegisteredResponse, ResponseSet
+
+BOOKMARK_ID = str(uuid.uuid4())
+
+_collection_id = str(uuid.uuid4())
+_name = "private datasets"
+_path = "/data_repository/private"
+_pinned = True
+
+
+RESPONSES = ResponseSet(
+    default=RegisteredResponse(
+        service="transfer",
+        method="PATCH",
+        path=f"/v2/bookmarks/{BOOKMARK_ID}",
+        status=200,
+        json={
+            "meta": {"request_id": "dDaKboC8I"},
+            "data": {
+                "type": "Bookmark",
+                "id": BOOKMARK_ID,
+                "attributes": {
+                    "name": _name,
+                    "path": _path,
+                    "pinned": _pinned,
+                },
+                "relationships": {
+                    "collection": {
+                        "data": {
+                            "type": "Collection",
+                            "id": _collection_id,
+                        }
+                    }
+                },
+            },
+        },
+        metadata={
+            "bookmark_id": BOOKMARK_ID,
+            "collection": _collection_id,
+            "name": _name,
+            "path": _path,
+            "pinned": _pinned,
+        },
+    )
+)

--- a/tests/functional/services/transfer/v2/test_create_bookmark.py
+++ b/tests/functional/services/transfer/v2/test_create_bookmark.py
@@ -1,0 +1,27 @@
+import json
+
+from globus_sdk.experimental import BookmarkCreateDocument
+from globus_sdk.testing import get_last_request, load_response
+
+
+def test_create_bookmark(client):
+    meta = load_response(client.create_bookmark).metadata
+
+    data = BookmarkCreateDocument(
+        meta["collection"],
+        meta["name"],
+        meta["path"],
+    )
+
+    res = client.create_bookmark(data)
+
+    assert res.http_status == 201
+    assert res["data"]["type"] == "Bookmark"
+
+    req = get_last_request()
+    sent = json.loads(req.body)
+    assert sent["data"]["attributes"]["name"] == meta["name"]
+    assert sent["data"]["attributes"]["path"] == meta["path"]
+    assert (
+        sent["data"]["relationships"]["collection"]["data"]["id"] == meta["collection"]
+    )

--- a/tests/functional/services/transfer/v2/test_delete_bookmark.py
+++ b/tests/functional/services/transfer/v2/test_delete_bookmark.py
@@ -1,0 +1,12 @@
+from globus_sdk.testing import get_last_request, load_response
+
+
+def test_delete_bookmark(client):
+    meta = load_response(client.delete_bookmark).metadata
+
+    res = client.delete_bookmark(meta["bookmark_id"])
+
+    assert res.http_status == 200
+
+    req = get_last_request()
+    assert req.body is None

--- a/tests/functional/services/transfer/v2/test_get_bookmark.py
+++ b/tests/functional/services/transfer/v2/test_get_bookmark.py
@@ -1,0 +1,20 @@
+from globus_sdk.testing import get_last_request, load_response
+
+
+def test_get_bookmark(client):
+    meta = load_response(client.get_bookmark).metadata
+
+    res = client.get_bookmark(
+        meta["bookmark_id"], query_params={"include": "collection"}
+    )
+
+    assert res.http_status == 200
+    assert res["data"]["type"] == "Bookmark"
+    assert res["data"]["id"] == meta["bookmark_id"]
+    assert (
+        res["data"]["relationships"]["collection"]["data"]["id"] == meta["collection"]
+    )
+
+    req = get_last_request()
+    assert "include=collection" in req.url
+    assert req.body is None

--- a/tests/functional/services/transfer/v2/test_list_bookmarks.py
+++ b/tests/functional/services/transfer/v2/test_list_bookmarks.py
@@ -1,0 +1,30 @@
+from globus_sdk.testing import get_last_request, load_response
+
+
+def test_list_bookmarks(client):
+    meta = load_response(client.list_bookmarks).metadata
+
+    res = client.list_bookmarks(
+        query_params={"include": "collection"},
+    )
+
+    assert res.http_status == 200
+    for i, bm in enumerate(res["data"]):
+        assert bm["type"] == "Bookmark"
+        assert bm["id"] == meta["bookmarks"][i]["bookmark_id"]
+        assert bm["attributes"]["name"] == meta["bookmarks"][i]["name"]
+        assert bm["attributes"]["path"] == meta["bookmarks"][i]["path"]
+        assert bm["attributes"]["pinned"] == meta["bookmarks"][i]["pinned"]
+
+        assert (
+            bm["relationships"]["collection"]["data"]["id"]
+            == meta["bookmarks"][i]["collection_id"]
+        )
+
+    for i, col in enumerate(res["included"]):
+        assert col["type"] == "Collection"
+        assert col["id"] == meta["bookmarks"][i]["collection_id"]
+
+    req = get_last_request()
+    assert "include=collection" in req.url
+    assert req.body is None

--- a/tests/functional/services/transfer/v2/test_update_bookmark.py
+++ b/tests/functional/services/transfer/v2/test_update_bookmark.py
@@ -1,0 +1,28 @@
+import json
+
+from globus_sdk.experimental import BookmarkUpdateDocument
+from globus_sdk.testing import get_last_request, load_response
+
+
+def test_update_bookmark(client):
+    meta = load_response(client.update_bookmark).metadata
+
+    data = BookmarkUpdateDocument(
+        meta["name"],
+        meta["path"],
+        pinned=meta["pinned"],
+    )
+
+    res = client.update_bookmark(meta["bookmark_id"], data)
+
+    assert res.http_status == 200
+    assert res["data"]["type"] == "Bookmark"
+    assert (
+        res["data"]["relationships"]["collection"]["data"]["id"] == meta["collection"]
+    )
+
+    req = get_last_request()
+    sent = json.loads(req.body)
+    assert sent["data"]["attributes"]["name"] == meta["name"]
+    assert sent["data"]["attributes"]["path"] == meta["path"]
+    assert sent["data"]["attributes"]["pinned"] == meta["pinned"]


### PR DESCRIPTION
**Shortcut Story**: https://app.shortcut.com/globus/story/47448/

Added the following methods to the experimental TransferClientV2:

* create_bookmark()
* update_bookmark()
* get_bookmark()
* delete_bookmark()
* list_bookmarks()

This provides access to the new Transfer v2 API operations for boomkark management, which includes support for high assurance collections.

Functional unit tests are provided for all methods. Change log entry is present.