### PR TITLE
removed pinned from v2 bookmarks

### DIFF
--- a/changelog.d/20260605_135304_aaschaer_remove_pinned.rst
+++ b/changelog.d/20260605_135304_aaschaer_remove_pinned.rst
@@ -1,0 +1,4 @@
+Removed
+-------
+
+ - The ``pinned`` field was removed from the experimental ``BookmarkCreateDocument`` and ``BookmarkUpdateDocument`` classes to align with the API which does not support the field.

--- a/src/globus_sdk/experimental/transfer_v2/data/bookmark_documents.py
+++ b/src/globus_sdk/experimental/transfer_v2/data/bookmark_documents.py
@@ -4,7 +4,6 @@ import logging
 import typing as t
 import uuid
 
-from globus_sdk._missing import MISSING, MissingType
 from globus_sdk._payload import GlobusPayload
 
 log = logging.getLogger(__name__)
@@ -23,7 +22,6 @@ class BookmarkCreateDocument(GlobusPayload):
         name: str,
         path: str,
         *,
-        pinned: bool | MissingType = MISSING,
         additional_fields: dict[str, t.Any] | None = None,
     ) -> None:
         super().__init__()
@@ -41,7 +39,6 @@ class BookmarkCreateDocument(GlobusPayload):
         attributes = {
             "name": name,
             "path": path,
-            "pinned": pinned,
         }
 
         if additional_fields is not None:
@@ -66,7 +63,6 @@ class BookmarkUpdateDocument(GlobusPayload):
         name: str,
         path: str,
         *,
-        pinned: bool | MissingType = MISSING,
         additional_fields: dict[str, t.Any] | None = None,
     ) -> None:
         super().__init__()
@@ -75,7 +71,6 @@ class BookmarkUpdateDocument(GlobusPayload):
         attributes = {
             "name": name,
             "path": path,
-            "pinned": pinned,
         }
 
         if additional_fields is not None:

--- a/src/globus_sdk/testing/data/transfer/v2/create_bookmark.py
+++ b/src/globus_sdk/testing/data/transfer/v2/create_bookmark.py
@@ -23,7 +23,6 @@ RESPONSES = ResponseSet(
                 "attributes": {
                     "name": _name,
                     "path": _path,
-                    "pinned": False,
                 },
                 "relationships": {
                     "collection": {

--- a/src/globus_sdk/testing/data/transfer/v2/get_bookmark.py
+++ b/src/globus_sdk/testing/data/transfer/v2/get_bookmark.py
@@ -19,7 +19,7 @@ RESPONSES = ResponseSet(
             "data": {
                 "type": "Bookmark",
                 "id": BOOKMARK_ID,
-                "attributes": {"name": _name, "path": _path, "pinned": True},
+                "attributes": {"name": _name, "path": _path},
                 "relationships": {
                     "collection": {
                         "data": {

--- a/src/globus_sdk/testing/data/transfer/v2/list_bookmarks.py
+++ b/src/globus_sdk/testing/data/transfer/v2/list_bookmarks.py
@@ -8,14 +8,12 @@ _bookmarks = [
         "collection_id": str(uuid.uuid4()),
         "name": "public datasets",
         "path": "/data_repository/public",
-        "pinned": True,
     },
     {
         "bookmark_id": str(uuid.uuid4()),
         "collection_id": str(uuid.uuid4()),
         "name": "private datasets",
         "path": "/data_repository/private",
-        "pinned": False,
     },
 ]
 
@@ -32,7 +30,6 @@ RESPONSES = ResponseSet(
                     "attributes": {
                         "name": b["name"],
                         "path": b["path"],
-                        "pinned": b["pinned"],
                     },
                     "relationships": {
                         "collection": {

--- a/src/globus_sdk/testing/data/transfer/v2/update_bookmark.py
+++ b/src/globus_sdk/testing/data/transfer/v2/update_bookmark.py
@@ -7,7 +7,6 @@ BOOKMARK_ID = str(uuid.uuid4())
 _collection_id = str(uuid.uuid4())
 _name = "private datasets"
 _path = "/data_repository/private"
-_pinned = True
 
 
 RESPONSES = ResponseSet(
@@ -24,7 +23,6 @@ RESPONSES = ResponseSet(
                 "attributes": {
                     "name": _name,
                     "path": _path,
-                    "pinned": _pinned,
                 },
                 "relationships": {
                     "collection": {
@@ -41,7 +39,6 @@ RESPONSES = ResponseSet(
             "collection": _collection_id,
             "name": _name,
             "path": _path,
-            "pinned": _pinned,
         },
     )
 )

--- a/tests/functional/services/transfer/v2/test_list_bookmarks.py
+++ b/tests/functional/services/transfer/v2/test_list_bookmarks.py
@@ -14,7 +14,6 @@ def test_list_bookmarks(client):
         assert bm["id"] == meta["bookmarks"][i]["bookmark_id"]
         assert bm["attributes"]["name"] == meta["bookmarks"][i]["name"]
         assert bm["attributes"]["path"] == meta["bookmarks"][i]["path"]
-        assert bm["attributes"]["pinned"] == meta["bookmarks"][i]["pinned"]
 
         assert (
             bm["relationships"]["collection"]["data"]["id"]

--- a/tests/functional/services/transfer/v2/test_update_bookmark.py
+++ b/tests/functional/services/transfer/v2/test_update_bookmark.py
@@ -10,7 +10,6 @@ def test_update_bookmark(client):
     data = BookmarkUpdateDocument(
         meta["name"],
         meta["path"],
-        pinned=meta["pinned"],
     )
 
     res = client.update_bookmark(meta["bookmark_id"], data)
@@ -25,4 +24,3 @@ def test_update_bookmark(client):
     sent = json.loads(req.body)
     assert sent["data"]["attributes"]["name"] == meta["name"]
     assert sent["data"]["attributes"]["path"] == meta["path"]
-    assert sent["data"]["attributes"]["pinned"] == meta["pinned"]


### PR DESCRIPTION
We made a somewhat late decision to pull `pinned` from bookmarks v2 as it was unused in v1 since 2024.

I'm marking this no-news-is-good-news since its removing a nonexistant field, but lmk if I should actually add a changelog