### PR TITLE
Fix a crash bug in the orjson compatibility module

### DIFF
--- a/changelog.d/20260616_111455_kurtmckee_fix_orjson_compat_getattr.rst
+++ b/changelog.d/20260616_111455_kurtmckee_fix_orjson_compat_getattr.rst
@@ -1,0 +1,7 @@
+Fixed
+-----
+
+- Fix a crash bug in the orjson compatibility module. (:pr:`NUMBER`)
+
+  This manifested as a ``RuntimeError``, and could occur when a test framework
+  accessed the module to check for warning registries in the module.

--- a/src/globus_sdk/_internal/orjson_compat.py
+++ b/src/globus_sdk/_internal/orjson_compat.py
@@ -35,10 +35,10 @@ else:
         return ["__all__", "__file__", "__path__"] + list(__all__)
 
     def __getattr__(name: str) -> t.Any:
-        require()
-
-        mod = sys.modules[__name__]
         if name in ("loads", "dumps"):
+            require()
+
+            mod = sys.modules[__name__]
             value = getattr(orjson, name)
             setattr(mod, name, value)
             return value


### PR DESCRIPTION
`globus_sdk._internal.orjson_compat.__getattr__` violates Python's attribute protocol. The contract for `getattr(obj, name, default)` and `hasattr(obj, name)` is that a missing attribute raises `AttributeError`, which those builtins catch to return the default / `False`. The module breaks this: when `orjson` is not installed, it raises `RuntimeError` for *every* unknown name, because `__getattr__` calls `require()` before checking which name was requested.

As a result, any code that defensively probes the module crashes:

``` python
from globus_sdk._internal import orjson_compat

hasattr(orjson_compat, 'anything')   # should be False; instead: RuntimeError
```

This is how it surfaced for us - unrelated tests failed because `unittest.assertWarns` / `pytest.warns` scan `sys.modules` and do `getattr(mod, "__warningregistry__", None)` on every module:

``` python
import warnings
from unittest import TestCase
from globus_sdk import TransferAPIError  # loads transport -> orjson_compat

with TestCase().assertWarns(UserWarning):
    warnings.warn("boom")
```

The fix is to move the call to `require()` inside the if-clause of `__get_attr__`.