### PR TITLE
Annotate `resource_server` as `str` for some cases

### DIFF
--- a/changelog.d/20260805_101317_sirosen_improve_resource_server_annotations.rst
+++ b/changelog.d/20260805_101317_sirosen_improve_resource_server_annotations.rst
@@ -1,0 +1,6 @@
+Changed
+-------
+
+-   The ``resource_server`` attribute of the clients for Auth, Compute, Flows,
+    Groups, Search, Timers, and Transfer is now annotated as ``str``, rather than
+    the inherited type of ``str | None``. (:pr:`NUMBER`)

--- a/src/globus_sdk/services/auth/client/base_login_client.py
+++ b/src/globus_sdk/services/auth/client/base_login_client.py
@@ -46,6 +46,10 @@ class AuthLoginClient(client.BaseClient):
     error_class = AuthAPIError
     scopes = AuthScopes
 
+    # annotate but do not assign 'resource_server'
+    # because we know that the classproperty of this name will evaluate to a string
+    resource_server: str
+
     def __init__(
         self,
         client_id: uuid.UUID | str | None = None,

--- a/src/globus_sdk/services/auth/client/service_client.py
+++ b/src/globus_sdk/services/auth/client/service_client.py
@@ -71,6 +71,10 @@ class AuthClient(client.BaseClient):
         AuthScopes.email,
     ]
 
+    # annotate but do not assign 'resource_server'
+    # because we know that the classproperty of this name will evaluate to a string
+    resource_server: str
+
     def __init__(
         self,
         environment: str | None = None,

--- a/src/globus_sdk/services/compute/client.py
+++ b/src/globus_sdk/services/compute/client.py
@@ -28,6 +28,10 @@ class ComputeClientV2(client.BaseClient):
     scopes = ComputeScopes
     default_scope_requirements = [ComputeScopes.all]
 
+    # annotate but do not assign 'resource_server'
+    # because we know that the classproperty of this name will evaluate to a string
+    resource_server: str
+
     def get_version(self, service: str | MissingType = MISSING) -> GlobusHTTPResponse:
         """Get the current version of the API and other services.
 

--- a/src/globus_sdk/services/flows/client.py
+++ b/src/globus_sdk/services/flows/client.py
@@ -52,6 +52,10 @@ class FlowsClient(client.BaseClient):
     scopes = FlowsScopes
     default_scope_requirements = [FlowsScopes.all]
 
+    # annotate but do not assign 'resource_server'
+    # because we know that the classproperty of this name will evaluate to a string
+    resource_server: str
+
     def create_flow(
         self,
         title: str,

--- a/src/globus_sdk/services/groups/client.py
+++ b/src/globus_sdk/services/groups/client.py
@@ -46,6 +46,10 @@ class GroupsClient(client.BaseClient):
     service_name = "groups"
     scopes = GroupsScopes
 
+    # annotate but do not assign 'resource_server'
+    # because we know that the classproperty of this name will evaluate to a string
+    resource_server: str
+
     @property
     def default_scope_requirements(self) -> list[Scope]:
         return [GroupsScopes.view_my_groups_and_memberships]

--- a/src/globus_sdk/services/search/client.py
+++ b/src/globus_sdk/services/search/client.py
@@ -42,6 +42,10 @@ class SearchClient(client.BaseClient):
     scopes = SearchScopes
     default_scope_requirements = [SearchScopes.search]
 
+    # annotate but do not assign 'resource_server'
+    # because we know that the classproperty of this name will evaluate to a string
+    resource_server: str
+
     #
     # Index Management
     #

--- a/src/globus_sdk/services/timers/client.py
+++ b/src/globus_sdk/services/timers/client.py
@@ -34,6 +34,10 @@ class TimersClient(client.BaseClient):
     scopes = TimersScopes
     default_scope_requirements = [TimersScopes.timer]
 
+    # annotate but do not assign 'resource_server'
+    # because we know that the classproperty of this name will evaluate to a string
+    resource_server: str
+
     def add_app_transfer_data_access_scope(
         self, collection_ids: uuid.UUID | str | t.Iterable[uuid.UUID | str]
     ) -> TimersClient:

--- a/src/globus_sdk/services/transfer/client.py
+++ b/src/globus_sdk/services/transfer/client.py
@@ -135,6 +135,10 @@ class TransferClient(client.BaseClient):
     scopes = TransferScopes
     default_scope_requirements = [TransferScopes.all]
 
+    # annotate but do not assign 'resource_server'
+    # because we know that the classproperty of this name will evaluate to a string
+    resource_server: str
+
     def _register_standard_retry_checks(self, retry_config: RetryConfig) -> None:
         """Override the default retry checks."""
         retry_config.checks.register_many_checks(TRANSFER_DEFAULT_RETRY_CHECKS)


### PR DESCRIPTION
Several classes set `scopes` as a class attribute, meaning that their `resource_server` class property will evaluate to `str`, rather than `str | None`.
_Technically_, this can be violated (if `scopes` is deleted from the class), but in terms of a closed system of type-safe code, the annotation is correct.

An annotation without an assignment does not rebind the name, so the subclasses' `resource_server` attribute still points at the classproperty descriptor.

This corrects several type-checking errors in the docs without requiring improper checks or type-ignores to provide type-safety.
