### PR TITLE
Update pinned dependencies

### DIFF
--- a/requirements/py3.10/test.txt
+++ b/requirements/py3.10/test.txt
@@ -4,50 +4,50 @@
 #
 #    tox p -m freezedeps
 #
-certifi==2025.11.12
+certifi==2026.4.22
     # via requests
-charset-normalizer==3.4.4
+charset-normalizer==3.4.7
     # via requests
-coverage==7.11.3
+coverage==7.14.0
     # via -r .test.in
-exceptiongroup==1.3.0
+exceptiongroup==1.3.1
     # via pytest
 execnet==2.1.2
     # via pytest-xdist
 flaky==3.8.1
     # via -r .test.in
-idna==3.11
+idna==3.15
     # via requests
 iniconfig==2.3.0
     # via pytest
-packaging==25.0
+packaging==26.2
     # via pytest
 pluggy==1.6.0
     # via pytest
-pygments==2.19.2
+pygments==2.20.0
     # via pytest
-pytest==9.0.1
+pytest==9.0.3
     # via
     #   -r .test.in
     #   pytest-randomly
     #   pytest-xdist
-pytest-randomly==4.0.1
+pytest-randomly==4.1.0
     # via -r .test.in
 pytest-xdist==3.8.0
     # via -r .test.in
 pyyaml==6.0.3
     # via responses
-requests==2.32.5
+requests==2.34.1
     # via responses
-responses==0.25.8
+responses==0.26.0
     # via -r .test.in
-tomli==2.3.0
+tomli==2.4.1
     # via
     #   coverage
     #   pytest
 typing-extensions==4.15.0
     # via exceptiongroup
-urllib3==2.5.0
+urllib3==2.7.0
     # via
     #   requests
     #   responses

--- a/requirements/py3.10/typing.txt
+++ b/requirements/py3.10/typing.txt
@@ -6,39 +6,43 @@
 #
 alabaster==1.0.0
     # via sphinx
-babel==2.17.0
+ast-serialize==0.3.0
+    # via mypy
+babel==2.18.0
     # via sphinx
-certifi==2025.11.12
+certifi==2026.4.22
     # via requests
-charset-normalizer==3.4.4
+charset-normalizer==3.4.7
     # via requests
 docutils==0.21.2
     # via sphinx
-idna==3.11
+idna==3.15
     # via requests
-imagesize==1.4.1
+imagesize==2.0.0
     # via sphinx
 jinja2==3.1.6
     # via sphinx
+librt==0.11.0
+    # via mypy
 markupsafe==3.0.3
     # via jinja2
-mypy==1.18.2
+mypy==2.1.0
     # via -r .typing.in
 mypy-extensions==1.1.0
     # via mypy
-packaging==25.0
+packaging==26.2
     # via sphinx
-pathspec==0.12.1
+pathspec==1.1.1
     # via mypy
-pygments==2.19.2
+pygments==2.20.0
     # via sphinx
 pyyaml==6.0.3
     # via responses
-requests==2.32.5
+requests==2.34.1
     # via
     #   responses
     #   sphinx
-responses==0.25.8
+responses==0.26.0
     # via -r .typing.in
 snowballstemmer==3.0.1
     # via sphinx
@@ -56,23 +60,23 @@ sphinxcontrib-qthelp==2.0.0
     # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-tomli==2.3.0
+tomli==2.4.1
     # via
     #   mypy
     #   sphinx
 types-cryptography==3.3.23.2
     # via types-jwt
-types-docutils==0.22.3.20251115
+types-docutils==0.22.3.20260508
     # via -r .typing.in
 types-jwt==0.1.3
     # via -r .typing.in
-types-requests==2.32.4.20250913
+types-requests==2.33.0.20260513
     # via -r .typing.in
 typing-extensions==4.15.0
     # via
     #   -r .typing.in
     #   mypy
-urllib3==2.5.0
+urllib3==2.7.0
     # via
     #   requests
     #   responses

