### PR TITLE
Remove flow run label length constraint documentation

### DIFF
--- a/changelog.d/20260730_164042_kurtmckee_harpoon_narwhals.rst
+++ b/changelog.d/20260730_164042_kurtmckee_harpoon_narwhals.rst
@@ -1,0 +1,5 @@
+Documentation
+-------------
+
+- Remove the ``SpecificFlowClient.run_flow`` and ``.update_run`` methods'
+  ``label`` parameter length constraint documentation. (:pr:`NUMBER`)

--- a/src/globus_sdk/services/flows/client.py
+++ b/src/globus_sdk/services/flows/client.py
@@ -812,7 +812,7 @@ class FlowsClient(client.BaseClient):
         Update the metadata of a specific run.
 
         :param run_id: The ID of the run to update
-        :param label: A short human-readable title (1 - 64 chars)
+        :param label: A short human-readable title.
         :param tags: A collection of searchable tags associated with the run.
             Tags are normalized by stripping leading and trailing whitespace,
             and replacing all whitespace with a single space.
@@ -1106,7 +1106,7 @@ class SpecificFlowClient(client.BaseClient):
         """
         :param body: The input json object handed to the first flow state. The flows
             service will validate this object against the flow's supplied input schema.
-        :param label: A short human-readable title (1 - 64 chars)
+        :param label: A short human-readable title.
         :param tags: A collection of searchable tags associated with the run. Tags are
             normalized by stripping leading and trailing whitespace, and replacing all
             whitespace with a single space.


### PR DESCRIPTION
It's not documented consistently across all methods and is subject to change in the service.