### PR TITLE
Only run codspeed CI on the main repo, not forks

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   benchmark:
+    if: github.repository == 'globus/globus-sdk-python'
     name: run benchmarks
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
One of our devs noticed that on a fork of the repo, you get red CI signal because the codspeed job fails.
