### PR TITLE
Fix references to 'ScopeBuilder' in docs

### DIFF
--- a/docs/authorization/scopes_and_consents/scope_collections.rst
+++ b/docs/authorization/scopes_and_consents/scope_collections.rst
@@ -103,7 +103,7 @@ To elaborate on the above example:
     auth_code = input("Please enter the code you get after login here: ").strip()
     token_response = client.oauth2_exchange_code_for_tokens(auth_code)
 
-    # use the `resource_server` of a ScopeBuilder to grab the associated token
+    # use the `resource_server` of a scope collection to grab the associated token
     # data from the response
     tokendata = token_response.by_resource_server[TransferScopes.resource_server]
 

--- a/docs/authorization/scopes_and_consents/scopes.rst
+++ b/docs/authorization/scopes_and_consents/scopes.rst
@@ -39,14 +39,16 @@ constructed by means of ``Scope`` methods thusly:
 
 .. code-block:: python
 
-    from globus_sdk.scopes import GCSCollectionScopeBuilder, TransferScopes, Scope
+    from globus_sdk.scopes import GCSCollectionScopes, TransferScopes, Scope
 
     MAPPED_COLLECTION_ID = "...ID HERE..."
 
     # create the scope object, and get the data_access_scope as a string
-    data_access_scope = GCSCollectionScopeBuilder(MAPPED_COLLECTION_ID).data_access
+    data_access_scope = GCSCollectionScopes(MAPPED_COLLECTION_ID).data_access
     # add data_access as an optional dependency
-    transfer_scope = TransferScopes.all.with_dependency(data_access_scope, optional=True)
+    transfer_scope = TransferScopes.all.with_dependency(
+        data_access_scope.with_optional(True)
+    )
 
 ``Scope``\s can be used in most of the same locations where scope
 strings can be used, but you can also call ``str(scope)`` to get a
@@ -72,11 +74,11 @@ strings. All scope objects support this by means of their defined
     >>> print(str(bar))
     bar[baz]
     >>> alpha = Scope("alpha")
-    >>> alpha = alpha.with_dependency("beta", optional=True)
+    >>> alpha = alpha.with_dependency(Scope("beta").with_optional(True))
     >>> print(str(alpha))
     alpha[*beta]
     >>> print(repr(alpha))
-    Scope("alpha", dependencies=[Scope("beta", optional=True)])
+    Scope("alpha", dependencies=(Scope("beta", optional=True),))
 
 Reference
 ~~~~~~~~~

--- a/docs/examples/guest_collection_creation.rst
+++ b/docs/examples/guest_collection_creation.rst
@@ -39,9 +39,9 @@ policy documents passed to create the user credential.
 
     # The scope the client will need, note that primary scope is for the endpoint,
     # but it has a dependency on the mapped collection's data_access scope
-    scope = scopes.Scope(scopes.GCSEndpointScopeBuilder(endpoint_id).manage_collections)
+    scope = scopes.Scope(scopes.GCSEndpointScopes(endpoint_id).manage_collections)
     scope = scope.with_dependency(
-        scopes.GCSCollectionScopeBuilder(mapped_collection_id).data_access
+        scopes.GCSCollectionScopes(mapped_collection_id).data_access
     )
 
     # Build a GCSClient to act as the client by using a ClientCredentialsAuthorizor


### PR DESCRIPTION
resolves #1403

Several pieces of documentation *other than the changelog and upgrading
guide* refer to `ScopeBuilder` objects. These were all renamed in SDK v4.

All of the offending references have been corrected.

As related changes, some docs for `Scope` objects were modified to
correct for v4 changes in the `Scope` API, related to the immutability of
scope objects.
