### PR TITLE
Remove trivial unused method

### DIFF
--- a/src/globus_sdk/paging/table.py
+++ b/src/globus_sdk/paging/table.py
@@ -42,11 +42,6 @@ class PaginatorTable:
         # return paginators
         self._bindings: dict[str, t.Callable[..., Paginator[t.Any]]] = {}
 
-    def _add_binding(
-        self, methodname: str, bound_method: t.Callable[..., t.Any]
-    ) -> None:
-        self._bindings[methodname] = Paginator.wrap(bound_method)
-
     def __getattr__(self, attrname: str) -> t.Callable[..., Paginator[t.Any]]:
         if attrname not in self._bindings:
             # this could raise AttributeError -- in which case, let it!


### PR DESCRIPTION
PaginatorTable._add_binding() is no longer used as part of pagination.
