### PR TITLE
Add a benchmark for filter_missing

### DIFF
--- a/tests/benchmark/test_filter_missing.py
+++ b/tests/benchmark/test_filter_missing.py
@@ -1,0 +1,38 @@
+import copy
+
+import pytest
+
+from globus_sdk.transport.representation_providers import RequestsRepresentationProvider
+
+
+@pytest.mark.parametrize(
+    ("width", "depth"),
+    (
+        # note that the expected number of objects is roughly "WIDTH raised to DEPTH"
+        # so relatively modest numbers like 5x10 = 5 to the 10th = 9.7 million
+        # be careful to build wide-but-shallow or deep-but-narrow trees
+        pytest.param(1, 1, id="1w-1d"),
+        pytest.param(5, 1, id="5w-1d"),
+        pytest.param(1, 5, id="1w-5d"),
+        pytest.param(1, 1000, id="1w-1000d"),
+        pytest.param(5, 5, id="5w-5d"),
+        pytest.param(10, 5, id="10w-5d"),
+    ),
+)
+def test_deeply_nested_object_encoding(benchmark, depth, width):
+    data = {}
+    for _ in range(depth):
+        data = {
+            # significant optimization: if we're building something really deep with
+            # width=1 we don't need to deepcopy
+            f"nested{i}": data if width == 1 else copy.deepcopy(data)
+            for i in range(width)
+        }
+
+    provider = RequestsRepresentationProvider()
+    method = "POST"
+    url = "https://example.api.globus.org/foo"
+    params = {}
+    headers = {}
+
+    benchmark(provider.encode, method, url, params, data, headers)

--- a/tests/benchmark/test_filter_missing.py
+++ b/tests/benchmark/test_filter_missing.py
@@ -2,6 +2,7 @@ import copy
 
 import pytest
 
+from globus_sdk.testing import get_response_set
 from globus_sdk.transport.representation_providers import RequestsRepresentationProvider
 
 
@@ -28,6 +29,30 @@ def test_deeply_nested_object_encoding(benchmark, depth, width):
             f"nested{i}": data if width == 1 else copy.deepcopy(data)
             for i in range(width)
         }
+
+    provider = RequestsRepresentationProvider()
+    method = "POST"
+    url = "https://example.api.globus.org/foo"
+    params = {}
+    headers = {}
+
+    benchmark(provider.encode, method, url, params, data, headers)
+
+
+# Use known response objects as "typical" JSON blobs.
+# These aren't a perfect representative sample, but they're more realistically similar
+# to request data than fully synthetic object graphs.
+@pytest.mark.parametrize(
+    "response_lookup_path",
+    (
+        "auth.get_consents",
+        "transfer.create_tunnel",
+        "flows.get_run_logs",
+    ),
+)
+def test_typical_object_encoding(benchmark, response_lookup_path):
+    response_set = get_response_set(response_lookup_path)
+    data = response_set.lookup("default").json
 
     provider = RequestsRepresentationProvider()
     method = "POST"

--- a/tox.ini
+++ b/tox.ini
@@ -78,7 +78,7 @@ commands =
 deps =
     -r requirements/py{py_dot_ver}/test.txt
     pytest-benchmark
-commands = pytest tests/benchmark/ {posargs}
+commands = pytest {posargs:tests/benchmark/}
 
 [testenv:pylint,pylint-{py3.9,py3.10,py3.11,py3.12,py3.13,py3.14}]
 deps = pylint


### PR DESCRIPTION
Add a benchmark for filtering out MISSING values from a wide and deep request body.

> [!NOTE]
> This is a benchmark developed during review of #1423, and is not safe to add to `main` until that fix merges.

@kurtmckee, I'm especially interested in what you think of this benchmark as the author of the original fix PR. I'm using a cherry-pick of this work to evaluate potential improvements.
(I think some measure of perf testing is important to validate my assumptions. I had some initial feedback that I scrapped once I actually measured the effects.)

EDIT: I added a small second benchmark which grabs testing registered response data as "typical" JSON data. This doesn't demonstrate any perf wins or losses in my testing across branches, but serves as a good "do no harm" signal.