### PR TITLE
Fix README link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ Testing, Development, and Contributing
 --------------------------------------
 
 Go to the
-`CONTRIBUTING <https://github.com/globus/globus-sdk-python/blob/main/CONTRIBUTING.adoc>`_
+`CONTRIBUTING <https://github.com/globus/globus-sdk-python/blob/main/CONTRIBUTING.rst>`_
 guide for detail.
 
 Links


### PR DESCRIPTION

https://github.com/globus/globus-sdk-python/pull/1393 moved CONTRIBUTING.adoc to CONTRIBUTING.rst, update the README link to point to this new location.