### PR TITLE
Enable zizmor linting on pushes and PRs

### DIFF
--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -1,0 +1,12 @@
+name: zizmor
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  zizmor:
+    permissions:
+      security-events: write
+
+    uses: zizmorcore/workflow/.github/workflows/reusable-zizmor.yml@465600191822382e76d26abf77772f21262ecdb6  # main

--- a/changelog.d/20260616_152921_sirosen_add_zizmor.rst
+++ b/changelog.d/20260616_152921_sirosen_add_zizmor.rst
@@ -1,0 +1,5 @@
+Security
+--------
+
+- GitHub Actions security is now checked with `zizmor <https://zizmor.sh>`_
+  (:pr:`NUMBER`)


### PR DESCRIPTION
This is a new workflow which has a single job, calling the zizmor
reusable workflow.
It publishes findings as SARIF data to GitHub security findings APIs.

The workflow will not fail on pull requests or pushes, but will flag new
and existing usages which fail zizmor checking.
