### PR TITLE
Fix create-guest-collection user guide examples

### DIFF
--- a/docs/user_guide/usage_patterns/data_transfer/create_guest_collection/create_guest_collection_client_owned.py
+++ b/docs/user_guide/usage_patterns/data_transfer/create_guest_collection/create_guest_collection_client_owned.py
@@ -12,7 +12,7 @@ STORAGE_GATEWAY_ID = "947460f6-3fcd-4acc-9683-d71e14e5ace1"
 MAPPED_COLLECTION_ID = "6c54cade-bde5-45c1-bdea-f4bd71dba2cc"
 
 
-def main():
+def main() -> None:
     with ClientApp(
         "my-simple-client-collection",
         client_id=CONFIDENTIAL_CLIENT_ID,
@@ -22,7 +22,7 @@ def main():
             create_guest_collection(gcs_client)
 
 
-def create_guest_collection(gcs_client: globus_sdk.GCSClient):
+def create_guest_collection(gcs_client: globus_sdk.GCSClient) -> None:
     # Comment out this line if the mapped collection is high assurance
     attach_data_access_scope(gcs_client, MAPPED_COLLECTION_ID)
 
@@ -39,20 +39,20 @@ def create_guest_collection(gcs_client: globus_sdk.GCSClient):
     print(f"Created guest collection. Collection ID: {collection['id']}")
 
 
-def attach_data_access_scope(gcs_client, collection_id):
+def attach_data_access_scope(
+    gcs_client: globus_sdk.GCSClient, collection_id: str
+) -> None:
     """Compose and attach a ``data_access`` scope for the supplied collection"""
     endpoint_scopes = gcs_client.get_gcs_endpoint_scopes(gcs_client.endpoint_client_id)
     collection_scopes = gcs_client.get_gcs_collection_scopes(collection_id)
 
-    data_access = globus_sdk.Scope(collection_scopes.data_access, optional=True)
-    manage_collections = globus_sdk.Scope(
-        endpoint_scopes.manage_collections, dependencies=(data_access,)
-    )
+    data_access = collection_scopes.data_access.with_optional(True)
+    manage_collections = endpoint_scopes.manage_collections.with_dependency(data_access)
 
     gcs_client.add_app_scope(manage_collections)
 
 
-def ensure_user_credential(gcs_client):
+def ensure_user_credential(gcs_client: globus_sdk.GCSClient) -> None:
     """
     Ensure that the client has a user credential on the client.
     This is the mapping between Globus Auth (OAuth2) and the local system's permissions.

--- a/docs/user_guide/usage_patterns/data_transfer/create_guest_collection/create_guest_collection_user_owned.py
+++ b/docs/user_guide/usage_patterns/data_transfer/create_guest_collection/create_guest_collection_user_owned.py
@@ -11,13 +11,13 @@ STORAGE_GATEWAY_ID = "947460f6-3fcd-4acc-9683-d71e14e5ace1"
 MAPPED_COLLECTION_ID = "6c54cade-bde5-45c1-bdea-f4bd71dba2cc"
 
 
-def main():
+def main() -> None:
     with UserApp("my-simple-user-collection", client_id=NATIVE_CLIENT_ID) as app:
         with globus_sdk.GCSClient(ENDPOINT_HOSTNAME, app=app) as client:
             create_guest_collection(client)
 
 
-def create_guest_collection(gcs_client: globus_sdk.GCSClient):
+def create_guest_collection(gcs_client: globus_sdk.GCSClient) -> None:
     # Comment out this line if the mapped collection is high assurance
     attach_data_access_scope(gcs_client, MAPPED_COLLECTION_ID)
 
@@ -34,20 +34,20 @@ def create_guest_collection(gcs_client: globus_sdk.GCSClient):
     print(f"Created guest collection. Collection ID: {collection['id']}")
 
 
-def attach_data_access_scope(gcs_client, collection_id):
+def attach_data_access_scope(
+    gcs_client: globus_sdk.GCSClient, collection_id: str
+) -> None:
     """Compose and attach a ``data_access`` scope for the supplied collection"""
     endpoint_scopes = gcs_client.get_gcs_endpoint_scopes(gcs_client.endpoint_client_id)
     collection_scopes = gcs_client.get_gcs_collection_scopes(collection_id)
 
-    data_access = globus_sdk.Scope(collection_scopes.data_access, optional=True)
-    manage_collections = globus_sdk.Scope(
-        endpoint_scopes.manage_collections, dependencies=(data_access,)
-    )
+    data_access = collection_scopes.data_access.with_optional(True)
+    manage_collections = endpoint_scopes.manage_collections.with_dependency(data_access)
 
     gcs_client.add_app_scope(manage_collections)
 
 
-def ensure_user_credential(gcs_client):
+def ensure_user_credential(gcs_client: globus_sdk.GCSClient) -> None:
     """
     Ensure that the user has a user credential on the client.
     This is the mapping between Globus Auth (OAuth2) and the local system's permissions.


### PR DESCRIPTION
These examples were written under SDK v3 and didn't get updated for v4.

In order to make maintenance easier, they are here updated such that they
can fully type-check under `mypy`. This checking flags the original
reported issue: improper use of updated `Scope` APIs.