--- a/requirements/py3.11/docs.txt
+++ b/requirements/py3.11/docs.txt
@@ -8,65 +8,65 @@ accessible-pygments==0.0.5
     # via furo
 alabaster==1.0.0
     # via sphinx
-attrs==25.4.0
+attrs==26.1.0
     # via scriv
-babel==2.17.0
+babel==2.18.0
     # via sphinx
-beautifulsoup4==4.14.2
+beautifulsoup4==4.14.3
     # via furo
-certifi==2025.11.12
+certifi==2026.4.22
     # via requests
-charset-normalizer==3.4.4
+charset-normalizer==3.4.7
     # via requests
-click==8.3.1
+click==8.3.3
     # via
     #   click-log
     #   scriv
 click-log==0.4.0
     # via scriv
-docutils==0.21.2
+docutils==0.22.4
     # via sphinx
-furo==2025.9.25
+furo==2025.12.19
     # via -r .docs.in
-idna==3.11
+idna==3.15
     # via requests
-imagesize==1.4.1
+imagesize==2.0.0
     # via sphinx
 jinja2==3.1.6
     # via
     #   scriv
     #   sphinx
-markdown-it-py==4.0.0
+markdown-it-py==4.2.0
     # via scriv
 markupsafe==3.0.3
     # via jinja2
 mdurl==0.1.2
     # via markdown-it-py
-packaging==25.0
+packaging==26.2
     # via sphinx
-pygments==2.19.2
+pygments==2.20.0
     # via
     #   accessible-pygments
     #   furo
     #   sphinx
 pyyaml==6.0.3
     # via responses
-requests==2.32.5
+requests==2.34.1
     # via
     #   responses
     #   scriv
     #   sphinx
-responses==0.25.8
+responses==0.26.0
     # via -r .docs.in
-roman-numerals-py==3.1.0
+roman-numerals==4.1.0
     # via sphinx
-scriv==1.7.0
+scriv==1.8.0
     # via -r .docs.in
 snowballstemmer==3.0.1
     # via sphinx
-soupsieve==2.8
+soupsieve==2.8.3
     # via beautifulsoup4
-sphinx==8.2.3
+sphinx==9.0.4
     # via
     #   -r .docs.in
     #   furo
@@ -78,9 +78,9 @@ sphinx-basic-ng==1.0.0b2
     # via furo
 sphinx-copybutton==0.5.2
     # via -r .docs.in
-sphinx-design==0.6.1
+sphinx-design==0.7.0
     # via -r .docs.in
-sphinx-issues==5.0.1
+sphinx-issues==6.0.0
     # via -r .docs.in
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
@@ -96,7 +96,7 @@ sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 typing-extensions==4.15.0
     # via beautifulsoup4
-urllib3==2.5.0
+urllib3==2.7.0
     # via
     #   requests
     #   responses

--- a/requirements/py3.11/test.txt
+++ b/requirements/py3.11/test.txt
@@ -4,42 +4,42 @@
 #
 #    tox p -m freezedeps
 #
-certifi==2025.11.12
+certifi==2026.4.22
     # via requests
-charset-normalizer==3.4.4
+charset-normalizer==3.4.7
     # via requests
-coverage==7.11.3
+coverage==7.14.0
     # via -r .test.in
 execnet==2.1.2
     # via pytest-xdist
 flaky==3.8.1
     # via -r .test.in
-idna==3.11
+idna==3.15
     # via requests
 iniconfig==2.3.0
     # via pytest
-packaging==25.0
+packaging==26.2
     # via pytest
 pluggy==1.6.0
     # via pytest
-pygments==2.19.2
+pygments==2.20.0
     # via pytest
-pytest==9.0.1
+pytest==9.0.3
     # via
     #   -r .test.in
     #   pytest-randomly
     #   pytest-xdist
