### PR TITLE
Add get_registered_api() to FlowsClient

### DIFF
--- a/changelog.d/20260507_152855_8730430+m1yag1_sc_49699_add_get_registered_api.rst
+++ b/changelog.d/20260507_152855_8730430+m1yag1_sc_49699_add_get_registered_api.rst
@@ -1,0 +1,4 @@
+Added
+-----
+
+- Added ``FlowsClient.get_registered_api()``, which retrieves a registered API by ID. (:pr:`NUMBER`)

--- a/src/globus_sdk/services/flows/client.py
+++ b/src/globus_sdk/services/flows/client.py
@@ -888,6 +888,45 @@ class FlowsClient(client.BaseClient):
 
         return self.post(f"/runs/{run_id}/release")
 
+    def get_registered_api(
+        self,
+        registered_api_id: uuid.UUID | str,
+        *,
+        query_params: dict[str, t.Any] | None = None,
+    ) -> GlobusHTTPResponse:
+        """
+        Retrieve a registered API by ID.
+
+        :param registered_api_id: The ID of the registered API to fetch
+        :param query_params: Any additional parameters to be passed through
+            as query params.
+
+        .. tab-set::
+
+            .. tab-item:: Example Usage
+
+                .. code-block:: python
+
+                    from globus_sdk import FlowsClient
+
+                    flows = FlowsClient(...)
+                    flows.get_registered_api("a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+
+            .. tab-item:: Example Response Data
+
+                .. expandtestfixture:: flows.get_registered_api
+
+            .. tab-item:: API Info
+
+                .. extdoclink:: Get Registered API
+                    :service: flows
+                    :ref: Registered APIs/paths/~1registered_apis~1
+                          {registered_api_id}/get
+        """
+        return self.get(
+            f"/registered_apis/{registered_api_id}", query_params=query_params
+        )
+
 
 class SpecificFlowClient(client.BaseClient):
     r"""

--- a/src/globus_sdk/testing/data/flows/get_registered_api.py
+++ b/src/globus_sdk/testing/data/flows/get_registered_api.py
@@ -1,0 +1,118 @@
+from globus_sdk.testing.models import RegisteredResponse, ResponseSet
+
+REGISTERED_API_ID = "9dc867a4-1c6d-46d9-911f-71c2ac67e38c"
+OWNER_URN = "urn:globus:auth:identity:a1234567-1234-1234-1234-123456789abc"
+ADMIN_URN = "urn:globus:auth:identity:b2345678-2345-2345-2345-234567890abc"
+VIEWER_URN = "urn:globus:auth:identity:c3456789-3456-3456-3456-345678901abc"
+
+REGISTERED_API_DOC = {
+    "id": REGISTERED_API_ID,
+    "name": "test-registered-api",
+    "description": "A test registered API for testing purposes",
+    "roles": {
+        "owners": [OWNER_URN],
+        "administrators": [ADMIN_URN],
+        "viewers": [VIEWER_URN],
+    },
+    "target": {
+        "type": "openapi",
+        "openapi_version": "3.1",
+        "destination": {
+            "method": "get",
+            "url": "https://example.com/api/v1/resource/{resource_id}",
+        },
+        "specification": {
+            "summary": "Get Resource",
+            "description": "Retrieve a resource by ID",
+            "deprecated": False,
+            "parameters": [
+                {
+                    "name": "resource_id",
+                    "in": "path",
+                    "required": True,
+                    "schema": {"type": "string"},
+                    "allowEmptyValue": False,
+                    "allowReserved": False,
+                    "deprecated": False,
+                }
+            ],
+            "responses": {
+                "200": {
+                    "description": "A resource response",
+                    "content": {
+                        "application/json": {
+                            "schema": {"$ref": "#/components/schemas/ResourceResponse"}
+                        }
+                    },
+                }
+            },
+            "security": [{"GlobusAuth": ["urn:globus:auth:scope:example.com:all"]}],
+        },
+        "transforms": None,
+        "components": {
+            "schemas": {
+                "ResourceResponse": {
+                    "type": "object",
+                    "properties": {
+                        "resource_id": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "The resource identifier",
+                        },
+                        "data": {
+                            "type": "object",
+                            "description": "The resource data",
+                        },
+                    },
+                    "required": ["resource_id", "data"],
+                    "additionalProperties": False,
+                }
+            }
+        },
+    },
+    "data_templates": {
+        "request": {
+            "template": {
+                "path": {"$T_ref": "$"},
+            }
+        },
+        "response": {
+            "2XX": {
+                "template": {"$T_ref": "$.body"},
+                "type": "success",
+            },
+            "default": {
+                "template": {
+                    "cause": {"$T_ref": "$.body"},
+                    "exception": "ActionUnableToRun",
+                },
+                "type": "failure",
+            },
+        },
+    },
+    "state_input_schema": {
+        "type": "object",
+        "properties": {
+            "resource_id": {"type": "string"},
+        },
+        "required": ["resource_id"],
+    },
+    "status": "ACTIVE",
+    "subscription_id": "4fa609fc-14f6-4c62-acfd-680873d3b6fe",
+    "created_timestamp": "2024-01-15T10:30:00+00:00",
+    "edited_timestamp": None,
+    "updated_timestamp": "2024-03-20T14:45:30+00:00",
+    "scheduled_deletion_timestamp": None,
+}
+
+RESPONSES = ResponseSet(
+    metadata={
+        "registered_api_id": REGISTERED_API_ID,
+        "name": REGISTERED_API_DOC["name"],
+    },
+    default=RegisteredResponse(
+        service="flows",
+        path=f"/registered_apis/{REGISTERED_API_ID}",
+        json=REGISTERED_API_DOC,
+    ),
+)

--- a/tests/functional/services/flows/test_get_registered_api.py
+++ b/tests/functional/services/flows/test_get_registered_api.py
@@ -1,0 +1,27 @@
+import uuid
+
+import pytest
+
+from globus_sdk.testing import get_last_request, load_response
+
+
+@pytest.mark.parametrize("use_uuid", [False, True])
+def test_get_registered_api(flows_client, use_uuid):
+    """Test get_registered_api with string ID and UUID ID"""
+    loaded_response = load_response(flows_client.get_registered_api)
+    _, meta = loaded_response.json, loaded_response.metadata
+
+    registered_api_id_str = meta["registered_api_id"]
+    registered_api_id = (
+        uuid.UUID(registered_api_id_str) if use_uuid else registered_api_id_str
+    )
+
+    res = flows_client.get_registered_api(registered_api_id)
+
+    assert res.http_status == 200
+    assert res["id"] == registered_api_id_str
+    assert res["name"] == meta["name"]
+
+    req = get_last_request()
+    assert req.body is None
+    assert f"/registered_apis/{registered_api_id_str}" in req.url


### PR DESCRIPTION
## WHAT

Add `get_registered_api()` to the FlowsClient

## WHY

Starting to move over API calls made by the [globus-registered-api](https://github.com/globus/globus-registered-api) client over to the SDK and CLI

## Related

Flows currently has a [PR](https://github.com/globusonline/globus-flows/pull/1705) that adds the OpenAPI spec for the endpoint. That will need to be merged in before the extdoclink directive will work to generate the docs.