### PR TITLE
Introduce manual mypy checking on the docs/ dir

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,6 +181,12 @@ sqlite_cache = true
 warn_unreachable = true
 warn_no_return = true
 
+[[tool.mypy.overrides]]
+module = "docs.*"
+allow_untyped_calls = true
+allow_untyped_defs = true
+ignore_missing_imports = true
+
 [tool.pylint]
 load-plugins = ["pylint.extensions.docparams"]
 accept-no-param-doc = "false"

--- a/tox.ini
+++ b/tox.ini
@@ -61,6 +61,12 @@ commands = mypy src/ {posargs}
 base = mypy
 commands = mypy --show-error-codes --warn-unused-ignores tests/non-pytest/mypy-ignore-tests/
 
+[testenv:mypy-docs]
+base = mypy
+# docs isn't really a package, so avoid errors related to it being improperly
+# treated like one (this doesn't work via config)
+commands = mypy --explicit-package-bases {posargs:docs/}
+
 [testenv:test-lazy-imports]
 deps = -r requirements/py{py_dot_ver}/test.txt
 commands =


### PR DESCRIPTION
This is not yet passing, so it cannot be safely introduced in CI.

This initial configuration makes it possible for devs to run `mypy` against our docs with a configuration which is more lenient than our primary (strict) config.