-pytest-randomly==4.0.1
+pytest-randomly==4.1.0
     # via -r .test.in
 pytest-xdist==3.8.0
     # via -r .test.in
 pyyaml==6.0.3
     # via responses
-requests==2.32.5
+requests==2.34.1
     # via responses
-responses==0.25.8
+responses==0.26.0
     # via -r .test.in
-urllib3==2.5.0
+urllib3==2.7.0
     # via
     #   requests
     #   responses

--- a/requirements/py3.11/typing.txt
+++ b/requirements/py3.11/typing.txt
@@ -6,45 +6,49 @@
 #
 alabaster==1.0.0
     # via sphinx
-babel==2.17.0
+ast-serialize==0.3.0
+    # via mypy
+babel==2.18.0
     # via sphinx
-certifi==2025.11.12
+certifi==2026.4.22
     # via requests
-charset-normalizer==3.4.4
+charset-normalizer==3.4.7
     # via requests
-docutils==0.21.2
+docutils==0.22.4
     # via sphinx
-idna==3.11
+idna==3.15
     # via requests
-imagesize==1.4.1
+imagesize==2.0.0
     # via sphinx
 jinja2==3.1.6
     # via sphinx
+librt==0.11.0
+    # via mypy
 markupsafe==3.0.3
     # via jinja2
-mypy==1.18.2
+mypy==2.1.0
     # via -r .typing.in
 mypy-extensions==1.1.0
     # via mypy
-packaging==25.0
+packaging==26.2
     # via sphinx
-pathspec==0.12.1
+pathspec==1.1.1
     # via mypy
-pygments==2.19.2
+pygments==2.20.0
     # via sphinx
 pyyaml==6.0.3
     # via responses
-requests==2.32.5
+requests==2.34.1
     # via
     #   responses
     #   sphinx
-responses==0.25.8
+responses==0.26.0
     # via -r .typing.in
-roman-numerals-py==3.1.0
+roman-numerals==4.1.0
     # via sphinx
 snowballstemmer==3.0.1
     # via sphinx
-sphinx==8.2.3
+sphinx==9.0.4
     # via -r .typing.in
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
@@ -60,17 +64,17 @@ sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 types-cryptography==3.3.23.2
     # via types-jwt
-types-docutils==0.22.3.20251115
+types-docutils==0.22.3.20260508
     # via -r .typing.in
 types-jwt==0.1.3
     # via -r .typing.in
-types-requests==2.32.4.20250913
+types-requests==2.33.0.20260513
     # via -r .typing.in
 typing-extensions==4.15.0
     # via
     #   -r .typing.in
     #   mypy
-urllib3==2.5.0
+urllib3==2.7.0
     # via
     #   requests
     #   responses

--- a/requirements/py3.12/test.txt
+++ b/requirements/py3.12/test.txt
@@ -4,42 +4,42 @@
 #
 #    tox p -m freezedeps
 #
-certifi==2025.11.12
+certifi==2026.4.22
     # via requests
-charset-normalizer==3.4.4
+charset-normalizer==3.4.7
     # via requests
-coverage==7.11.3
+coverage==7.14.0
     # via -r .test.in
 execnet==2.1.2
     # via pytest-xdist
 flaky==3.8.1
     # via -r .test.in
-idna==3.11
+idna==3.15
     # via requests
 iniconfig==2.3.0
     # via pytest
-packaging==25.0
+packaging==26.2
     # via pytest
 pluggy==1.6.0
     # via pytest
-pygments==2.19.2
+pygments==2.20.0
     # via pytest
-pytest==9.0.1
+pytest==9.0.3
     # via
     #   -r .test.in
     #   pytest-randomly
     #   pytest-xdist
-pytest-randomly==4.0.1
+pytest-randomly==4.1.0
     # via -r .test.in
 pytest-xdist==3.8.0
     # via -r .test.in
 pyyaml==6.0.3
     # via responses
-requests==2.32.5
+requests==2.34.1
     # via responses
