### PR TITLE
Update usage patterns docs to pass mypy

### DIFF
--- a/docs/user_guide/usage_patterns/data_transfer/scheduled_transfers/create_timer.py
+++ b/docs/user_guide/usage_patterns/data_transfer/scheduled_transfers/create_timer.py
@@ -1,7 +1,6 @@
 import datetime
 
 import globus_sdk
-from globus_sdk.experimental.globus_app import UserApp
 
 # Tutorial Client ID - <replace this with your own client>
 NATIVE_CLIENT_ID = "61338d24-54d5-408f-a10d-66c06b59f6d2"
@@ -35,7 +34,7 @@ schedule = globus_sdk.RecurringTimerSchedule(
     },
 )
 
-with UserApp("manage-timers-example", client_id=NATIVE_CLIENT_ID) as app:
+with globus_sdk.UserApp("manage-timers-example", client_id=NATIVE_CLIENT_ID) as app:
     # create a TimersClient to interact with the service, and register any data_access
     # scopes for the collections
     with globus_sdk.TimersClient(app=app) as timers_client:

--- a/docs/user_guide/usage_patterns/data_transfer/scheduled_transfers/create_timer_detect_data_access.py
+++ b/docs/user_guide/usage_patterns/data_transfer/scheduled_transfers/create_timer_detect_data_access.py
@@ -1,7 +1,6 @@
 import datetime
 
 import globus_sdk
-from globus_sdk.experimental.globus_app import UserApp
 
 # Tutorial Client ID - <replace this with your own client>
 NATIVE_CLIENT_ID = "61338d24-54d5-408f-a10d-66c06b59f6d2"
@@ -46,7 +45,7 @@ schedule = globus_sdk.RecurringTimerSchedule(
 )
 
 
-with UserApp("manage-timers-example", client_id=NATIVE_CLIENT_ID) as app:
+with globus_sdk.UserApp("manage-timers-example", client_id=NATIVE_CLIENT_ID) as app:
     # as with an immediate data transfer, we take our input data and wrap them in
     # a TransferData object, representing the transfer task
     transfer_request = globus_sdk.TransferData(SRC_COLLECTION, DST_COLLECTION)

--- a/docs/user_guide/usage_patterns/data_transfer/submit_transfer/submit_transfer_collections_known.py
+++ b/docs/user_guide/usage_patterns/data_transfer/submit_transfer/submit_transfer_collections_known.py
@@ -15,13 +15,13 @@ DST_COLLECTION = "31ce9ba0-176d-45a5-add3-f37d233ba47d"
 DST_PATH = "/~/example-transfer-script-destination.txt"
 
 
-def main():
+def main() -> None:
     with UserApp("my-simple-transfer", client_id=NATIVE_CLIENT_ID) as app:
         with globus_sdk.TransferClient(app=app) as client:
             submit_transfer(client)
 
 
-def submit_transfer(transfer_client: globus_sdk.TransferClient):
+def submit_transfer(transfer_client: globus_sdk.TransferClient) -> None:
     # Comment out each of these lines if the referenced collection is either
     #   (1) A guest collection or (2) high assurance.
     transfer_client.add_app_data_access_scope(SRC_COLLECTION)

--- a/docs/user_guide/usage_patterns/data_transfer/submit_transfer/submit_transfer_collections_unknown.py
+++ b/docs/user_guide/usage_patterns/data_transfer/submit_transfer/submit_transfer_collections_unknown.py
@@ -15,7 +15,7 @@ DST_COLLECTION = "31ce9ba0-176d-45a5-add3-f37d233ba47d"
 DST_PATH = "/~/example-transfer-script-destination.txt"
 
 
-def main():
+def main() -> None:
     with UserApp(
         "my-simple-transfer",
         client_id=NATIVE_CLIENT_ID,
@@ -25,7 +25,7 @@ def main():
             submit_transfer(client)
 
 
-def submit_transfer(transfer_client: globus_sdk.TransferClient):
+def submit_transfer(transfer_client: globus_sdk.TransferClient) -> None:
     transfer_request = globus_sdk.TransferData(SRC_COLLECTION, DST_COLLECTION)
     transfer_request.add_item(SRC_PATH, DST_PATH)
 

--- a/docs/user_guide/usage_patterns/sessions_and_consents/coalescing_requirements_errors/coalesce_gares.py
+++ b/docs/user_guide/usage_patterns/sessions_and_consents/coalescing_requirements_errors/coalesce_gares.py
@@ -89,26 +89,38 @@ def _concat(values: list[list[str] | None]) -> list[str] | None:
 
 
 if __name__ == "__main__":
+    import typing as t
+
+    def to_gare(data: t.Any) -> globus_sdk.gare.GARE:
+        """
+        to_gare() returns None if coercion fails; this wrapper treats that as an error
+        instead, for nicer types
+        """
+        g = globus_sdk.gare.to_gare(data)
+        if g is None:
+            raise ValueError(f"data unexpectedly did not validate as a GARE: {data!r}")
+        return g
+
     # these are example errors
-    case1 = globus_sdk.gare.to_gare(
+    case1 = to_gare(
         {
             "code": "ConsentRequired",
             "authorization_parameters": {"required_scopes": ["foo"]},
         }
     )
-    case2 = globus_sdk.gare.to_gare(
+    case2 = to_gare(
         {
             "code": "ConsentRequired",
             "authorization_parameters": {"required_scopes": ["bar"]},
         }
     )
-    case3 = globus_sdk.gare.to_gare(
+    case3 = to_gare(
         {
             "code": "AuthorizationRequired",
             "authorization_parameters": {"required_scopes": ["baz"]},
         }
     )
-    case4 = globus_sdk.gare.to_gare(
+    case4 = to_gare(
         {
             "code": "AuthorizationRequired",
             "authorization_parameters": {
@@ -119,7 +131,7 @@ if __name__ == "__main__":
             },
         }
     )
-    case5 = globus_sdk.gare.to_gare(
+    case5 = to_gare(
         {
             "code": "AuthorizationRequired",
             "authorization_parameters": {
@@ -131,7 +143,7 @@ if __name__ == "__main__":
             },
         }
     )
-    case6 = globus_sdk.gare.to_gare(
+    case6 = to_gare(
         {
             "code": "AuthorizationRequired",
             "authorization_parameters": {
@@ -140,7 +152,7 @@ if __name__ == "__main__":
             },
         }
     )
-    case7 = globus_sdk.gare.to_gare(
+    case7 = to_gare(
         {
             "code": "AuthorizationRequired",
             "authorization_parameters": {

--- a/docs/user_guide/usage_patterns/sessions_and_consents/handling_transfer_auth_params/ls_with_session_handling.py
+++ b/docs/user_guide/usage_patterns/sessions_and_consents/handling_transfer_auth_params/ls_with_session_handling.py
@@ -36,6 +36,8 @@ with globus_sdk.UserApp("ls-session", client_id=NATIVE_CLIENT_ID) as app:
             print("An authorization requirement was not met. Logging in again...")
 
             gare = globus_sdk.gare.to_gare(err)
+            if not gare:
+                raise
             params = gare.authorization_parameters
             # set 'prompt=login', which guarantees a fresh login without
             # reliance on the browser session


### PR DESCRIPTION
Several of these changes are minor annotation changes but not fixes.
However, in a few cases `mypy` flagged improper usage, including stale imports of `UserApp` from the experimental namespace.

---

_This change was tested against #1412 and passes mypy in concert with #1411._
