### PR TITLE
Make tox factor usage more extensible

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,31 +18,36 @@ labels =
 # build a wheel, not a tarball, and use a common env to do it (so that the wheel is shared)
 package = wheel
 wheel_build_env = build_wheel
-
-deps =
-    !mindeps: -r requirements/py{py_dot_ver}/test.txt
-    mindeps: -r requirements/py{py_dot_ver}/test-mindeps.txt
-    sphinxext: -r requirements/py{py_dot_ver}/docs.txt
+deps = -r requirements/py{py_dot_ver}/test.txt
 commands = coverage run -m pytest {posargs}
-depends =
-    py{3.14,3.13,3.12,3.11,3.10,3.9}{-mindeps,-sphinxext,}: coverage_clean, lint
-    coverage_report: py{3.14,3.13,3.12,3.11,3.10,3.9}{-mindeps,-sphinxext,}
+depends = coverage_clean,lint
+
+[testenv:py{3.14,3.13,3.12,3.11,3.10,3.9}-mindeps]
+deps = -r requirements/py{py_dot_ver}/test-mindeps.txt
+
+[testenv:py{3.14,3.13,3.12,3.11,3.10,3.9}-sphinxext]
+deps =
+    -r requirements/py{py_dot_ver}/test.txt
+    -r requirements/py{py_dot_ver}/docs.txt
 
 [testenv:coverage_clean]
 dependency_groups = coverage
 skip_install = true
 commands = coverage erase
+depends =
 
 [testenv:coverage_report]
 dependency_groups = coverage
 skip_install = true
 commands_pre = -coverage combine
 commands = coverage report --skip-covered
+depends = py{3.14,3.13,3.12,3.11,3.10,3.9}{-mindeps,-sphinxext,}
 
 [testenv:lint]
 deps = pre-commit
 skip_install = true
 commands = pre-commit run --all-files
+depends =
 
 [testenv:mypy,mypy-{py3.9,py3.14}]
 deps = -r requirements/py{py_dot_ver}/typing.txt


### PR DESCRIPTION
Previously, the test environments were binary flagged between `mindeps`
and `!mindeps`. This is unfortunately bad for adding additional factors,
as discovered when testing `orjson` as a factor. Because `tox` does not
allow negative factors to be layered with "OR" semantics, it becomes
difficult to deselect the locked requirements in `test.txt` in order
to replace them.

The base testenv is simplified to have unconditional dependencies, and
factor-based dependency selection is done in descendant envs which can
therefore fully replace the deps declared by the base env.

The change in configuration also provides an opportunity to refactor the
`depends` declaration into the list form which makes it inheritable.