-responses==0.25.8
+responses==0.26.0
     # via -r .test.in
-urllib3==2.5.0
+urllib3==2.7.0
     # via
     #   requests
     #   responses

--- a/requirements/py3.12/typing.txt
+++ b/requirements/py3.12/typing.txt
@@ -6,45 +6,49 @@
 #
 alabaster==1.0.0
     # via sphinx
-babel==2.17.0
+ast-serialize==0.3.0
+    # via mypy
+babel==2.18.0
     # via sphinx
-certifi==2025.11.12
+certifi==2026.4.22
     # via requests
-charset-normalizer==3.4.4
+charset-normalizer==3.4.7
     # via requests
-docutils==0.21.2
+docutils==0.22.4
     # via sphinx
-idna==3.11
+idna==3.15
     # via requests
-imagesize==1.4.1
+imagesize==2.0.0
     # via sphinx
 jinja2==3.1.6
     # via sphinx
+librt==0.11.0
+    # via mypy
 markupsafe==3.0.3
     # via jinja2
-mypy==1.18.2
+mypy==2.1.0
     # via -r .typing.in
 mypy-extensions==1.1.0
     # via mypy
-packaging==25.0
+packaging==26.2
     # via sphinx
-pathspec==0.12.1
+pathspec==1.1.1
     # via mypy
-pygments==2.19.2
+pygments==2.20.0
     # via sphinx
 pyyaml==6.0.3
     # via responses
-requests==2.32.5
+requests==2.34.1
     # via
     #   responses
     #   sphinx
-responses==0.25.8
+responses==0.26.0
     # via -r .typing.in
-roman-numerals-py==3.1.0
+roman-numerals==4.1.0
     # via sphinx
 snowballstemmer==3.0.1
     # via sphinx
-sphinx==8.2.3
+sphinx==9.1.0
     # via -r .typing.in
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
@@ -60,17 +64,17 @@ sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 types-cryptography==3.3.23.2
     # via types-jwt
-types-docutils==0.22.3.20251115
+types-docutils==0.22.3.20260508
     # via -r .typing.in
 types-jwt==0.1.3
     # via -r .typing.in
-types-requests==2.32.4.20250913
+types-requests==2.33.0.20260513
     # via -r .typing.in
 typing-extensions==4.15.0
     # via
     #   -r .typing.in
     #   mypy
-urllib3==2.5.0
+urllib3==2.7.0
     # via
     #   requests
     #   responses

--- a/requirements/py3.13/test.txt
+++ b/requirements/py3.13/test.txt
@@ -4,42 +4,42 @@
 #
 #    tox p -m freezedeps
 #
-certifi==2025.11.12
+certifi==2026.4.22
     # via requests
-charset-normalizer==3.4.4
+charset-normalizer==3.4.7
     # via requests
-coverage==7.11.3
+coverage==7.14.0
     # via -r .test.in
 execnet==2.1.2
     # via pytest-xdist
 flaky==3.8.1
     # via -r .test.in
-idna==3.11
+idna==3.15
     # via requests
 iniconfig==2.3.0
     # via pytest
-packaging==25.0
+packaging==26.2
     # via pytest
 pluggy==1.6.0
     # via pytest
-pygments==2.19.2
+pygments==2.20.0
     # via pytest
-pytest==9.0.1
+pytest==9.0.3
     # via
     #   -r .test.in
     #   pytest-randomly
     #   pytest-xdist
-pytest-randomly==4.0.1
+pytest-randomly==4.1.0
     # via -r .test.in
 pytest-xdist==3.8.0
     # via -r .test.in
 pyyaml==6.0.3
     # via responses
-requests==2.32.5
+requests==2.34.1
     # via responses
-responses==0.25.8
+responses==0.26.0
     # via -r .test.in
-urllib3==2.5.0
+urllib3==2.7.0
     # via
     #   requests
     #   responses

