### PR TITLE
Add a cooldown to dependabot pypi config

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -16,5 +16,7 @@ updates:
     directory: "/requirements/"
     schedule:
       interval: "semiannually"
+    cooldown:
+      default-days: 20
     ignore:
       - dependency-name: "*"


### PR DESCRIPTION
This change only applies to the dependabot config for PyPI packages,
specifically our locked test package data.

Dependabot is already running on these very infrequently, but
- this is flagged by zizmor
- there is no harm in having the cooldown
- in a rare case, it may help
