### PR TITLE
Add 'permissions' blocks to github workflows

### DIFF
--- a/.github/workflows/has_changelog.yaml
+++ b/.github/workflows/has_changelog.yaml
@@ -9,6 +9,9 @@ on:
       - reopened
       - synchronize
 
+permissions:
+  contents: read
+
 jobs:
   check_has_news_in_changelog_dir:
     if: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,6 +9,9 @@ on:
   schedule:
     - cron: '0 4 * * 1'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: "${{ matrix.name }}"


### PR DESCRIPTION
Where missing, `permissions` are now declared.

Our publishing workflows already have permissions at the job level, and
therefore do not need workflow-level permissions to be set.