--- a/requirements/py3.13/typing.txt
+++ b/requirements/py3.13/typing.txt
@@ -6,45 +6,49 @@
 #
 alabaster==1.0.0
     # via sphinx
-babel==2.17.0
+ast-serialize==0.3.0
+    # via mypy
+babel==2.18.0
     # via sphinx
-certifi==2025.11.12
+certifi==2026.4.22
     # via requests
-charset-normalizer==3.4.4
+charset-normalizer==3.4.7
     # via requests
-docutils==0.21.2
+docutils==0.22.4
     # via sphinx
-idna==3.11
+idna==3.15
     # via requests
-imagesize==1.4.1
+imagesize==2.0.0
     # via sphinx
 jinja2==3.1.6
     # via sphinx
+librt==0.11.0
+    # via mypy
 markupsafe==3.0.3
     # via jinja2
-mypy==1.18.2
+mypy==2.1.0
     # via -r .typing.in
 mypy-extensions==1.1.0
     # via mypy
-packaging==25.0
+packaging==26.2
     # via sphinx
-pathspec==0.12.1
+pathspec==1.1.1
     # via mypy
-pygments==2.19.2
+pygments==2.20.0
     # via sphinx
 pyyaml==6.0.3
     # via responses
-requests==2.32.5
+requests==2.34.1
     # via
     #   responses
     #   sphinx
-responses==0.25.8
+responses==0.26.0
     # via -r .typing.in
-roman-numerals-py==3.1.0
+roman-numerals==4.1.0
     # via sphinx
 snowballstemmer==3.0.1
     # via sphinx
-sphinx==8.2.3
+sphinx==9.1.0
     # via -r .typing.in
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
@@ -60,17 +64,17 @@ sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 types-cryptography==3.3.23.2
     # via types-jwt
-types-docutils==0.22.3.20251115
+types-docutils==0.22.3.20260508
     # via -r .typing.in
 types-jwt==0.1.3
     # via -r .typing.in
-types-requests==2.32.4.20250913
+types-requests==2.33.0.20260513
     # via -r .typing.in
 typing-extensions==4.15.0
     # via
     #   -r .typing.in
     #   mypy
-urllib3==2.5.0
+urllib3==2.7.0
     # via
     #   requests
     #   responses

--- a/requirements/py3.14/test.txt
+++ b/requirements/py3.14/test.txt
@@ -4,42 +4,42 @@
 #
 #    tox p -m freezedeps
 #
-certifi==2025.11.12
+certifi==2026.4.22
     # via requests
-charset-normalizer==3.4.4
+charset-normalizer==3.4.7
     # via requests
-coverage==7.11.3
+coverage==7.14.0
     # via -r .test.in
 execnet==2.1.2
     # via pytest-xdist
 flaky==3.8.1
     # via -r .test.in
-idna==3.11
+idna==3.15
     # via requests
 iniconfig==2.3.0
     # via pytest
-packaging==25.0
+packaging==26.2
     # via pytest
 pluggy==1.6.0
     # via pytest
-pygments==2.19.2
+pygments==2.20.0
     # via pytest
-pytest==9.0.1
+pytest==9.0.3
     # via
     #   -r .test.in
     #   pytest-randomly
     #   pytest-xdist
-pytest-randomly==4.0.1
+pytest-randomly==4.1.0
     # via -r .test.in
 pytest-xdist==3.8.0
     # via -r .test.in
 pyyaml==6.0.3
     # via responses
-requests==2.32.5
+requests==2.34.1
     # via responses
-responses==0.25.8
+responses==0.26.0
     # via -r .test.in
-urllib3==2.5.0
+urllib3==2.7.0
     # via
     #   requests
     #   responses

--- a/requirements/py3.14/typing.txt
+++ b/requirements/py3.14/typing.txt
@@ -6,45 +6,49 @@
 #
 alabaster==1.0.0
     # via sphinx
