### PR TITLE
Release v4.6.0

### DIFF
--- a/changelog.d/20260408_210055_pjhinton_sc_47448_transfer_v2_bookmark_sdk_support.rst
+++ b/changelog.d/20260408_210055_pjhinton_sc_47448_transfer_v2_bookmark_sdk_support.rst
@@ -1,4 +1,0 @@
-Added
------
-
-- Support for managing bookmarks via the Transfer v2 client (:pr:`1379`)

--- a/changelog.d/20260427_125748_alok.kamatar_ak2000_fix_1380.rst
+++ b/changelog.d/20260427_125748_alok.kamatar_ak2000_fix_1380.rst
@@ -1,4 +1,0 @@
-Fixed
------
-
-- Switch to lazy reading of response json to work with streaming responses. (:pr:`1381`)

--- a/changelog.d/20260507_152855_8730430+m1yag1_sc_49699_add_get_registered_api.rst
+++ b/changelog.d/20260507_152855_8730430+m1yag1_sc_49699_add_get_registered_api.rst
@@ -1,4 +1,0 @@
-Added
------
-
-- Added ``FlowsClient.get_registered_api()``, which retrieves a registered API by ID. (:pr:`1386`)

--- a/changelog.d/20260512_120913_8730430+m1yag1_sc_49700_add_list_gras.rst
+++ b/changelog.d/20260512_120913_8730430+m1yag1_sc_49700_add_list_gras.rst
@@ -1,4 +1,0 @@
-Added
------
-
-- Added ``FlowsClient.list_registered_apis()``, which retrieves a list of registered APIs. (:pr:`1387`)

--- a/changelog.rst
+++ b/changelog.rst
@@ -12,6 +12,25 @@ to a major new version of the SDK.
 
 .. scriv-insert-here
 
+.. _changelog-4.6.0:
+
+v4.6.0 (2026-05-14)
+===================
+
+Added
+-----
+
+- Support for managing bookmarks via the Transfer v2 client (:pr:`1379`)
+
+- Added ``FlowsClient.get_registered_api()``, which retrieves a registered API by ID. (:pr:`1386`)
+
+- Added ``FlowsClient.list_registered_apis()``, which retrieves a list of registered APIs. (:pr:`1387`)
+
+Fixed
+-----
+
+- Switch to lazy reading of response json to work with streaming responses. (:pr:`1381`)
+
 .. _changelog-4.5.0:
 
 v4.5.0 (2026-03-30)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "globus-sdk"
-version = "4.5.0"
+version = "4.6.0"
 authors = [
     { name = "Globus Team", email = "support@globus.org" },
 ]


### PR DESCRIPTION
## Added

- Support for managing bookmarks via the Transfer v2 client (#1379)

- Added `FlowsClient.get_registered_api()`, which retrieves a registered API by ID. (#1386)

- Added `FlowsClient.list_registered_apis()`, which retrieves a list of registered APIs. (#1387)

## Fixed

- Switch to lazy reading of response json to work with streaming responses. (#1381)