-babel==2.17.0
+ast-serialize==0.3.0
+    # via mypy
+babel==2.18.0
     # via sphinx
-certifi==2025.11.12
+certifi==2026.4.22
     # via requests
-charset-normalizer==3.4.4
+charset-normalizer==3.4.7
     # via requests
-docutils==0.21.2
+docutils==0.22.4
     # via sphinx
-idna==3.11
+idna==3.15
     # via requests
-imagesize==1.4.1
+imagesize==2.0.0
     # via sphinx
 jinja2==3.1.6
     # via sphinx
+librt==0.11.0
+    # via mypy
 markupsafe==3.0.3
     # via jinja2
-mypy==1.18.2
+mypy==2.1.0
     # via -r .typing.in
 mypy-extensions==1.1.0
     # via mypy
-packaging==25.0
+packaging==26.2
     # via sphinx
-pathspec==0.12.1
+pathspec==1.1.1
     # via mypy
-pygments==2.19.2
+pygments==2.20.0
     # via sphinx
 pyyaml==6.0.3
     # via responses
-requests==2.32.5
+requests==2.34.1
     # via
     #   responses
     #   sphinx
-responses==0.25.8
+responses==0.26.0
     # via -r .typing.in
-roman-numerals-py==3.1.0
+roman-numerals==4.1.0
     # via sphinx
 snowballstemmer==3.0.1
     # via sphinx
-sphinx==8.2.3
+sphinx==9.1.0
     # via -r .typing.in
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
@@ -60,17 +64,17 @@ sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 types-cryptography==3.3.23.2
     # via types-jwt
-types-docutils==0.22.3.20251115
+types-docutils==0.22.3.20260508
     # via -r .typing.in
 types-jwt==0.1.3
     # via -r .typing.in
-types-requests==2.32.4.20250913
+types-requests==2.33.0.20260513
     # via -r .typing.in
 typing-extensions==4.15.0
     # via
     #   -r .typing.in
     #   mypy
-urllib3==2.5.0
+urllib3==2.7.0
     # via
     #   requests
     #   responses

--- a/requirements/py3.9/test-mindeps.txt
+++ b/requirements/py3.9/test-mindeps.txt
@@ -4,7 +4,7 @@
 #
 #    tox p -m freezedeps
 #
-certifi==2025.11.12
+certifi==2026.4.22
     # via requests
 cffi==2.0.0
     # via cryptography
@@ -22,17 +22,17 @@ flaky==3.8.1
     # via -r .test-mindeps.in
 idna==2.8
     # via requests
-importlib-metadata==8.7.0
+importlib-metadata==8.7.1
     # via pytest-randomly
 iniconfig==2.1.0
     # via pytest
-packaging==25.0
+packaging==26.2
     # via pytest
 pluggy==1.6.0
     # via pytest
 pycparser==2.23
     # via cffi
-pygments==2.19.2
+pygments==2.20.0
     # via pytest
 pyjwt==2.0.0
     # via -r .test-mindeps.in
@@ -55,7 +55,7 @@ responses==0.23.1
     # via -r .test-mindeps.in
 six==1.17.0
     # via cryptography
-tomli==2.3.0
+tomli==2.4.1
     # via
     #   coverage
     #   pytest
@@ -67,5 +67,5 @@ urllib3==1.25.11
     # via
     #   requests
     #   responses
-zipp==3.23.0
+zipp==3.23.1
     # via importlib-metadata

--- a/requirements/py3.9/test.txt
+++ b/requirements/py3.9/test.txt
@@ -4,29 +4,29 @@
 #
 #    tox p -m freezedeps
 #
-certifi==2025.11.12
+certifi==2026.4.22
     # via requests
-charset-normalizer==3.4.4
+charset-normalizer==3.4.7
     # via requests
 coverage==7.10.7
     # via -r .test.in
-exceptiongroup==1.3.0
+exceptiongroup==1.3.1
     # via pytest
 execnet==2.1.2
     # via pytest-xdist
 flaky==3.8.1
     # via -r .test.in
-idna==3.11
+idna==3.15
     # via requests
-importlib-metadata==8.7.0
+importlib-metadata==8.7.1
     # via pytest-randomly
 iniconfig==2.1.0
     # via pytest
-packaging==25.0
+packaging==26.2
     # via pytest
 pluggy==1.6.0
     # via pytest
-pygments==2.19.2
+pygments==2.20.0
     # via pytest
 pytest==8.4.2
     # via
@@ -41,17 +41,17 @@ pyyaml==6.0.3
     # via responses
 requests==2.32.5
     # via responses
-responses==0.25.8
+responses==0.26.0
     # via -r .test.in
-tomli==2.3.0
+tomli==2.4.1
     # via
     #   coverage
     #   pytest
 typing-extensions==4.15.0
     # via exceptiongroup
-urllib3==2.5.0
+urllib3==2.6.3
     # via
     #   requests
     #   responses
-zipp==3.23.0
+zipp==3.23.1
     # via importlib-metadata

--- a/requirements/py3.9/typing.txt
+++ b/requirements/py3.9/typing.txt
@@ -6,33 +6,35 @@
 #
 alabaster==0.7.16
     # via sphinx
-babel==2.17.0
+babel==2.18.0
     # via sphinx
-certifi==2025.11.12
+certifi==2026.4.22
     # via requests
-charset-normalizer==3.4.4
+charset-normalizer==3.4.7
     # via requests
 docutils==0.21.2
     # via sphinx
-idna==3.11
+idna==3.15
     # via requests
-imagesize==1.4.1
+imagesize==1.5.0
     # via sphinx
-importlib-metadata==8.7.0
+importlib-metadata==8.7.1
     # via sphinx
 jinja2==3.1.6
     # via sphinx
+librt==0.11.0
+    # via mypy
 markupsafe==3.0.3
     # via jinja2
-mypy==1.18.2
+mypy==1.19.1
     # via -r .typing.in
 mypy-extensions==1.1.0
     # via mypy
-packaging==25.0
+packaging==26.2
     # via sphinx
-pathspec==0.12.1
+pathspec==1.1.1
     # via mypy
-pygments==2.19.2
+pygments==2.20.0
     # via sphinx
 pyyaml==6.0.3
     # via responses
@@ -40,7 +42,7 @@ requests==2.32.5
     # via
     #   responses
     #   sphinx
-responses==0.25.8
+responses==0.26.0
     # via -r .typing.in
 snowballstemmer==3.0.1
     # via sphinx
@@ -58,7 +60,7 @@ sphinxcontrib-qthelp==2.0.0
     # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-tomli==2.3.0
+tomli==2.4.1
     # via
     #   mypy
     #   sphinx
@@ -68,16 +70,16 @@ types-docutils==0.22.3.20251115
     # via -r .typing.in
 types-jwt==0.1.3
     # via -r .typing.in
-types-requests==2.32.4.20250913
+types-requests==2.32.4.20260107
     # via -r .typing.in
 typing-extensions==4.15.0
     # via
     #   -r .typing.in
     #   mypy
-urllib3==2.5.0
+urllib3==2.6.3
     # via
     #   requests
     #   responses
     #   types-requests
-zipp==3.23.0
+zipp==3.23.1
     # via importlib-metadata

--- a/src/globus_sdk/testing/registry.py
+++ b/src/globus_sdk/testing/registry.py
@@ -7,6 +7,7 @@ import typing as t
 import responses
 
 import globus_sdk
+import globus_sdk.experimental
 
 from .models import RegisteredResponse, ResponseList, ResponseSet
 


### PR DESCRIPTION
This should resolve a number of Dependabot warnings associated with the versions pinned in these files.

This was mechanically created by running `tox run -m freezedeps`.

_Alert count at the time this PR was opened: 130_
_Alert count after this PR was merged: 52_